### PR TITLE
fix(release): Update changelog formatting for better readability

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,32 +123,33 @@ jobs:
           OTHERS=$(echo "$COMMITS" | grep -viE "^- (feat|feature|fix|bugfix)(\(.+\))?:" || echo "")
 
           # Build changelog
-          CHANGELOG="## What's Changed\n\n"
+          CHANGELOG="## What's Changed"
+          CHANGELOG="${CHANGELOG}\n"
 
           if [ -n "$BREAKING" ]; then
-            CHANGELOG="${CHANGELOG}### ⚠️ Breaking Changes\n\n${BREAKING}\n\n"
+            CHANGELOG="${CHANGELOG}\n### ⚠️ Breaking Changes\n\n${BREAKING}\n"
           fi
 
           if [ -n "$FEATURES" ]; then
-            CHANGELOG="${CHANGELOG}### ✨ Features\n\n${FEATURES}\n\n"
+            CHANGELOG="${CHANGELOG}\n### ✨ Features\n\n${FEATURES}\n"
           fi
 
           if [ -n "$FIXES" ]; then
-            CHANGELOG="${CHANGELOG}### 🐛 Bug Fixes\n\n${FIXES}\n\n"
+            CHANGELOG="${CHANGELOG}\n### 🐛 Bug Fixes\n\n${FIXES}\n"
           fi
 
           if [ -n "$OTHERS" ]; then
-            CHANGELOG="${CHANGELOG}### 📦 Other Changes\n\n${OTHERS}\n\n"
+            CHANGELOG="${CHANGELOG}\n### 📦 Other Changes\n\n${OTHERS}\n"
           fi
 
           if [ -n "$LATEST_TAG" ]; then
-            CHANGELOG="${CHANGELOG}**Full Changelog**: https://github.com/${{ github.repository }}/compare/${LATEST_TAG}...v${VERSION}"
+            CHANGELOG="${CHANGELOG}\n**Full Changelog**: https://github.com/${{ github.repository }}/compare/${LATEST_TAG}...v${VERSION}"
           else
-            CHANGELOG="${CHANGELOG}**Full Changelog**: https://github.com/${{ github.repository }}/commits/v${VERSION}"
+            CHANGELOG="${CHANGELOG}\n**Full Changelog**: https://github.com/${{ github.repository }}/commits/v${VERSION}"
           fi
 
-          # Save to file for multi-line output
-          echo "$CHANGELOG" > changelog.txt
+          # Save to file for multi-line output with proper newline interpretation
+          echo -e "$CHANGELOG" > changelog.txt
           echo "Generated changelog for version $VERSION"
 
       - name: Commit version bump
@@ -170,7 +171,7 @@ jobs:
         uses: softprops/action-gh-release@62c96d0c4e8a889135c1f3a25910db8dbe0e85f7 # v2.3.4
         with:
           tag_name: v${{ steps.version.outputs.version }}
-          name: Release v${{ steps.version.outputs.version }}
+          name: v${{ steps.version.outputs.version }}
           body_path: changelog.txt
           draft: false
           prerelease: false

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -74,35 +74,38 @@ jobs:
           BREAKING=$(echo "$COMMITS" | grep -iE "^- (feat|feature)(\(.+\))?!:|BREAKING CHANGE" || echo "")
           OTHERS=$(echo "$COMMITS" | grep -viE "^- (feat|feature|fix|bugfix)(\(.+\))?:" || echo "")
 
-          NOTES="## Release v${VERSION}\n\n"
+          NOTES="## What's Changed"
+          NOTES="${NOTES}\n"
 
           if [ -n "$BREAKING" ]; then
-            NOTES="${NOTES}### ⚠️ Breaking Changes\n\n${BREAKING}\n\n"
+            NOTES="${NOTES}\n### ⚠️ Breaking Changes\n\n${BREAKING}\n"
           fi
 
           if [ -n "$FEATURES" ]; then
-            NOTES="${NOTES}### ✨ Features\n\n${FEATURES}\n\n"
+            NOTES="${NOTES}\n### ✨ Features\n\n${FEATURES}\n"
           fi
 
           if [ -n "$FIXES" ]; then
-            NOTES="${NOTES}### 🐛 Bug Fixes\n\n${FIXES}\n\n"
+            NOTES="${NOTES}\n### 🐛 Bug Fixes\n\n${FIXES}\n"
           fi
 
           if [ -n "$OTHERS" ]; then
-            NOTES="${NOTES}### 📦 Other Changes\n\n${OTHERS}\n\n"
+            NOTES="${NOTES}\n### 📦 Other Changes\n\n${OTHERS}\n"
           fi
 
           if [ -n "$PREV_TAG" ]; then
-            NOTES="${NOTES}**Full Changelog**: https://github.com/${{ github.repository }}/compare/${PREV_TAG}...${TAG}"
+            NOTES="${NOTES}\n**Full Changelog**: https://github.com/${{ github.repository }}/compare/${PREV_TAG}...${TAG}"
+          else
+            NOTES="${NOTES}\n**Full Changelog**: https://github.com/${{ github.repository }}/commits/${TAG}"
           fi
 
-          echo "$NOTES" > release_notes.txt
+          echo -e "$NOTES" > release_notes.txt
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@62c96d0c4e8a889135c1f3a25910db8dbe0e85f7 # v2.3.4
         with:
           tag_name: ${{ steps.tag.outputs.tag }}
-          name: Release ${{ steps.tag.outputs.tag }}
+          name: ${{ steps.tag.outputs.tag }}
           body_path: release_notes.txt
           draft: false
           prerelease: ${{ contains(steps.tag.outputs.version, '-') }}


### PR DESCRIPTION
This pull request updates the release automation workflows to improve the formatting and consistency of generated changelogs and release notes. The changes focus on better handling of newlines, more consistent section headers, and streamlined release naming.

**Changelog and release notes formatting improvements:**

* Changed how newlines are added to the `CHANGELOG` and `NOTES` variables, ensuring each section starts on a new line and improves readability in both `.github/workflows/release.yml` and `.github/workflows/tag-release.yml`. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L126-R152) [[2]](diffhunk://#diff-21e1251c1676ed10064d2d98ab1a8f6471a9718058bd316970abe934169f2b60L77-R108)
* Updated the echo command to use `echo -e` when writing changelogs and release notes to files, so that newline characters are interpreted correctly and the output is formatted as intended. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L126-R152) [[2]](diffhunk://#diff-21e1251c1676ed10064d2d98ab1a8f6471a9718058bd316970abe934169f2b60L77-R108)

**Release naming consistency:**

* Simplified the release name by removing the "Release" prefix, so releases are now named just by their version tag (e.g., `v1.2.3`), in both workflows. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L173-R174) [[2]](diffhunk://#diff-21e1251c1676ed10064d2d98ab1a8f6471a9718058bd316970abe934169f2b60L77-R108)

**Changelog link improvements:**

* Ensured that the "Full Changelog" link always starts on a new line and added a fallback to show the commits link if a previous tag is not available. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L126-R152) [[2]](diffhunk://#diff-21e1251c1676ed10064d2d98ab1a8f6471a9718058bd316970abe934169f2b60L77-R108)