### PR TITLE
fix(release): Improve version determination and changelog generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
+  discussions: write
 
 jobs:
   release:
@@ -174,6 +175,7 @@ jobs:
           draft: false
           prerelease: false
           generate_release_notes: true
+          discussion_category_name: 'Announcements'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,17 +57,25 @@ jobs:
             echo "version=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
           else
             # Get the latest tag
-            LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
-            echo "Latest tag: $LATEST_TAG"
+            LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+            echo "Latest tag: ${LATEST_TAG:-none}"
 
-            # Remove 'v' prefix if present
-            LATEST_VERSION=${LATEST_TAG#v}
+            if [ -z "$LATEST_TAG" ]; then
+              # No tags exist, start from 0.0.0 and check all commits
+              MAJOR=0
+              MINOR=0
+              PATCH=0
+              COMMITS=$(git log --pretty=format:"%s")
+            else
+              # Remove 'v' prefix if present
+              LATEST_VERSION=${LATEST_TAG#v}
 
-            # Parse version components
-            IFS='.' read -r MAJOR MINOR PATCH <<< "$LATEST_VERSION"
+              # Parse version components
+              IFS='.' read -r MAJOR MINOR PATCH <<< "$LATEST_VERSION"
 
-            # Check commit messages for version bump type
-            COMMITS=$(git log ${LATEST_TAG}..HEAD --pretty=format:"%s")
+              # Check commit messages for version bump type
+              COMMITS=$(git log ${LATEST_TAG}..HEAD --pretty=format:"%s")
+            fi
 
             if echo "$COMMITS" | grep -qiE "^(feat|feature)(\(.+\))?!:|^BREAKING CHANGE:|breaking change"; then
               # Major version bump for breaking changes
@@ -132,7 +140,11 @@ jobs:
             CHANGELOG="${CHANGELOG}### 📦 Other Changes\n\n${OTHERS}\n\n"
           fi
 
-          CHANGELOG="${CHANGELOG}**Full Changelog**: https://github.com/${{ github.repository }}/compare/${LATEST_TAG}...v${VERSION}"
+          if [ -n "$LATEST_TAG" ]; then
+            CHANGELOG="${CHANGELOG}**Full Changelog**: https://github.com/${{ github.repository }}/compare/${LATEST_TAG}...v${VERSION}"
+          else
+            CHANGELOG="${CHANGELOG}**Full Changelog**: https://github.com/${{ github.repository }}/commits/v${VERSION}"
+          fi
 
           # Save to file for multi-line output
           echo "$CHANGELOG" > changelog.txt


### PR DESCRIPTION
This pull request updates the `release.yml` GitHub Actions workflow to improve the release automation process, especially around handling repositories with no tags and enhancing release communication. The main improvements include better handling of initial releases, more informative changelog links, and integration with GitHub Discussions.

Release workflow improvements:

* Added support for repositories with no tags by initializing version numbers and collecting all commit messages if no previous tag exists. This ensures the release workflow works smoothly even for the first release. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L60-R70) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R79)
* Enhanced changelog generation: If there is no previous tag, the changelog now links to the commit history rather than a tag comparison, providing accurate context for the initial release.

GitHub Discussions integration:

* Granted `discussions: write` permission to the workflow, enabling it to interact with GitHub Discussions.
* Configured releases to automatically post announcements to the 'Announcements' discussion category, improving visibility of new releases.