### PR TITLE
fix: Refactor imports and enhance error handling in signup function

### DIFF
--- a/components/features/marketing/CTAButton.tsx
+++ b/components/features/marketing/CTAButton.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { Button, ButtonProps, alpha } from '@mui/material';
+import { Button, ButtonProps } from '@mui/material';
+import { alpha } from '@mui/material/styles';
 import Link from 'next/link';
 import { trackConversion } from '@/lib/analytics/tracking';
 
@@ -19,11 +20,11 @@ interface CTAButtonProps {
 /**
  * Enhanced CTA Button with conversion tracking and optimized hover states
  */
-export default function CTAButton({ 
-  href, 
-  trackingAction, 
-  trackingLabel, 
-  children, 
+export default function CTAButton({
+  href,
+  trackingAction,
+  trackingLabel,
+  children,
   variant = 'marketing',
   size,
   fullWidth,
@@ -63,7 +64,7 @@ export default function CTAButton({
             outlineOffset: '2px',
           },
         };
-        
+
         // Merge with custom sx prop if provided
         if (sx) {
           if (typeof sx === 'function') {
@@ -71,7 +72,7 @@ export default function CTAButton({
           }
           return { ...baseSx, ...sx };
         }
-        
+
         return baseSx;
       }}
     >

--- a/components/features/navigation/MarketingHeader.tsx
+++ b/components/features/navigation/MarketingHeader.tsx
@@ -11,7 +11,6 @@ import {
   Typography,
   Stack,
   Divider,
-  useTheme,
   useMediaQuery,
   IconButton,
   Drawer,
@@ -20,6 +19,7 @@ import {
   ListItemButton,
   ListItemText,
 } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
 import MenuIcon from '@mui/icons-material/Menu';
 import CloseIcon from '@mui/icons-material/Close';
 import Logo from '@/components/ui/Logo';
@@ -56,10 +56,10 @@ export default function MarketingHeader() {
       }}
     >
       <Container maxWidth="lg">
-        <Toolbar 
-          disableGutters 
-          sx={{ 
-            justifyContent: 'space-between', 
+        <Toolbar
+          disableGutters
+          sx={{
+            justifyContent: 'space-between',
             py: 1.5,
             minHeight: { xs: 64, md: 72 }
           }}
@@ -104,7 +104,7 @@ export default function MarketingHeader() {
                   component={Link}
                   href={link.href}
                   color="inherit"
-                  sx={{ 
+                  sx={{
                     color: 'text.primary',
                     fontWeight: 500,
                     px: 2,
@@ -120,12 +120,12 @@ export default function MarketingHeader() {
                 </Button>
               ))}
               <Divider orientation="vertical" flexItem sx={{ mx: 1, height: 24 }} />
-              <Button 
-                component={Link} 
-                href="/login" 
-                color="inherit" 
+              <Button
+                component={Link}
+                href="/login"
+                color="inherit"
                 onClick={() => marketingEvents.headerSignInClick()}
-                sx={{ 
+                sx={{
                   color: 'text.primary',
                   fontWeight: 500,
                   px: 2,
@@ -139,8 +139,8 @@ export default function MarketingHeader() {
               >
                 Sign In
               </Button>
-              <CTAButton 
-                href="/signup" 
+              <CTAButton
+                href="/signup"
                 variant="marketing"
                 trackingAction="header_sign_up_click"
                 trackingLabel="header"
@@ -157,7 +157,7 @@ export default function MarketingHeader() {
                 aria-label="open menu"
                 edge="end"
                 onClick={handleDrawerToggle}
-                sx={{ 
+                sx={{
                   color: 'text.primary',
                   '&:hover': {
                     backgroundColor: 'rgba(25, 118, 210, 0.04)',
@@ -171,7 +171,7 @@ export default function MarketingHeader() {
                 open={mobileMenuOpen}
                 onClose={handleDrawerToggle}
                 sx={{
-                  '& .MuiDrawer-paper': { 
+                  '& .MuiDrawer-paper': {
                     width: 280,
                     pt: 2,
                   },
@@ -196,7 +196,7 @@ export default function MarketingHeader() {
                           }
                         }}
                       >
-                        <ListItemText 
+                        <ListItemText
                           primary={link.label}
                           primaryTypographyProps={{
                             fontWeight: 500,
@@ -208,9 +208,9 @@ export default function MarketingHeader() {
                   ))}
                   <Divider sx={{ my: 2 }} />
                   <ListItem disablePadding sx={{ mb: 1 }}>
-                    <ListItemButton 
-                      component={Link} 
-                      href="/login" 
+                    <ListItemButton
+                      component={Link}
+                      href="/login"
                       onClick={() => {
                         marketingEvents.headerSignInClick();
                         handleDrawerToggle();
@@ -222,7 +222,7 @@ export default function MarketingHeader() {
                         }
                       }}
                     >
-                      <ListItemText 
+                      <ListItemText
                         primary="Sign In"
                         primaryTypographyProps={{
                           fontWeight: 500,

--- a/components/features/team/DragDropTeams.tsx
+++ b/components/features/team/DragDropTeams.tsx
@@ -12,7 +12,8 @@ import {
   type DragStartEvent,
   type DragEndEvent,
 } from '@dnd-kit/core';
-import { Box, Typography, Card, CardContent, Avatar, alpha } from '@mui/material';
+import { Box, Typography, Card, CardContent, Avatar } from '@mui/material';
+import { alpha } from '@mui/material/styles';
 import { Groups as TeamsIcon, DragIndicator as DragIcon } from '@mui/icons-material';
 import { assignTeamToDivision } from '@/lib/actions/league';
 import { useRouter } from 'next/navigation';

--- a/components/features/team/DraggableTeamCard.tsx
+++ b/components/features/team/DraggableTeamCard.tsx
@@ -3,7 +3,10 @@
 import React from 'react';
 import { useDraggable } from '@dnd-kit/core';
 import { CSS } from '@dnd-kit/utilities';
-import { Box, alpha } from '@mui/material';
+import { Draggable } from '@hello-pangea/dnd';
+import { Box } from '@mui/material';
+import { alpha } from '@mui/material/styles';
+import { Team } from '@prisma/client';
 import { DragIndicator as DragIcon } from '@mui/icons-material';
 
 interface DraggableTeamCardProps {

--- a/components/features/team/DroppableDivision.tsx
+++ b/components/features/team/DroppableDivision.tsx
@@ -2,7 +2,8 @@
 
 import React from 'react';
 import { useDroppable } from '@dnd-kit/core';
-import { Box, alpha } from '@mui/material';
+import { Box } from '@mui/material';
+import { alpha } from '@mui/material/styles';
 
 interface DroppableDivisionProps {
   id: string;


### PR DESCRIPTION
This pull request primarily refactors how the `alpha` utility from MUI is imported throughout the codebase, ensuring it is consistently imported from `@mui/material/styles` rather than directly from `@mui/material`. Additionally, it improves the signup action's error handling and response serialization to provide cleaner, more predictable API responses.

**Refactoring imports for MUI's `alpha` utility:**

* Updated all relevant components (`CTAButton.tsx`, `DragDropTeams.tsx`, `DraggableTeamCard.tsx`, `DroppableDivision.tsx`) to import `alpha` from `@mui/material/styles` instead of `@mui/material` for consistency and to align with best practices. [[1]](diffhunk://#diff-7a713047ed614db2342236a29af24eb189bfc99ad958efa9bbc7d036730f196cL3-R4) [[2]](diffhunk://#diff-a5eaecb28424e8feba79304e2575f67e220a9c3d3fdf002ff7957f0b4d79fb77L15-R16) [[3]](diffhunk://#diff-d2ce56408746893392f1fe1580283d946dfc46e09bd95a042c863326ac6f12cbL6-R9) [[4]](diffhunk://#diff-f2441e9709573466b2205ab505dcb8549ac544ef5df0c86fc011f2639769f85fL5-R6)
* Adjusted the import of `useTheme` in `MarketingHeader.tsx` to come from `@mui/material/styles`, and removed it from the destructured imports from `@mui/material`. [[1]](diffhunk://#diff-8b22a18cfc6d74cb5e3cb2ce41dce6ac7917a44b937b1bdea4424cb17724f7a9L14) [[2]](diffhunk://#diff-8b22a18cfc6d74cb5e3cb2ce41dce6ac7917a44b937b1bdea4424cb17724f7a9R22)

**Improvements to signup action response and error handling:**

* Modified the `signup` function in `auth.ts` to return a serializable, minimal user object on success, and to provide more structured error details for Zod validation errors. Also improved error logging and ensured all responses are clean and predictable for API consumers.