### PR TITLE
fix(seo): remove 'as const' from SITE_CONFIG and spread keywords meta

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -27,7 +27,7 @@ export const metadata: Metadata = {
     template: "%s - OpenLeague",
   },
   description: SITE_CONFIG.description,
-  keywords: SITE_CONFIG.keywords,
+  keywords: [...SITE_CONFIG.keywords],
   authors: [{ name: "OpenLeague Team" }],
   creator: "OpenLeague",
   publisher: "OpenLeague",

--- a/lib/config/seo.ts
+++ b/lib/config/seo.ts
@@ -24,7 +24,7 @@ export const SITE_CONFIG = {
         'RSVP tracking',
         'open source sports',
     ],
-} as const;
+};
 
 /**
  * Generate metadata for a page


### PR DESCRIPTION
This pull request makes a minor update to how keywords are handled in the SEO configuration and metadata generation. The main change ensures that the `keywords` property in the metadata is always an array, improving type consistency and future-proofing the code.

SEO configuration improvements:

* Changed the `keywords` property in `SITE_CONFIG` to be a regular array instead of a TypeScript `as const` tuple, allowing for easier manipulation and spreading.
* Updated the `keywords` field in the `metadata` export in `app/layout.tsx` to use the spread operator, ensuring it is always an array.