### PR TITLE
fix: Refine marketing layout logic for unauthenticated users

### DIFF
--- a/components/providers/LayoutProvider.tsx
+++ b/components/providers/LayoutProvider.tsx
@@ -32,13 +32,31 @@ export default function LayoutProvider({ children }: LayoutProviderProps) {
     '/security',
     '/docs',
   ];
+  // Routes that already render their own marketing layout components
+  const marketingRouteGroupPaths = [
+    '/features',
+    '/pricing',
+    '/about',
+    '/contact',
+    '/get-started',
+    '/blog',
+    '/careers',
+    '/privacy',
+    '/terms',
+    '/cookies',
+    '/security',
+  ];
   const isMarketingRoute = marketingPaths.some(path => 
     pathname === path || (path !== '/' && pathname.startsWith(path))
+  );
+  const isMarketingRouteGroup = marketingRouteGroupPaths.some(path =>
+    pathname === path || pathname.startsWith(`${path}/`)
   );
   const isAuthRoute = pathname.startsWith('/login') || pathname.startsWith('/signup');
   
   // Show marketing layout for unauthenticated users on marketing routes
-  const shouldShowMarketingLayout = !session?.user && (isMarketingRoute || isAuthRoute);
+  const shouldShowMarketingLayout =
+    !session?.user && ((isMarketingRoute && !isMarketingRouteGroup) || isAuthRoute);
   
   if (shouldShowMarketingLayout) {
     return (


### PR DESCRIPTION
This pull request refines the logic in `LayoutProvider.tsx` to better control when the marketing layout is shown for unauthenticated users. The main improvement is the introduction of a new set of route groups that already handle their own marketing layouts, preventing redundant rendering.

Layout logic improvements:

* Added a new `marketingRouteGroupPaths` array to specify routes that already render their own marketing layout components, such as `/features`, `/pricing`, `/about`, and others.
* Updated the `shouldShowMarketingLayout` condition to exclude these routes, ensuring that the marketing layout is not rendered redundantly for unauthenticated users on these paths.