### PR TITLE
feat: Update marketing landing page with new header and trial promotion

### DIFF
--- a/app/(marketing)/get-started/page.tsx
+++ b/app/(marketing)/get-started/page.tsx
@@ -22,7 +22,7 @@ const steps = [
   {
     label: 'Create Your Account',
     description:
-      'Sign up with your email address. No credit card required, no commitment. Your account is free forever.',
+      'Sign up with your email address and start your 14-day free trial. No credit card required to start.',
     action: 'Sign Up Now',
     actionHref: '/signup',
   },

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -17,10 +17,10 @@ const roboto = Roboto({
 });
 
 export const metadata: Metadata = {
-  title: "OpenLeague - Free Sports Team Management Platform",
+  title: "OpenLeague - Affordable Sports Team Management Platform",
   description:
-    "Replace chaotic spreadsheets, group chats, and email chains with a single source of truth for sports team management. Free forever.",
-  keywords: "sports team management, team organization, roster management, scheduling, free team management software",
+    "Replace chaotic spreadsheets, group chats, and email chains with a single source of truth for sports team management. Transparent, affordable pricing.",
+  keywords: "sports team management, team organization, roster management, scheduling, affordable team management software, open source",
   manifest: "/site.webmanifest",
   icons: {
     icon: [
@@ -37,15 +37,15 @@ export const metadata: Metadata = {
     ],
   },
   openGraph: {
-    title: "OpenLeague - Free Sports Team Management Platform",
-    description: "Replace chaotic spreadsheets, group chats, and email chains with a single source of truth for sports team management. Free forever.",
+    title: "OpenLeague - Affordable Sports Team Management Platform",
+    description: "Replace chaotic spreadsheets, group chats, and email chains with a single source of truth for sports team management. Transparent, affordable pricing.",
     type: "website",
     url: "https://openl.app",
   },
   twitter: {
     card: "summary_large_image",
-    title: "OpenLeague - Free Sports Team Management Platform",
-    description: "Replace chaotic spreadsheets, group chats, and email chains with a single source of truth for sports team management. Free forever.",
+    title: "OpenLeague - Affordable Sports Team Management Platform",
+    description: "Replace chaotic spreadsheets, group chats, and email chains with a single source of truth for sports team management. Transparent, affordable pricing.",
   },
 };
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,8 +3,9 @@
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
 import { useEffect } from "react";
-import { Box, Typography, Container, Button, CircularProgress } from "@mui/material";
+import { Box, Typography, Container, Button, CircularProgress, AppBar, Toolbar } from "@mui/material";
 import Link from "next/link";
+import Image from "next/image";
 
 /**
  * Marketing Landing Page
@@ -48,26 +49,70 @@ export default function HomePage() {
 
   // Unauthenticated user - show marketing landing page
   return (
-    <Container maxWidth="lg">
-      <Box
+    <>
+      {/* Simple header with logo */}
+      <AppBar
+        position="sticky"
+        elevation={0}
         sx={{
-          marginTop: 8,
-          display: "flex",
-          flexDirection: "column",
-          alignItems: "center",
-          textAlign: "center",
+          bgcolor: 'background.paper',
+          borderBottom: 1,
+          borderColor: 'divider',
         }}
       >
-        {/* Hero Section */}
+        <Container maxWidth="lg">
+          <Toolbar disableGutters sx={{ justifyContent: 'space-between', py: 1 }}>
+            <Link href="/" style={{ textDecoration: 'none', color: 'inherit', display: 'flex', alignItems: 'center', gap: '12px' }}>
+              <Image
+                src="/images/logo.webp"
+                alt="OpenLeague Logo"
+                width={40}
+                height={40}
+                priority
+              />
+              <Typography
+                variant="h6"
+                component="div"
+                sx={{
+                  fontWeight: 700,
+                  color: 'primary.main',
+                }}
+              >
+                OpenLeague
+              </Typography>
+            </Link>
+            <Box sx={{ display: 'flex', gap: 1 }}>
+              <Button component={Link} href="/login" color="inherit" sx={{ color: 'text.primary' }}>
+                Sign In
+              </Button>
+              <Button component={Link} href="/signup" variant="contained">
+                Start Free Trial
+              </Button>
+            </Box>
+          </Toolbar>
+        </Container>
+      </AppBar>
+
+      <Container maxWidth="lg">
+        <Box
+          sx={{
+            marginTop: 8,
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            textAlign: "center",
+          }}
+        >
+          {/* Hero Section */}
         <Typography component="h1" variant="h2" gutterBottom>
           Replace Chaotic Spreadsheets with OpenLeague
         </Typography>
         <Typography variant="h5" color="text.secondary" sx={{ mb: 4, maxWidth: 800 }}>
-          The free sports team management platform that brings order to your team&apos;s chaos.
+          Affordable sports team management that brings order to your team&apos;s chaos.
           One source of truth for Who, What, When, and Where.
         </Typography>
         <Typography variant="body1" color="text.secondary" sx={{ mb: 6, maxWidth: 600 }}>
-          Stop juggling spreadsheets, group chats, and email chains. OpenLeague centralizes 
+          Stop juggling spreadsheets, group chats, and email chains. OpenLeague centralizes
           your roster, schedule, and communication in one simple, mobile-friendly platform.
         </Typography>
 
@@ -79,7 +124,7 @@ export default function HomePage() {
             size="large"
             sx={{ minWidth: 160, py: 1.5 }}
           >
-            Get Started Free
+            Start Free Trial
           </Button>
           <Button
             component={Link}
@@ -97,7 +142,7 @@ export default function HomePage() {
           <Typography variant="h4" component="h2" gutterBottom sx={{ textAlign: 'center', mb: 4 }}>
             Why Teams Choose OpenLeague
           </Typography>
-          
+
           <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', md: '1fr 1fr' }, gap: 4 }}>
             <Box>
               <Typography variant="h6" component="h3" gutterBottom>
@@ -107,7 +152,7 @@ export default function HomePage() {
                 Send email invitations, manage player information, and keep everyone&apos;s contact details in one place.
               </Typography>
             </Box>
-            
+
             <Box>
               <Typography variant="h6" component="h3" gutterBottom>
                 📅 Smart Scheduling
@@ -116,7 +161,7 @@ export default function HomePage() {
                 Create games and practices with RSVP tracking. Know who&apos;s coming before you show up.
               </Typography>
             </Box>
-            
+
             <Box>
               <Typography variant="h6" component="h3" gutterBottom>
                 📱 Mobile-First Design
@@ -125,13 +170,13 @@ export default function HomePage() {
                 Works perfectly on phones, tablets, and desktops. Your team can access everything on the go.
               </Typography>
             </Box>
-            
+
             <Box>
               <Typography variant="h6" component="h3" gutterBottom>
-                💰 Free Forever
+                💰 Affordable Pricing
               </Typography>
               <Typography variant="body2" color="text.secondary">
-                No hidden costs, no premium tiers, no credit card required. Just powerful team management tools.
+                Transparent pricing starting at $5/month. 14-day free trial, no credit card required.
               </Typography>
             </Box>
           </Box>
@@ -157,5 +202,6 @@ export default function HomePage() {
         </Box>
       </Box>
     </Container>
+    </>
   );
 }


### PR DESCRIPTION
This pull request updates the marketing language and landing page design to reflect a shift from a "free forever" model to emphasizing "affordable pricing" and a 14-day free trial. It also introduces a new header with branding and navigation on the unauthenticated landing page. The most important changes are summarized below.

**Marketing and Messaging Updates:**

* Changed all references from "Free" to "Affordable" or "Transparent, affordable pricing" across the site metadata, OpenGraph, Twitter cards, and landing page content. Updated keywords to include "affordable" and "open source" instead of "free". [[1]](diffhunk://#diff-eca96d2c09f31517696a26e1d0be4070e1fbab02831481bed006e275741d030bL20-R23) [[2]](diffhunk://#diff-eca96d2c09f31517696a26e1d0be4070e1fbab02831481bed006e275741d030bL40-R48) [[3]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0L66-R111) [[4]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0L131-R179)
* Updated the call-to-action buttons and step descriptions to reflect a "Start Free Trial" and a 14-day trial period, rather than "Get Started Free" or "Free Forever". [[1]](diffhunk://#diff-69aff6044933a57dc1bc211a759e4a41063085c647745057ebf763dd7930a1caL25-R25) [[2]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0L82-R127)

**Landing Page UI Improvements:**

* Added a simple header (`AppBar`) with the OpenLeague logo and navigation buttons ("Sign In" and "Start Free Trial") to the unauthenticated marketing landing page for improved branding and user navigation. [[1]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0L6-R8) [[2]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0R52-R95) [[3]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0R205)