### PR TITLE
fix: skip environment validation during build phase

### DIFF
--- a/lib/env.ts
+++ b/lib/env.ts
@@ -22,6 +22,19 @@ const envSchema = z.object({
 
 // Validate environment variables
 function validateEnv() {
+    // Skip validation during build time - environment variables are only needed at runtime
+    if (process.env.NEXT_PHASE === 'phase-production-build') {
+        return {
+            DATABASE_URL: process.env.DATABASE_URL || '',
+            NEXTAUTH_URL: process.env.NEXTAUTH_URL || '',
+            NEXTAUTH_SECRET: process.env.NEXTAUTH_SECRET || '',
+            MAILCHIMP_API_KEY: process.env.MAILCHIMP_API_KEY || '',
+            EMAIL_FROM: process.env.EMAIL_FROM || '',
+            NODE_ENV: (process.env.NODE_ENV || 'development') as 'development' | 'production' | 'test',
+            AWS_REGION: process.env.AWS_REGION,
+        }
+    }
+
     try {
         const env = envSchema.parse(process.env)
         return env


### PR DESCRIPTION
Environment variables are only needed at runtime, not during Next.js build. This prevents build failures in CI/CD environments.

The validation now checks for NEXT_PHASE=phase-production-build and returns empty defaults during build, while still validating at runtime when the variables are actually needed.

This pull request updates the environment variable validation logic in `lib/env.ts` to better handle build-time scenarios for Next.js applications. The main change is to skip strict environment variable validation during the production build phase, preventing build-time errors due to missing runtime-only environment variables.

Environment validation improvements:

* Modified the `validateEnv` function to detect when the build is running in the production build phase (`NEXT_PHASE === 'phase-production-build'`) and, in that case, skip strict validation by returning a fallback object with environment variables or defaults.