### PR TITLE
feat: update deployment process with migration handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,10 @@
 # Get your connection string from: https://console.neon.tech
 DATABASE_URL="postgresql://user:password@ep-xxx.us-east-2.aws.neon.tech/dbname?sslmode=require"
 
+# Optional: Force Prisma migration deployment during Vercel preview/local builds.
+# Only enable when the build targets a safe, isolated database.
+# OPENLEAGUE_RUN_MIGRATIONS_ON_BUILD="false"
+
 # Auth.js Configuration
 # Generate NEXTAUTH_SECRET with: openssl rand -base64 32
 NEXTAUTH_URL="http://localhost:3000"

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -70,13 +70,15 @@ UPTIME_CHECK_TOKEN="your-generated-uptime-token-here"
 
 #### Database Migrations
 
-The `postinstall` script generates the Prisma Client during dependency installation. Apply schema migrations as an explicit deployment step against the target database:
+The `postinstall` script generates the Prisma Client during dependency installation. Vercel production builds run `bun run vercel:build`, which applies schema migrations against the target database before `next build`.
+
+For non-Vercel deployments or one-off production repairs, apply schema migrations explicitly against the target database:
 
 ```bash
 bun run db:migrate:deploy
 ```
 
-Run migrations before promoting a production deployment, or configure the Vercel project/deployment pipeline to run `bun run db:migrate:deploy` with the production `DATABASE_URL`.
+Preview deployments skip automatic migration deployment by default. Set `OPENLEAGUE_RUN_MIGRATIONS_ON_BUILD=true` only for previews connected to a safe, isolated database.
 
 ### Email Service Setup
 
@@ -270,8 +272,8 @@ docker run -p 3000:3000 --env-file .env.production openleague
 
    ```bash
    bun install
-   bunx prisma generate
-   bunx prisma migrate deploy
+   bun run db:generate
+   bun run db:migrate:deploy
    bun run build
    bun run start
    ```

--- a/README.md
+++ b/README.md
@@ -184,11 +184,17 @@ bun run dev
 
 ### Production Deployment
 
-Migrations are automatically applied during deployment via the `postinstall` script:
+Prisma Client generation runs during dependency installation via `postinstall`.
+For Vercel production deployments, `bun run vercel:build` applies pending Prisma
+migrations with `bun run db:migrate:deploy` before `next build`. Preview builds
+skip migration deployment by default; set `OPENLEAGUE_RUN_MIGRATIONS_ON_BUILD=true`
+only when the preview has its own safe target database.
+
+For non-Vercel deployments, run migrations explicitly before promoting the new
+application version:
 
 ```bash
-# This runs automatically on Vercel deployment
-prisma generate && prisma migrate deploy
+bun run db:migrate:deploy
 ```
 
 ### Migration Commands
@@ -450,17 +456,11 @@ AWS_REGION="us-east-1"
 
 #### 4. Database Migration
 
-Migrations run automatically on deployment via the `postinstall` script in `package.json`:
-
-```json
-{
-  "scripts": {
-    "postinstall": "prisma generate && prisma migrate deploy"
-  }
-}
-```
-
-This ensures your production database is always up-to-date with your schema.
+Prisma Client generation runs automatically through `postinstall`. Vercel
+production builds run `bun run vercel:build`, which applies pending migrations
+with `bun run db:migrate:deploy` before building the app. For non-Vercel
+deployments, run the migration command explicitly against the production
+`DATABASE_URL` before promoting the deployment.
 
 #### 5. Custom Domain (Optional)
 
@@ -509,7 +509,7 @@ docker run -p 3000:3000 --env-file .env.local openleague
 
 1. **Build the application**: `bun run build`
 2. **Set environment variables** on your platform
-3. **Run migrations**: `bunx prisma migrate deploy`
+3. **Run migrations**: `bun run db:migrate:deploy`
 4. **Start the server**: `bun run start`
 
 ### Deployment Checklist

--- a/__tests__/deployment/deployment-config.test.ts
+++ b/__tests__/deployment/deployment-config.test.ts
@@ -59,6 +59,19 @@ describe('deployment configuration', () => {
     expect(envExample).toContain('safe, isolated database');
   });
 
+  it('keeps Sport enum value repair separate from column casts and defaults', async () => {
+    const enumRepair = await readText('prisma/migrations/20260517000000_repair_public_sport_enum/migration.sql');
+    const columnRepair = await readText('prisma/migrations/20260517000001_repair_public_sport_columns/migration.sql');
+
+    expect(enumRepair).toContain('ALTER TYPE public."Sport" ADD VALUE IF NOT EXISTS');
+    expect(enumRepair).not.toContain('ALTER TABLE public."Team"');
+    expect(enumRepair).not.toContain('ALTER TABLE public."leagues"');
+
+    expect(columnRepair).toContain('ALTER TABLE public."Team"');
+    expect(columnRepair).toContain('ALTER TABLE public."leagues"');
+    expect(columnRepair).not.toContain('ADD VALUE IF NOT EXISTS');
+  });
+
   it('publishes documentation to GitHub Pages with the custom domain artifact', async () => {
     const docsWorkflow = await readText('.github/workflows/docs-pages.yml');
     const docsBuilder = await readText('scripts/build-docs-pages.ts');

--- a/__tests__/deployment/deployment-config.test.ts
+++ b/__tests__/deployment/deployment-config.test.ts
@@ -37,7 +37,7 @@ describe('deployment configuration', () => {
     }>('vercel.json');
 
     expect(vercel.framework).toBe('nextjs');
-    expect(vercel.buildCommand).toBe('bun run build');
+    expect(vercel.buildCommand).toBe('bun run vercel:build');
     expect(vercel.installCommand).toBe('bun install --frozen-lockfile');
     expect(vercel.crons).toEqual(expect.arrayContaining([
       expect.objectContaining({ path: '/api/cron/rsvp-reminders', schedule: '0 * * * *' }),
@@ -50,6 +50,13 @@ describe('deployment configuration', () => {
       'X-Content-Type-Options',
       'Referrer-Policy',
     ]));
+  });
+
+  it('documents the preview migration override environment flag', async () => {
+    const envExample = await readText('.env.example');
+
+    expect(envExample).toContain('OPENLEAGUE_RUN_MIGRATIONS_ON_BUILD');
+    expect(envExample).toContain('safe, isolated database');
   });
 
   it('publishes documentation to GitHub Pages with the custom domain artifact', async () => {

--- a/__tests__/deployment/vercel-build.test.ts
+++ b/__tests__/deployment/vercel-build.test.ts
@@ -1,0 +1,125 @@
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { describe, expect, it, vi } from 'vitest';
+
+const rootDir = process.cwd();
+
+interface SpawnResult {
+  error?: Error;
+  status?: number | null;
+}
+
+interface TestLogger {
+  error: ReturnType<typeof vi.fn>;
+  log: ReturnType<typeof vi.fn>;
+  warn: ReturnType<typeof vi.fn>;
+}
+
+interface VercelBuildModule {
+  MIGRATION_OVERRIDE_ENV: string;
+  shouldRunMigrations: (env: NodeJS.ProcessEnv) => boolean;
+  runVercelBuild: (options: {
+    env: NodeJS.ProcessEnv;
+    logger: TestLogger;
+    spawn: (command: string, args: string[], options: unknown) => SpawnResult;
+  }) => number;
+}
+
+async function loadVercelBuildModule(): Promise<VercelBuildModule> {
+  return import(pathToFileURL(path.join(rootDir, 'scripts', 'vercel-build.mjs')).href) as Promise<VercelBuildModule>;
+}
+
+function createLogger(): TestLogger {
+  return {
+    error: vi.fn(),
+    log: vi.fn(),
+    warn: vi.fn(),
+  };
+}
+
+function createEnv(values: Record<string, string>): NodeJS.ProcessEnv {
+  return {
+    NODE_ENV: 'test',
+    ...values,
+  };
+}
+
+describe('Vercel build wrapper', () => {
+  it('runs migrations before the build for production deployments', async () => {
+    const { runVercelBuild } = await loadVercelBuildModule();
+    const env = createEnv({ VERCEL_ENV: 'production' });
+    const logger = createLogger();
+    const spawn = vi.fn(() => ({ status: 0 }));
+
+    expect(runVercelBuild({ env, logger, spawn })).toBe(0);
+
+    expect(spawn).toHaveBeenCalledTimes(2);
+    expect(spawn).toHaveBeenNthCalledWith(1, 'bun', ['run', 'db:migrate:deploy'], { stdio: 'inherit', env });
+    expect(spawn).toHaveBeenNthCalledWith(2, 'bun', ['run', 'build'], { stdio: 'inherit', env });
+    expect(logger.log).toHaveBeenCalledWith('Applying Prisma migrations before build...');
+  });
+
+  it('runs migrations for previews only when the explicit override is enabled', async () => {
+    const { MIGRATION_OVERRIDE_ENV, runVercelBuild, shouldRunMigrations } = await loadVercelBuildModule();
+    const env = createEnv({ VERCEL_ENV: 'preview', [MIGRATION_OVERRIDE_ENV]: 'true' });
+    const logger = createLogger();
+    const spawn = vi.fn(() => ({ status: 0 }));
+
+    expect(shouldRunMigrations(env)).toBe(true);
+    expect(runVercelBuild({ env, logger, spawn })).toBe(0);
+
+    expect(spawn).toHaveBeenCalledTimes(2);
+    expect(spawn).toHaveBeenNthCalledWith(1, 'bun', ['run', 'db:migrate:deploy'], { stdio: 'inherit', env });
+    expect(spawn).toHaveBeenNthCalledWith(2, 'bun', ['run', 'build'], { stdio: 'inherit', env });
+  });
+
+  it('skips migrations outside production by default', async () => {
+    const { runVercelBuild, shouldRunMigrations } = await loadVercelBuildModule();
+    const env = createEnv({ VERCEL_ENV: 'preview' });
+    const logger = createLogger();
+    const spawn = vi.fn(() => ({ status: 0 }));
+
+    expect(shouldRunMigrations(env)).toBe(false);
+    expect(runVercelBuild({ env, logger, spawn })).toBe(0);
+
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(spawn).toHaveBeenCalledWith('bun', ['run', 'build'], { stdio: 'inherit', env });
+    expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('Skipping Prisma migrations for VERCEL_ENV=preview'));
+  });
+
+  it('warns and safely skips migrations for invalid override values', async () => {
+    const { MIGRATION_OVERRIDE_ENV, runVercelBuild } = await loadVercelBuildModule();
+    const env = createEnv({ VERCEL_ENV: 'preview', [MIGRATION_OVERRIDE_ENV]: 'yes' });
+    const logger = createLogger();
+    const spawn = vi.fn(() => ({ status: 0 }));
+
+    expect(runVercelBuild({ env, logger, spawn })).toBe(0);
+
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining(`${MIGRATION_OVERRIDE_ENV}="yes" is not "true"`));
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(spawn).toHaveBeenCalledWith('bun', ['run', 'build'], { stdio: 'inherit', env });
+  });
+
+  it('stops the build and propagates a migration failure exit code', async () => {
+    const { runVercelBuild } = await loadVercelBuildModule();
+    const env = createEnv({ VERCEL_ENV: 'production' });
+    const logger = createLogger();
+    const spawn = vi.fn(() => ({ status: 2 }));
+
+    expect(runVercelBuild({ env, logger, spawn })).toBe(2);
+    expect(spawn).toHaveBeenCalledTimes(1);
+  });
+
+  it('logs spawn errors and returns a failing exit code', async () => {
+    const { runVercelBuild } = await loadVercelBuildModule();
+    const env = createEnv({ VERCEL_ENV: 'production' });
+    const logger = createLogger();
+    const error = new Error('bun executable missing');
+    const spawn = vi.fn(() => ({ error, status: null }));
+
+    expect(runVercelBuild({ env, logger, spawn })).toBe(1);
+
+    expect(logger.error).toHaveBeenCalledWith(error);
+    expect(spawn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dev": "next dev --turbopack",
     "dev:wake": "tsx scripts/wake-db.ts && bun run dev",
     "build": "next build",
+    "vercel:build": "node scripts/vercel-build.mjs",
     "start": "next start",
     "lint": "eslint .",
     "type": "tsc --noEmit",

--- a/prisma/migrations/20260517000000_repair_public_sport_enum/migration.sql
+++ b/prisma/migrations/20260517000000_repair_public_sport_enum/migration.sql
@@ -1,0 +1,99 @@
+-- Repair production drift where Prisma Client casts Sport values to public."Sport"
+-- but an older database still has Team.sport/leagues.sport as TEXT or the enum
+-- was not created in the public schema.
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_type t
+    JOIN pg_namespace n ON n.oid = t.typnamespace
+    WHERE n.nspname = 'public'
+      AND t.typname = 'Sport'
+  ) THEN
+    CREATE TYPE public."Sport" AS ENUM (
+      'HOCKEY',
+      'LACROSSE',
+      'SOCCER',
+      'BASKETBALL',
+      'BASEBALL',
+      'SOFTBALL',
+      'FOOTBALL',
+      'VOLLEYBALL',
+      'OTHER'
+    );
+  END IF;
+END $$;
+
+ALTER TYPE public."Sport" ADD VALUE IF NOT EXISTS 'HOCKEY';
+ALTER TYPE public."Sport" ADD VALUE IF NOT EXISTS 'LACROSSE';
+ALTER TYPE public."Sport" ADD VALUE IF NOT EXISTS 'SOCCER';
+ALTER TYPE public."Sport" ADD VALUE IF NOT EXISTS 'BASKETBALL';
+ALTER TYPE public."Sport" ADD VALUE IF NOT EXISTS 'BASEBALL';
+ALTER TYPE public."Sport" ADD VALUE IF NOT EXISTS 'SOFTBALL';
+ALTER TYPE public."Sport" ADD VALUE IF NOT EXISTS 'FOOTBALL';
+ALTER TYPE public."Sport" ADD VALUE IF NOT EXISTS 'VOLLEYBALL';
+ALTER TYPE public."Sport" ADD VALUE IF NOT EXISTS 'OTHER';
+
+DO $$
+DECLARE
+  target_type regtype := 'public."Sport"'::regtype;
+  team_sport_type regtype;
+  league_sport_type regtype;
+BEGIN
+  SELECT a.atttypid::regtype
+  INTO team_sport_type
+  FROM pg_attribute a
+  JOIN pg_class c ON c.oid = a.attrelid
+  JOIN pg_namespace n ON n.oid = c.relnamespace
+  WHERE n.nspname = 'public'
+    AND c.relname = 'Team'
+    AND a.attname = 'sport'
+    AND NOT a.attisdropped
+    AND c.relkind IN ('r', 'p');
+
+  IF team_sport_type IS NOT NULL AND team_sport_type <> target_type THEN
+    ALTER TABLE public."Team" ALTER COLUMN "sport" DROP DEFAULT;
+    ALTER TABLE public."Team" ALTER COLUMN "sport" TYPE public."Sport"
+      USING (
+        CASE
+          WHEN "sport" IS NULL THEN NULL
+          WHEN UPPER("sport"::text) IN ('HOCKEY', 'LACROSSE', 'SOCCER', 'BASKETBALL', 'BASEBALL', 'SOFTBALL', 'FOOTBALL', 'VOLLEYBALL', 'OTHER')
+            THEN UPPER("sport"::text)::public."Sport"
+          ELSE 'OTHER'::public."Sport"
+        END
+      );
+  END IF;
+
+  IF team_sport_type IS NOT NULL THEN
+    ALTER TABLE public."Team" ALTER COLUMN "sport" SET DEFAULT 'HOCKEY'::public."Sport";
+  END IF;
+
+  SELECT a.atttypid::regtype
+  INTO league_sport_type
+  FROM pg_attribute a
+  JOIN pg_class c ON c.oid = a.attrelid
+  JOIN pg_namespace n ON n.oid = c.relnamespace
+  WHERE n.nspname = 'public'
+    AND c.relname = 'leagues'
+    AND a.attname = 'sport'
+    AND NOT a.attisdropped
+    AND c.relkind IN ('r', 'p');
+
+  IF league_sport_type IS NOT NULL AND league_sport_type <> target_type THEN
+    ALTER TABLE public."leagues" ALTER COLUMN "sport" DROP DEFAULT;
+    ALTER TABLE public."leagues" ALTER COLUMN "sport" TYPE public."Sport"
+      USING (
+        CASE
+          WHEN "sport" IS NULL THEN NULL
+          WHEN UPPER("sport"::text) IN ('HOCKEY', 'LACROSSE', 'SOCCER', 'BASKETBALL', 'BASEBALL', 'SOFTBALL', 'FOOTBALL', 'VOLLEYBALL', 'OTHER')
+            THEN UPPER("sport"::text)::public."Sport"
+          ELSE 'OTHER'::public."Sport"
+        END
+      );
+  END IF;
+
+  IF league_sport_type IS NOT NULL THEN
+    ALTER TABLE public."leagues" ALTER COLUMN "sport" SET DEFAULT 'HOCKEY'::public."Sport";
+  END IF;
+END $$;

--- a/prisma/migrations/20260517000000_repair_public_sport_enum/migration.sql
+++ b/prisma/migrations/20260517000000_repair_public_sport_enum/migration.sql
@@ -1,6 +1,10 @@
 -- Repair production drift where Prisma Client casts Sport values to public."Sport"
--- but an older database still has Team.sport/leagues.sport as TEXT or the enum
--- was not created in the public schema.
+-- but an older database does not have the enum in the public schema or is
+-- missing one or more labels.
+--
+-- Keep this migration limited to enum creation/value repair. The follow-up
+-- migration converts columns/defaults so runners that wrap each migration in a
+-- transaction commit newly-added enum values before they are used.
 
 DO $$
 BEGIN
@@ -34,66 +38,3 @@ ALTER TYPE public."Sport" ADD VALUE IF NOT EXISTS 'SOFTBALL';
 ALTER TYPE public."Sport" ADD VALUE IF NOT EXISTS 'FOOTBALL';
 ALTER TYPE public."Sport" ADD VALUE IF NOT EXISTS 'VOLLEYBALL';
 ALTER TYPE public."Sport" ADD VALUE IF NOT EXISTS 'OTHER';
-
-DO $$
-DECLARE
-  target_type regtype := 'public."Sport"'::regtype;
-  team_sport_type regtype;
-  league_sport_type regtype;
-BEGIN
-  SELECT a.atttypid::regtype
-  INTO team_sport_type
-  FROM pg_attribute a
-  JOIN pg_class c ON c.oid = a.attrelid
-  JOIN pg_namespace n ON n.oid = c.relnamespace
-  WHERE n.nspname = 'public'
-    AND c.relname = 'Team'
-    AND a.attname = 'sport'
-    AND NOT a.attisdropped
-    AND c.relkind IN ('r', 'p');
-
-  IF team_sport_type IS NOT NULL AND team_sport_type <> target_type THEN
-    ALTER TABLE public."Team" ALTER COLUMN "sport" DROP DEFAULT;
-    ALTER TABLE public."Team" ALTER COLUMN "sport" TYPE public."Sport"
-      USING (
-        CASE
-          WHEN "sport" IS NULL THEN NULL
-          WHEN UPPER("sport"::text) IN ('HOCKEY', 'LACROSSE', 'SOCCER', 'BASKETBALL', 'BASEBALL', 'SOFTBALL', 'FOOTBALL', 'VOLLEYBALL', 'OTHER')
-            THEN UPPER("sport"::text)::public."Sport"
-          ELSE 'OTHER'::public."Sport"
-        END
-      );
-  END IF;
-
-  IF team_sport_type IS NOT NULL THEN
-    ALTER TABLE public."Team" ALTER COLUMN "sport" SET DEFAULT 'HOCKEY'::public."Sport";
-  END IF;
-
-  SELECT a.atttypid::regtype
-  INTO league_sport_type
-  FROM pg_attribute a
-  JOIN pg_class c ON c.oid = a.attrelid
-  JOIN pg_namespace n ON n.oid = c.relnamespace
-  WHERE n.nspname = 'public'
-    AND c.relname = 'leagues'
-    AND a.attname = 'sport'
-    AND NOT a.attisdropped
-    AND c.relkind IN ('r', 'p');
-
-  IF league_sport_type IS NOT NULL AND league_sport_type <> target_type THEN
-    ALTER TABLE public."leagues" ALTER COLUMN "sport" DROP DEFAULT;
-    ALTER TABLE public."leagues" ALTER COLUMN "sport" TYPE public."Sport"
-      USING (
-        CASE
-          WHEN "sport" IS NULL THEN NULL
-          WHEN UPPER("sport"::text) IN ('HOCKEY', 'LACROSSE', 'SOCCER', 'BASKETBALL', 'BASEBALL', 'SOFTBALL', 'FOOTBALL', 'VOLLEYBALL', 'OTHER')
-            THEN UPPER("sport"::text)::public."Sport"
-          ELSE 'OTHER'::public."Sport"
-        END
-      );
-  END IF;
-
-  IF league_sport_type IS NOT NULL THEN
-    ALTER TABLE public."leagues" ALTER COLUMN "sport" SET DEFAULT 'HOCKEY'::public."Sport";
-  END IF;
-END $$;

--- a/prisma/migrations/20260517000001_repair_public_sport_columns/migration.sql
+++ b/prisma/migrations/20260517000001_repair_public_sport_columns/migration.sql
@@ -1,0 +1,66 @@
+-- Convert drifted Sport columns after the enum-label repair migration has
+-- committed. This keeps ALTER TYPE ... ADD VALUE separate from any casts or
+-- defaults that use the new labels.
+
+DO $$
+DECLARE
+  target_type regtype := 'public."Sport"'::regtype;
+  team_sport_type regtype;
+  league_sport_type regtype;
+BEGIN
+  SELECT a.atttypid::regtype
+  INTO team_sport_type
+  FROM pg_attribute a
+  JOIN pg_class c ON c.oid = a.attrelid
+  JOIN pg_namespace n ON n.oid = c.relnamespace
+  WHERE n.nspname = 'public'
+    AND c.relname = 'Team'
+    AND a.attname = 'sport'
+    AND NOT a.attisdropped
+    AND c.relkind IN ('r', 'p');
+
+  IF team_sport_type IS NOT NULL AND team_sport_type <> target_type THEN
+    ALTER TABLE public."Team" ALTER COLUMN "sport" DROP DEFAULT;
+    ALTER TABLE public."Team" ALTER COLUMN "sport" TYPE public."Sport"
+      USING (
+        CASE
+          WHEN "sport" IS NULL THEN NULL
+          WHEN UPPER("sport"::text) IN ('HOCKEY', 'LACROSSE', 'SOCCER', 'BASKETBALL', 'BASEBALL', 'SOFTBALL', 'FOOTBALL', 'VOLLEYBALL', 'OTHER')
+            THEN UPPER("sport"::text)::public."Sport"
+          ELSE 'OTHER'::public."Sport"
+        END
+      );
+  END IF;
+
+  IF team_sport_type IS NOT NULL THEN
+    ALTER TABLE public."Team" ALTER COLUMN "sport" SET DEFAULT 'HOCKEY'::public."Sport";
+  END IF;
+
+  SELECT a.atttypid::regtype
+  INTO league_sport_type
+  FROM pg_attribute a
+  JOIN pg_class c ON c.oid = a.attrelid
+  JOIN pg_namespace n ON n.oid = c.relnamespace
+  WHERE n.nspname = 'public'
+    AND c.relname = 'leagues'
+    AND a.attname = 'sport'
+    AND NOT a.attisdropped
+    AND c.relkind IN ('r', 'p');
+
+  IF league_sport_type IS NOT NULL AND league_sport_type <> target_type THEN
+    ALTER TABLE public."leagues" ALTER COLUMN "sport" DROP DEFAULT;
+    ALTER TABLE public."leagues" ALTER COLUMN "sport" TYPE public."Sport"
+      USING (
+        CASE
+          WHEN "sport" IS NULL THEN NULL
+          WHEN UPPER("sport"::text) IN ('HOCKEY', 'LACROSSE', 'SOCCER', 'BASKETBALL', 'BASEBALL', 'SOFTBALL', 'FOOTBALL', 'VOLLEYBALL', 'OTHER')
+            THEN UPPER("sport"::text)::public."Sport"
+          ELSE 'OTHER'::public."Sport"
+        END
+      );
+  END IF;
+
+  IF league_sport_type IS NOT NULL THEN
+    ALTER TABLE public."leagues" ALTER COLUMN "sport" SET DEFAULT 'HOCKEY'::public."Sport";
+  END IF;
+END $$;

--- a/scripts/validate-deployment-config.ts
+++ b/scripts/validate-deployment-config.ts
@@ -58,7 +58,7 @@ export async function validateDeploymentConfig(rootDir = process.cwd()): Promise
   ]);
 
   requireCondition(failures, vercel.framework === 'nextjs', 'vercel.json must declare the Next.js framework preset.');
-  requireCondition(failures, vercel.buildCommand === 'bun run build', 'vercel.json buildCommand must be `bun run build`.');
+  requireCondition(failures, vercel.buildCommand === 'bun run vercel:build', 'vercel.json buildCommand must be `bun run vercel:build`.');
   requireCondition(
     failures,
     vercel.installCommand === 'bun install --frozen-lockfile',
@@ -81,7 +81,7 @@ export async function validateDeploymentConfig(rootDir = process.cwd()): Promise
     'vercel.json Content-Security-Policy must explicitly restrict frame ancestors.',
   );
 
-  for (const script of ['build', 'start', 'type-check', 'lint', 'test', 'validate-env', 'docs:build-pages', 'uptime:check']) {
+  for (const script of ['build', 'vercel:build', 'start', 'type-check', 'lint', 'test', 'validate-env', 'docs:build-pages', 'uptime:check']) {
     requireCondition(failures, Boolean(packageJson.scripts?.[script]), `package.json must define a ${script} script.`);
   }
 
@@ -89,7 +89,7 @@ export async function validateDeploymentConfig(rootDir = process.cwd()): Promise
     requireCondition(failures, envExample.includes(`${envName}=`), `.env.example must document ${envName}.`);
   }
 
-  for (const envName of [DOCS_PAGES_DOMAIN_ENV, ...Object.values(UPTIME_CHECK_ENV_NAMES)]) {
+  for (const envName of ['OPENLEAGUE_RUN_MIGRATIONS_ON_BUILD', DOCS_PAGES_DOMAIN_ENV, ...Object.values(UPTIME_CHECK_ENV_NAMES)]) {
     requireCondition(failures, envExample.includes(envName), `.env.example must document optional ${envName}.`);
   }
 

--- a/scripts/vercel-build.mjs
+++ b/scripts/vercel-build.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
+
+export const MIGRATION_OVERRIDE_ENV = 'OPENLEAGUE_RUN_MIGRATIONS_ON_BUILD';
+
+export function shouldRunMigrations(env = process.env) {
+  return env.VERCEL_ENV === 'production' || env[MIGRATION_OVERRIDE_ENV] === 'true';
+}
+
+export function getMigrationOverrideWarning(env = process.env) {
+  const value = env[MIGRATION_OVERRIDE_ENV];
+
+  if (value && value !== 'true' && value !== 'false') {
+    return `Warning: ${MIGRATION_OVERRIDE_ENV}=${JSON.stringify(value)} is not "true". Migrations will be skipped unless VERCEL_ENV=production.`;
+  }
+
+  return null;
+}
+
+export function runCommand(command, args, { env = process.env, logger = console, spawn = spawnSync } = {}) {
+  const result = spawn(command, args, {
+    stdio: 'inherit',
+    env,
+  });
+
+  if (result.error) {
+    logger.error(result.error);
+    return 1;
+  }
+
+  if (result.status !== 0) {
+    return result.status ?? 1;
+  }
+
+  return 0;
+}
+
+export function runVercelBuild({ env = process.env, logger = console, spawn = spawnSync } = {}) {
+  const migrationOverrideWarning = getMigrationOverrideWarning(env);
+
+  if (migrationOverrideWarning) {
+    logger.warn(migrationOverrideWarning);
+  }
+
+  if (shouldRunMigrations(env)) {
+    logger.log('Applying Prisma migrations before build...');
+    const migrationStatus = runCommand('bun', ['run', 'db:migrate:deploy'], { env, logger, spawn });
+
+    if (migrationStatus !== 0) {
+      return migrationStatus;
+    }
+  } else {
+    logger.log(
+      `Skipping Prisma migrations for VERCEL_ENV=${env.VERCEL_ENV ?? 'local'}. ` +
+        `Set ${MIGRATION_OVERRIDE_ENV}=true to force migration deployment.`,
+    );
+  }
+
+  return runCommand('bun', ['run', 'build'], { env, logger, spawn });
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const status = runVercelBuild();
+
+  if (status !== 0) {
+    process.exit(status);
+  }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,5 @@
 {
-  "buildCommand": "bun run build",
+  "buildCommand": "bun run vercel:build",
   "installCommand": "bun install --frozen-lockfile",
   "framework": "nextjs",
   "crons": [


### PR DESCRIPTION
This pull request introduces a robust and safer approach to database migrations during deployment, particularly for Vercel environments, and includes a production repair migration for the `Sport` enum. The main changes are the addition of a custom Vercel build wrapper script that conditionally runs Prisma migrations, improved documentation and environment variable handling for migration control, and a new migration script to repair enum drift in production databases.

**Deployment and Migration Workflow Improvements:**

* Added a new script `scripts/vercel-build.mjs` that wraps the build process, ensuring Prisma migrations are applied before building in production, and only in preview environments when `OPENLEAGUE_RUN_MIGRATIONS_ON_BUILD=true` is set. The script handles errors, logs warnings for invalid override values, and propagates exit codes for failed migrations.
* Updated `vercel.json` to use `bun run vercel:build` as the build command, and adjusted validation logic and tests to require and check for this new build step. [[1]](diffhunk://#diff-a3265310f552fb66876e8bfe8809737e59e5ba946bdf39138b44d9baf4e21240L2-R2) [[2]](diffhunk://#diff-3a2665ef3235bc5eee92065308aa8b766dfffeb0ca2bc2afcc218dc436dc0a37L61-R61) [[3]](diffhunk://#diff-24cc773d526867d781d645ecffe1e38fc4a5f315730c3320828a2a3f252fa9acL40-R40) [[4]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R9)
* Documented the new migration override environment variable in `.env.example`, `README.md`, and `DEPLOYMENT.md`, clarifying when and how migrations are run for production and preview deployments. [[1]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR5-R8) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L187-R197) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L453-R463) [[4]](diffhunk://#diff-04615394c116398fb5fcb0aa2d880df854202e4c94907dc81cd2647101ad3306L73-R81)
* Updated deployment and Docker instructions to use `bun run db:migrate:deploy` instead of direct Prisma CLI commands for consistency with the new workflow. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L512-R512) [[2]](diffhunk://#diff-04615394c116398fb5fcb0aa2d880df854202e4c94907dc81cd2647101ad3306L273-R276)

**Production Database Repair:**

* Added a migration (`prisma/migrations/20260517000000_repair_public_sport_enum/migration.sql`) to repair drift in the `public."Sport"` enum, ensuring `Team.sport` and `leagues.sport` columns are of the correct enum type and values, with safe casting from legacy text columns.

**Testing and Validation:**

* Added comprehensive unit tests for the new Vercel build wrapper, covering migration logic, environment overrides, error handling, and logging.
* Enhanced deployment configuration validation and tests to require the new build script and environment variable documentation. [[1]](diffhunk://#diff-3a2665ef3235bc5eee92065308aa8b766dfffeb0ca2bc2afcc218dc436dc0a37L84-R92) [[2]](diffhunk://#diff-24cc773d526867d781d645ecffe1e38fc4a5f315730c3320828a2a3f252fa9acR55-R61)

These changes ensure safer, more predictable migrations in all deployment environments, prevent accidental schema changes in shared preview databases, and repair critical production schema drift.