### PR TITLE
feat: add sanitization tests for HTML and database inputs

### DIFF
--- a/__tests__/lib/utils/sanitization.test.ts
+++ b/__tests__/lib/utils/sanitization.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import { sanitizeForDatabase, sanitizeHtml } from "@/lib/utils/sanitization";
+
+describe("sanitizeHtml", () => {
+  it("escapes script and iframe markup instead of filtering with bypassable regexes", () => {
+    const input = '<script>alert("xss")</script><iframe src="https://evil.test"></iframe>';
+
+    expect(sanitizeHtml(input)).toBe(
+      "&lt;script&gt;alert(&quot;xss&quot;)&lt;&#x2F;script&gt;&lt;iframe src&#x3D;&quot;https:&#x2F;&#x2F;evil.test&quot;&gt;&lt;&#x2F;iframe&gt;",
+    );
+  });
+
+  it("neutralizes event-handler attributes by encoding the containing tag", () => {
+    const input = "<img src=x onerror=alert(1)>";
+
+    expect(sanitizeHtml(input)).toBe("&lt;img src&#x3D;x onerror&#x3D;alert(1)&gt;");
+  });
+
+  it("keeps dangerous URL schemes inert when they appear inside markup", () => {
+    const input = '<a href="java\nscript:alert(1)">open</a>';
+
+    expect(sanitizeHtml(input)).toBe(
+      "&lt;a href&#x3D;&quot;java\nscript:alert(1)&quot;&gt;open&lt;&#x2F;a&gt;",
+    );
+  });
+
+  it("removes unsafe control characters while preserving tabs and newlines", () => {
+    expect(sanitizeHtml("hello\u0000\u0008world\nnext\tcell")).toBe("helloworld\nnext\tcell");
+  });
+});
+
+describe("sanitizeForDatabase", () => {
+  it("applies SQL-pattern cleanup before HTML escaping so entities stay intact", () => {
+    expect(sanitizeForDatabase("<b>League</b>; DROP SELECT")).toBe(
+      "&lt;b&gt;League&lt;&#x2F;b&gt;  ",
+    );
+  });
+});

--- a/__tests__/lib/utils/sanitization.test.ts
+++ b/__tests__/lib/utils/sanitization.test.ts
@@ -1,12 +1,21 @@
 import { describe, expect, it } from "vitest";
 
-import { sanitizeForDatabase, sanitizeHtml } from "@/lib/utils/sanitization";
+import {
+  escapeHtml,
+  escapeHtmlAttribute,
+  normalizeEmail,
+  sanitizeForDatabase,
+  sanitizeHtml,
+  sanitizePhoneNumber,
+  sanitizeRateLimitKey,
+  sanitizeUrl,
+} from "@/lib/utils/sanitization";
 
-describe("sanitizeHtml", () => {
+describe("escapeHtml", () => {
   it("escapes script and iframe markup instead of filtering with bypassable regexes", () => {
     const input = '<script>alert("xss")</script><iframe src="https://evil.test"></iframe>';
 
-    expect(sanitizeHtml(input)).toBe(
+    expect(escapeHtml(input)).toBe(
       "&lt;script&gt;alert(&quot;xss&quot;)&lt;&#x2F;script&gt;&lt;iframe src&#x3D;&quot;https:&#x2F;&#x2F;evil.test&quot;&gt;&lt;&#x2F;iframe&gt;",
     );
   });
@@ -14,19 +23,88 @@ describe("sanitizeHtml", () => {
   it("neutralizes event-handler attributes by encoding the containing tag", () => {
     const input = "<img src=x onerror=alert(1)>";
 
-    expect(sanitizeHtml(input)).toBe("&lt;img src&#x3D;x onerror&#x3D;alert(1)&gt;");
+    expect(escapeHtml(input)).toBe("&lt;img src&#x3D;x onerror&#x3D;alert(1)&gt;");
   });
 
   it("keeps dangerous URL schemes inert when they appear inside markup", () => {
     const input = '<a href="java\nscript:alert(1)">open</a>';
 
-    expect(sanitizeHtml(input)).toBe(
+    expect(escapeHtml(input)).toBe(
       "&lt;a href&#x3D;&quot;java\nscript:alert(1)&quot;&gt;open&lt;&#x2F;a&gt;",
     );
   });
 
-  it("removes unsafe control characters while preserving tabs and newlines", () => {
-    expect(sanitizeHtml("hello\u0000\u0008world\nnext\tcell")).toBe("helloworld\nnext\tcell");
+  it("removes unsafe C0 and C1 control characters while preserving tabs and newlines", () => {
+    expect(escapeHtml("hello\u0000\u0008world\u0085\nnext\tcell")).toBe(
+      "helloworld\nnext\tcell",
+    );
+  });
+});
+
+describe("sanitizeHtml", () => {
+  it("keeps the legacy function name as an alias for HTML escaping", () => {
+    expect(sanitizeHtml("<strong>OpenLeague</strong>")).toBe(
+      escapeHtml("<strong>OpenLeague</strong>"),
+    );
+  });
+});
+
+describe("escapeHtmlAttribute", () => {
+  it("escapes attribute-breaking characters and collapses whitespace", () => {
+    expect(escapeHtmlAttribute('  row\nname" onclick="alert(1)  ')).toBe(
+      "row name&quot; onclick&#x3D;&quot;alert(1)",
+    );
+  });
+});
+
+describe("sanitizeUrl", () => {
+  it("allows safe absolute and relative URLs", () => {
+    expect(sanitizeUrl("https://openleague.test/rinks?q=ice time")).toBe(
+      "https://openleague.test/rinks?q=ice%20time",
+    );
+    expect(sanitizeUrl("/rinks/north-ice")).toBe("/rinks/north-ice");
+  });
+
+  it("blocks unsafe and whitespace-obfuscated schemes", () => {
+    expect(sanitizeUrl("javascript:alert(1)")).toBeNull();
+    expect(sanitizeUrl("JaVaScRiPt:alert(1)")).toBeNull();
+    expect(sanitizeUrl("java\nscript:alert(1)")).toBeNull();
+    expect(sanitizeUrl("java\tscript:alert(1)")).toBeNull();
+    expect(sanitizeUrl(" java\rscript:alert(1) ")).toBeNull();
+    expect(sanitizeUrl("data:text/html,<svg onload=alert(1)>")).toBeNull();
+    expect(sanitizeUrl("vbscript:msgbox(1)")).toBeNull();
+    expect(sanitizeUrl("ftp://example.com/file.txt")).toBeNull();
+  });
+
+  it("blocks protocol-relative and malformed absolute URLs", () => {
+    expect(sanitizeUrl("//evil.test/path")).toBeNull();
+    expect(sanitizeUrl("https://")).toBeNull();
+  });
+
+  it("blocks browser-normalized backslash URL forms", () => {
+    expect(sanitizeUrl("/\\evil.test/path")).toBeNull();
+    expect(sanitizeUrl("/\\\\evil.test/path")).toBeNull();
+    expect(sanitizeUrl("\\/evil.test/path")).toBeNull();
+    expect(sanitizeUrl("\\\\evil.test/path")).toBeNull();
+    expect(sanitizeUrl("http:\\evil.test/path")).toBeNull();
+  });
+
+  it("can require absolute URLs with custom protocol allowlists", () => {
+    expect(sanitizeUrl("/relative", { allowRelative: false })).toBeNull();
+    expect(sanitizeUrl("tel:+15551234567")).toBe("tel:+15551234567");
+    expect(sanitizeUrl("mailto:coach@example.com", { allowedProtocols: ["mailto"] })).toBe(
+      "mailto:coach@example.com",
+    );
+    expect(sanitizeUrl("https://openleague.test", { allowedProtocols: ["mailto"] })).toBeNull();
+  });
+
+  it("does not replace context-specific HTML attribute escaping", () => {
+    const url = sanitizeUrl('/relative" onclick="alert(1)');
+
+    expect(url).toBe('/relative" onclick="alert(1)');
+    expect(escapeHtmlAttribute(url ?? "")).toBe(
+      "&#x2F;relative&quot; onclick&#x3D;&quot;alert(1)",
+    );
   });
 });
 
@@ -34,6 +112,22 @@ describe("sanitizeForDatabase", () => {
   it("applies SQL-pattern cleanup before HTML escaping so entities stay intact", () => {
     expect(sanitizeForDatabase("<b>League</b>; DROP SELECT")).toBe(
       "&lt;b&gt;League&lt;&#x2F;b&gt;  ",
+    );
+  });
+});
+
+describe("small text sanitizers", () => {
+  it("normalizes emails after removing unsafe control characters", () => {
+    expect(normalizeEmail("  COACH\u0000@Example.COM  ")).toBe("coach@example.com");
+  });
+
+  it("keeps only common phone number characters", () => {
+    expect(sanitizePhoneNumber("+1 (555) 123-4567 ext<script>")).toBe("+1 (555) 123-4567");
+  });
+
+  it("keeps rate limit keys bounded and token-safe", () => {
+    expect(sanitizeRateLimitKey("user:abc/../../<script>".repeat(10))).toMatch(
+      /^[a-zA-Z0-9_.-]{1,100}$/,
     );
   });
 });

--- a/lib/utils/sanitization.ts
+++ b/lib/utils/sanitization.ts
@@ -15,17 +15,31 @@
  * - Third-party data processing
  */
 
+const HTML_ESCAPE_MAP: Record<string, string> = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': "&quot;",
+  "'": "&#x27;",
+  "`": "&#x60;",
+  "=": "&#x3D;",
+  "/": "&#x2F;",
+};
+
+const HTML_ESCAPE_PATTERN = /[&<>"'`=/]/g;
+const UNSAFE_CONTROL_CHAR_PATTERN = /[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g;
+
 /**
- * Remove potentially dangerous HTML/script content
- * Basic XSS prevention for text fields
+ * Escape potentially dangerous HTML/script content for text contexts.
+ *
+ * This intentionally encodes markup instead of attempting to remove tags or
+ * URL schemes with regexes. Regex-based HTML filtering is easy to bypass and
+ * can create new dangerous strings as pieces are removed.
  */
 export function sanitizeHtml(input: string): string {
   return input
-    .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, "") // Remove script tags
-    .replace(/<iframe\b[^<]*(?:(?!<\/iframe>)<[^<]*)*<\/iframe>/gi, "") // Remove iframe tags
-    .replace(/javascript:/gi, "") // Remove javascript: URLs
-    .replace(/on\w+\s*=/gi, "") // Remove event handlers like onclick=
-    .replace(/data:/gi, ""); // Remove data: URLs
+    .replace(UNSAFE_CONTROL_CHAR_PATTERN, "")
+    .replace(HTML_ESCAPE_PATTERN, (character) => HTML_ESCAPE_MAP[character] ?? "");
 }
 
 /**
@@ -76,7 +90,7 @@ export function validateCuid(id: string): boolean {
  * Combines multiple sanitization methods
  */
 export function sanitizeForDatabase(input: string): string {
-  return sanitizeSqlInput(sanitizeHtml(input.trim()));
+  return sanitizeHtml(sanitizeSqlInput(input.trim()));
 }
 
 /**

--- a/lib/utils/sanitization.ts
+++ b/lib/utils/sanitization.ts
@@ -27,7 +27,24 @@ const HTML_ESCAPE_MAP: Record<string, string> = {
 };
 
 const HTML_ESCAPE_PATTERN = /[&<>"'`=/]/g;
-const UNSAFE_CONTROL_CHAR_PATTERN = /[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g;
+const UNSAFE_CONTROL_CHAR_PATTERN = /[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F-\u009F]/g;
+const HTML_ATTRIBUTE_WHITESPACE_PATTERN = /[\t\n\f\r ]+/g;
+const URL_SCHEME_PATTERN = /^([a-zA-Z][a-zA-Z\d+.-]*):/;
+const URL_SCHEME_NORMALIZATION_PATTERN = /[\u0000-\u0020\u007F-\u009F]+/g;
+const DEFAULT_SAFE_URL_PROTOCOLS = new Set(["http:", "https:", "mailto:", "tel:"]);
+
+export type SanitizeUrlOptions = {
+  allowedProtocols?: readonly string[];
+  allowRelative?: boolean;
+};
+
+function stripUnsafeControlCharacters(input: string): string {
+  return input.replace(UNSAFE_CONTROL_CHAR_PATTERN, "");
+}
+
+function normalizeProtocol(protocol: string): string {
+  return protocol.trim().toLowerCase().replace(/:?$/, ":");
+}
 
 /**
  * Escape potentially dangerous HTML/script content for text contexts.
@@ -36,18 +53,81 @@ const UNSAFE_CONTROL_CHAR_PATTERN = /[\u0000-\u0008\u000B\u000C\u000E-\u001F\u00
  * URL schemes with regexes. Regex-based HTML filtering is easy to bypass and
  * can create new dangerous strings as pieces are removed.
  */
-export function sanitizeHtml(input: string): string {
-  return input
-    .replace(UNSAFE_CONTROL_CHAR_PATTERN, "")
-    .replace(HTML_ESCAPE_PATTERN, (character) => HTML_ESCAPE_MAP[character] ?? "");
+export function escapeHtml(input: string): string {
+  return stripUnsafeControlCharacters(input).replace(
+    HTML_ESCAPE_PATTERN,
+    (character) => HTML_ESCAPE_MAP[character] ?? "",
+  );
 }
 
 /**
- * Sanitize SQL-like input (though Prisma handles this, extra safety)
- * Remove common SQL injection patterns
+ * @deprecated Prefer escapeHtml() for new code. This name is retained for
+ * compatibility with older call sites that treated sanitization as escaping.
+ */
+export function sanitizeHtml(input: string): string {
+  return escapeHtml(input);
+}
+
+/**
+ * Escape text for use inside quoted HTML attributes.
+ */
+export function escapeHtmlAttribute(input: string): string {
+  return escapeHtml(input).replace(HTML_ATTRIBUTE_WHITESPACE_PATTERN, " ").trim();
+}
+
+/**
+ * Validate and normalize a URL intended for href/src-style attributes using a
+ * protocol allowlist.
+ *
+ * This does not HTML-escape the returned string. Use the result through React
+ * props/DOM properties, or pass it through escapeHtmlAttribute() before manual
+ * HTML string interpolation.
+ *
+ * Returns null when the URL is empty, rejected by parsing or policy, contains
+ * browser-normalized backslashes, is protocol-relative, or uses an unsafe scheme
+ * such as javascript:, data:, vbscript:, or whitespace-obfuscated variants like
+ * java\nscript:.
+ */
+export function sanitizeUrl(input: string, options: SanitizeUrlOptions = {}): string | null {
+  const allowedProtocols = new Set(
+    (options.allowedProtocols ?? [...DEFAULT_SAFE_URL_PROTOCOLS]).map(normalizeProtocol),
+  );
+  const allowRelative = options.allowRelative ?? true;
+  const value = stripUnsafeControlCharacters(input).trim();
+
+  if (!value || value.startsWith("//") || value.includes("\\")) {
+    return null;
+  }
+
+  const normalizedForSchemeCheck = value.replace(URL_SCHEME_NORMALIZATION_PATTERN, "");
+  const schemeMatch = normalizedForSchemeCheck.match(URL_SCHEME_PATTERN);
+
+  if (!schemeMatch) {
+    return allowRelative && !value.startsWith("\\") ? value : null;
+  }
+
+  const protocol = normalizeProtocol(schemeMatch[1]);
+
+  if (!allowedProtocols.has(protocol)) {
+    return null;
+  }
+
+  try {
+    return new URL(value).href;
+  } catch {
+    return protocol === "mailto:" || protocol === "tel:" ? value : null;
+  }
+}
+
+/**
+ * Sanitize SQL-like input.
+ *
+ * Do not use this as SQL injection protection. Prisma parameterized queries are
+ * the real protection layer. This helper only exists for legacy defense-in-depth
+ * text cleanup where intentionally removing SQL-looking tokens is acceptable.
  */
 export function sanitizeSqlInput(input: string): string {
-  return input
+  return stripUnsafeControlCharacters(input)
     .replace(/['";]/g, "") // Remove quotes and semicolons
     .replace(/--/g, "") // Remove SQL comments
     .replace(/\/\*/g, "") // Remove block comment start
@@ -65,15 +145,18 @@ export function sanitizeSqlInput(input: string): string {
  * Convert to lowercase and trim whitespace
  */
 export function normalizeEmail(email: string): string {
-  return email.trim().toLowerCase();
+  return stripUnsafeControlCharacters(email).trim().toLowerCase();
 }
 
 /**
  * Sanitize phone numbers
- * Remove non-numeric characters except +, -, (, ), and spaces
+ * Keep digits plus common phone punctuation, then collapse whitespace.
  */
 export function sanitizePhoneNumber(phone: string): string {
-  return phone.replace(/[^\d+\-() ]/g, "").trim();
+  return stripUnsafeControlCharacters(phone)
+    .replace(/[^\d+\-().\s]/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
 }
 
 /**
@@ -86,11 +169,13 @@ export function validateCuid(id: string): boolean {
 }
 
 /**
- * Sanitize text for safe database storage
- * Combines multiple sanitization methods
+ * Legacy text cleanup before storage; not SQL injection protection.
+ *
+ * Prefer storing validated plain text and escaping at render time. Use this only
+ * when callers intentionally want HTML-escaped text persisted at rest.
  */
 export function sanitizeForDatabase(input: string): string {
-  return sanitizeHtml(sanitizeSqlInput(input.trim()));
+  return escapeHtml(sanitizeSqlInput(input.trim()));
 }
 
 /**
@@ -98,5 +183,5 @@ export function sanitizeForDatabase(input: string): string {
  * Ensure rate limiting keys are safe
  */
 export function sanitizeRateLimitKey(key: string): string {
-  return key.replace(/[^a-zA-Z0-9\-_.]/g, "").substring(0, 100);
+  return stripUnsafeControlCharacters(key).replace(/[^a-zA-Z0-9\-_.]/g, "").substring(0, 100);
 }


### PR DESCRIPTION
This pull request improves the security and correctness of our HTML and database input sanitization utilities. The main change is a complete rewrite of the `sanitizeHtml` function to use robust character escaping rather than unreliable regex-based filtering. This approach better protects against XSS and related attacks. The tests have also been updated and expanded to verify the new behavior.

**Sanitization logic improvements:**

* Rewrote `sanitizeHtml` in `lib/utils/sanitization.ts` to escape all HTML special characters and remove unsafe control characters, instead of attempting to filter dangerous tags or attributes with regexes. This prevents bypasses and ensures all markup is safely encoded.
* Updated the order of operations in `sanitizeForDatabase` to apply SQL-pattern cleanup before HTML escaping, preserving HTML entities.

**Testing updates:**

* Added comprehensive tests for `sanitizeHtml` and `sanitizeForDatabase` in `__tests__/lib/utils/sanitization.test.ts`, covering script/iframe markup, event-handler attributes, dangerous URL schemes, and control characters.