### PR TITLE
feat: add DATABASE_URL fallback Prisma client generation workflows

### DIFF
--- a/.github/workflows/deployment-checks.yml
+++ b/.github/workflows/deployment-checks.yml
@@ -48,6 +48,10 @@ jobs:
   deployment-readiness:
     name: Deployment readiness
     runs-on: ubuntu-latest
+    env:
+      # Prisma client generation runs during bun install. A real secret is used
+      # when available; the fallback only satisfies generate-time URL parsing.
+      DATABASE_URL: ${{ secrets.DATABASE_URL || 'postgresql://postgres:postgres@localhost:5432/openleague_ci' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -28,6 +28,10 @@ jobs:
   build:
     name: Build documentation site
     runs-on: ubuntu-latest
+    env:
+      # Prisma client generation runs during bun install. A real secret is used
+      # when available; the fallback only satisfies generate-time URL parsing.
+      DATABASE_URL: ${{ secrets.DATABASE_URL || 'postgresql://postgres:postgres@localhost:5432/openleague_ci' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,10 @@ jobs:
     name: Create Release
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}
+    env:
+      # Prisma client generation runs during bun install. A real secret is used
+      # when available; the fallback only satisfies generate-time URL parsing.
+      DATABASE_URL: ${{ secrets.DATABASE_URL || 'postgresql://postgres:postgres@localhost:5432/openleague_ci' }}
 
     steps:
       - name: Checkout code
@@ -43,7 +47,7 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Generate Prisma Client
-        run: bunx prisma generate
+        run: bun run db:generate
 
       - name: Run type check
         run: bun run type-check

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -13,6 +13,10 @@ jobs:
   validate-and-release:
     name: Validate Tag and Create Release
     runs-on: ubuntu-latest
+    env:
+      # Prisma client generation runs during bun install. A real secret is used
+      # when available; the fallback only satisfies generate-time URL parsing.
+      DATABASE_URL: ${{ secrets.DATABASE_URL || 'postgresql://postgres:postgres@localhost:5432/openleague_ci' }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/uptime-monitoring.yml
+++ b/.github/workflows/uptime-monitoring.yml
@@ -22,6 +22,10 @@ jobs:
     name: Check production uptime
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    env:
+      # Prisma client generation runs during bun install. A real secret is used
+      # when available; the fallback only satisfies generate-time URL parsing.
+      DATABASE_URL: ${{ secrets.DATABASE_URL || 'postgresql://postgres:postgres@localhost:5432/openleague_ci' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/scripts/validate-deployment-config.ts
+++ b/scripts/validate-deployment-config.ts
@@ -18,6 +18,7 @@ interface PackageJson {
 }
 
 const PRISMA_CONFIG_PATH = 'prisma/prisma.config.ts';
+const CI_DATABASE_URL_FALLBACK = "DATABASE_URL: ${{ secrets.DATABASE_URL || 'postgresql://postgres:postgres@localhost:5432/openleague_ci' }}";
 
 const REQUIRED_PRISMA_CONFIG_SCRIPTS: Record<string, string> = {
   postinstall: `prisma generate --config ${PRISMA_CONFIG_PATH}`,
@@ -59,6 +60,10 @@ function workflowUsesPinnedAction(workflow: string, actionName: string): boolean
 
 function includesAll(value: string, snippets: string[]): boolean {
   return snippets.every((snippet) => value.includes(snippet));
+}
+
+function hasCiDatabaseUrlFallback(workflow: string): boolean {
+  return workflow.includes(CI_DATABASE_URL_FALLBACK);
 }
 
 export async function validateDeploymentConfig(rootDir = process.cwd()): Promise<string[]> {
@@ -121,16 +126,31 @@ export async function validateDeploymentConfig(rootDir = process.cwd()): Promise
   const docsWorkflowPath = path.join(rootDir, '.github', 'workflows', 'docs-pages.yml');
   const deploymentChecksWorkflowPath = path.join(rootDir, '.github', 'workflows', 'deployment-checks.yml');
   const uptimeWorkflowPath = path.join(rootDir, '.github', 'workflows', 'uptime-monitoring.yml');
+  const releaseWorkflowPath = path.join(rootDir, '.github', 'workflows', 'release.yml');
+  const tagReleaseWorkflowPath = path.join(rootDir, '.github', 'workflows', 'tag-release.yml');
   const docsBuildScriptPath = path.join(rootDir, 'scripts', 'build-docs-pages.ts');
   const uptimeCheckScriptPath = path.join(rootDir, 'scripts', 'check-uptime.ts');
   const healthRoutePath = path.join(rootDir, 'app', 'api', 'health', 'route.ts');
 
   requireCondition(failures, existsSync(deploymentChecksWorkflowPath), 'Deployment checks workflow is required.');
   requireCondition(failures, existsSync(docsWorkflowPath), 'GitHub Pages docs workflow is required.');
+  requireCondition(failures, existsSync(releaseWorkflowPath), 'Release workflow is required.');
+  requireCondition(failures, existsSync(tagReleaseWorkflowPath), 'Tag release workflow is required.');
   requireCondition(failures, existsSync(docsBuildScriptPath), 'Documentation Pages build script is required.');
   requireCondition(failures, existsSync(uptimeWorkflowPath), 'Scheduled uptime monitoring workflow is required.');
   requireCondition(failures, existsSync(uptimeCheckScriptPath), 'Uptime monitoring check script is required.');
   requireCondition(failures, existsSync(healthRoutePath), 'Protected application health endpoint is required.');
+
+  for (const workflowPath of [docsWorkflowPath, deploymentChecksWorkflowPath, uptimeWorkflowPath, releaseWorkflowPath, tagReleaseWorkflowPath]) {
+    if (existsSync(workflowPath)) {
+      const workflow = await readFile(workflowPath, 'utf8');
+      requireCondition(
+        failures,
+        hasCiDatabaseUrlFallback(workflow),
+        `${path.relative(rootDir, workflowPath)} must provide DATABASE_URL during install so Prisma postinstall generation works in CI.`,
+      );
+    }
+  }
 
   if (existsSync(docsWorkflowPath)) {
     const docsWorkflow = await readFile(docsWorkflowPath, 'utf8');


### PR DESCRIPTION
This pull request improves the reliability and consistency of CI workflows by ensuring that a fallback `DATABASE_URL` environment variable is set for Prisma client generation across all major GitHub Actions workflows. Additionally, it updates the deployment config validation script to enforce this requirement, helping to prevent CI failures due to missing database URLs.

**CI/CD workflow improvements:**

* Added a fallback `DATABASE_URL` environment variable to the following GitHub Actions workflows to ensure Prisma client generation works even if a secret is not set: `deployment-checks.yml`, `docs-pages.yml`, `release.yml`, `tag-release.yml`, and `uptime-monitoring.yml`. This uses a default PostgreSQL URL when the secret is unavailable. [[1]](diffhunk://#diff-0c9119b170e6fec44f807073fe7ad835c4ae0555d683eb905a3875457bad0d7dR51-R54) [[2]](diffhunk://#diff-738a3c9bde302e642a211c808ff1d1b2a01a8efaa4a1d698dd5fe7697528dd84R31-R34) [[3]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R29-R32) [[4]](diffhunk://#diff-21e1251c1676ed10064d2d98ab1a8f6471a9718058bd316970abe934169f2b60R16-R19) [[5]](diffhunk://#diff-dab1c1d1a53f100e4054893551437c2afed3d731b29883fa7c6682440fa08342R25-R28)
* Changed the Prisma client generation step in `release.yml` to use `bun run db:generate` instead of directly running `bunx prisma generate`, aligning it with project conventions.

**Deployment config validation enhancements:**

* Updated `scripts/validate-deployment-config.ts` to:
  - Define a reusable fallback `DATABASE_URL` string constant for validation.
  - Add a helper to check for the fallback in workflow files.
  - Enforce the presence of the fallback `DATABASE_URL` in all relevant workflows, failing validation if missing.