### PR TITLE
feat: enhance team management workflows with new pages & revalidation

### DIFF
--- a/__tests__/app/team-route-aliases.test.ts
+++ b/__tests__/app/team-route-aliases.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockIsActiveTeamInLeague,
+  mockNotFound,
+  mockRedirect,
+} = vi.hoisted(() => ({
+  mockIsActiveTeamInLeague: vi.fn(),
+  mockNotFound: vi.fn(() => {
+    throw new Error("NEXT_NOT_FOUND");
+  }),
+  mockRedirect: vi.fn((url: string) => {
+    throw new Error(`NEXT_REDIRECT:${url}`);
+  }),
+}));
+
+vi.mock("next/navigation", () => ({
+  notFound: () => mockNotFound(),
+  redirect: (url: string) => mockRedirect(url),
+}));
+
+vi.mock("@/lib/actions/team-context", () => ({
+  isActiveTeamInLeague: (...args: unknown[]) => mockIsActiveTeamInLeague(...args),
+}));
+
+import LeagueTeamRedirectPage from "@/app/(dashboard)/league/[leagueId]/teams/[teamId]/page";
+import LeagueTeamRosterRedirectPage from "@/app/(dashboard)/league/[leagueId]/teams/[teamId]/roster/page";
+
+const LEAGUE_ID = "clleague00000000000000000";
+const TEAM_ID = "clteam000000000000000000";
+const params = Promise.resolve({ leagueId: LEAGUE_ID, teamId: TEAM_ID });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("league team route aliases", () => {
+  it("redirects a valid league team alias to the canonical team page", async () => {
+    mockIsActiveTeamInLeague.mockResolvedValue(true);
+
+    await expect(LeagueTeamRedirectPage({ params })).rejects.toThrow(
+      `NEXT_REDIRECT:/team/${TEAM_ID}`,
+    );
+
+    expect(mockIsActiveTeamInLeague).toHaveBeenCalledWith(TEAM_ID, LEAGUE_ID);
+    expect(mockRedirect).toHaveBeenCalledWith(`/team/${TEAM_ID}`);
+    expect(mockNotFound).not.toHaveBeenCalled();
+  });
+
+  it("redirects a valid league team roster alias to the canonical team roster page", async () => {
+    mockIsActiveTeamInLeague.mockResolvedValue(true);
+
+    await expect(LeagueTeamRosterRedirectPage({ params })).rejects.toThrow(
+      `NEXT_REDIRECT:/team/${TEAM_ID}/roster`,
+    );
+
+    expect(mockIsActiveTeamInLeague).toHaveBeenCalledWith(TEAM_ID, LEAGUE_ID);
+    expect(mockRedirect).toHaveBeenCalledWith(`/team/${TEAM_ID}/roster`);
+    expect(mockNotFound).not.toHaveBeenCalled();
+  });
+
+  it("returns not found when the team does not belong to the requested league", async () => {
+    mockIsActiveTeamInLeague.mockResolvedValue(false);
+
+    await expect(LeagueTeamRedirectPage({ params })).rejects.toThrow("NEXT_NOT_FOUND");
+
+    expect(mockIsActiveTeamInLeague).toHaveBeenCalledWith(TEAM_ID, LEAGUE_ID);
+    expect(mockNotFound).toHaveBeenCalledTimes(1);
+    expect(mockRedirect).not.toHaveBeenCalled();
+  });
+
+  it("returns not found for invalid roster aliases", async () => {
+    mockIsActiveTeamInLeague.mockResolvedValue(false);
+
+    await expect(LeagueTeamRosterRedirectPage({ params })).rejects.toThrow("NEXT_NOT_FOUND");
+
+    expect(mockIsActiveTeamInLeague).toHaveBeenCalledWith(TEAM_ID, LEAGUE_ID);
+    expect(mockNotFound).toHaveBeenCalledTimes(1);
+    expect(mockRedirect).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/app/team-route-aliases.test.ts
+++ b/__tests__/app/team-route-aliases.test.ts
@@ -1,11 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
-  mockIsActiveTeamInLeague,
+  mockCanAccessActiveTeamInLeague,
   mockNotFound,
   mockRedirect,
 } = vi.hoisted(() => ({
-  mockIsActiveTeamInLeague: vi.fn(),
+  mockCanAccessActiveTeamInLeague: vi.fn(),
   mockNotFound: vi.fn(() => {
     throw new Error("NEXT_NOT_FOUND");
   }),
@@ -20,7 +20,7 @@ vi.mock("next/navigation", () => ({
 }));
 
 vi.mock("@/lib/actions/team-context", () => ({
-  isActiveTeamInLeague: (...args: unknown[]) => mockIsActiveTeamInLeague(...args),
+  canAccessActiveTeamInLeague: (...args: unknown[]) => mockCanAccessActiveTeamInLeague(...args),
 }));
 
 import LeagueTeamRedirectPage from "@/app/(dashboard)/league/[leagueId]/teams/[teamId]/page";
@@ -36,45 +36,45 @@ beforeEach(() => {
 
 describe("league team route aliases", () => {
   it("redirects a valid league team alias to the canonical team page", async () => {
-    mockIsActiveTeamInLeague.mockResolvedValue(true);
+    mockCanAccessActiveTeamInLeague.mockResolvedValue(true);
 
     await expect(LeagueTeamRedirectPage({ params })).rejects.toThrow(
       `NEXT_REDIRECT:/team/${TEAM_ID}`,
     );
 
-    expect(mockIsActiveTeamInLeague).toHaveBeenCalledWith(TEAM_ID, LEAGUE_ID);
+    expect(mockCanAccessActiveTeamInLeague).toHaveBeenCalledWith(TEAM_ID, LEAGUE_ID);
     expect(mockRedirect).toHaveBeenCalledWith(`/team/${TEAM_ID}`);
     expect(mockNotFound).not.toHaveBeenCalled();
   });
 
   it("redirects a valid league team roster alias to the canonical team roster page", async () => {
-    mockIsActiveTeamInLeague.mockResolvedValue(true);
+    mockCanAccessActiveTeamInLeague.mockResolvedValue(true);
 
     await expect(LeagueTeamRosterRedirectPage({ params })).rejects.toThrow(
       `NEXT_REDIRECT:/team/${TEAM_ID}/roster`,
     );
 
-    expect(mockIsActiveTeamInLeague).toHaveBeenCalledWith(TEAM_ID, LEAGUE_ID);
+    expect(mockCanAccessActiveTeamInLeague).toHaveBeenCalledWith(TEAM_ID, LEAGUE_ID);
     expect(mockRedirect).toHaveBeenCalledWith(`/team/${TEAM_ID}/roster`);
     expect(mockNotFound).not.toHaveBeenCalled();
   });
 
   it("returns not found when the team does not belong to the requested league", async () => {
-    mockIsActiveTeamInLeague.mockResolvedValue(false);
+    mockCanAccessActiveTeamInLeague.mockResolvedValue(false);
 
     await expect(LeagueTeamRedirectPage({ params })).rejects.toThrow("NEXT_NOT_FOUND");
 
-    expect(mockIsActiveTeamInLeague).toHaveBeenCalledWith(TEAM_ID, LEAGUE_ID);
+    expect(mockCanAccessActiveTeamInLeague).toHaveBeenCalledWith(TEAM_ID, LEAGUE_ID);
     expect(mockNotFound).toHaveBeenCalledTimes(1);
     expect(mockRedirect).not.toHaveBeenCalled();
   });
 
   it("returns not found for invalid roster aliases", async () => {
-    mockIsActiveTeamInLeague.mockResolvedValue(false);
+    mockCanAccessActiveTeamInLeague.mockResolvedValue(false);
 
     await expect(LeagueTeamRosterRedirectPage({ params })).rejects.toThrow("NEXT_NOT_FOUND");
 
-    expect(mockIsActiveTeamInLeague).toHaveBeenCalledWith(TEAM_ID, LEAGUE_ID);
+    expect(mockCanAccessActiveTeamInLeague).toHaveBeenCalledWith(TEAM_ID, LEAGUE_ID);
     expect(mockNotFound).toHaveBeenCalledTimes(1);
     expect(mockRedirect).not.toHaveBeenCalled();
   });

--- a/__tests__/lib/actions/team-context.test.ts
+++ b/__tests__/lib/actions/team-context.test.ts
@@ -34,6 +34,7 @@ vi.mock("@/lib/db/prisma", () => ({
 }));
 
 import {
+  canAccessActiveTeamInLeague,
   getTeamOverviewData,
   getTeamRosterDataById,
   isActiveTeamInLeague,
@@ -146,8 +147,54 @@ describe("team context Server Actions", () => {
       expect(result).toMatchObject({
         role: "LEAGUE_ADMIN",
         isAdmin: false,
-        canOpenEventDetails: false,
+        canOpenEventDetails: true,
         league: { id: LEAGUE_ID, name: "Metro Hockey" },
+      });
+    });
+
+    it("prioritizes a league-admin role over a less-permissive direct team role", async () => {
+      mockPrisma.team.findFirst.mockResolvedValue(
+        buildTeam({
+          members: [{ role: "MEMBER" }],
+          league: {
+            id: LEAGUE_ID,
+            name: "Metro Hockey",
+            isActive: true,
+            users: [{ role: "LEAGUE_ADMIN" }],
+          },
+        }),
+      );
+      mockPrisma.event.findMany.mockResolvedValue([]);
+
+      const result = await getTeamOverviewData(TEAM_ID);
+
+      expect(result).toMatchObject({
+        role: "LEAGUE_ADMIN",
+        isAdmin: false,
+        canOpenEventDetails: true,
+      });
+    });
+
+    it("prioritizes a league team-admin role over a direct member role", async () => {
+      mockPrisma.team.findFirst.mockResolvedValue(
+        buildTeam({
+          members: [{ role: "MEMBER" }],
+          league: {
+            id: LEAGUE_ID,
+            name: "Metro Hockey",
+            isActive: true,
+            users: [{ role: "TEAM_ADMIN" }],
+          },
+        }),
+      );
+      mockPrisma.event.findMany.mockResolvedValue([]);
+
+      const result = await getTeamOverviewData(TEAM_ID);
+
+      expect(result).toMatchObject({
+        role: "TEAM_ADMIN",
+        isAdmin: false,
+        canOpenEventDetails: true,
       });
     });
 
@@ -296,6 +343,66 @@ describe("team context Server Actions", () => {
       mockPrisma.team.findFirst.mockResolvedValue(null);
 
       await expect(isActiveTeamInLeague(TEAM_ID, LEAGUE_ID)).resolves.toBe(false);
+    });
+  });
+
+  describe("canAccessActiveTeamInLeague", () => {
+    it("returns true when the current user has direct team membership", async () => {
+      mockPrisma.team.findFirst.mockResolvedValue({
+        members: [{ id: "member-1" }],
+        league: { users: [] },
+      });
+
+      await expect(canAccessActiveTeamInLeague(TEAM_ID, LEAGUE_ID)).resolves.toBe(true);
+      expect(mockRequireUserId).toHaveBeenCalled();
+      expect(mockPrisma.team.findFirst).toHaveBeenCalledWith({
+        where: {
+          id: TEAM_ID,
+          leagueId: LEAGUE_ID,
+          isActive: true,
+          league: { isActive: true },
+        },
+        select: {
+          members: {
+            where: { userId: USER_ID },
+            select: { id: true },
+            take: 1,
+          },
+          league: {
+            select: {
+              users: {
+                where: { userId: USER_ID },
+                select: { id: true },
+                take: 1,
+              },
+            },
+          },
+        },
+      });
+    });
+
+    it("returns true when the current user has league membership", async () => {
+      mockPrisma.team.findFirst.mockResolvedValue({
+        members: [],
+        league: { users: [{ id: "league-user-1" }] },
+      });
+
+      await expect(canAccessActiveTeamInLeague(TEAM_ID, LEAGUE_ID)).resolves.toBe(true);
+    });
+
+    it("returns false when the team belongs to the league but the user lacks access", async () => {
+      mockPrisma.team.findFirst.mockResolvedValue({
+        members: [],
+        league: { users: [] },
+      });
+
+      await expect(canAccessActiveTeamInLeague(TEAM_ID, LEAGUE_ID)).resolves.toBe(false);
+    });
+
+    it("returns false when the active team/league relationship is missing", async () => {
+      mockPrisma.team.findFirst.mockResolvedValue(null);
+
+      await expect(canAccessActiveTeamInLeague(TEAM_ID, LEAGUE_ID)).resolves.toBe(false);
     });
   });
 });

--- a/__tests__/lib/actions/team-context.test.ts
+++ b/__tests__/lib/actions/team-context.test.ts
@@ -1,0 +1,301 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockPrisma, mockRequireUserId } = vi.hoisted(() => ({
+  mockPrisma: {
+    team: {
+      findFirst: vi.fn(),
+    },
+    event: {
+      findMany: vi.fn(),
+    },
+    player: {
+      findMany: vi.fn(),
+    },
+    teamMember: {
+      findFirst: vi.fn(),
+      findMany: vi.fn(),
+    },
+    practiceSession: {
+      findMany: vi.fn(),
+    },
+    invitation: {
+      findMany: vi.fn(),
+    },
+  },
+  mockRequireUserId: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/session", () => ({
+  requireUserId: (...args: unknown[]) => mockRequireUserId(...args),
+}));
+
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: mockPrisma,
+}));
+
+import {
+  getTeamOverviewData,
+  getTeamRosterDataById,
+  isActiveTeamInLeague,
+} from "@/lib/actions/team-context";
+
+const USER_ID = "user-123";
+const TEAM_ID = "clteam000000000000000000";
+const LEAGUE_ID = "clleague00000000000000000";
+
+function buildTeam(overrides: Record<string, unknown> = {}) {
+  return {
+    id: TEAM_ID,
+    name: "Northside Wolves",
+    sport: "HOCKEY",
+    season: "Winter 2026",
+    createdAt: new Date("2026-01-01T12:00:00.000Z"),
+    members: [{ role: "ADMIN" }],
+    league: null,
+    division: null,
+    _count: {
+      players: 18,
+      events: 7,
+      members: 3,
+    },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockRequireUserId.mockResolvedValue(USER_ID);
+});
+
+describe("team context Server Actions", () => {
+  describe("getTeamOverviewData", () => {
+    it("returns a serialized overview for a direct team admin", async () => {
+      mockPrisma.team.findFirst.mockResolvedValue(buildTeam());
+      mockPrisma.event.findMany.mockResolvedValue([
+        {
+          id: "event-1",
+          type: "GAME",
+          title: "Wolves vs Bears",
+          startAt: new Date("2026-02-01T18:30:00.000Z"),
+          location: "Rink 1",
+          opponent: "Bears",
+        },
+      ]);
+
+      const result = await getTeamOverviewData(TEAM_ID);
+
+      expect(result).toEqual({
+        id: TEAM_ID,
+        name: "Northside Wolves",
+        sport: "HOCKEY",
+        season: "Winter 2026",
+        createdAt: "2026-01-01T12:00:00.000Z",
+        role: "ADMIN",
+        isAdmin: true,
+        canOpenEventDetails: true,
+        league: null,
+        division: null,
+        stats: {
+          players: 18,
+          events: 7,
+          members: 3,
+        },
+        upcomingEvents: [
+          {
+            id: "event-1",
+            type: "GAME",
+            title: "Wolves vs Bears",
+            startAt: "2026-02-01T18:30:00.000Z",
+            location: "Rink 1",
+            opponent: "Bears",
+          },
+        ],
+      });
+      expect(mockPrisma.team.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: TEAM_ID, isActive: true },
+        }),
+      );
+      expect(mockPrisma.event.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            teamId: TEAM_ID,
+            startAt: { gte: expect.any(Date) },
+          },
+          take: 5,
+        }),
+      );
+    });
+
+    it("allows league-admin overview access without exposing direct team-admin privileges", async () => {
+      mockPrisma.team.findFirst.mockResolvedValue(
+        buildTeam({
+          members: [],
+          league: {
+            id: LEAGUE_ID,
+            name: "Metro Hockey",
+            isActive: true,
+            users: [{ role: "LEAGUE_ADMIN" }],
+          },
+        }),
+      );
+      mockPrisma.event.findMany.mockResolvedValue([]);
+
+      const result = await getTeamOverviewData(TEAM_ID);
+
+      expect(result).toMatchObject({
+        role: "LEAGUE_ADMIN",
+        isAdmin: false,
+        canOpenEventDetails: false,
+        league: { id: LEAGUE_ID, name: "Metro Hockey" },
+      });
+    });
+
+    it("returns null when the user has no direct or league access", async () => {
+      mockPrisma.team.findFirst.mockResolvedValue(
+        buildTeam({
+          members: [],
+          league: {
+            id: LEAGUE_ID,
+            name: "Metro Hockey",
+            isActive: true,
+            users: [],
+          },
+        }),
+      );
+
+      const result = await getTeamOverviewData(TEAM_ID);
+
+      expect(result).toBeNull();
+      expect(mockPrisma.event.findMany).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("getTeamRosterDataById", () => {
+    it("fetches admin-only roster fields and invitations for a direct team admin", async () => {
+      mockPrisma.team.findFirst.mockResolvedValue(buildTeam());
+      mockPrisma.player.findMany.mockResolvedValue([
+        {
+          id: "player-1",
+          name: "Alex Goalie",
+          email: "alex@example.com",
+          phone: null,
+          emergencyContact: "Taylor",
+          emergencyPhone: "555-0100",
+          jerseyNumber: 30,
+          usahMemberId: "USAH123",
+        },
+      ]);
+      mockPrisma.teamMember.findMany.mockResolvedValue([
+        {
+          id: "member-1",
+          role: "ADMIN",
+          usahMemberId: "COACH123",
+          user: { id: USER_ID, name: "Coach", email: "coach@example.com" },
+        },
+      ]);
+      mockPrisma.invitation.findMany.mockResolvedValue([
+        {
+          id: "invite-1",
+          email: "new@example.com",
+          status: "PENDING",
+          expiresAt: new Date("2026-03-01T00:00:00.000Z"),
+          createdAt: new Date("2026-02-01T00:00:00.000Z"),
+        },
+      ]);
+
+      const result = await getTeamRosterDataById(TEAM_ID);
+
+      expect(result).toMatchObject({
+        teamId: TEAM_ID,
+        teamName: "Northside Wolves",
+        isAdmin: true,
+        invitations: [
+          {
+            id: "invite-1",
+            email: "new@example.com",
+            status: "PENDING",
+            expiresAt: "2026-03-01T00:00:00.000Z",
+            createdAt: "2026-02-01T00:00:00.000Z",
+          },
+        ],
+      });
+      expect(mockPrisma.player.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          select: expect.objectContaining({
+            emergencyContact: true,
+            emergencyPhone: true,
+            usahMemberId: true,
+          }),
+        }),
+      );
+      expect(mockPrisma.invitation.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { teamId: TEAM_ID } }),
+      );
+    });
+
+    it("does not expose admin-only roster fields or invitations to league-only admins", async () => {
+      mockPrisma.team.findFirst.mockResolvedValue(
+        buildTeam({
+          members: [],
+          league: {
+            id: LEAGUE_ID,
+            name: "Metro Hockey",
+            isActive: true,
+            users: [{ role: "LEAGUE_ADMIN" }],
+          },
+        }),
+      );
+      mockPrisma.player.findMany.mockResolvedValue([]);
+      mockPrisma.teamMember.findMany.mockResolvedValue([]);
+
+      const result = await getTeamRosterDataById(TEAM_ID);
+
+      expect(result).toMatchObject({
+        teamId: TEAM_ID,
+        isAdmin: false,
+        invitations: [],
+      });
+      expect(mockPrisma.player.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          select: expect.objectContaining({
+            emergencyContact: false,
+            emergencyPhone: false,
+            usahMemberId: false,
+          }),
+        }),
+      );
+      expect(mockPrisma.teamMember.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          select: expect.objectContaining({
+            usahMemberId: false,
+          }),
+        }),
+      );
+      expect(mockPrisma.invitation.findMany).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("isActiveTeamInLeague", () => {
+    it("returns true when an active team belongs to an active league", async () => {
+      mockPrisma.team.findFirst.mockResolvedValue({ id: TEAM_ID });
+
+      await expect(isActiveTeamInLeague(TEAM_ID, LEAGUE_ID)).resolves.toBe(true);
+      expect(mockPrisma.team.findFirst).toHaveBeenCalledWith({
+        where: {
+          id: TEAM_ID,
+          leagueId: LEAGUE_ID,
+          isActive: true,
+          league: { isActive: true },
+        },
+        select: { id: true },
+      });
+    });
+
+    it("returns false when the active team/league relationship is missing", async () => {
+      mockPrisma.team.findFirst.mockResolvedValue(null);
+
+      await expect(isActiveTeamInLeague(TEAM_ID, LEAGUE_ID)).resolves.toBe(false);
+    });
+  });
+});

--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -235,7 +235,7 @@ export default async function DashboardPage() {
           <Typography variant="h5" component="h2" gutterBottom>
             {userMode.isLeagueMode ? "Create New Team" : "Create Another Team"}
           </Typography>
-          <CreateTeamForm />
+          <CreateTeamForm title={null} />
         </Box>
       </Box>
     </Container>

--- a/app/(dashboard)/league/[leagueId]/teams/[teamId]/page.tsx
+++ b/app/(dashboard)/league/[leagueId]/teams/[teamId]/page.tsx
@@ -1,0 +1,16 @@
+import { notFound, redirect } from "next/navigation";
+import { isActiveTeamInLeague } from "@/lib/actions/team-context";
+
+interface LeagueTeamRedirectPageProps {
+  params: Promise<{ leagueId: string; teamId: string }>;
+}
+
+export default async function LeagueTeamRedirectPage({ params }: LeagueTeamRedirectPageProps) {
+  const { leagueId, teamId } = await params;
+
+  if (!(await isActiveTeamInLeague(teamId, leagueId))) {
+    notFound();
+  }
+
+  redirect(`/team/${teamId}`);
+}

--- a/app/(dashboard)/league/[leagueId]/teams/[teamId]/page.tsx
+++ b/app/(dashboard)/league/[leagueId]/teams/[teamId]/page.tsx
@@ -1,5 +1,5 @@
 import { notFound, redirect } from "next/navigation";
-import { isActiveTeamInLeague } from "@/lib/actions/team-context";
+import { canAccessActiveTeamInLeague } from "@/lib/actions/team-context";
 
 interface LeagueTeamRedirectPageProps {
   params: Promise<{ leagueId: string; teamId: string }>;
@@ -8,7 +8,7 @@ interface LeagueTeamRedirectPageProps {
 export default async function LeagueTeamRedirectPage({ params }: LeagueTeamRedirectPageProps) {
   const { leagueId, teamId } = await params;
 
-  if (!(await isActiveTeamInLeague(teamId, leagueId))) {
+  if (!(await canAccessActiveTeamInLeague(teamId, leagueId))) {
     notFound();
   }
 

--- a/app/(dashboard)/league/[leagueId]/teams/[teamId]/roster/page.tsx
+++ b/app/(dashboard)/league/[leagueId]/teams/[teamId]/roster/page.tsx
@@ -1,0 +1,16 @@
+import { notFound, redirect } from "next/navigation";
+import { isActiveTeamInLeague } from "@/lib/actions/team-context";
+
+interface LeagueTeamRosterRedirectPageProps {
+  params: Promise<{ leagueId: string; teamId: string }>;
+}
+
+export default async function LeagueTeamRosterRedirectPage({ params }: LeagueTeamRosterRedirectPageProps) {
+  const { leagueId, teamId } = await params;
+
+  if (!(await isActiveTeamInLeague(teamId, leagueId))) {
+    notFound();
+  }
+
+  redirect(`/team/${teamId}/roster`);
+}

--- a/app/(dashboard)/league/[leagueId]/teams/[teamId]/roster/page.tsx
+++ b/app/(dashboard)/league/[leagueId]/teams/[teamId]/roster/page.tsx
@@ -1,5 +1,5 @@
 import { notFound, redirect } from "next/navigation";
-import { isActiveTeamInLeague } from "@/lib/actions/team-context";
+import { canAccessActiveTeamInLeague } from "@/lib/actions/team-context";
 
 interface LeagueTeamRosterRedirectPageProps {
   params: Promise<{ leagueId: string; teamId: string }>;
@@ -8,7 +8,7 @@ interface LeagueTeamRosterRedirectPageProps {
 export default async function LeagueTeamRosterRedirectPage({ params }: LeagueTeamRosterRedirectPageProps) {
   const { leagueId, teamId } = await params;
 
-  if (!(await isActiveTeamInLeague(teamId, leagueId))) {
+  if (!(await canAccessActiveTeamInLeague(teamId, leagueId))) {
     notFound();
   }
 

--- a/app/(dashboard)/team/[teamId]/page.tsx
+++ b/app/(dashboard)/team/[teamId]/page.tsx
@@ -46,14 +46,13 @@ function formatEventDate(value: string) {
 }
 
 function formatAccessRole(role: string, isAdmin: boolean) {
-  if (isAdmin) return "Team Admin";
-
   switch (role) {
     case "LEAGUE_ADMIN":
       return "League Admin";
     case "TEAM_ADMIN":
       return "League Team Admin";
     default:
+      if (isAdmin) return "Team Admin";
       return "Member";
   }
 }

--- a/app/(dashboard)/team/[teamId]/page.tsx
+++ b/app/(dashboard)/team/[teamId]/page.tsx
@@ -1,0 +1,260 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import {
+  Avatar,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Chip,
+  Container,
+  Stack,
+  Typography,
+} from "@mui/material";
+import {
+  ArrowBack as ArrowBackIcon,
+  CalendarToday as CalendarIcon,
+  Event as EventIcon,
+  Groups as GroupsIcon,
+  People as PeopleIcon,
+  SportsSoccer as SportsIcon,
+} from "@mui/icons-material";
+import { getTeamOverviewData } from "@/lib/actions/team-context";
+import { formatSport } from "@/lib/utils/validation";
+
+interface TeamPageProps {
+  params: Promise<{ teamId: string }>;
+}
+
+function getTeamInitials(name: string) {
+  return name
+    .split(" ")
+    .map((word) => word[0])
+    .join("")
+    .toUpperCase()
+    .slice(0, 2);
+}
+
+function formatEventDate(value: string) {
+  return new Intl.DateTimeFormat("en-US", {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(new Date(value));
+}
+
+function formatAccessRole(role: string, isAdmin: boolean) {
+  if (isAdmin) return "Team Admin";
+
+  switch (role) {
+    case "LEAGUE_ADMIN":
+      return "League Admin";
+    case "TEAM_ADMIN":
+      return "League Team Admin";
+    default:
+      return "Member";
+  }
+}
+
+export default async function TeamPage({ params }: TeamPageProps) {
+  const { teamId } = await params;
+  const team = await getTeamOverviewData(teamId);
+
+  if (!team) {
+    notFound();
+  }
+
+  return (
+    <Container maxWidth="lg">
+      <Box sx={{ py: 4 }}>
+        <Button
+          component={Link}
+          href="/dashboard"
+          startIcon={<ArrowBackIcon />}
+          sx={{ mb: 3 }}
+        >
+          Back to dashboard
+        </Button>
+
+        <Card
+          sx={{
+            mb: 3,
+            overflow: "hidden",
+            border: "1px solid",
+            borderColor: "divider",
+          }}
+        >
+          <CardContent sx={{ p: { xs: 3, md: 4 } }}>
+            <Stack
+              direction={{ xs: "column", md: "row" }}
+              justifyContent="space-between"
+              alignItems={{ xs: "flex-start", md: "center" }}
+              spacing={3}
+            >
+              <Stack direction="row" spacing={2} alignItems="center">
+                <Avatar
+                  sx={{
+                    width: 64,
+                    height: 64,
+                    bgcolor: "primary.main",
+                    fontSize: "1.25rem",
+                    fontWeight: 800,
+                  }}
+                >
+                  {getTeamInitials(team.name)}
+                </Avatar>
+                <Box>
+                  <Typography variant="h4" component="h1" fontWeight={800} gutterBottom>
+                    {team.name}
+                  </Typography>
+                  <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+                    <Chip icon={<SportsIcon />} label={formatSport(team.sport)} />
+                    <Chip label={team.season} variant="outlined" />
+                    <Chip
+                      label={formatAccessRole(team.role, team.isAdmin)}
+                      color={team.isAdmin ? "primary" : "default"}
+                      variant={team.isAdmin ? "filled" : "outlined"}
+                    />
+                    {team.league ? <Chip label={team.league.name} color="secondary" variant="outlined" /> : null}
+                    {team.division ? <Chip label={`Division: ${team.division.name}`} variant="outlined" /> : null}
+                  </Stack>
+                </Box>
+              </Stack>
+
+              <Stack direction={{ xs: "column", sm: "row" }} spacing={1} sx={{ width: { xs: "100%", md: "auto" } }}>
+                <Button
+                  component={Link}
+                  href={`/team/${team.id}/roster`}
+                  variant="contained"
+                  startIcon={<PeopleIcon />}
+                  fullWidth
+                >
+                  {team.isAdmin ? "Manage roster" : "View roster"}
+                </Button>
+                {team.league ? (
+                  <Button
+                    component={Link}
+                    href={`/league/${team.league.id}/teams`}
+                    variant="outlined"
+                    startIcon={<GroupsIcon />}
+                    fullWidth
+                  >
+                    League teams
+                  </Button>
+                ) : null}
+              </Stack>
+            </Stack>
+          </CardContent>
+        </Card>
+
+        <Box
+          sx={{
+            display: "grid",
+            gridTemplateColumns: { xs: "1fr", sm: "repeat(3, 1fr)" },
+            gap: 2,
+            mb: 3,
+          }}
+        >
+          <StatCard icon={<PeopleIcon color="primary" />} label="Players" value={team.stats.players} />
+          <StatCard icon={<EventIcon color="primary" />} label="Events" value={team.stats.events} />
+          <StatCard icon={<GroupsIcon color="primary" />} label="Members" value={team.stats.members} />
+        </Box>
+
+        <Card variant="outlined">
+          <CardContent>
+            <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 2 }}>
+              <CalendarIcon color="primary" />
+              <Typography variant="h5" component="h2" fontWeight={700}>
+                Upcoming events
+              </Typography>
+            </Stack>
+
+            {team.upcomingEvents.length === 0 ? (
+              <Typography variant="body2" color="text.secondary">
+                No upcoming games or practices are scheduled for this team yet.
+              </Typography>
+            ) : (
+              <Stack spacing={1.5}>
+                {team.upcomingEvents.map((event) => (
+                  <Card
+                    key={event.id}
+                    {...(team.canOpenEventDetails
+                      ? { component: Link, href: `/events/${event.id}` }
+                      : {})}
+                    variant="outlined"
+                    sx={{
+                      color: "inherit",
+                      textDecoration: "none",
+                      transition: "border-color 0.2s, box-shadow 0.2s",
+                      ...(team.canOpenEventDetails && {
+                        cursor: "pointer",
+                      }),
+                      "&:hover": team.canOpenEventDetails ? {
+                        borderColor: "primary.main",
+                        boxShadow: 1,
+                      } : undefined,
+                    }}
+                  >
+                    <CardContent sx={{ py: 1.5, "&:last-child": { pb: 1.5 } }}>
+                      <Stack
+                        direction={{ xs: "column", sm: "row" }}
+                        justifyContent="space-between"
+                        spacing={1}
+                      >
+                        <Box>
+                          <Typography variant="subtitle1" fontWeight={700}>
+                            {event.title}
+                          </Typography>
+                          <Typography variant="body2" color="text.secondary">
+                            {event.location || "Location TBD"}
+                            {event.opponent ? ` • vs. ${event.opponent}` : ""}
+                          </Typography>
+                        </Box>
+                        <Stack direction="row" spacing={1} alignItems="center">
+                          <Chip size="small" label={event.type === "GAME" ? "Game" : "Practice"} />
+                          <Typography variant="body2" color="text.secondary">
+                            {formatEventDate(event.startAt)}
+                          </Typography>
+                        </Stack>
+                      </Stack>
+                    </CardContent>
+                  </Card>
+                ))}
+              </Stack>
+            )}
+          </CardContent>
+        </Card>
+      </Box>
+    </Container>
+  );
+}
+
+function StatCard({
+  icon,
+  label,
+  value,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  value: number;
+}) {
+  return (
+    <Card variant="outlined">
+      <CardContent>
+        <Stack direction="row" spacing={1.5} alignItems="center">
+          {icon}
+          <Box>
+            <Typography variant="h4" component="p" fontWeight={800}>
+              {value}
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              {label}
+            </Typography>
+          </Box>
+        </Stack>
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/(dashboard)/team/[teamId]/roster/page.tsx
+++ b/app/(dashboard)/team/[teamId]/roster/page.tsx
@@ -1,0 +1,66 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { Box, Button, Container, Divider, Stack, Typography } from "@mui/material";
+import { ArrowBack as ArrowBackIcon } from "@mui/icons-material";
+import RosterList from "@/components/features/roster/RosterList";
+import InvitationManager from "@/components/features/roster/InvitationManager";
+import { getTeamRosterDataById } from "@/lib/actions/team-context";
+
+interface TeamRosterPageProps {
+  params: Promise<{ teamId: string }>;
+}
+
+export default async function TeamRosterPage({ params }: TeamRosterPageProps) {
+  const { teamId } = await params;
+  const data = await getTeamRosterDataById(teamId);
+
+  if (!data) {
+    notFound();
+  }
+
+  return (
+    <Container maxWidth="lg">
+      <Box sx={{ py: 4 }}>
+        <Button
+          component={Link}
+          href={`/team/${teamId}`}
+          startIcon={<ArrowBackIcon />}
+          sx={{ mb: 3 }}
+        >
+          Back to team
+        </Button>
+
+        <Stack
+          direction={{ xs: "column", sm: "row" }}
+          justifyContent="space-between"
+          alignItems={{ xs: "flex-start", sm: "center" }}
+          spacing={2}
+          sx={{ mb: 3 }}
+        >
+          <Box>
+            <Typography variant="h4" component="h1" fontWeight={800}>
+              {data.teamName} roster
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              {data.isAdmin ? "Manage players, invitations, and team official IDs." : "View players and team officials."}
+            </Typography>
+          </Box>
+        </Stack>
+
+        {data.isAdmin && (
+          <>
+            <InvitationManager invitations={data.invitations} teamId={data.teamId} />
+            <Divider sx={{ my: 4 }} />
+          </>
+        )}
+
+        <RosterList
+          players={data.players}
+          teamMembers={data.teamMembers}
+          teamId={data.teamId}
+          isAdmin={data.isAdmin}
+        />
+      </Box>
+    </Container>
+  );
+}

--- a/components/features/events/EventDetail.tsx
+++ b/components/features/events/EventDetail.tsx
@@ -53,6 +53,8 @@ interface EventDetailProps {
         email: string;
       };
     }>;
+    canRSVP?: boolean;
+    canManageEvent?: boolean;
   };
   userRole: string;
   currentUserId: string;
@@ -64,8 +66,9 @@ export default function EventDetail({ event, userRole, currentUserId }: EventDet
   const [isDeleting, setIsDeleting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const isAdmin = userRole === "ADMIN";
-  
+  const isAdmin = event.canManageEvent ?? userRole === "ADMIN";
+  const canRSVP = event.canRSVP ?? true;
+
   // Find current user's RSVP status
   const currentUserRSVP = event.rsvps.find((rsvp) => rsvp.user.id === currentUserId);
   const currentStatus = currentUserRSVP?.status || "NO_RESPONSE";
@@ -190,12 +193,14 @@ export default function EventDetail({ event, userRole, currentUserId }: EventDet
       </Card>
 
       {/* RSVP Buttons */}
-      <Box sx={{ mt: 3 }}>
-        <Typography variant="h6" gutterBottom>
-          Your Response
-        </Typography>
-        <RSVPButtons eventId={event.id} currentStatus={currentStatus} />
-      </Box>
+      {canRSVP && (
+        <Box sx={{ mt: 3 }}>
+          <Typography variant="h6" gutterBottom>
+            Your Response
+          </Typography>
+          <RSVPButtons eventId={event.id} currentStatus={currentStatus} />
+        </Box>
+      )}
 
       {/* Attendance View (Admin only) */}
       {isAdmin && (

--- a/components/features/team/CreateTeamForm.tsx
+++ b/components/features/team/CreateTeamForm.tsx
@@ -23,7 +23,11 @@ import {
 } from "@/lib/utils/validation";
 import { trackTeam } from "@/lib/analytics/umami";
 
-export default function CreateTeamForm() {
+type CreateTeamFormProps = {
+  title?: string | null;
+};
+
+export default function CreateTeamForm({ title = "Create Your Team" }: CreateTeamFormProps) {
   const router = useRouter();
   const [formData, setFormData] = useState<CreateTeamInput>({
     name: "",
@@ -88,7 +92,7 @@ export default function CreateTeamForm() {
           sport: formData.sport,
           season: formData.season,
         });
-        router.push("/");
+        router.push(`/team/${result.data.id}`);
       } else {
         setError(result.error);
       }
@@ -112,9 +116,11 @@ export default function CreateTeamForm() {
         width: "100%",
       }}
     >
-      <Typography variant="h5" component="h2" gutterBottom>
-        Create Your Team
-      </Typography>
+      {title && (
+        <Typography variant="h5" component="h2" gutterBottom>
+          {title}
+        </Typography>
+      )}
 
       {error && (
         <Alert severity="error" onClose={() => setError(null)}>

--- a/components/features/team/LeagueTeamsView.tsx
+++ b/components/features/team/LeagueTeamsView.tsx
@@ -11,12 +11,7 @@ import {
   CardActions,
   Chip,
   Avatar,
-  IconButton,
-  Menu,
   MenuItem,
-  ListItemIcon,
-  ListItemText,
-  Divider,
   Fab,
   TextField,
   InputAdornment,
@@ -30,11 +25,7 @@ import {
   Groups as TeamsIcon,
   People as PlayersIcon,
   Event as EventIcon,
-  MoreVert as MoreVertIcon,
-  Edit as EditIcon,
-  Delete as DeleteIcon,
   Category as DivisionIcon,
-  Schedule as ScheduleIcon,
   Search as SearchIcon,
   FileDownload as DownloadIcon,
 } from '@mui/icons-material';
@@ -102,17 +93,6 @@ interface TeamCardProps {
 }
 
 function TeamCard({ team, leagueId }: TeamCardProps) {
-  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
-  const menuOpen = Boolean(anchorEl);
-
-  const handleMenuOpen = (event: React.MouseEvent<HTMLElement>) => {
-    setAnchorEl(event.currentTarget);
-  };
-
-  const handleMenuClose = () => {
-    setAnchorEl(null);
-  };
-
   return (
     <Card>
       <CardContent>
@@ -138,14 +118,6 @@ function TeamCard({ team, leagueId }: TeamCardProps) {
               </Typography>
             </Box>
           </Box>
-          <IconButton
-            size="small"
-            onClick={handleMenuOpen}
-            aria-label="team options"
-            sx={{ mt: -0.5 }}
-          >
-            <MoreVertIcon fontSize="small" />
-          </IconButton>
         </Box>
 
         <Box sx={{ display: 'flex', gap: { xs: 1.5, sm: 2 }, mb: 2, flexWrap: 'wrap' }}>
@@ -198,42 +170,6 @@ function TeamCard({ team, leagueId }: TeamCardProps) {
           Roster
         </Button>
       </CardActions>
-
-      <Menu
-        anchorEl={anchorEl}
-        open={menuOpen}
-        onClose={handleMenuClose}
-        anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
-        transformOrigin={{ vertical: 'top', horizontal: 'right' }}
-      >
-        <MenuItem
-          component={Link}
-          href={`/league/${leagueId}/teams/${team.id}/edit`}
-          onClick={handleMenuClose}
-        >
-          <ListItemIcon>
-            <EditIcon fontSize="small" />
-          </ListItemIcon>
-          <ListItemText>Edit Team</ListItemText>
-        </MenuItem>
-        <MenuItem
-          component={Link}
-          href={`/league/${leagueId}/teams/${team.id}/schedule`}
-          onClick={handleMenuClose}
-        >
-          <ListItemIcon>
-            <ScheduleIcon fontSize="small" />
-          </ListItemIcon>
-          <ListItemText>Schedule</ListItemText>
-        </MenuItem>
-        <Divider />
-        <MenuItem onClick={handleMenuClose} sx={{ color: 'error.main' }}>
-          <ListItemIcon>
-            <DeleteIcon fontSize="small" color="error" />
-          </ListItemIcon>
-          <ListItemText>Delete Team</ListItemText>
-        </MenuItem>
-      </Menu>
     </Card>
   );
 }

--- a/lib/actions/events.ts
+++ b/lib/actions/events.ts
@@ -387,6 +387,7 @@ export async function getEvent(eventId: string) {
           select: {
             id: true,
             name: true,
+            leagueId: true,
           },
         },
         rsvps: {
@@ -421,14 +422,30 @@ export async function getEvent(eventId: string) {
       },
     });
 
-    // If user is not a member of the team, return null as before.
-    if (!teamMember) {
+    const eventLeagueId = event.leagueId ?? event.team.leagueId;
+    const leagueAdmin = !teamMember && eventLeagueId
+      ? await prisma.leagueUser.findFirst({
+          where: {
+            userId,
+            leagueId: eventLeagueId,
+            role: "LEAGUE_ADMIN",
+            league: { isActive: true },
+          },
+          select: { role: true },
+        })
+      : null;
+
+    // Direct team members can RSVP; league admins can inspect league events
+    // without receiving broken RSVP/edit/delete controls for teams they do not belong to.
+    if (!teamMember && !leagueAdmin) {
       return null;
     }
 
     return {
       ...event,
-      userRole: teamMember.role,
+      userRole: teamMember?.role ?? "LEAGUE_ADMIN",
+      canRSVP: !!teamMember,
+      canManageEvent: teamMember?.role === "ADMIN",
     };
   } catch (error) {
     console.error("Error fetching event:", error);

--- a/lib/actions/roster.ts
+++ b/lib/actions/roster.ts
@@ -15,7 +15,11 @@ import {
   type UpdateTeamMemberUsahIdInput,
 } from "@/lib/utils/validation";
 
-
+function revalidateRosterPaths(teamId: string) {
+  revalidatePath("/roster");
+  revalidatePath(`/team/${teamId}`);
+  revalidatePath(`/team/${teamId}/roster`);
+}
 
 /**
  * Add a player to the team roster
@@ -59,8 +63,8 @@ export async function addPlayer(input: AddPlayerInput) {
       }
     }
 
-    // Revalidate roster page
-    revalidatePath(`/roster`);
+    // Revalidate roster pages
+    revalidateRosterPaths(validated.teamId);
 
     return {
       success: true,
@@ -144,8 +148,8 @@ export async function updatePlayer(input: UpdatePlayerInput) {
       }
     }
 
-    // Revalidate roster page
-    revalidatePath(`/roster`);
+    // Revalidate roster pages
+    revalidateRosterPaths(validated.teamId);
 
     return {
       success: true,
@@ -201,8 +205,8 @@ export async function deletePlayer(playerId: string, teamId: string) {
       },
     });
 
-    // Revalidate roster page
-    revalidatePath(`/roster`);
+    // Revalidate roster pages
+    revalidateRosterPaths(teamId);
 
     return {
       success: true,
@@ -328,7 +332,8 @@ export async function transferPlayer(input: TransferPlayerInput) {
 
     // Revalidate relevant pages
     revalidatePath(`/league/${validated.leagueId}/roster`);
-    revalidatePath(`/roster`);
+    revalidateRosterPaths(validated.fromTeamId);
+    revalidateRosterPaths(validated.toTeamId);
 
     return {
       success: true,
@@ -384,7 +389,7 @@ export async function updateTeamMemberUsahId(input: UpdateTeamMemberUsahIdInput)
       select: { id: true, usahMemberId: true },
     });
 
-    revalidatePath("/roster");
+    revalidateRosterPaths(validated.teamId);
 
     return { success: true as const, data: updated };
   } catch (error) {

--- a/lib/actions/roster.ts
+++ b/lib/actions/roster.ts
@@ -15,10 +15,13 @@ import {
   type UpdateTeamMemberUsahIdInput,
 } from "@/lib/utils/validation";
 
-function revalidateRosterPaths(teamId: string) {
+function revalidateRosterPaths(...teamIds: string[]) {
   revalidatePath("/roster");
-  revalidatePath(`/team/${teamId}`);
-  revalidatePath(`/team/${teamId}/roster`);
+
+  for (const teamId of new Set(teamIds)) {
+    revalidatePath(`/team/${teamId}`);
+    revalidatePath(`/team/${teamId}/roster`);
+  }
 }
 
 /**
@@ -332,8 +335,7 @@ export async function transferPlayer(input: TransferPlayerInput) {
 
     // Revalidate relevant pages
     revalidatePath(`/league/${validated.leagueId}/roster`);
-    revalidateRosterPaths(validated.fromTeamId);
-    revalidateRosterPaths(validated.toTeamId);
+    revalidateRosterPaths(validated.fromTeamId, validated.toTeamId);
 
     return {
       success: true,

--- a/lib/actions/team-context.ts
+++ b/lib/actions/team-context.ts
@@ -181,10 +181,10 @@ export async function getCalendarData(): Promise<{
   };
 }
 
-/**
- * Get roster data for the user's primary team.
- */
-export async function getRosterData(): Promise<{
+type TeamRole = "ADMIN" | "MEMBER";
+type LeagueRole = "LEAGUE_ADMIN" | "TEAM_ADMIN" | "MEMBER";
+
+type TeamRosterData = {
   teamId: string;
   teamName: string;
   isAdmin: boolean;
@@ -202,23 +202,33 @@ export async function getRosterData(): Promise<{
     expiresAt: string;
     createdAt: string;
   }>;
-} | null> {
-  const userId = await requireUserId();
+};
 
-  const teamMember = await prisma.teamMember.findFirst({
-    where: { userId },
-    select: {
-      role: true,
-      team: { select: { id: true, name: true } },
-    },
-    orderBy: { joinedAt: "desc" },
-  });
+function getEffectiveTeamRole(directRole: TeamRole | null, leagueRole: LeagueRole | null): string {
+  if (leagueRole === "LEAGUE_ADMIN") {
+    return "LEAGUE_ADMIN";
+  }
 
-  if (!teamMember) return null;
+  if (directRole === "ADMIN") {
+    return "ADMIN";
+  }
 
-  const teamId = teamMember.team.id;
-  const isAdmin = teamMember.role === "ADMIN";
+  if (leagueRole === "TEAM_ADMIN") {
+    return "TEAM_ADMIN";
+  }
 
+  return directRole ?? leagueRole ?? "MEMBER";
+}
+
+async function getRosterPayload({
+  teamId,
+  teamName,
+  isAdmin,
+}: {
+  teamId: string;
+  teamName: string;
+  isAdmin: boolean;
+}): Promise<TeamRosterData> {
   const [players, teamMembers, rawInvitations] = await Promise.all([
     prisma.player.findMany({
       where: { teamId },
@@ -270,12 +280,57 @@ export async function getRosterData(): Promise<{
 
   return {
     teamId,
-    teamName: teamMember.team.name,
+    teamName,
     isAdmin,
     players,
     teamMembers,
     invitations,
   };
+}
+
+/**
+ * Get roster data for the user's primary team.
+ */
+export async function getRosterData(): Promise<{
+  teamId: string;
+  teamName: string;
+  isAdmin: boolean;
+  players: Player[];
+  teamMembers: Array<{
+    id: string;
+    role: string;
+    usahMemberId: string | null;
+    user: { id: string; name: string | null; email: string };
+  }>;
+  invitations: Array<{
+    id: string;
+    email: string;
+    status: "PENDING" | "ACCEPTED" | "EXPIRED";
+    expiresAt: string;
+    createdAt: string;
+  }>;
+} | null> {
+  const userId = await requireUserId();
+
+  const teamMember = await prisma.teamMember.findFirst({
+    where: { userId },
+    select: {
+      role: true,
+      team: { select: { id: true, name: true } },
+    },
+    orderBy: { joinedAt: "desc" },
+  });
+
+  if (!teamMember) return null;
+
+  const teamId = teamMember.team.id;
+  const isAdmin = teamMember.role === "ADMIN";
+
+  return getRosterPayload({
+    teamId,
+    teamName: teamMember.team.name,
+    isAdmin,
+  });
 }
 
 type AccessibleTeamData = {
@@ -348,9 +403,9 @@ async function getAccessibleTeamData(teamId: string): Promise<AccessibleTeamData
     sport: team.sport,
     season: team.season,
     createdAt: team.createdAt,
-    role: directRole ?? leagueRole ?? "MEMBER",
+    role: getEffectiveTeamRole(directRole as TeamRole | null, leagueRole as LeagueRole | null),
     isAdmin: directRole === "ADMIN",
-    canOpenEventDetails: !!directRole,
+    canOpenEventDetails: !!directRole || leagueRole === "LEAGUE_ADMIN",
     league: team.league?.isActive ? { id: team.league.id, name: team.league.name } : null,
     division: team.division,
     stats: {
@@ -445,63 +500,11 @@ export async function getTeamRosterDataById(teamId: string): Promise<{
   const team = await getAccessibleTeamData(teamId);
   if (!team) return null;
 
-  const [players, teamMembers, rawInvitations] = await Promise.all([
-    prisma.player.findMany({
-      where: { teamId: team.id },
-      orderBy: { name: "asc" },
-      select: {
-        id: true,
-        name: true,
-        email: true,
-        phone: true,
-        emergencyContact: team.isAdmin,
-        emergencyPhone: team.isAdmin,
-        jerseyNumber: true,
-        // FR-008: USAH Member IDs are admin-only — must not appear in non-admin queries
-        usahMemberId: team.isAdmin,
-      },
-    }),
-    prisma.teamMember.findMany({
-      where: { teamId: team.id },
-      select: {
-        id: true,
-        role: true,
-        // FR-008: USAH Member IDs are admin-only
-        usahMemberId: team.isAdmin,
-        user: { select: { id: true, name: true, email: true } },
-      },
-      orderBy: [{ role: "asc" }, { joinedAt: "asc" }],
-    }),
-    team.isAdmin
-      ? prisma.invitation.findMany({
-          where: { teamId: team.id },
-          orderBy: { createdAt: "desc" },
-          select: {
-            id: true,
-            email: true,
-            status: true,
-            expiresAt: true,
-            createdAt: true,
-          },
-        })
-      : Promise.resolve([]),
-  ]);
-
-  const invitations = rawInvitations.map((inv) => ({
-    ...inv,
-    status: inv.status as "PENDING" | "ACCEPTED" | "EXPIRED",
-    expiresAt: inv.expiresAt.toISOString(),
-    createdAt: inv.createdAt.toISOString(),
-  }));
-
-  return {
+  return getRosterPayload({
     teamId: team.id,
     teamName: team.name,
     isAdmin: team.isAdmin,
-    players,
-    teamMembers,
-    invitations,
-  };
+  });
 }
 
 /**
@@ -520,4 +523,40 @@ export async function isActiveTeamInLeague(teamId: string, leagueId: string): Pr
   });
 
   return !!team;
+}
+
+/**
+ * Verify that the current user can safely follow a league-scoped team alias.
+ * Prevents redirect-vs-404 probing of team/league relationships by requiring
+ * either direct team membership or active league membership before redirecting.
+ */
+export async function canAccessActiveTeamInLeague(teamId: string, leagueId: string): Promise<boolean> {
+  const userId = await requireUserId();
+
+  const team = await prisma.team.findFirst({
+    where: {
+      id: teamId,
+      leagueId,
+      isActive: true,
+      league: { isActive: true },
+    },
+    select: {
+      members: {
+        where: { userId },
+        select: { id: true },
+        take: 1,
+      },
+      league: {
+        select: {
+          users: {
+            where: { userId },
+            select: { id: true },
+            take: 1,
+          },
+        },
+      },
+    },
+  });
+
+  return !!team && (team.members.length > 0 || (team.league?.users.length ?? 0) > 0);
 }

--- a/lib/actions/team-context.ts
+++ b/lib/actions/team-context.ts
@@ -277,3 +277,247 @@ export async function getRosterData(): Promise<{
     invitations,
   };
 }
+
+type AccessibleTeamData = {
+  id: string;
+  name: string;
+  sport: string;
+  season: string;
+  createdAt: Date;
+  role: string;
+  isAdmin: boolean;
+  canOpenEventDetails: boolean;
+  league: { id: string; name: string } | null;
+  division: { id: string; name: string } | null;
+  stats: {
+    players: number;
+    events: number;
+    members: number;
+  };
+};
+
+async function getAccessibleTeamData(teamId: string): Promise<AccessibleTeamData | null> {
+  const userId = await requireUserId();
+
+  const team = await prisma.team.findFirst({
+    where: { id: teamId, isActive: true },
+    select: {
+      id: true,
+      name: true,
+      sport: true,
+      season: true,
+      createdAt: true,
+      league: {
+        select: {
+          id: true,
+          name: true,
+          isActive: true,
+          users: {
+            where: { userId },
+            select: { role: true },
+          },
+        },
+      },
+      division: { select: { id: true, name: true } },
+      members: {
+        where: { userId },
+        select: { role: true },
+      },
+      _count: {
+        select: {
+          players: true,
+          events: true,
+          members: true,
+        },
+      },
+    },
+  });
+
+  if (!team) return null;
+
+  const directRole = team.members[0]?.role ?? null;
+  const leagueRole = team.league?.isActive ? team.league.users[0]?.role ?? null : null;
+
+  if (!directRole && !leagueRole) {
+    return null;
+  }
+
+  return {
+    id: team.id,
+    name: team.name,
+    sport: team.sport,
+    season: team.season,
+    createdAt: team.createdAt,
+    role: directRole ?? leagueRole ?? "MEMBER",
+    isAdmin: directRole === "ADMIN",
+    canOpenEventDetails: !!directRole,
+    league: team.league?.isActive ? { id: team.league.id, name: team.league.name } : null,
+    division: team.division,
+    stats: {
+      players: team._count.players,
+      events: team._count.events,
+      members: team._count.members,
+    },
+  };
+}
+
+/**
+ * Get overview data for a specific team the current user can access.
+ */
+export async function getTeamOverviewData(teamId: string): Promise<{
+  id: string;
+  name: string;
+  sport: string;
+  season: string;
+  createdAt: string;
+  role: string;
+  isAdmin: boolean;
+  canOpenEventDetails: boolean;
+  league: { id: string; name: string } | null;
+  division: { id: string; name: string } | null;
+  stats: {
+    players: number;
+    events: number;
+    members: number;
+  };
+  upcomingEvents: Array<{
+    id: string;
+    type: "GAME" | "PRACTICE";
+    title: string;
+    startAt: string;
+    location: string;
+    opponent: string | null;
+  }>;
+} | null> {
+  const team = await getAccessibleTeamData(teamId);
+  if (!team) return null;
+
+  const upcomingEvents = await prisma.event.findMany({
+    where: {
+      teamId: team.id,
+      startAt: { gte: new Date() },
+    },
+    orderBy: { startAt: "asc" },
+    take: 5,
+    select: {
+      id: true,
+      type: true,
+      title: true,
+      startAt: true,
+      location: true,
+      opponent: true,
+    },
+  });
+
+  return {
+    ...team,
+    createdAt: team.createdAt.toISOString(),
+    upcomingEvents: upcomingEvents.map((event) => ({
+      ...event,
+      type: event.type as "GAME" | "PRACTICE",
+      startAt: event.startAt.toISOString(),
+    })),
+  };
+}
+
+/**
+ * Get roster data for a specific team the current user can access.
+ */
+export async function getTeamRosterDataById(teamId: string): Promise<{
+  teamId: string;
+  teamName: string;
+  isAdmin: boolean;
+  players: Player[];
+  teamMembers: Array<{
+    id: string;
+    role: string;
+    usahMemberId: string | null;
+    user: { id: string; name: string | null; email: string };
+  }>;
+  invitations: Array<{
+    id: string;
+    email: string;
+    status: "PENDING" | "ACCEPTED" | "EXPIRED";
+    expiresAt: string;
+    createdAt: string;
+  }>;
+} | null> {
+  const team = await getAccessibleTeamData(teamId);
+  if (!team) return null;
+
+  const [players, teamMembers, rawInvitations] = await Promise.all([
+    prisma.player.findMany({
+      where: { teamId: team.id },
+      orderBy: { name: "asc" },
+      select: {
+        id: true,
+        name: true,
+        email: true,
+        phone: true,
+        emergencyContact: team.isAdmin,
+        emergencyPhone: team.isAdmin,
+        jerseyNumber: true,
+        // FR-008: USAH Member IDs are admin-only — must not appear in non-admin queries
+        usahMemberId: team.isAdmin,
+      },
+    }),
+    prisma.teamMember.findMany({
+      where: { teamId: team.id },
+      select: {
+        id: true,
+        role: true,
+        // FR-008: USAH Member IDs are admin-only
+        usahMemberId: team.isAdmin,
+        user: { select: { id: true, name: true, email: true } },
+      },
+      orderBy: [{ role: "asc" }, { joinedAt: "asc" }],
+    }),
+    team.isAdmin
+      ? prisma.invitation.findMany({
+          where: { teamId: team.id },
+          orderBy: { createdAt: "desc" },
+          select: {
+            id: true,
+            email: true,
+            status: true,
+            expiresAt: true,
+            createdAt: true,
+          },
+        })
+      : Promise.resolve([]),
+  ]);
+
+  const invitations = rawInvitations.map((inv) => ({
+    ...inv,
+    status: inv.status as "PENDING" | "ACCEPTED" | "EXPIRED",
+    expiresAt: inv.expiresAt.toISOString(),
+    createdAt: inv.createdAt.toISOString(),
+  }));
+
+  return {
+    teamId: team.id,
+    teamName: team.name,
+    isAdmin: team.isAdmin,
+    players,
+    teamMembers,
+    invitations,
+  };
+}
+
+/**
+ * Verify that an active team belongs to an active league.
+ * Used by route aliases before redirecting to canonical team pages.
+ */
+export async function isActiveTeamInLeague(teamId: string, leagueId: string): Promise<boolean> {
+  const team = await prisma.team.findFirst({
+    where: {
+      id: teamId,
+      leagueId,
+      isActive: true,
+      league: { isActive: true },
+    },
+    select: { id: true },
+  });
+
+  return !!team;
+}

--- a/lib/actions/team.ts
+++ b/lib/actions/team.ts
@@ -51,8 +51,10 @@ export async function createTeam(
       },
     });
 
-    // Revalidate the dashboard page to show the new team
+    // Revalidate dashboard/team pages to show the new team immediately.
     revalidatePath("/");
+    revalidatePath("/dashboard");
+    revalidatePath(`/team/${team.id}`);
 
     return {
       success: true,


### PR DESCRIPTION
This pull request introduces new server components and comprehensive tests for team and roster pages, adds robust route alias handling and redirection for league/team URLs, and improves the team creation flow. It also enhances the test coverage for team context actions. The changes are grouped below by theme.

### New Server Components for Team and Roster Pages

* Added a server component for the team overview page at `app/(dashboard)/team/[teamId]/page.tsx`, displaying team details, stats, and upcoming events, with role-based access and navigation. ([app/(dashboard)/team/[teamId]/page.tsxR1-R260](diffhunk://#diff-5ebb46782cc3243f12d528f8cb32a7265785d517ce3d4fb0db329a48dd3ee60eR1-R260))
* Added a server component for the team roster page at `app/(dashboard)/team/[teamId]/roster/page.tsx`, showing players, team members, and invitations, with admin-only controls. ([app/(dashboard)/team/[teamId]/roster/page.tsxR1-R66](diffhunk://#diff-17eff2a52e6258ee7f40c5b20bddf06bee3f2839e5671e57c539dfe9e0382a93R1-R66))

### Route Alias Handling and Redirection

* Added route alias handlers for legacy or league-based team URLs in `app/(dashboard)/league/[leagueId]/teams/[teamId]/page.tsx` and `app/(dashboard)/league/[leagueId]/teams/[teamId]/roster/page.tsx`, redirecting to canonical team or roster URLs if the team is active in the league, or returning a 404 otherwise. ([app/(dashboard)/league/[leagueId]/teams/[teamId]/page.tsxR1-R16](diffhunk://#diff-af56a88e84c128b48611bfd1710122d5a45e92fa5087e1c8dbe5adeb68cc6942R1-R16), [app/(dashboard)/league/[leagueId]/teams/[teamId]/roster/page.tsxR1-R16](diffhunk://#diff-d64d89d9d4480840332d76ec5e5f0fc0395d9fef82337b17f55a0ec35f8a6389R1-R16))

### Test Coverage Improvements

* Introduced comprehensive tests for route alias logic in `__tests__/app/team-route-aliases.test.ts`, verifying correct redirection and not-found behavior for various scenarios.
* Added detailed tests for team context server actions in `__tests__/lib/actions/team-context.test.ts`, covering admin and league-admin access, data serialization, and field-level access restrictions.

### Team Creation Flow Enhancement

* Modified `CreateTeamForm` to accept an optional `title` prop and updated the team creation flow to redirect users to the new team's page upon creation instead of the dashboard root. [[1]](diffhunk://#diff-22522c55d916a1c6d4be9ba0ac3960a50f4527cd5c7446f437f9397936ebbf8eL26-R30) [[2]](diffhunk://#diff-22522c55d916a1c6d4be9ba0ac3960a50f4527cd5c7446f437f9397936ebbf8eL91-R95) [[3]](diffhunk://#diff-50f759f838439527a05eda1b4478268096a334cb4d5104cf7fb5311dd6e70938L238-R238)

These changes collectively improve the user experience, maintainability, and reliability of the team management features.