### PR TITLE
refactor: replace Link component anchor tags in team & roster pages

### DIFF
--- a/app/(dashboard)/team/[teamId]/page.tsx
+++ b/app/(dashboard)/team/[teamId]/page.tsx
@@ -2,7 +2,6 @@ import { notFound } from "next/navigation";
 import {
   Avatar,
   Box,
-  Button,
   Card,
   CardContent,
   Chip,
@@ -20,6 +19,7 @@ import {
 } from "@mui/icons-material";
 import { getTeamOverviewData } from "@/lib/actions/team-context";
 import { formatSport } from "@/lib/utils/validation";
+import { NextLinkButton, NextLinkCard } from "@/components/ui/NextLinkComponents";
 
 interface TeamPageProps {
   params: Promise<{ teamId: string }>;
@@ -67,13 +67,13 @@ export default async function TeamPage({ params }: TeamPageProps) {
   return (
     <Container maxWidth="lg">
       <Box sx={{ py: 4 }}>
-        <Button
+        <NextLinkButton
           href="/dashboard"
           startIcon={<ArrowBackIcon />}
           sx={{ mb: 3 }}
         >
           Back to dashboard
-        </Button>
+        </NextLinkButton>
 
         <Card
           sx={{
@@ -121,23 +121,23 @@ export default async function TeamPage({ params }: TeamPageProps) {
               </Stack>
 
               <Stack direction={{ xs: "column", sm: "row" }} spacing={1} sx={{ width: { xs: "100%", md: "auto" } }}>
-                <Button
+                <NextLinkButton
                   href={`/team/${team.id}/roster`}
                   variant="contained"
                   startIcon={<PeopleIcon />}
                   fullWidth
                 >
                   {team.isAdmin ? "Manage roster" : "View roster"}
-                </Button>
+                </NextLinkButton>
                 {team.league ? (
-                  <Button
+                  <NextLinkButton
                     href={`/league/${team.league.id}/teams`}
                     variant="outlined"
                     startIcon={<GroupsIcon />}
                     fullWidth
                   >
                     League teams
-                  </Button>
+                  </NextLinkButton>
                 ) : null}
               </Stack>
             </Stack>
@@ -172,14 +172,10 @@ export default async function TeamPage({ params }: TeamPageProps) {
               </Typography>
             ) : (
               <Stack spacing={1.5}>
-                {team.upcomingEvents.map((event) => (
-                  <Card
-                    key={event.id}
-                    {...(team.canOpenEventDetails
-                      ? { component: "a", href: `/events/${event.id}` }
-                      : {})}
-                    variant="outlined"
-                    sx={{
+                {team.upcomingEvents.map((event) => {
+                  const eventCardProps = {
+                    variant: "outlined" as const,
+                    sx: {
                       color: "inherit",
                       textDecoration: "none",
                       transition: "border-color 0.2s, box-shadow 0.2s",
@@ -190,8 +186,10 @@ export default async function TeamPage({ params }: TeamPageProps) {
                         borderColor: "primary.main",
                         boxShadow: 1,
                       } : undefined,
-                    }}
-                  >
+                    },
+                  };
+
+                  const eventCardContent = (
                     <CardContent sx={{ py: 1.5, "&:last-child": { pb: 1.5 } }}>
                       <Stack
                         direction={{ xs: "column", sm: "row" }}
@@ -215,8 +213,18 @@ export default async function TeamPage({ params }: TeamPageProps) {
                         </Stack>
                       </Stack>
                     </CardContent>
-                  </Card>
-                ))}
+                  );
+
+                  return team.canOpenEventDetails ? (
+                    <NextLinkCard key={event.id} href={`/events/${event.id}`} {...eventCardProps}>
+                      {eventCardContent}
+                    </NextLinkCard>
+                  ) : (
+                    <Card key={event.id} {...eventCardProps}>
+                      {eventCardContent}
+                    </Card>
+                  );
+                })}
               </Stack>
             )}
           </CardContent>

--- a/app/(dashboard)/team/[teamId]/page.tsx
+++ b/app/(dashboard)/team/[teamId]/page.tsx
@@ -1,4 +1,3 @@
-import Link from "next/link";
 import { notFound } from "next/navigation";
 import {
   Avatar,
@@ -69,7 +68,6 @@ export default async function TeamPage({ params }: TeamPageProps) {
     <Container maxWidth="lg">
       <Box sx={{ py: 4 }}>
         <Button
-          component={Link}
           href="/dashboard"
           startIcon={<ArrowBackIcon />}
           sx={{ mb: 3 }}
@@ -124,7 +122,6 @@ export default async function TeamPage({ params }: TeamPageProps) {
 
               <Stack direction={{ xs: "column", sm: "row" }} spacing={1} sx={{ width: { xs: "100%", md: "auto" } }}>
                 <Button
-                  component={Link}
                   href={`/team/${team.id}/roster`}
                   variant="contained"
                   startIcon={<PeopleIcon />}
@@ -134,7 +131,6 @@ export default async function TeamPage({ params }: TeamPageProps) {
                 </Button>
                 {team.league ? (
                   <Button
-                    component={Link}
                     href={`/league/${team.league.id}/teams`}
                     variant="outlined"
                     startIcon={<GroupsIcon />}
@@ -180,7 +176,7 @@ export default async function TeamPage({ params }: TeamPageProps) {
                   <Card
                     key={event.id}
                     {...(team.canOpenEventDetails
-                      ? { component: Link, href: `/events/${event.id}` }
+                      ? { component: "a", href: `/events/${event.id}` }
                       : {})}
                     variant="outlined"
                     sx={{

--- a/app/(dashboard)/team/[teamId]/roster/page.tsx
+++ b/app/(dashboard)/team/[teamId]/roster/page.tsx
@@ -1,4 +1,3 @@
-import Link from "next/link";
 import { notFound } from "next/navigation";
 import { Box, Button, Container, Divider, Stack, Typography } from "@mui/material";
 import { ArrowBack as ArrowBackIcon } from "@mui/icons-material";
@@ -22,7 +21,6 @@ export default async function TeamRosterPage({ params }: TeamRosterPageProps) {
     <Container maxWidth="lg">
       <Box sx={{ py: 4 }}>
         <Button
-          component={Link}
           href={`/team/${teamId}`}
           startIcon={<ArrowBackIcon />}
           sx={{ mb: 3 }}

--- a/app/(dashboard)/team/[teamId]/roster/page.tsx
+++ b/app/(dashboard)/team/[teamId]/roster/page.tsx
@@ -1,9 +1,10 @@
 import { notFound } from "next/navigation";
-import { Box, Button, Container, Divider, Stack, Typography } from "@mui/material";
+import { Box, Container, Divider, Stack, Typography } from "@mui/material";
 import { ArrowBack as ArrowBackIcon } from "@mui/icons-material";
 import RosterList from "@/components/features/roster/RosterList";
 import InvitationManager from "@/components/features/roster/InvitationManager";
 import { getTeamRosterDataById } from "@/lib/actions/team-context";
+import { NextLinkButton } from "@/components/ui/NextLinkComponents";
 
 interface TeamRosterPageProps {
   params: Promise<{ teamId: string }>;
@@ -20,13 +21,13 @@ export default async function TeamRosterPage({ params }: TeamRosterPageProps) {
   return (
     <Container maxWidth="lg">
       <Box sx={{ py: 4 }}>
-        <Button
+        <NextLinkButton
           href={`/team/${teamId}`}
           startIcon={<ArrowBackIcon />}
           sx={{ mb: 3 }}
         >
           Back to team
-        </Button>
+        </NextLinkButton>
 
         <Stack
           direction={{ xs: "column", sm: "row" }}

--- a/components/ui/NextLinkComponents.tsx
+++ b/components/ui/NextLinkComponents.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import type { ElementType } from "react";
+import Link from "next/link";
+import { Button, Card, type ButtonProps, type CardProps } from "@mui/material";
+
+type NextLinkButtonProps = Omit<ButtonProps, "component" | "href"> & {
+  href: string;
+};
+
+type NextLinkCardProps = Omit<CardProps, "component" | "href"> & {
+  href: string;
+};
+
+const NextLinkComponent = Link as ElementType;
+
+export function NextLinkButton({ href, ...props }: NextLinkButtonProps) {
+  return <Button component={NextLinkComponent} href={href} {...props} />;
+}
+
+export function NextLinkCard({ href, ...props }: NextLinkCardProps) {
+  return <Card component={NextLinkComponent} href={href} {...props} />;
+}


### PR DESCRIPTION
This pull request refactors navigation-related code in the team dashboard and roster pages by removing the use of Next.js's `Link` component from Material UI `Button` elements and replacing it with direct `href` usage. This streamlines navigation and resolves compatibility issues between Material UI components and Next.js routing.

Navigation refactoring:

* Removed imports of the `Link` component from `next/link` in both `page.tsx` and `roster/page.tsx` files, as it is no longer used. ([app/(dashboard)/team/[teamId]/page.tsxL1](diffhunk://#diff-5ebb46782cc3243f12d528f8cb32a7265785d517ce3d4fb0db329a48dd3ee60eL1), [app/(dashboard)/team/[teamId]/roster/page.tsxL1](diffhunk://#diff-17eff2a52e6258ee7f40c5b20bddf06bee3f2839e5671e57c539dfe9e0382a93L1))
* Updated all `Button` components that previously used `component={Link}` to instead rely on the `href` prop directly, ensuring navigation works as expected with Material UI buttons. ([app/(dashboard)/team/[teamId]/page.tsxL72](diffhunk://#diff-5ebb46782cc3243f12d528f8cb32a7265785d517ce3d4fb0db329a48dd3ee60eL72), [app/(dashboard)/team/[teamId]/page.tsxL127](diffhunk://#diff-5ebb46782cc3243f12d528f8cb32a7265785d517ce3d4fb0db329a48dd3ee60eL127), [app/(dashboard)/team/[teamId]/page.tsxL137](diffhunk://#diff-5ebb46782cc3243f12d528f8cb32a7265785d517ce3d4fb0db329a48dd3ee60eL137), [app/(dashboard)/team/[teamId]/roster/page.tsxL25](diffhunk://#diff-17eff2a52e6258ee7f40c5b20bddf06bee3f2839e5671e57c539dfe9e0382a93L25))
* Changed event `Card` components to use `component="a"` instead of `component={Link}` for linking to event details, aligning with the new navigation approach. ([app/(dashboard)/team/[teamId]/page.tsxL183-R179](diffhunk://#diff-5ebb46782cc3243f12d528f8cb32a7265785d517ce3d4fb0db329a48dd3ee60eL183-R179))