### PR TITLE
fix(security): allow Umami analytics in CSP and enable trustHost auth

### DIFF
--- a/lib/auth/config.ts
+++ b/lib/auth/config.ts
@@ -108,6 +108,8 @@ export const authOptions: NextAuthConfig = {
   secret: env.NEXTAUTH_SECRET,
   // Enable CSRF protection (enabled by default, but explicit for clarity)
   useSecureCookies: isProduction,
+  // Trust host header in production (required for Auth.js v5 with proxies/Vercel)
+  trustHost: true,
   // Additional security settings
   debug: isDevelopment,
 };

--- a/next.config.ts
+++ b/next.config.ts
@@ -50,11 +50,11 @@ const nextConfig: NextConfig = {
             key: "Content-Security-Policy",
             value: [
               "default-src 'self'",
-              "script-src 'self' 'unsafe-eval' 'unsafe-inline'", // Next.js requires unsafe-eval and unsafe-inline
+              "script-src 'self' 'unsafe-eval' 'unsafe-inline' https://cloud.umami.is", // Next.js requires unsafe-eval and unsafe-inline, Umami for analytics
               "style-src 'self' 'unsafe-inline' fonts.googleapis.com", // MUI requires unsafe-inline
               "font-src 'self' fonts.gstatic.com",
               "img-src 'self' data: blob:",
-              "connect-src 'self'",
+              "connect-src 'self' https://cloud.umami.is", // Allow Umami analytics connections
               "frame-ancestors 'self'",
               "base-uri 'self'",
               "form-action 'self'",


### PR DESCRIPTION
- Add https://cloud.umami.is to script-src and connect-src in Content-Security-Policy so Umami analytics can load.
- Enable trustHost in next-auth/auth config (required for Auth.js v5 when running behind proxies/Vercel).

This pull request introduces some important security and configuration updates to support analytics integration and improve authentication reliability in production. The main changes are grouped below:

**Authentication Configuration Updates:**

* Added `trustHost: true` to the `authOptions` in `lib/auth/config.ts` to ensure proper handling of the host header when running behind proxies or on Vercel, as required by Auth.js v5.

**Content Security Policy and Analytics Integration:**

* Updated the Content Security Policy in `next.config.ts` to allow scripts and connections to `https://cloud.umami.is`, enabling Umami analytics integration:
  - Extended `script-src` to include `https://cloud.umami.is`.
  - Extended `connect-src` to include `https://cloud.umami.is`.