### PR TITLE
fix: stop passing next/link across the RSC boundary as a component prop

### DIFF
--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -1,5 +1,5 @@
-import { Box, Container, Typography, Card, CardContent, Chip, Stack, Button } from "@mui/material";
-import Link from "next/link";
+import { Box, Container, Typography, Card, CardContent, Chip, Stack } from "@mui/material";
+import { LinkButton, LinkCard } from "@/components/ui/NextLinkComposites";
 import {
   SportsHockey as SportsHockeyIcon,
   AccessTime as ClockIcon,
@@ -141,21 +141,19 @@ export default async function DashboardPage() {
               <Typography variant="h5" component="h2">
                 Upcoming Practices
               </Typography>
-              <Button
-                component={Link}
+              <LinkButton
                 href="/practice-planner"
                 endIcon={<ArrowForwardIcon />}
                 size="small"
               >
                 View All
-              </Button>
+              </LinkButton>
             </Stack>
             <Stack spacing={1.5}>
               {upcomingPractices.map((practice) => (
-                <Card
+                <LinkCard
                   key={practice.id}
                   variant="outlined"
-                  component={Link}
                   href={`/practice-planner/${practice.id}`}
                   sx={{
                     textDecoration: "none",
@@ -200,7 +198,7 @@ export default async function DashboardPage() {
                       </Stack>
                     </Stack>
                   </CardContent>
-                </Card>
+                </LinkCard>
               ))}
             </Stack>
           </Box>
@@ -219,9 +217,9 @@ export default async function DashboardPage() {
                       <Typography variant="subtitle1">{relationship.venue.name}</Typography>
                       <Chip size="small" label={relationship.relationshipType} />
                       {relationship.venue.slug ? (
-                        <Button component={Link} href={`/rinks/${relationship.venue.slug}`} size="small">
+                        <LinkButton href={`/rinks/${relationship.venue.slug}`} size="small">
                           View rink
-                        </Button>
+                        </LinkButton>
                       ) : null}
                     </Stack>
                   </CardContent>

--- a/app/(dashboard)/league/[leagueId]/schedule/page.tsx
+++ b/app/(dashboard)/league/[leagueId]/schedule/page.tsx
@@ -1,7 +1,7 @@
-import { Container, Box, Typography, Button } from "@mui/material";
+import { Container, Box, Typography } from "@mui/material";
 import { Add } from "@mui/icons-material";
-import Link from "next/link";
 import { notFound } from "next/navigation";
+import { LinkButton } from "@/components/ui/NextLinkComposites";
 import LeagueCalendar from "@/components/features/calendar/LeagueCalendar";
 import { getLeagueScheduleData } from "@/lib/actions/league-context";
 import { formatSport } from "@/lib/utils/validation";
@@ -39,14 +39,13 @@ export default async function LeagueSchedulePage({ params }: LeagueSchedulePageP
           </Box>
 
           {data.canCreateGames && (
-            <Button
-              component={Link}
+            <LinkButton
               href={`/league/${leagueId}/schedule/new-game`}
               variant="contained"
               startIcon={<Add />}
             >
               Schedule Game
-            </Button>
+            </LinkButton>
           )}
         </Box>
 

--- a/app/(dashboard)/practice-planner/library/page.tsx
+++ b/app/(dashboard)/practice-planner/library/page.tsx
@@ -1,7 +1,7 @@
-import { Box, Container, Typography, Button, Stack, Alert } from "@mui/material";
+import { Box, Container, Typography, Stack, Alert } from "@mui/material";
 import { redirect } from "next/navigation";
-import Link from "next/link";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
+import { LinkButton } from "@/components/ui/NextLinkComposites";
 import { PlayLibrary } from "@/components/features/practice-planner/PlayLibrary";
 import { getPlayLibraryContext } from "@/lib/actions/practice-session-queries";
 import type { Metadata } from "next";
@@ -25,14 +25,13 @@ export default async function PlayLibraryPage() {
           <Alert severity="warning">
             Only team admins can access the play library.
           </Alert>
-          <Button
-            component={Link}
+          <LinkButton
             href="/practice-planner"
             startIcon={<ArrowBackIcon />}
             sx={{ mt: 2 }}
           >
             Back to Practice Planner
-          </Button>
+          </LinkButton>
         </Box>
       </Container>
     );
@@ -48,14 +47,13 @@ export default async function PlayLibraryPage() {
           sx={{ mb: 3 }}
         >
           <Stack direction="row" alignItems="center" spacing={2}>
-            <Button
-              component={Link}
+            <LinkButton
               href="/practice-planner"
               startIcon={<ArrowBackIcon />}
               size="small"
             >
               Back
-            </Button>
+            </LinkButton>
             <Typography variant="h4" component="h1">
               Play Library
             </Typography>

--- a/app/(dashboard)/seasons/[seasonId]/page.tsx
+++ b/app/(dashboard)/seasons/[seasonId]/page.tsx
@@ -1,6 +1,6 @@
-import Link from "next/link";
 import { notFound } from "next/navigation";
-import { Button, Container, Stack } from "@mui/material";
+import { Container, Stack } from "@mui/material";
+import { LinkButton } from "@/components/ui/NextLinkComposites";
 import { getSeasonDetail } from "@/lib/actions/seasons";
 import { getAvailableVenues } from "@/lib/actions/venues";
 import { prisma } from "@/lib/db/prisma";
@@ -222,13 +222,12 @@ export default async function SeasonDetailPage({
             <>
               {canManage && season.leagueId ? (
                 <Stack direction="row" justifyContent="flex-end">
-                  <Button
-                    component={Link}
+                  <LinkButton
                     href={`/seasons/${season.id}/placement`}
                     sx={{ minHeight: 44 }}
                   >
                     Pre-season placement
-                  </Button>
+                  </LinkButton>
                 </Stack>
               ) : null}
               {canManage ? (

--- a/app/(dashboard)/seasons/[seasonId]/placement/page.tsx
+++ b/app/(dashboard)/seasons/[seasonId]/placement/page.tsx
@@ -1,6 +1,6 @@
-import Link from "next/link";
-import { Alert, Button, Chip, Container, Stack, Typography } from "@mui/material";
+import { Alert, Container, Stack, Typography } from "@mui/material";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
+import { LinkButton, LinkChip } from "@/components/ui/NextLinkComposites";
 import { prisma } from "@/lib/db/prisma";
 import { requireUserId } from "@/lib/auth/session";
 import { getPlacementBoard } from "@/lib/actions/placements";
@@ -31,14 +31,13 @@ export default async function PlacementPage({
 
   const backLink = (
     <Stack direction="row">
-      <Button
-        component={Link}
+      <LinkButton
         href={`/seasons/${seasonId}`}
         startIcon={<ArrowBackIcon />}
         sx={{ minHeight: 44 }}
       >
         Back to season
-      </Button>
+      </LinkButton>
     </Stack>
   );
 
@@ -93,8 +92,7 @@ export default async function PlacementPage({
 
         {phases.length > 0 ? (
           <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
-            <Chip
-              component={Link}
+            <LinkChip
               href={`/seasons/${seasonId}/placement`}
               clickable
               label="All games"
@@ -102,9 +100,8 @@ export default async function PlacementPage({
               variant={phaseId ? "outlined" : "filled"}
             />
             {phases.map((phase) => (
-              <Chip
+              <LinkChip
                 key={phase.id}
-                component={Link}
                 href={`/seasons/${seasonId}/placement?phaseId=${phase.id}`}
                 clickable
                 label={phase.name}

--- a/app/(dashboard)/seasons/page.tsx
+++ b/app/(dashboard)/seasons/page.tsx
@@ -1,6 +1,6 @@
-import Link from "next/link";
-import { Button, Container, Stack, Typography } from "@mui/material";
+import { Container, Stack, Typography } from "@mui/material";
 import AddIcon from "@mui/icons-material/Add";
+import { LinkButton } from "@/components/ui/NextLinkComposites";
 import { getSeasons } from "@/lib/actions/seasons";
 import { SeasonList, type SeasonListItem } from "@/components/features/seasons/SeasonList";
 
@@ -35,18 +35,17 @@ export default async function SeasonsPage({
             Seasons
           </Typography>
           <Stack direction="row" spacing={1}>
-            <Button component={Link} href="/seasons/proposals" sx={{ minHeight: 44 }}>
+            <LinkButton href="/seasons/proposals" sx={{ minHeight: 44 }}>
               Game proposals
-            </Button>
-            <Button
-              component={Link}
+            </LinkButton>
+            <LinkButton
               href="/seasons/new"
               variant="contained"
               startIcon={<AddIcon />}
               sx={{ minHeight: 44 }}
             >
               New season
-            </Button>
+            </LinkButton>
           </Stack>
         </Stack>
 

--- a/app/(dashboard)/signup-events/[eventId]/page.tsx
+++ b/app/(dashboard)/signup-events/[eventId]/page.tsx
@@ -1,8 +1,6 @@
-import Link from "next/link";
 import { notFound } from "next/navigation";
 import {
   Alert,
-  Button,
   Card,
   CardContent,
   Chip,
@@ -10,6 +8,7 @@ import {
   Stack,
   Typography,
 } from "@mui/material";
+import { LinkButton } from "@/components/ui/NextLinkComposites";
 import EditIcon from "@mui/icons-material/Edit";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import { getManagedSignupEvent } from "@/lib/actions/signup-events";
@@ -127,17 +126,16 @@ export default async function ManageSignupEventPage({
             </Typography>
           </Stack>
           <Stack direction="row" spacing={1}>
-            <Button component={Link} href={`/signup-events/${event.id}/edit`} startIcon={<EditIcon />}>
+            <LinkButton href={`/signup-events/${event.id}/edit`} startIcon={<EditIcon />}>
               Edit
-            </Button>
+            </LinkButton>
             {event.status === "PUBLISHED" && (event.visibility === "PUBLIC" || event.visibility === "LINK") ? (
-              <Button
-                component={Link}
+              <LinkButton
                 href={event.visibility === "LINK" && event.linkToken ? `/signups/l/${event.linkToken}` : `/signups/${event.id}`}
                 startIcon={<OpenInNewIcon />}
               >
                 View page
-              </Button>
+              </LinkButton>
             ) : null}
           </Stack>
         </Stack>

--- a/app/(dashboard)/signup-events/page.tsx
+++ b/app/(dashboard)/signup-events/page.tsx
@@ -1,8 +1,5 @@
-import Link from "next/link";
 import {
-  Button,
   Card,
-  CardActionArea,
   CardContent,
   Chip,
   Container,
@@ -10,6 +7,7 @@ import {
   Typography,
 } from "@mui/material";
 import AddIcon from "@mui/icons-material/Add";
+import { LinkButton, LinkCardActionArea } from "@/components/ui/NextLinkComposites";
 import { listMySignupEvents } from "@/lib/actions/signup-events";
 import { formatDateTime } from "@/lib/utils/date";
 
@@ -32,9 +30,9 @@ export default async function SignupEventsPage() {
           <Typography variant="h4" component="h1">
             Signup events
           </Typography>
-          <Button component={Link} href="/signup-events/new" variant="contained" startIcon={<AddIcon />}>
+          <LinkButton href="/signup-events/new" variant="contained" startIcon={<AddIcon />}>
             New event
-          </Button>
+          </LinkButton>
         </Stack>
 
         {events.length === 0 ? (
@@ -49,7 +47,7 @@ export default async function SignupEventsPage() {
                 event.hostOrganization?.name ?? event.hostLeague?.name ?? event.hostTeam?.name ?? "";
               return (
                 <Card key={event.id}>
-                  <CardActionArea component={Link} href={`/signup-events/${event.id}`}>
+                  <LinkCardActionArea href={`/signup-events/${event.id}`}>
                     <CardContent>
                       <Stack
                         direction={{ xs: "column", sm: "row" }}
@@ -78,7 +76,7 @@ export default async function SignupEventsPage() {
                         </Stack>
                       </Stack>
                     </CardContent>
-                  </CardActionArea>
+                  </LinkCardActionArea>
                 </Card>
               );
             })}

--- a/app/(dashboard)/venue-admin/[organizationId]/venues/[venueId]/layout/page.tsx
+++ b/app/(dashboard)/venue-admin/[organizationId]/venues/[venueId]/layout/page.tsx
@@ -1,7 +1,7 @@
-import Link from "next/link";
 import { notFound } from "next/navigation";
-import { Box, Button, Container, Stack, Typography } from "@mui/material";
+import { Box, Container, Stack, Typography } from "@mui/material";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
+import { LinkButton } from "@/components/ui/NextLinkComposites";
 import { prisma } from "@/lib/db/prisma";
 import { requireVenueProfileManager } from "@/lib/auth/session";
 import { getVenueLayout } from "@/lib/actions/venue-layout";
@@ -35,14 +35,13 @@ export default async function VenueLayoutPage({ params }: VenueLayoutPageProps) 
     <Container maxWidth="lg">
       <Stack spacing={3} sx={{ py: 4 }}>
         <Box>
-          <Button
-            component={Link}
+          <LinkButton
             href={`/venue-admin/${organizationId}/venues/${venueId}/profile`}
             startIcon={<ArrowBackIcon />}
             size="small"
           >
             Back to venue profile
-          </Button>
+          </LinkButton>
           <Typography variant="h4" component="h1" sx={{ mt: 1 }}>
             Facility Layout — {venue.name}
           </Typography>

--- a/app/(dashboard)/venue-admin/page.tsx
+++ b/app/(dashboard)/venue-admin/page.tsx
@@ -1,5 +1,5 @@
-import { Box, Button, Card, CardContent, Container, Stack, Typography } from "@mui/material";
-import Link from "next/link";
+import { Box, Card, CardContent, Container, Stack, Typography } from "@mui/material";
+import { LinkButton } from "@/components/ui/NextLinkComposites";
 import { getVenueAdminDashboard } from "@/lib/actions/venue-organizations";
 
 export default async function VenueAdminPage() {
@@ -22,9 +22,9 @@ export default async function VenueAdminPage() {
             <Typography variant="body1">
               Create a rink or venue organization to publish a branded profile and manage ice time.
             </Typography>
-            <Button component={Link} href="/venue-admin/new" variant="contained">
+            <LinkButton href="/venue-admin/new" variant="contained">
               Create Venue Organization
-            </Button>
+            </LinkButton>
           </Stack>
         ) : (
           <Stack spacing={2}>
@@ -39,46 +39,41 @@ export default async function VenueAdminPage() {
                       </Typography>
                     </Box>
                     <Box>
-                      <Button
-                        component={Link}
+                      <LinkButton
                         href={`/venue-admin/${organization.id}/payments`}
                         variant="text"
                         size="small"
                       >
                         Payments &amp; payouts
-                      </Button>
+                      </LinkButton>
                     </Box>
                       <Stack spacing={1}>
                       {organization.venues.map((venue) => (
                           <Stack key={venue.id} direction={{ xs: "column", sm: "row" }} spacing={1}>
-                            <Button
-                              component={Link}
+                            <LinkButton
                               href={`/venue-admin/${organization.id}/venues/${venue.id}/profile`}
                               variant="outlined"
                             >
                               Manage {venue.name}
-                            </Button>
-                            <Button
-                              component={Link}
+                            </LinkButton>
+                            <LinkButton
                               href={`/venue-admin/${organization.id}/venues/${venue.id}/schedule`}
                               variant="text"
                             >
                               Schedule
-                            </Button>
-                            <Button
-                              component={Link}
+                            </LinkButton>
+                            <LinkButton
                               href={`/venue-admin/${organization.id}/venues/${venue.id}/layout`}
                               variant="text"
                             >
                               Layout
-                            </Button>
-                            <Button
-                              component={Link}
+                            </LinkButton>
+                            <LinkButton
                               href={`/venue-admin/${organization.id}/venues/${venue.id}/registrations`}
                               variant="text"
                             >
                               Registrations
-                            </Button>
+                            </LinkButton>
                           </Stack>
                       ))}
                     </Stack>

--- a/app/(marketing)/associations/[slug]/events/page.tsx
+++ b/app/(marketing)/associations/[slug]/events/page.tsx
@@ -1,14 +1,13 @@
-import Link from "next/link";
 import { notFound } from "next/navigation";
 import {
   Card,
-  CardActionArea,
   CardContent,
   Chip,
   Container,
   Stack,
   Typography,
 } from "@mui/material";
+import { LinkCardActionArea } from "@/components/ui/NextLinkComposites";
 import { prisma } from "@/lib/db/prisma";
 import { listPublicSignupEvents } from "@/lib/actions/signup-events";
 import { AGE_CLASSIFICATION_LABELS } from "@/lib/utils/age-level";
@@ -53,7 +52,7 @@ export default async function AssociationEventsPage({
           <Stack spacing={2}>
             {events.map((event) => (
               <Card key={event.id}>
-                <CardActionArea component={Link} href={`/signups/${event.id}`}>
+                <LinkCardActionArea href={`/signups/${event.id}`}>
                   <CardContent>
                     <Stack spacing={0.5}>
                       <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap" useFlexGap>
@@ -73,7 +72,7 @@ export default async function AssociationEventsPage({
                       </Typography>
                     </Stack>
                   </CardContent>
-                </CardActionArea>
+                </LinkCardActionArea>
               </Card>
             ))}
           </Stack>

--- a/app/(marketing)/rinks/[slug]/schedule/page.tsx
+++ b/app/(marketing)/rinks/[slug]/schedule/page.tsx
@@ -1,6 +1,6 @@
-import Link from "next/link";
 import { notFound } from "next/navigation";
-import { Alert, Button, Card, CardContent, Chip, Container, Divider, Stack, Typography } from "@mui/material";
+import { Alert, Card, CardContent, Chip, Container, Divider, Stack, Typography } from "@mui/material";
+import { LinkButton } from "@/components/ui/NextLinkComposites";
 import { auth } from "@/auth";
 import { getSkillLevelReferences } from "@/lib/actions/venue-content";
 import { getPublicVenueSchedule } from "@/lib/actions/venue-schedules";
@@ -224,9 +224,9 @@ export default async function PublicRinkSchedulePage({ params, searchParams }: P
                             </Typography>
                           ))}
                       </Stack>
-                      <Button component={Link} href={`/signups/${event.id}`} variant="outlined" size="small">
+                      <LinkButton href={`/signups/${event.id}`} variant="outlined" size="small">
                         View & sign up
-                      </Button>
+                      </LinkButton>
                     </Stack>
                   </CardContent>
                 </Card>

--- a/app/(marketing)/signups/page.tsx
+++ b/app/(marketing)/signups/page.tsx
@@ -1,14 +1,13 @@
-import Link from "next/link";
 import type { Metadata } from "next";
 import {
   Card,
-  CardActionArea,
   CardContent,
   Chip,
   Container,
   Stack,
   Typography,
 } from "@mui/material";
+import { LinkCardActionArea } from "@/components/ui/NextLinkComposites";
 import { listPublicSignupEvents } from "@/lib/actions/signup-events";
 import { AGE_CLASSIFICATION_LABELS } from "@/lib/utils/age-level";
 import { formatDateTime } from "@/lib/utils/date";
@@ -45,7 +44,7 @@ export default async function PublicEventsPage() {
                 event.hostOrganization?.name ?? event.hostLeague?.name ?? event.hostTeam?.name ?? "";
               return (
                 <Card key={event.id}>
-                  <CardActionArea component={Link} href={`/signups/${event.id}`}>
+                  <LinkCardActionArea href={`/signups/${event.id}`}>
                     <CardContent>
                       <Stack spacing={0.5}>
                         <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap" useFlexGap>
@@ -70,7 +69,7 @@ export default async function PublicEventsPage() {
                         </Stack>
                       </Stack>
                     </CardContent>
-                  </CardActionArea>
+                  </LinkCardActionArea>
                 </Card>
               );
             })}

--- a/components/features/venue-admin/PublicRinkFilters.tsx
+++ b/components/features/venue-admin/PublicRinkFilters.tsx
@@ -1,5 +1,5 @@
-import Link from "next/link";
-import { Button, Card, CardContent, Stack, Typography } from "@mui/material";
+import { Card, CardContent, Stack, Typography } from "@mui/material";
+import { LinkButton } from "@/components/ui/NextLinkComposites";
 
 interface PublicRinkFilterOption {
   id: string;
@@ -18,9 +18,9 @@ export function PublicRinkFilters({ skillLevels, basePath }: { skillLevels: Publ
           <Typography variant="h6">Filter by level</Typography>
           <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
             {skillLevels.map((level) => (
-              <Button key={level.id} component={Link} href={`${basePath}?level=${level.id}`} variant="outlined" size="small">
+              <LinkButton key={level.id} href={`${basePath}?level=${level.id}`} variant="outlined" size="small">
                 {level.label}
-              </Button>
+              </LinkButton>
             ))}
           </Stack>
         </Stack>

--- a/components/features/venue-admin/PublicRinkProfile.tsx
+++ b/components/features/venue-admin/PublicRinkProfile.tsx
@@ -1,5 +1,5 @@
-import Link from "next/link";
-import { Box, Button, Card, CardContent, Chip, Stack, Typography } from "@mui/material";
+import { Box, Card, CardContent, Chip, Stack, Typography } from "@mui/material";
+import { LinkButton } from "@/components/ui/NextLinkComposites";
 import type { PublicVenueProfile, PublicVenueSummary } from "@/lib/utils/public-venues";
 
 interface PublicVenueRelationship {
@@ -28,9 +28,9 @@ export function PublicRinkProfileCard({ venue }: { venue: PublicVenueSummary }) 
             <Typography variant="body2">{venue.publicDescription}</Typography>
           ) : null}
           {venue.slug ? (
-            <Button component={Link} href={`/rinks/${venue.slug}`} variant="outlined">
+            <LinkButton href={`/rinks/${venue.slug}`} variant="outlined">
               View rink profile
-            </Button>
+            </LinkButton>
           ) : null}
         </Stack>
       </CardContent>
@@ -74,9 +74,9 @@ export function PublicRinkProfile({
             {venue.publicEmail ? <Typography>{venue.publicEmail}</Typography> : null}
             {venue.publicPhone ? <Typography>{venue.publicPhone}</Typography> : null}
             {venue.website ? (
-              <Button component={Link} href={venue.website} target="_blank" rel="noopener noreferrer">
+              <LinkButton href={venue.website} target="_blank" rel="noopener noreferrer">
                 Visit website
-              </Button>
+              </LinkButton>
             ) : null}
           </CardContent>
         </Card>
@@ -132,9 +132,9 @@ export function PublicRinkProfile({
               ))
             )}
             {venue.slug ? (
-              <Button component={Link} href={`/rinks/${venue.slug}/schedule`} variant="outlined">
+              <LinkButton href={`/rinks/${venue.slug}/schedule`} variant="outlined">
                 View full schedule
-              </Button>
+              </LinkButton>
             ) : null}
           </Stack>
         </CardContent>

--- a/components/ui/BrandLogo.tsx
+++ b/components/ui/BrandLogo.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import Image from 'next/image';
 import Link from 'next/link';
 import { Box, SxProps, Theme } from '@mui/material';

--- a/components/ui/NextLinkComposites.tsx
+++ b/components/ui/NextLinkComposites.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import Link from "next/link";
+import {
+  Button,
+  Card,
+  CardActionArea,
+  Chip,
+  Link as MuiLink,
+  ListItemButton,
+  type ButtonProps,
+  type CardActionAreaProps,
+  type CardProps,
+  type ChipProps,
+  type LinkProps as MuiLinkProps,
+  type ListItemButtonProps,
+} from "@mui/material";
+
+/**
+ * "use client" composites that bind `component={Link}` inside the client graph.
+ *
+ * In Next.js 16 `next/link` renders natively in Server Components (it is no
+ * longer a client reference), so passing it as `component={Link}` from a
+ * Server Component into an MUI client component throws
+ * "Functions cannot be passed directly to Client Components" at render time.
+ * Server Components should use these wrappers instead; Client Components can
+ * keep using `component={Link}` directly.
+ */
+
+export type LinkButtonProps = Omit<ButtonProps<typeof Link>, "component" | "href"> & {
+  href: string;
+};
+
+export function LinkButton(props: LinkButtonProps) {
+  return <Button component={Link} {...props} />;
+}
+
+export type LinkCardActionAreaProps = Omit<
+  CardActionAreaProps<typeof Link>,
+  "component" | "href"
+> & {
+  href: string;
+};
+
+export function LinkCardActionArea(props: LinkCardActionAreaProps) {
+  return <CardActionArea component={Link} {...props} />;
+}
+
+export type LinkListItemButtonProps = Omit<
+  ListItemButtonProps<typeof Link>,
+  "component" | "href"
+> & {
+  href: string;
+};
+
+export function LinkListItemButton(props: LinkListItemButtonProps) {
+  return <ListItemButton component={Link} {...props} />;
+}
+
+export type LinkMuiLinkProps = Omit<MuiLinkProps<typeof Link>, "component" | "href"> & {
+  href: string;
+};
+
+export function LinkMuiLink(props: LinkMuiLinkProps) {
+  return <MuiLink component={Link} {...props} />;
+}
+
+export type LinkCardProps = Omit<CardProps<typeof Link>, "component" | "href"> & {
+  href: string;
+};
+
+export function LinkCard(props: LinkCardProps) {
+  return <Card component={Link} {...props} />;
+}
+
+export type LinkChipProps = Omit<ChipProps<typeof Link>, "component" | "href"> & {
+  href: string;
+};
+
+export function LinkChip(props: LinkChipProps) {
+  return <Chip component={Link} {...props} />;
+}


### PR DESCRIPTION
## Summary

Fixes the production Server Component render errors on event, signup, venue, seasons, and dashboard pages (digest \`869086247\` and friends): **"Functions cannot be passed directly to Client Components."**

### Root cause

In Next 16, \`next/link\` renders natively in Server Components and is **no longer a client-reference module**. Passing it as \`component={Link}\` from a *server* component into MUI client components (Button, CardActionArea, Card, Chip, ListItemButton, MUI Link) sends a raw function across the RSC serialization boundary, which throws at render time. It is invisible to \`tsc\` and \`next build\` (these pages are dynamic and never prerendered) and only detonates when the element actually renders — which is why long-standing pages appeared fine until real click-through traffic hit them.

### Fix

New \`"use client"\` module \`components/ui/NextLinkComposites.tsx\` exporting \`LinkButton\`, \`LinkCardActionArea\`, \`LinkCard\`, \`LinkChip\`, \`LinkListItemButton\`, \`LinkMuiLink\` — thin wrappers that bind \`component={Link}\` *inside* the client graph (the same reason the existing client-component usages always worked). All 16 server files using the broken pattern are swept; client components are untouched; direct \`<Link href>\` element usage in server files remains (that's fine in Next 16).

Reproduced and verified end-to-end against a local production build with an authenticated session: \`/signup-events\` 500 → renders; \`/seasons\`, \`/venue-admin\`, \`/signups\`, \`/dashboard\` all clean.

### Follow-up noted

\`components/ui/NextLinkComponents.tsx\` (from #242) is an older parallel wrapper pair — worth consolidating into this module later.

## Test plan

- [x] Reproduced the exact production error locally (prod build + real login) before the fix
- [x] All five affected page groups verified rendering after the fix (browser-driven)
- [x] \`bun run type-check\`, full test suite, \`bun run build\` — green
- [x] Guard grep: every remaining \`component={Link}\` lives in a \`"use client"\` file