### PR TITLE
fix(seo): add explicit TypeScript return type for getSoftwareApp

### DIFF
--- a/lib/config/seo.ts
+++ b/lib/config/seo.ts
@@ -129,7 +129,24 @@ export function getOrganizationSchema() {
 /**
  * Software Application structured data (JSON-LD)
  */
-export function getSoftwareApplicationSchema() {
+export function getSoftwareApplicationSchema(): {
+    '@context': string;
+    '@type': string;
+    name: string;
+    applicationCategory: string;
+    operatingSystem: string;
+    offers: {
+        '@type': string;
+        price: string;
+        priceCurrency: string;
+        description: string;
+    };
+    description: string;
+    url: string;
+    screenshot: string;
+    featureList: string;
+    aggregateRating?: undefined;
+} {
     return {
         '@context': 'https://schema.org',
         '@type': 'SoftwareApplication',


### PR DESCRIPTION
This pull request adds a TypeScript return type annotation to the `getSoftwareApplicationSchema` function in `lib/config/seo.ts` to improve type safety and code clarity.

Type safety improvements:

* Added an explicit return type annotation to the `getSoftwareApplicationSchema` function, specifying the structure of the returned object.