### PR TITLE
fix: Add Prisma Client generation step in release workflow 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Generate Prisma Client
+        run: bunx prisma generate
+
       - name: Run type check
         run: bun run type-check
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "echo \"Tests not yet implemented\" && exit 0",
     "test:watch": "echo \"Tests not yet implemented\" && exit 0",
     "test:coverage": "echo \"Tests not yet implemented\" && exit 0",
-    "postinstall": "prisma generate && prisma migrate deploy",
+    "postinstall": "prisma generate",
     "db:studio": "prisma studio",
     "db:push": "prisma db push",
     "db:migrate": "prisma migrate dev",


### PR DESCRIPTION
(And update postinstall script).

This pull request makes minor adjustments to the Prisma client generation process to improve reliability and clarity in setup and deployment. The main changes are:

Dependency management and deployment:

* The Prisma client is now explicitly generated in the GitHub Actions release workflow using `bunx prisma generate`, ensuring the client is always up-to-date during CI/CD.
* The `postinstall` script in `package.json` has been simplified to only run `prisma generate`, removing the automatic deployment of migrations during install for greater control and to avoid unintended schema changes.