### PR TITLE
refactor: Remove changelog and release notes generation from workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,54 +104,6 @@ jobs:
           mv package.json.tmp package.json
           echo "Updated package.json to version $VERSION"
 
-      - name: Generate changelog
-        id: changelog
-        run: |
-          VERSION=${{ steps.version.outputs.version }}
-          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
-
-          if [ -z "$LATEST_TAG" ]; then
-            COMMITS=$(git log --pretty=format:"- %s (%h)" --reverse)
-          else
-            COMMITS=$(git log ${LATEST_TAG}..HEAD --pretty=format:"- %s (%h)" --reverse)
-          fi
-
-          # Categorize commits
-          FEATURES=$(echo "$COMMITS" | grep -iE "^- (feat|feature)(\(.+\))?:" || echo "")
-          FIXES=$(echo "$COMMITS" | grep -iE "^- (fix|bugfix)(\(.+\))?:" || echo "")
-          BREAKING=$(echo "$COMMITS" | grep -iE "^- (feat|feature)(\(.+\))?!:|BREAKING CHANGE" || echo "")
-          OTHERS=$(echo "$COMMITS" | grep -viE "^- (feat|feature|fix|bugfix)(\(.+\))?:" || echo "")
-
-          # Build changelog
-          CHANGELOG="## What's Changed"
-          CHANGELOG="${CHANGELOG}\n"
-
-          if [ -n "$BREAKING" ]; then
-            CHANGELOG="${CHANGELOG}\n### ⚠️ Breaking Changes\n\n${BREAKING}\n"
-          fi
-
-          if [ -n "$FEATURES" ]; then
-            CHANGELOG="${CHANGELOG}\n### ✨ Features\n\n${FEATURES}\n"
-          fi
-
-          if [ -n "$FIXES" ]; then
-            CHANGELOG="${CHANGELOG}\n### 🐛 Bug Fixes\n\n${FIXES}\n"
-          fi
-
-          if [ -n "$OTHERS" ]; then
-            CHANGELOG="${CHANGELOG}\n### 📦 Other Changes\n\n${OTHERS}\n"
-          fi
-
-          if [ -n "$LATEST_TAG" ]; then
-            CHANGELOG="${CHANGELOG}\n**Full Changelog**: https://github.com/${{ github.repository }}/compare/${LATEST_TAG}...v${VERSION}"
-          else
-            CHANGELOG="${CHANGELOG}\n**Full Changelog**: https://github.com/${{ github.repository }}/commits/v${VERSION}"
-          fi
-
-          # Save to file for multi-line output with proper newline interpretation
-          echo -e "$CHANGELOG" > changelog.txt
-          echo "Generated changelog for version $VERSION"
-
       - name: Commit version bump
         run: |
           VERSION=${{ steps.version.outputs.version }}
@@ -172,7 +124,6 @@ jobs:
         with:
           tag_name: v${{ steps.version.outputs.version }}
           name: v${{ steps.version.outputs.version }}
-          body_path: changelog.txt
           draft: false
           prerelease: false
           generate_release_notes: true

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -55,58 +55,11 @@ jobs:
       - name: Run build
         run: bun run build
 
-      - name: Generate release notes
-        id: notes
-        run: |
-          TAG=${{ steps.tag.outputs.tag }}
-          VERSION=${{ steps.tag.outputs.version }}
-          PREV_TAG=$(git describe --tags --abbrev=0 ${TAG}^ 2>/dev/null || echo "")
-
-          if [ -z "$PREV_TAG" ]; then
-            COMMITS=$(git log --pretty=format:"- %s (%h)" --reverse)
-          else
-            COMMITS=$(git log ${PREV_TAG}..${TAG} --pretty=format:"- %s (%h)" --reverse)
-          fi
-
-          # Categorize commits
-          FEATURES=$(echo "$COMMITS" | grep -iE "^- (feat|feature)(\(.+\))?:" || echo "")
-          FIXES=$(echo "$COMMITS" | grep -iE "^- (fix|bugfix)(\(.+\))?:" || echo "")
-          BREAKING=$(echo "$COMMITS" | grep -iE "^- (feat|feature)(\(.+\))?!:|BREAKING CHANGE" || echo "")
-          OTHERS=$(echo "$COMMITS" | grep -viE "^- (feat|feature|fix|bugfix)(\(.+\))?:" || echo "")
-
-          NOTES="## What's Changed"
-          NOTES="${NOTES}\n"
-
-          if [ -n "$BREAKING" ]; then
-            NOTES="${NOTES}\n### ⚠️ Breaking Changes\n\n${BREAKING}\n"
-          fi
-
-          if [ -n "$FEATURES" ]; then
-            NOTES="${NOTES}\n### ✨ Features\n\n${FEATURES}\n"
-          fi
-
-          if [ -n "$FIXES" ]; then
-            NOTES="${NOTES}\n### 🐛 Bug Fixes\n\n${FIXES}\n"
-          fi
-
-          if [ -n "$OTHERS" ]; then
-            NOTES="${NOTES}\n### 📦 Other Changes\n\n${OTHERS}\n"
-          fi
-
-          if [ -n "$PREV_TAG" ]; then
-            NOTES="${NOTES}\n**Full Changelog**: https://github.com/${{ github.repository }}/compare/${PREV_TAG}...${TAG}"
-          else
-            NOTES="${NOTES}\n**Full Changelog**: https://github.com/${{ github.repository }}/commits/${TAG}"
-          fi
-
-          echo -e "$NOTES" > release_notes.txt
-
       - name: Create GitHub Release
         uses: softprops/action-gh-release@62c96d0c4e8a889135c1f3a25910db8dbe0e85f7 # v2.3.4
         with:
           tag_name: ${{ steps.tag.outputs.tag }}
           name: ${{ steps.tag.outputs.tag }}
-          body_path: release_notes.txt
           draft: false
           prerelease: ${{ contains(steps.tag.outputs.version, '-') }}
           generate_release_notes: true


### PR DESCRIPTION
This pull request simplifies the release automation workflows by removing custom shell scripts for generating changelogs and release notes. Instead, it now relies entirely on GitHub's built-in release notes generation feature. This reduces maintenance overhead and potential points of failure in the release process.

**Workflow simplification:**

* Removed the custom shell script that generated and categorized changelogs in the `release.yml` workflow, and stopped passing a manually generated changelog to the release step. Now, the workflow uses GitHub's `generate_release_notes` feature to automatically create release notes. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L107-L154) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L175)
* Similarly, eliminated the custom release notes generation script in the `tag-release.yml` workflow and switched to using GitHub's automatic release notes.