### PR TITLE
chore: Add local prompt ignore rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,3 +146,6 @@ local-context/
 
 # Playwright MCP files
 .playwright-mcp/
+
+# Github prompt files intentionally left ignored
+.github/prompts/local-*.prompt.md


### PR DESCRIPTION
This PR adds a .gitignore entry to allow contributors to add custom prompts only intended for local use by naming them with the path pattern: `.github/prompts/local-*.prompt.md`