### PR TITLE
feat: Add launch configuration for Next.js debugging and enhance rate…

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,12 +8,7 @@
       "runtimeExecutable": "bun",
       "runtimeArgs": ["run", "dev"],
       "attachSimplePort": 9229,
-      "console": "integratedTerminal",
-      "serverReadyAction": {
-        "pattern": "- Local:.+(https?://.+)",
-        "uriFormat": "%s",
-        "action": "debugWithChrome"
-      }
+      "console": "integratedTerminal"
     },
     {
       "type": "chrome",
@@ -24,25 +19,11 @@
       "sourceMapPathOverrides": {
         "webpack://_N_E/./*": "${webRoot}/*"
       }
-    },
-    {
-      "type": "node",
-      "request": "launch",
-      "name": "Next.js: debug full stack",
-      "runtimeExecutable": "bun",
-      "runtimeArgs": ["run", "dev"],
-      "attachSimplePort": 9229,
-      "console": "integratedTerminal",
-      "serverReadyAction": {
-        "pattern": "- Local:.+(https?://.+)",
-        "uriFormat": "%s",
-        "action": "debugWithChrome"
-      }
     }
   ],
   "compounds": [
     {
-      "name": "Next.js: debug full stack (all)",
+      "name": "Next.js: debug full stack",
       "configurations": [
         "Next.js: debug server-side",
         "Next.js: debug client-side"

--- a/lib/utils/rate-limit.ts
+++ b/lib/utils/rate-limit.ts
@@ -15,7 +15,7 @@ class RateLimiter {
         this.windowMs = windowMs;
     }
 
-    isAllowed(identifier: string): { allowed: boolean; remaining: number; resetTime: number } {
+    isAllowed(identifier: string): { allowed: boolean; remaining: number; resetTime: number; limit: number } {
         const now = Date.now();
         const record = this.requests.get(identifier);
 
@@ -23,18 +23,18 @@ class RateLimiter {
             // First request or window has expired
             const resetTime = now + this.windowMs;
             this.requests.set(identifier, { count: 1, resetTime });
-            return { allowed: true, remaining: this.maxRequests - 1, resetTime };
+            return { allowed: true, remaining: this.maxRequests - 1, resetTime, limit: this.maxRequests };
         }
 
         if (record.count >= this.maxRequests) {
             // Rate limit exceeded
-            return { allowed: false, remaining: 0, resetTime: record.resetTime };
+            return { allowed: false, remaining: 0, resetTime: record.resetTime, limit: this.maxRequests };
         }
 
         // Increment count
         record.count++;
         this.requests.set(identifier, record);
-        return { allowed: true, remaining: this.maxRequests - record.count, resetTime: record.resetTime };
+        return { allowed: true, remaining: this.maxRequests - record.count, resetTime: record.resetTime, limit: this.maxRequests };
     }
 
     // Clean up expired entries periodically

--- a/middleware.ts
+++ b/middleware.ts
@@ -41,7 +41,7 @@ export function middleware(request: NextRequest) {
                     status: 429,
                     headers: {
                         "Content-Type": "application/json",
-                        "X-RateLimit-Limit": process.env.NODE_ENV === "production" ? "5" : "50",
+                        "X-RateLimit-Limit": rateLimitResult.limit.toString(),
                         "X-RateLimit-Remaining": "0",
                         "X-RateLimit-Reset": new Date(rateLimitResult.resetTime).toISOString(),
                         "Retry-After": retryAfter.toString(),
@@ -52,8 +52,7 @@ export function middleware(request: NextRequest) {
 
         // Add rate limit headers to successful responses
         const response = NextResponse.next();
-        const maxLimit = process.env.NODE_ENV === "production" ? "5" : "50";
-        response.headers.set("X-RateLimit-Limit", maxLimit);
+        response.headers.set("X-RateLimit-Limit", rateLimitResult.limit.toString());
         response.headers.set("X-RateLimit-Remaining", rateLimitResult.remaining.toString());
         response.headers.set("X-RateLimit-Reset", new Date(rateLimitResult.resetTime).toISOString());
 


### PR DESCRIPTION
… limiting in development

This pull request introduces improvements to the development workflow and rate limiting logic. It adds VSCode debug configurations for easier debugging of Next.js apps and makes the rate limiter more permissive in development to accommodate rapid testing flows like signup and signin. Additionally, it enhances rate limit response headers and logging for better developer experience.

**Development tooling:**

* Added a `.vscode/launch.json` file with pre-configured debug setups for server-side, client-side, and full-stack Next.js development, including support for Bun and Chrome debugging.

**Rate limiting improvements:**

* Increased the rate limit for authentication endpoints in development from 5 to 50 requests per 15 minutes, while keeping production limits strict.
* Updated comments and logic in `rate-limit.ts` and `middleware.ts` to clarify the more permissive development limits and to log rate limit hits in development for easier debugging. [[1]](diffhunk://#diff-682175e15195f46855be34a7412749ccfaee4e31a31cdbb483c31eeeb36c54c2R5-R7) [[2]](diffhunk://#diff-3c67eb27b539c61276d7c7cbcdbe15d4b37a6cbf58bf8bc12c1c4d7619c96d1cL16-R16) [[3]](diffhunk://#diff-3c67eb27b539c61276d7c7cbcdbe15d4b37a6cbf58bf8bc12c1c4d7619c96d1cR28-R34)
* Dynamically set the `X-RateLimit-Limit` and `Retry-After` headers in API responses based on the environment, ensuring accurate feedback for both development and production.