### PR TITLE
feat(123): integrate Umami analytics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,11 @@ MAILCHIMP_API_KEY=""
 EMAIL_FROM="noreply@openl.app"
 
 # Analytics and Tracking
+# Umami Analytics (privacy-friendly, open-source)
+# Get your website ID from: https://cloud.umami.is
+# Leave empty to disable Umami tracking
+NEXT_PUBLIC_UMAMI_WEBSITE_ID=""
+
 # Google Analytics 4 Measurement ID
 NEXT_PUBLIC_GA_MEASUREMENT_ID=""
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ NEXTAUTH_SECRET=""  # Generate with: openssl rand -base64 32
 MAILCHIMP_API_KEY=""  # Get from Mailchimp Transactional dashboard
 EMAIL_FROM="noreply@yourdomain.com"  # Your sender email address
 
+# Optional: Analytics (Umami - privacy-friendly)
+NEXT_PUBLIC_UMAMI_WEBSITE_ID=""  # Get from https://cloud.umami.is
+
 # Optional: For future AWS migration
 AWS_REGION="us-east-1"
 ```
@@ -91,6 +94,10 @@ AWS_REGION="us-east-1"
 - `NEXTAUTH_SECRET` - Random 32+ character secret for JWT signing
 - `MAILCHIMP_API_KEY` - API key for sending emails
 - `EMAIL_FROM` - Verified sender email address
+
+**Optional Environment Variables:**
+
+- `NEXT_PUBLIC_UMAMI_WEBSITE_ID` - Umami analytics website ID (leave empty to disable tracking)
 
 ## Development Workflow
 

--- a/__tests__/lib/analytics/umami.test.ts
+++ b/__tests__/lib/analytics/umami.test.ts
@@ -1,0 +1,383 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  trackEvent,
+  identifyUser,
+  trackAuth,
+  trackTeam,
+  trackEventAction,
+  trackRSVP,
+  UmamiEvents,
+} from '@/lib/analytics/umami';
+
+describe('Umami Analytics Utilities', () => {
+  beforeEach(() => {
+    // Reset window.umami before each test
+    if (typeof window !== 'undefined') {
+      delete (window as any).umami;
+    }
+    vi.clearAllMocks();
+  });
+
+  describe('trackEvent', () => {
+    it('should track event when umami is available', () => {
+      const mockTrack = vi.fn();
+      (window as any).umami = { track: mockTrack };
+
+      trackEvent('test-event', { foo: 'bar' });
+
+      expect(mockTrack).toHaveBeenCalledWith('test-event', { foo: 'bar' });
+      expect(mockTrack).toHaveBeenCalledTimes(1);
+    });
+
+    it('should track event without data', () => {
+      const mockTrack = vi.fn();
+      (window as any).umami = { track: mockTrack };
+
+      trackEvent('test-event');
+
+      expect(mockTrack).toHaveBeenCalledWith('test-event', undefined);
+      expect(mockTrack).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not throw error when umami is not available', () => {
+      expect(() => trackEvent('test-event')).not.toThrow();
+    });
+
+    it('should not throw error when window is undefined', () => {
+      const originalWindow = global.window;
+      delete (global as any).window;
+
+      expect(() => trackEvent('test-event')).not.toThrow();
+
+      global.window = originalWindow;
+    });
+
+    it('should handle errors gracefully when track throws', () => {
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const mockTrack = vi.fn().mockImplementation(() => {
+        throw new Error('Track failed');
+      });
+      (window as any).umami = { track: mockTrack };
+
+      expect(() => trackEvent('test-event')).not.toThrow();
+      expect(consoleErrorSpy).toHaveBeenCalledWith('Error tracking event:', expect.any(Error));
+
+      consoleErrorSpy.mockRestore();
+    });
+  });
+
+  describe('identifyUser', () => {
+    it('should identify user with ID and data when umami is available', () => {
+      const mockIdentify = vi.fn();
+      (window as any).umami = { identify: mockIdentify };
+
+      identifyUser('user-123', { role: 'admin' });
+
+      expect(mockIdentify).toHaveBeenCalledWith('user-123', { role: 'admin' });
+      expect(mockIdentify).toHaveBeenCalledTimes(1);
+    });
+
+    it('should identify user with ID only', () => {
+      const mockIdentify = vi.fn();
+      (window as any).umami = { identify: mockIdentify };
+
+      identifyUser('user-123');
+
+      expect(mockIdentify).toHaveBeenCalledWith('user-123', undefined);
+      expect(mockIdentify).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not throw error when umami is not available', () => {
+      expect(() => identifyUser('user-123')).not.toThrow();
+    });
+
+    it('should handle errors gracefully when identify throws', () => {
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const mockIdentify = vi.fn().mockImplementation(() => {
+        throw new Error('Identify failed');
+      });
+      (window as any).umami = { identify: mockIdentify };
+
+      expect(() => identifyUser('user-123')).not.toThrow();
+      expect(consoleErrorSpy).toHaveBeenCalledWith('Error identifying user:', expect.any(Error));
+
+      consoleErrorSpy.mockRestore();
+    });
+  });
+
+  describe('UmamiEvents constants', () => {
+    it('should have authentication event names', () => {
+      expect(UmamiEvents.SIGNUP).toBe('user-signup');
+      expect(UmamiEvents.LOGIN).toBe('user-login');
+      expect(UmamiEvents.LOGOUT).toBe('user-logout');
+    });
+
+    it('should have team event names', () => {
+      expect(UmamiEvents.TEAM_CREATE).toBe('team-create');
+      expect(UmamiEvents.TEAM_JOIN).toBe('team-join');
+      expect(UmamiEvents.TEAM_LEAVE).toBe('team-leave');
+    });
+
+    it('should have event/game event names', () => {
+      expect(UmamiEvents.EVENT_CREATE).toBe('event-create');
+      expect(UmamiEvents.EVENT_UPDATE).toBe('event-update');
+      expect(UmamiEvents.EVENT_DELETE).toBe('event-delete');
+      expect(UmamiEvents.GAME_CREATE).toBe('game-create');
+      expect(UmamiEvents.PRACTICE_CREATE).toBe('practice-create');
+    });
+
+    it('should have RSVP event names', () => {
+      expect(UmamiEvents.RSVP_GOING).toBe('rsvp-going');
+      expect(UmamiEvents.RSVP_NOT_GOING).toBe('rsvp-not-going');
+      expect(UmamiEvents.RSVP_MAYBE).toBe('rsvp-maybe');
+    });
+
+    it('should have invitation event names', () => {
+      expect(UmamiEvents.INVITATION_SEND).toBe('invitation-send');
+      expect(UmamiEvents.INVITATION_ACCEPT).toBe('invitation-accept');
+      expect(UmamiEvents.INVITATION_DECLINE).toBe('invitation-decline');
+    });
+
+    it('should have navigation event names', () => {
+      expect(UmamiEvents.VIEW_CALENDAR).toBe('view-calendar');
+      expect(UmamiEvents.VIEW_ROSTER).toBe('view-roster');
+      expect(UmamiEvents.VIEW_EVENTS).toBe('view-events');
+      expect(UmamiEvents.VIEW_DASHBOARD).toBe('view-dashboard');
+    });
+
+    it('should have league event names', () => {
+      expect(UmamiEvents.LEAGUE_CREATE).toBe('league-create');
+      expect(UmamiEvents.LEAGUE_JOIN).toBe('league-join');
+      expect(UmamiEvents.DIVISION_CREATE).toBe('division-create');
+      expect(UmamiEvents.INTER_TEAM_GAME_CREATE).toBe('inter-team-game-create');
+    });
+
+    it('should have feature usage event names', () => {
+      expect(UmamiEvents.EMAIL_NOTIFICATION_SENT).toBe('email-notification-sent');
+      expect(UmamiEvents.CALENDAR_FILTER_USED).toBe('calendar-filter-used');
+      expect(UmamiEvents.EXPORT_CALENDAR).toBe('export-calendar');
+    });
+
+    it('should have roster event names', () => {
+      expect(UmamiEvents.PLAYER_ADD).toBe('player-add');
+      expect(UmamiEvents.PLAYER_UPDATE).toBe('player-update');
+      expect(UmamiEvents.PLAYER_REMOVE).toBe('player-remove');
+    });
+  });
+
+  describe('trackAuth helper', () => {
+    it('should track signup event', () => {
+      const mockTrack = vi.fn();
+      (window as any).umami = { track: mockTrack };
+
+      trackAuth('signup', { hasInvitation: true });
+
+      expect(mockTrack).toHaveBeenCalledWith('user-signup', { hasInvitation: true });
+    });
+
+    it('should track login event', () => {
+      const mockTrack = vi.fn();
+      (window as any).umami = { track: mockTrack };
+
+      trackAuth('login');
+
+      expect(mockTrack).toHaveBeenCalledWith('user-login', undefined);
+    });
+
+    it('should track logout event', () => {
+      const mockTrack = vi.fn();
+      (window as any).umami = { track: mockTrack };
+
+      trackAuth('logout', { sessionDuration: 3600 });
+
+      expect(mockTrack).toHaveBeenCalledWith('user-logout', { sessionDuration: 3600 });
+    });
+
+    it('should work without umami configured', () => {
+      expect(() => trackAuth('signup')).not.toThrow();
+    });
+  });
+
+  describe('trackTeam helper', () => {
+    it('should track team create event', () => {
+      const mockTrack = vi.fn();
+      (window as any).umami = { track: mockTrack };
+
+      trackTeam('create', { sport: 'Soccer', season: 'Fall 2025' });
+
+      expect(mockTrack).toHaveBeenCalledWith('team-create', { sport: 'Soccer', season: 'Fall 2025' });
+    });
+
+    it('should track team join event', () => {
+      const mockTrack = vi.fn();
+      (window as any).umami = { track: mockTrack };
+
+      trackTeam('join', { teamId: 'team-123' });
+
+      expect(mockTrack).toHaveBeenCalledWith('team-join', { teamId: 'team-123' });
+    });
+
+    it('should track team leave event', () => {
+      const mockTrack = vi.fn();
+      (window as any).umami = { track: mockTrack };
+
+      trackTeam('leave');
+
+      expect(mockTrack).toHaveBeenCalledWith('team-leave', undefined);
+    });
+
+    it('should work without umami configured', () => {
+      expect(() => trackTeam('create')).not.toThrow();
+    });
+  });
+
+  describe('trackEventAction helper', () => {
+    it('should track game creation', () => {
+      const mockTrack = vi.fn();
+      (window as any).umami = { track: mockTrack };
+
+      trackEventAction('create', 'game', { hasOpponent: true });
+
+      expect(mockTrack).toHaveBeenCalledWith('game-create', { hasOpponent: true });
+    });
+
+    it('should track practice creation', () => {
+      const mockTrack = vi.fn();
+      (window as any).umami = { track: mockTrack };
+
+      trackEventAction('create', 'practice', { duration: 90 });
+
+      expect(mockTrack).toHaveBeenCalledWith('practice-create', { duration: 90 });
+    });
+
+    it('should track generic event creation', () => {
+      const mockTrack = vi.fn();
+      (window as any).umami = { track: mockTrack };
+
+      trackEventAction('create', 'event');
+
+      expect(mockTrack).toHaveBeenCalledWith('event-create', undefined);
+    });
+
+    it('should track event update with event type', () => {
+      const mockTrack = vi.fn();
+      (window as any).umami = { track: mockTrack };
+
+      trackEventAction('update', 'game', { eventId: 'event-123' });
+
+      expect(mockTrack).toHaveBeenCalledWith('event-update', { eventId: 'event-123', eventType: 'game' });
+    });
+
+    it('should track event deletion with event type', () => {
+      const mockTrack = vi.fn();
+      (window as any).umami = { track: mockTrack };
+
+      trackEventAction('delete', 'practice', { eventId: 'event-456' });
+
+      expect(mockTrack).toHaveBeenCalledWith('event-delete', { eventId: 'event-456', eventType: 'practice' });
+    });
+
+    it('should work without umami configured', () => {
+      expect(() => trackEventAction('create', 'game')).not.toThrow();
+    });
+  });
+
+  describe('trackRSVP helper', () => {
+    it('should track going RSVP', () => {
+      const mockTrack = vi.fn();
+      (window as any).umami = { track: mockTrack };
+
+      trackRSVP('going', { eventId: 'event-123' });
+
+      expect(mockTrack).toHaveBeenCalledWith('rsvp-going', { eventId: 'event-123' });
+    });
+
+    it('should track not-going RSVP', () => {
+      const mockTrack = vi.fn();
+      (window as any).umami = { track: mockTrack };
+
+      trackRSVP('not-going', { eventId: 'event-456', reason: 'conflict' });
+
+      expect(mockTrack).toHaveBeenCalledWith('rsvp-not-going', { eventId: 'event-456', reason: 'conflict' });
+    });
+
+    it('should track maybe RSVP', () => {
+      const mockTrack = vi.fn();
+      (window as any).umami = { track: mockTrack };
+
+      trackRSVP('maybe', { eventId: 'event-789' });
+
+      expect(mockTrack).toHaveBeenCalledWith('rsvp-maybe', { eventId: 'event-789' });
+    });
+
+    it('should work without umami configured', () => {
+      expect(() => trackRSVP('going')).not.toThrow();
+    });
+  });
+
+  describe('Error handling and edge cases', () => {
+    it('should handle null data gracefully', () => {
+      const mockTrack = vi.fn();
+      (window as any).umami = { track: mockTrack };
+
+      trackEvent('test-event', undefined);
+
+      expect(mockTrack).toHaveBeenCalledWith('test-event', undefined);
+    });
+
+    it('should handle empty objects as data', () => {
+      const mockTrack = vi.fn();
+      (window as any).umami = { track: mockTrack };
+
+      trackEvent('test-event', {});
+
+      expect(mockTrack).toHaveBeenCalledWith('test-event', {});
+    });
+
+    it('should handle complex nested data', () => {
+      const mockTrack = vi.fn();
+      (window as any).umami = { track: mockTrack };
+
+      const complexData = {
+        level1: {
+          level2: {
+            level3: 'value',
+          },
+          array: [1, 2, 3],
+        },
+        boolean: true,
+        number: 42,
+      };
+
+      trackEvent('test-event', complexData);
+
+      expect(mockTrack).toHaveBeenCalledWith('test-event', complexData);
+    });
+
+    it('should handle special characters in event names', () => {
+      const mockTrack = vi.fn();
+      (window as any).umami = { track: mockTrack };
+
+      trackEvent('test-event-with-dashes_and_underscores');
+
+      expect(mockTrack).toHaveBeenCalledWith('test-event-with-dashes_and_underscores', undefined);
+    });
+  });
+
+  describe('Multiple consecutive calls', () => {
+    it('should track multiple events in sequence', () => {
+      const mockTrack = vi.fn();
+      (window as any).umami = { track: mockTrack };
+
+      trackAuth('login');
+      trackTeam('create', { sport: 'Soccer' });
+      trackRSVP('going', { eventId: '123' });
+
+      expect(mockTrack).toHaveBeenCalledTimes(3);
+      expect(mockTrack).toHaveBeenNthCalledWith(1, 'user-login', undefined);
+      expect(mockTrack).toHaveBeenNthCalledWith(2, 'team-create', { sport: 'Soccer' });
+      expect(mockTrack).toHaveBeenNthCalledWith(3, 'rsvp-going', { eventId: '123' });
+    });
+  });
+});

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -17,6 +17,7 @@ import Link from "next/link";
 import Logo from "@/components/ui/Logo";
 import { loginSchema } from "@/lib/utils/validation";
 import { AUTH_MESSAGES } from "@/lib/config/constants";
+import { trackAuth } from "@/lib/analytics/umami";
 
 function LoginForm() {
   const router = useRouter();
@@ -114,6 +115,9 @@ function LoginForm() {
         setGeneralError(result.error || "Invalid email or password");
         return;
       }
+
+      // Track successful login
+      trackAuth('login');
 
       // Redirect to callback URL or dashboard
       router.push(callbackUrl);

--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -16,6 +16,7 @@ import Logo from "@/components/ui/Logo";
 import { signup } from "@/lib/actions/auth";
 import { signupSchema } from "@/lib/utils/validation";
 import { AUTH_MESSAGES } from "@/lib/config/constants";
+import { trackAuth } from "@/lib/analytics/umami";
 
 function SignupForm() {
   const router = useRouter();
@@ -123,6 +124,12 @@ function SignupForm() {
         // Show success message instead of trying to sign in
         setErrors({});
         setFormData({ email: "", password: "", name: "", invitationToken: undefined });
+
+        // Track signup event
+        trackAuth('signup', {
+          hasInvitation: !!invitationToken,
+          teamName: teamName || undefined,
+        });
 
         // Redirect to login with a success message
         router.push(`/login?message=${AUTH_MESSAGES.SIGNUP_PENDING_APPROVAL}`);

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Roboto } from "next/font/google";
+import Script from "next/script";
 import "./globals.css";
 import { SessionProvider } from "@/components/providers/SessionProvider";
 import { ThemeProvider } from "@/components/providers/ThemeProvider";
@@ -55,9 +56,18 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const umamiWebsiteId = process.env.NEXT_PUBLIC_UMAMI_WEBSITE_ID;
+
   return (
     <html lang="en">
       <body className={roboto.variable}>
+        {umamiWebsiteId && (
+          <Script
+            src="https://cloud.umami.is/script.js"
+            data-website-id={umamiWebsiteId}
+            strategy="afterInteractive"
+          />
+        )}
         <ErrorBoundary>
           <ThemeProvider>
             <ToastProvider>

--- a/components/features/events/EventForm.tsx
+++ b/components/features/events/EventForm.tsx
@@ -22,6 +22,7 @@ import {
 } from "@/lib/actions/events";
 import { createEventSchema, updateEventSchema } from "@/lib/utils/validation";
 import { formatDateTimeLocal } from "@/lib/utils/date";
+import { trackEventAction } from "@/lib/analytics/umami";
 
 interface EventFormProps {
   teamId: string;
@@ -115,6 +116,16 @@ export default function EventForm({
         : await createEvent(formData);
 
       if (result.success) {
+        // Track event action
+        const eventType = formData.type === 'GAME' ? 'game' : 'practice';
+        if (isEditMode) {
+          trackEventAction('update', eventType, {});
+        } else {
+          trackEventAction('create', eventType, {
+            hasOpponent: !!formData.opponent,
+          });
+        }
+
         // Redirect to event detail page after successful update, calendar after create
         router.push(isEditMode ? `/events/${eventId}` : "/calendar");
       } else {

--- a/components/features/events/RSVPButtons.tsx
+++ b/components/features/events/RSVPButtons.tsx
@@ -6,6 +6,7 @@ import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import CancelIcon from "@mui/icons-material/Cancel";
 import HelpIcon from "@mui/icons-material/Help";
 import { updateRSVP } from "@/lib/actions/rsvp";
+import { trackRSVP } from "@/lib/analytics/umami";
 
 type RSVPStatus = "GOING" | "NOT_GOING" | "MAYBE" | "NO_RESPONSE";
 
@@ -36,6 +37,14 @@ export function RSVPButtons({
       });
 
       if (result.success) {
+        // Track RSVP event
+        const rsvpStatusMap = {
+          GOING: 'going',
+          NOT_GOING: 'not-going',
+          MAYBE: 'maybe',
+        } as const;
+        trackRSVP(rsvpStatusMap[status], { eventId });
+
         // Notify parent component if callback provided
         onStatusChange?.(status);
       } else {

--- a/components/features/team/CreateTeamForm.tsx
+++ b/components/features/team/CreateTeamForm.tsx
@@ -12,6 +12,7 @@ import {
 } from "@mui/material";
 import { createTeam } from "@/lib/actions/team";
 import { createTeamSchema, type CreateTeamInput } from "@/lib/utils/validation";
+import { trackTeam } from "@/lib/analytics/umami";
 
 export default function CreateTeamForm() {
   const router = useRouter();
@@ -79,6 +80,12 @@ export default function CreateTeamForm() {
       const result = await createTeam(formData);
 
       if (result.success) {
+        // Track team creation event
+        trackTeam('create', {
+          sport: formData.sport,
+          season: formData.season,
+        });
+
         // Redirect to dashboard after successful creation
         router.push("/");
       } else {

--- a/lib/analytics/README.md
+++ b/lib/analytics/README.md
@@ -1,15 +1,150 @@
 # Analytics
 
-This directory contains analytics and tracking utilities for the OpenLeague marketing site.
+This directory contains analytics and tracking utilities for OpenLeague.
 
-## Features
+## Umami Analytics
+
+OpenLeague uses [Umami](https://umami.is) for privacy-friendly, open-source web analytics.
+
+### Setup
+
+1. **Create a Umami account** at [cloud.umami.is](https://cloud.umami.is) or self-host Umami
+2. **Add your website** and get your Website ID
+3. **Configure environment variable** in `.env.local`:
+   ```bash
+   NEXT_PUBLIC_UMAMI_WEBSITE_ID="your-website-id-here"
+   ```
+4. The Umami tracking script will automatically load when the environment variable is set
+
+**Note**: If `NEXT_PUBLIC_UMAMI_WEBSITE_ID` is not set, Umami tracking will be disabled. This allows contributors to run the app without analytics in development.
+
+### Event Tracking
+
+Event tracking is implemented using the utilities in `umami.ts`. The module provides:
+
+- **Type-safe event tracking** - Predefined event names in `UmamiEvents`
+- **Helper functions** - `trackAuth()`, `trackTeam()`, `trackEventAction()`, `trackRSVP()`
+- **Safe execution** - Automatically checks if Umami is loaded before tracking
+
+### Tracked Events
+
+#### Authentication Events
+- `user-signup` - User creates account (includes invitation context)
+- `user-login` - User logs in successfully
+- `user-logout` - User logs out
+
+#### Team Events
+- `team-create` - Team is created (includes sport and season)
+- `team-join` - User joins a team via invitation
+- `team-leave` - User leaves a team
+
+#### Event/Game Events
+- `event-create` - Generic event created
+- `game-create` - Game event created (includes opponent info)
+- `practice-create` - Practice event created
+- `event-update` - Event is updated
+- `event-delete` - Event is deleted
+
+#### RSVP Events
+- `rsvp-going` - User responds "Going"
+- `rsvp-not-going` - User responds "Not Going"
+- `rsvp-maybe` - User responds "Maybe"
+
+#### Navigation Events (Available for future use)
+- `view-calendar` - User views calendar page
+- `view-roster` - User views roster page
+- `view-events` - User views events page
+- `view-dashboard` - User views dashboard
+
+### Usage Examples
+
+```typescript
+import { trackAuth, trackTeam, trackRSVP, trackEvent } from '@/lib/analytics/umami';
+
+// Track authentication
+trackAuth('signup', { hasInvitation: true });
+trackAuth('login');
+
+// Track team actions
+trackTeam('create', { sport: 'Soccer', season: 'Fall 2025' });
+
+// Track RSVP
+trackRSVP('going', { eventId: '123' });
+
+// Track custom events
+trackEvent('custom-event-name', { custom: 'data' });
+```
+
+### Implementation Locations
+
+Event tracking has been integrated into:
+
+1. **Signup** - `app/(auth)/signup/page.tsx`
+2. **Login** - `app/(auth)/login/page.tsx`
+3. **Team Creation** - `components/features/team/CreateTeamForm.tsx`
+4. **Event Creation/Update** - `components/features/events/EventForm.tsx`
+5. **RSVP Actions** - `components/features/events/RSVPButtons.tsx`
+
+### Adding New Events
+
+To track a new event:
+
+1. Add the event name to `UmamiEvents` in `umami.ts`
+2. Use `trackEvent()` or create a helper function
+3. Call it after the successful action completes
+
+```typescript
+// In umami.ts
+export const UmamiEvents = {
+  // ... existing events
+  NEW_FEATURE_USED: 'new-feature-used',
+} as const;
+
+// In your component
+import { trackEvent, UmamiEvents } from '@/lib/analytics/umami';
+
+function handleNewFeature() {
+  // ... do something
+  trackEvent(UmamiEvents.NEW_FEATURE_USED, { feature: 'name' });
+}
+```
+
+### Privacy & GDPR Compliance
+
+Umami is GDPR-compliant and privacy-friendly:
+- No cookies used
+- No personal data collected
+- Fully anonymous analytics
+- Open source and self-hostable
+
+### Event Data Limits
+
+Per Umami documentation:
+- Event names: max 50 characters
+- Event data strings: max 500 characters
+- Event data objects: max 50 properties
+- Numbers: max 4 decimal places
+
+### Viewing Analytics
+
+Analytics can be viewed at: https://cloud.umami.is
+
+**Note**: Contributors should use their own Umami Website ID for development and testing.
+
+---
+
+## Marketing Analytics
+
+The marketing site also uses Google Analytics 4 for tracking conversions and engagement.
+
+### Features
 
 - Google Analytics 4 event tracking
 - Marketing conversion tracking
 - User engagement analytics
 - Privacy-compliant tracking
 
-## Usage
+### Usage
 
 ```typescript
 import { trackConversion, trackEngagement, MarketingEvents } from '@/lib/analytics';
@@ -21,13 +156,13 @@ trackConversion(MarketingEvents.SIGNUP_COMPLETE, 'hero_cta', 1);
 trackEngagement(MarketingEvents.FEATURE_VIEW, 'roster_management');
 ```
 
-## Environment Variables
+### Environment Variables
 
 - `NEXT_PUBLIC_GA_MEASUREMENT_ID` - Google Analytics 4 Measurement ID
 - `NEXT_PUBLIC_SENTRY_DSN` - Sentry error tracking DSN (optional)
 - `NEXT_PUBLIC_HOTJAR_ID` - Hotjar tracking ID (optional)
 - `NEXT_PUBLIC_MIXPANEL_TOKEN` - Mixpanel analytics token (optional)
 
-## Privacy
+### Privacy
 
 All tracking is designed to be privacy-compliant and respects user consent preferences.

--- a/lib/analytics/umami.ts
+++ b/lib/analytics/umami.ts
@@ -1,0 +1,160 @@
+/**
+ * Umami Analytics Tracking Utilities
+ *
+ * This module provides type-safe wrappers for Umami event tracking.
+ * It handles the window.umami object safely and provides clear event types.
+ */
+
+// Extend the Window interface to include umami
+declare global {
+  interface Window {
+    umami?: {
+      track: (event: string, data?: Record<string, unknown>) => void;
+      identify: (idOrData: string | Record<string, unknown>, data?: Record<string, unknown>) => void;
+    };
+  }
+}
+
+/**
+ * Track a custom event with optional data
+ * Safely checks if umami is available before tracking
+ */
+export function trackEvent(eventName: string, data?: Record<string, unknown>): void {
+  if (typeof window !== 'undefined' && window.umami) {
+    try {
+      window.umami.track(eventName, data);
+    } catch (error) {
+      console.error('Error tracking event:', error);
+    }
+  }
+}
+
+/**
+ * Identify a user session with custom data
+ */
+export function identifyUser(userId: string, userData?: Record<string, unknown>): void {
+  if (typeof window !== 'undefined' && window.umami) {
+    try {
+      window.umami.identify(userId, userData);
+    } catch (error) {
+      console.error('Error identifying user:', error);
+    }
+  }
+}
+
+/**
+ * Predefined event names for consistency across the app
+ */
+export const UmamiEvents = {
+  // Authentication events
+  SIGNUP: 'user-signup',
+  LOGIN: 'user-login',
+  LOGOUT: 'user-logout',
+
+  // Team events
+  TEAM_CREATE: 'team-create',
+  TEAM_JOIN: 'team-join',
+  TEAM_LEAVE: 'team-leave',
+
+  // Roster events
+  PLAYER_ADD: 'player-add',
+  PLAYER_UPDATE: 'player-update',
+  PLAYER_REMOVE: 'player-remove',
+
+  // Event/Game events
+  EVENT_CREATE: 'event-create',
+  EVENT_UPDATE: 'event-update',
+  EVENT_DELETE: 'event-delete',
+  GAME_CREATE: 'game-create',
+  PRACTICE_CREATE: 'practice-create',
+
+  // RSVP events
+  RSVP_GOING: 'rsvp-going',
+  RSVP_NOT_GOING: 'rsvp-not-going',
+  RSVP_MAYBE: 'rsvp-maybe',
+
+  // Invitation events
+  INVITATION_SEND: 'invitation-send',
+  INVITATION_ACCEPT: 'invitation-accept',
+  INVITATION_DECLINE: 'invitation-decline',
+
+  // Navigation events
+  VIEW_CALENDAR: 'view-calendar',
+  VIEW_ROSTER: 'view-roster',
+  VIEW_EVENTS: 'view-events',
+  VIEW_DASHBOARD: 'view-dashboard',
+
+  // League events
+  LEAGUE_CREATE: 'league-create',
+  LEAGUE_JOIN: 'league-join',
+  DIVISION_CREATE: 'division-create',
+  INTER_TEAM_GAME_CREATE: 'inter-team-game-create',
+
+  // Feature usage
+  EMAIL_NOTIFICATION_SENT: 'email-notification-sent',
+  CALENDAR_FILTER_USED: 'calendar-filter-used',
+  EXPORT_CALENDAR: 'export-calendar',
+} as const;
+
+/**
+ * Type for event names
+ */
+export type UmamiEventName = typeof UmamiEvents[keyof typeof UmamiEvents];
+
+/**
+ * Helper to track authentication events
+ */
+export function trackAuth(action: 'signup' | 'login' | 'logout', data?: Record<string, unknown>): void {
+  const eventMap = {
+    signup: UmamiEvents.SIGNUP,
+    login: UmamiEvents.LOGIN,
+    logout: UmamiEvents.LOGOUT,
+  };
+  trackEvent(eventMap[action], data);
+}
+
+/**
+ * Helper to track team-related events
+ */
+export function trackTeam(action: 'create' | 'join' | 'leave', data?: Record<string, unknown>): void {
+  const eventMap = {
+    create: UmamiEvents.TEAM_CREATE,
+    join: UmamiEvents.TEAM_JOIN,
+    leave: UmamiEvents.TEAM_LEAVE,
+  };
+  trackEvent(eventMap[action], data);
+}
+
+/**
+ * Helper to track event/game creation
+ */
+export function trackEventAction(
+  action: 'create' | 'update' | 'delete',
+  eventType: 'game' | 'practice' | 'event',
+  data?: Record<string, unknown>
+): void {
+  if (action === 'create') {
+    const eventMap = {
+      game: UmamiEvents.GAME_CREATE,
+      practice: UmamiEvents.PRACTICE_CREATE,
+      event: UmamiEvents.EVENT_CREATE,
+    };
+    trackEvent(eventMap[eventType], data);
+  } else if (action === 'update') {
+    trackEvent(UmamiEvents.EVENT_UPDATE, { ...data, eventType });
+  } else if (action === 'delete') {
+    trackEvent(UmamiEvents.EVENT_DELETE, { ...data, eventType });
+  }
+}
+
+/**
+ * Helper to track RSVP actions
+ */
+export function trackRSVP(status: 'going' | 'not-going' | 'maybe', data?: Record<string, unknown>): void {
+  const eventMap = {
+    going: UmamiEvents.RSVP_GOING,
+    'not-going': UmamiEvents.RSVP_NOT_GOING,
+    maybe: UmamiEvents.RSVP_MAYBE,
+  };
+  trackEvent(eventMap[status], data);
+}

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -20,6 +20,7 @@ const envSchema = z.object({
     CRON_SECRET: z.string().min(32, 'CRON_SECRET must be at least 32 characters long').optional(),
 
     // Analytics and Tracking (optional)
+    NEXT_PUBLIC_UMAMI_WEBSITE_ID: z.string().optional(),
     NEXT_PUBLIC_GA_MEASUREMENT_ID: z.string().optional(),
     NEXT_PUBLIC_SENTRY_DSN: z.string().optional(),
     SENTRY_ORG: z.string().optional(),
@@ -44,6 +45,7 @@ function validateEnv() {
             EMAIL_FROM: process.env.EMAIL_FROM || '',
             NODE_ENV: (process.env.NODE_ENV || 'development') as 'development' | 'production' | 'test',
             CRON_SECRET: process.env.CRON_SECRET,
+            NEXT_PUBLIC_UMAMI_WEBSITE_ID: process.env.NEXT_PUBLIC_UMAMI_WEBSITE_ID,
             NEXT_PUBLIC_GA_MEASUREMENT_ID: process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID,
             NEXT_PUBLIC_SENTRY_DSN: process.env.NEXT_PUBLIC_SENTRY_DSN,
             SENTRY_ORG: process.env.SENTRY_ORG,


### PR DESCRIPTION
This pull request adds support for Umami analytics tracking throughout the application, including environment configuration, client-side event tracking utilities, and integration into key user actions. It also introduces comprehensive tests for the new analytics utilities. The changes are grouped into analytics infrastructure, usage in application flows, and testing.

**Analytics Infrastructure:**

* Added `NEXT_PUBLIC_UMAMI_WEBSITE_ID` to `.env.example` and documented its usage in `README.md` for configuring Umami analytics. [[1]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR16-R20) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R83-R85) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R98-R101)
* Updated `app/layout.tsx` to inject the Umami tracking script dynamically if the website ID is present in the environment variables. [[1]](diffhunk://#diff-eca96d2c09f31517696a26e1d0be4070e1fbab02831481bed006e275741d030bR3) [[2]](diffhunk://#diff-eca96d2c09f31517696a26e1d0be4070e1fbab02831481bed006e275741d030bR59-R70)

**Analytics Tracking in Application Flows:**

* Integrated Umami event tracking into authentication flows by calling `trackAuth` on successful login and signup, capturing relevant metadata. [[1]](diffhunk://#diff-87bb40e63a4105a08e29f7d5602a447e94a68619080a086bc510bcac0cba6932R20) [[2]](diffhunk://#diff-87bb40e63a4105a08e29f7d5602a447e94a68619080a086bc510bcac0cba6932R119-R121) [[3]](diffhunk://#diff-6573984fa57dc7e4e1fddb3716bbca8e1888c0af157bbe6db5118d8ef8e320ddR19) [[4]](diffhunk://#diff-6573984fa57dc7e4e1fddb3716bbca8e1888c0af157bbe6db5118d8ef8e320ddR128-R133)
* Added event tracking for team creation (`trackTeam`), event creation/update (`trackEventAction`), and RSVP actions (`trackRSVP`) in their respective forms and components. [[1]](diffhunk://#diff-22522c55d916a1c6d4be9ba0ac3960a50f4527cd5c7446f437f9397936ebbf8eR15) [[2]](diffhunk://#diff-22522c55d916a1c6d4be9ba0ac3960a50f4527cd5c7446f437f9397936ebbf8eR83-R88) [[3]](diffhunk://#diff-c6f1e9b0ffe0ae71728520103312bd4bc3c43c5e5c0c9911eae06f90d02d4fedR25) [[4]](diffhunk://#diff-c6f1e9b0ffe0ae71728520103312bd4bc3c43c5e5c0c9911eae06f90d02d4fedR119-R134) [[5]](diffhunk://#diff-c907d0ae619e5aae2b61da01bf2b823054828b6480eb5629ecab8af4d25f2094R9) [[6]](diffhunk://#diff-c907d0ae619e5aae2b61da01bf2b823054828b6480eb5629ecab8af4d25f2094R40-R45)

**Testing:**

* Introduced a comprehensive test suite for the Umami analytics utilities in `__tests__/lib/analytics/umami.test.ts`, covering all tracking helpers, event constants, error handling, and edge cases.

Closes #123