### PR TITLE
fix: Await params in LeagueInvitationsPage and LeagueRosterPage

### DIFF
--- a/app/(dashboard)/league/[leagueId]/invitations/page.tsx
+++ b/app/(dashboard)/league/[leagueId]/invitations/page.tsx
@@ -5,14 +5,14 @@ import { notFound } from "next/navigation";
 import LeagueInvitationManager from "@/components/features/roster/LeagueInvitationManager";
 
 interface LeagueInvitationsPageProps {
-  params: {
+  params: Promise<{
     leagueId: string;
-  };
+  }>;
 }
 
 export default async function LeagueInvitationsPage({ params }: LeagueInvitationsPageProps) {
   const userId = await requireUserId();
-  const { leagueId } = params;
+  const { leagueId } = await params;
 
   // Verify user has access to this league
   const leagueUser = await prisma.leagueUser.findFirst({

--- a/app/(dashboard)/league/[leagueId]/invitations/page.tsx
+++ b/app/(dashboard)/league/[leagueId]/invitations/page.tsx
@@ -11,8 +11,8 @@ interface LeagueInvitationsPageProps {
 }
 
 export default async function LeagueInvitationsPage({ params }: LeagueInvitationsPageProps) {
-  const userId = await requireUserId();
-  const { leagueId } = await params;
+  // Parallelize independent async operations for better performance
+  const [{ leagueId }, userId] = await Promise.all([params, requireUserId()]);
 
   // Verify user has access to this league
   const leagueUser = await prisma.leagueUser.findFirst({

--- a/app/(dashboard)/league/[leagueId]/roster/page.tsx
+++ b/app/(dashboard)/league/[leagueId]/roster/page.tsx
@@ -6,14 +6,14 @@ import LeagueRosterView from "@/components/features/roster/LeagueRosterView";
 import LeagueInvitationManager from "@/components/features/roster/LeagueInvitationManager";
 
 interface LeagueRosterPageProps {
-  params: {
+  params: Promise<{
     leagueId: string;
-  };
+  }>;
 }
 
 export default async function LeagueRosterPage({ params }: LeagueRosterPageProps) {
   const userId = await requireUserId();
-  const { leagueId } = params;
+  const { leagueId } = await params;
 
   // Verify user has access to this league
   const leagueUser = await prisma.leagueUser.findFirst({

--- a/app/(dashboard)/league/[leagueId]/roster/page.tsx
+++ b/app/(dashboard)/league/[leagueId]/roster/page.tsx
@@ -12,8 +12,8 @@ interface LeagueRosterPageProps {
 }
 
 export default async function LeagueRosterPage({ params }: LeagueRosterPageProps) {
-  const userId = await requireUserId();
-  const { leagueId } = await params;
+  // Parallelize independent async operations for better performance
+  const [{ leagueId }, userId] = await Promise.all([params, requireUserId()]);
 
   // Verify user has access to this league
   const leagueUser = await prisma.leagueUser.findFirst({


### PR DESCRIPTION
 (for correct leagueId retrieval).

This pull request updates the typing of the `params` prop in two dashboard page components to be a `Promise` that resolves to the expected object, and updates usage accordingly. This change ensures that the components correctly handle asynchronous resolution of route parameters.

Props typing and usage updates:

* Changed the `params` prop in both `LeagueInvitationsPage` (`page.tsx` in `invitations`) and `LeagueRosterPage` (`page.tsx` in `roster`) to be a `Promise` resolving to an object with `leagueId`, and updated the destructuring to `await` the promise. ([app/(dashboard)/league/[leagueId]/invitations/page.tsxL8-R15](diffhunk://#diff-e54f2639d9c8ed948a155e38b409beae216e912384143373abde783df1605c98L8-R15), [app/(dashboard)/league/[leagueId]/roster/page.tsxL9-R16](diffhunk://#diff-16dff660669531cfd29e712b602951b97e0b753f17196b1f75ce4d8872ae1925L9-R16))