### PR TITLE
fix: Await params in NewGamePage and LeagueSchedulePage for proper as…

### DIFF
--- a/app/(dashboard)/league/[leagueId]/schedule/new-game/page.tsx
+++ b/app/(dashboard)/league/[leagueId]/schedule/new-game/page.tsx
@@ -5,14 +5,14 @@ import { notFound } from "next/navigation";
 import InterTeamGameForm from "@/components/features/events/InterTeamGameForm";
 
 interface NewGamePageProps {
-  params: {
+  params: Promise<{
     leagueId: string;
-  };
+  }>;
 }
 
 export default async function NewGamePage({ params }: NewGamePageProps) {
   const userId = await requireUserId();
-  const { leagueId } = params;
+  const { leagueId } = await params;
 
   // Verify user has access to this league and can create games
   const leagueUser = await prisma.leagueUser.findFirst({

--- a/app/(dashboard)/league/[leagueId]/schedule/page.tsx
+++ b/app/(dashboard)/league/[leagueId]/schedule/page.tsx
@@ -7,14 +7,14 @@ import { notFound } from "next/navigation";
 import LeagueCalendar from "@/components/features/calendar/LeagueCalendar";
 
 interface LeagueSchedulePageProps {
-  params: {
+  params: Promise<{
     leagueId: string;
-  };
+  }>;
 }
 
 export default async function LeagueSchedulePage({ params }: LeagueSchedulePageProps) {
   const userId = await requireUserId();
-  const { leagueId } = params;
+  const { leagueId } = await params;
 
   // Verify user has access to this league
   const leagueUser = await prisma.leagueUser.findFirst({


### PR DESCRIPTION
…ync handling

This pull request updates the handling of route parameters in the dashboard league schedule pages to better support asynchronous parameter resolution. The main change is that the `params` prop is now a `Promise` that must be awaited, rather than a plain object.

Parameter handling updates:

* Changed the `params` prop in both `NewGamePage` (`page.tsx` in `league/[leagueId]/schedule/new-game/`) and `LeagueSchedulePage` (`page.tsx` in `league/[leagueId]/schedule/`) to be a `Promise` of the parameter object, and updated the function bodies to await this promise when extracting `leagueId`. ([app/(dashboard)/league/[leagueId]/schedule/new-game/page.tsxL8-R15](diffhunk://#diff-d1ec9e160a5f22886f597d6d3524eb3a1def9744e33e820f36247136e127d7daL8-R15), [app/(dashboard)/league/[leagueId]/schedule/page.tsxL10-R17](diffhunk://#diff-c01f463298d47dc12bd251c9e672d673165500b24e773469d145742ef32ab1ccL10-R17))