### PR TITLE
feat: Tier 1 foundations — app shell, date pickers, dev fixtures, dashboard v1

### DIFF
--- a/__tests__/components/features/seasons/SeasonForm.test.tsx
+++ b/__tests__/components/features/seasons/SeasonForm.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { SeasonForm } from "@/components/features/seasons/SeasonForm";
 import { createSeason } from "@/lib/actions/seasons";
@@ -35,8 +35,9 @@ describe("SeasonForm", () => {
 
       expect(screen.getByLabelText(/season name/i)).toBeInTheDocument();
       expect(screen.getByLabelText(/description/i)).toBeInTheDocument();
-      expect(screen.getByLabelText(/starts/i)).toBeInTheDocument();
-      expect(screen.getByLabelText(/ends/i)).toBeInTheDocument();
+      // MUI X pickers render an accessible group per date field
+      expect(screen.getByRole("group", { name: /starts/i })).toBeInTheDocument();
+      expect(screen.getByRole("group", { name: /ends/i })).toBeInTheDocument();
       expect(screen.getByRole("button", { name: /create season/i })).toBeInTheDocument();
     });
 
@@ -76,8 +77,14 @@ describe("SeasonForm", () => {
       render(<SeasonForm ownerOptions={singleOwner} />);
 
       await user.type(screen.getByLabelText(/season name/i), "Fall 2026");
-      fireEvent.change(screen.getByLabelText(/starts/i), { target: { value: "2026-09-01" } });
-      fireEvent.change(screen.getByLabelText(/ends/i), { target: { value: "2026-12-01" } });
+      // Type into the picker sections (MM/DD/YYYY) — auto-advances per section
+      // and flows through DateField state into the hidden form input.
+      const starts = screen.getByRole("group", { name: /starts/i });
+      await user.click(within(starts).getAllByRole("spinbutton")[0]);
+      await user.keyboard("09012026");
+      const ends = screen.getByRole("group", { name: /ends/i });
+      await user.click(within(ends).getAllByRole("spinbutton")[0]);
+      await user.keyboard("12012026");
       await user.click(screen.getByRole("button", { name: /create season/i }));
 
       await waitFor(() => {
@@ -127,8 +134,9 @@ describe("SeasonForm", () => {
 
       expect(screen.getByLabelText(/season name/i)).toHaveValue("Fall 2026");
       expect(screen.getByLabelText(/description/i)).toHaveValue("Our fall season");
-      expect(screen.getByLabelText(/starts/i)).toHaveValue("2026-09-01");
-      expect(screen.getByLabelText(/ends/i)).toHaveValue("2026-12-01");
+      // Canonical values live in the DateField hidden inputs the form submits
+      expect(document.querySelector('input[name="startDate"]')).toHaveValue("2026-09-01");
+      expect(document.querySelector('input[name="endDate"]')).toHaveValue("2026-12-01");
       expect(screen.getByRole("button", { name: /save changes/i })).toBeInTheDocument();
     });
   });

--- a/__tests__/components/ui/date/date-fields.test.tsx
+++ b/__tests__/components/ui/date/date-fields.test.tsx
@@ -107,6 +107,20 @@ describe("canonical string ↔ display Date conversion", () => {
     expect(parseTimeValue("12:75")).toBeNull();
   });
 
+  it("rejects rolled-over dates and times instead of silently shifting them", () => {
+    // The Date constructor would roll these into March / the next day.
+    expect(parseDateTimeValue("2026-02-31T14:30")).toBeNull();
+    expect(parseDateTimeValue("2026-07-11T25:00")).toBeNull();
+    expect(parseDateTimeValue("2026-07-11T14:61")).toBeNull();
+    expect(parseDateTimeValue("2026-13-01T14:30")).toBeNull();
+    expect(parseDateValue("2026-02-31")).toBeNull();
+    expect(parseDateValue("2026-13-01")).toBeNull();
+    expect(parseDateValue("2026-04-31")).toBeNull();
+    // Leap-day handling stays correct in both directions.
+    expect(parseDateValue("2024-02-29")).toEqual(new Date(2024, 1, 29));
+    expect(parseDateValue("2026-02-29")).toBeNull();
+  });
+
   it("formats null and Invalid Date as ''", () => {
     for (const format of [formatDateTimeValue, formatDateValue, formatTimeValue]) {
       expect(format(null)).toBe("");

--- a/__tests__/components/ui/date/date-fields.test.tsx
+++ b/__tests__/components/ui/date/date-fields.test.tsx
@@ -1,0 +1,326 @@
+/**
+ * Tests for the shared date/time field wrappers (components/ui/date).
+ *
+ * The public API of these components speaks canonical wall-clock strings
+ * ('YYYY-MM-DDTHH:MM' / 'YYYY-MM-DD' / 'HH:MM'); the internal display Date is
+ * presentation-only. These tests cover the string→display→string round-trip,
+ * hidden-input emission for FormData forms, empty/clear behavior, and that
+ * invalid input never emits garbage.
+ */
+
+import { ThemeProvider } from "@mui/material/styles";
+import { render, renderHook, screen, act, fireEvent, within } from "@testing-library/react";
+import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
+import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFns";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import theme from "@/lib/theme";
+import { DateTimeField } from "@/components/ui/date/DateTimeField";
+import { DateField } from "@/components/ui/date/DateField";
+import { TimeField } from "@/components/ui/date/TimeField";
+import {
+  formatDateTimeValue,
+  formatDateValue,
+  formatTimeValue,
+  parseDateTimeValue,
+  parseDateValue,
+  parseTimeValue,
+  useDateFieldState,
+} from "@/components/ui/date/internal";
+
+// jsdom's matchMedia never matches, which would force the pickers into their
+// mobile (read-only field + dialog) variant. Match MUI's desktop media query
+// ('(pointer: fine)') so the desktop popover variant renders in tests.
+const originalMatchMedia = window.matchMedia;
+
+beforeAll(() => {
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches: query.includes("pointer: fine"),
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+});
+
+afterAll(() => {
+  window.matchMedia = originalMatchMedia;
+});
+
+function renderField(ui: React.ReactElement) {
+  return render(
+    <ThemeProvider theme={theme}>
+      <LocalizationProvider dateAdapter={AdapterDateFns}>{ui}</LocalizationProvider>
+    </ThemeProvider>
+  );
+}
+
+function hiddenInput(name: string): HTMLInputElement | null {
+  return document.querySelector(`input[type="hidden"][name="${name}"]`);
+}
+
+/** Open the picker's popover via its toolbar button and return the dialog. */
+function openPicker(): HTMLElement {
+  fireEvent.click(screen.getByRole("button", { name: /Choose (date|time)/ }));
+  return screen.getByRole("dialog");
+}
+
+describe("canonical string ↔ display Date conversion", () => {
+  it("round-trips 'YYYY-MM-DDTHH:MM'", () => {
+    const date = parseDateTimeValue("2026-07-11T14:30");
+    expect(date).toEqual(new Date(2026, 6, 11, 14, 30));
+    expect(formatDateTimeValue(date)).toBe("2026-07-11T14:30");
+  });
+
+  it("round-trips 'YYYY-MM-DD'", () => {
+    const date = parseDateValue("2026-07-11");
+    expect(date).toEqual(new Date(2026, 6, 11));
+    expect(formatDateValue(date)).toBe("2026-07-11");
+  });
+
+  it("round-trips 'HH:MM' (including zero-padding)", () => {
+    const date = parseTimeValue("09:05");
+    expect(date?.getHours()).toBe(9);
+    expect(date?.getMinutes()).toBe(5);
+    expect(formatTimeValue(date)).toBe("09:05");
+  });
+
+  it("accepts an optional seconds suffix but never emits one", () => {
+    expect(formatDateTimeValue(parseDateTimeValue("2026-07-11T14:30:45"))).toBe(
+      "2026-07-11T14:30"
+    );
+    expect(formatTimeValue(parseTimeValue("14:30:45"))).toBe("14:30");
+  });
+
+  it("returns null for empty and malformed input", () => {
+    for (const parse of [parseDateTimeValue, parseDateValue, parseTimeValue]) {
+      expect(parse("")).toBeNull();
+      expect(parse(null)).toBeNull();
+      expect(parse(undefined)).toBeNull();
+      expect(parse("garbage")).toBeNull();
+    }
+    expect(parseDateTimeValue("2026-07-11")).toBeNull();
+    expect(parseDateValue("2026-07-11T14:30")).toBeNull();
+    expect(parseTimeValue("25:00")).toBeNull();
+    expect(parseTimeValue("12:75")).toBeNull();
+  });
+
+  it("formats null and Invalid Date as ''", () => {
+    for (const format of [formatDateTimeValue, formatDateValue, formatTimeValue]) {
+      expect(format(null)).toBe("");
+      expect(format(new Date(NaN))).toBe("");
+    }
+  });
+});
+
+describe("useDateFieldState", () => {
+  it("emits the canonical string for a valid picker change", () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() =>
+      useDateFieldState(parseDateTimeValue, formatDateTimeValue, { onChange })
+    );
+
+    act(() => result.current.handleChange(new Date(2026, 6, 11, 14, 30)));
+
+    expect(onChange).toHaveBeenCalledWith("2026-07-11T14:30");
+    expect(result.current.canonicalValue).toBe("2026-07-11T14:30");
+  });
+
+  it("emits '' (not garbage) for invalid picker input", () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() =>
+      useDateFieldState(parseDateTimeValue, formatDateTimeValue, { onChange })
+    );
+
+    act(() => result.current.handleChange(new Date(NaN)));
+
+    expect(onChange).toHaveBeenCalledWith("");
+    expect(result.current.canonicalValue).toBe("");
+  });
+
+  it("emits '' on clear", () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() =>
+      useDateFieldState(parseDateTimeValue, formatDateTimeValue, {
+        defaultValue: "2026-07-11T14:30",
+        onChange,
+      })
+    );
+
+    act(() => result.current.handleChange(null));
+
+    expect(onChange).toHaveBeenCalledWith("");
+    expect(result.current.canonicalValue).toBe("");
+  });
+
+  it("re-derives the display when a controlled value prop changes", () => {
+    const { result, rerender } = renderHook(
+      ({ value }: { value: string }) =>
+        useDateFieldState(parseDateTimeValue, formatDateTimeValue, { value }),
+      { initialProps: { value: "2026-07-11T14:30" } }
+    );
+
+    expect(result.current.displayValue).toEqual(new Date(2026, 6, 11, 14, 30));
+
+    rerender({ value: "2026-08-01T09:00" });
+    expect(result.current.displayValue).toEqual(new Date(2026, 7, 1, 9, 0));
+
+    rerender({ value: "" });
+    expect(result.current.displayValue).toBeNull();
+    expect(result.current.canonicalValue).toBe("");
+  });
+
+  it("does not clobber partial (invalid) input when the parent echoes back ''", () => {
+    const onChange = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ value }: { value: string }) =>
+        useDateFieldState(parseDateTimeValue, formatDateTimeValue, { value, onChange }),
+      { initialProps: { value: "" } }
+    );
+
+    const partial = new Date(NaN); // MUI emits Invalid Date while sections are incomplete
+    act(() => result.current.handleChange(partial));
+    expect(onChange).toHaveBeenCalledWith("");
+
+    // Controlled parent stores the '' we emitted and passes it back down —
+    // the in-progress display Date must survive.
+    rerender({ value: "" });
+    expect(result.current.displayValue).toBe(partial);
+  });
+});
+
+describe("DateTimeField", () => {
+  it("renders the hidden input with the canonical string (uncontrolled)", () => {
+    renderField(
+      <DateTimeField label="Starts at" name="startAt" defaultValue="2026-07-11T14:30" />
+    );
+
+    expect(hiddenInput("startAt")).toHaveValue("2026-07-11T14:30");
+    // The accessible field DOM renders a labelled group of editable sections.
+    expect(screen.getByRole("group", { name: /Starts at/ })).toBeInTheDocument();
+  });
+
+  it("renders empty and emits '' in the hidden input when no value is given", () => {
+    renderField(<DateTimeField label="Starts at" name="startAt" />);
+
+    expect(hiddenInput("startAt")).toHaveValue("");
+  });
+
+  it("omits the hidden input when no name is given", () => {
+    renderField(<DateTimeField label="Starts at" defaultValue="2026-07-11T14:30" />);
+
+    expect(document.querySelector('input[type="hidden"][name]')).toBeNull();
+  });
+
+  it("follows controlled value updates and clears to empty", () => {
+    const { rerender } = renderField(
+      <DateTimeField label="Starts at" name="startAt" value="2026-07-11T14:30" />
+    );
+    expect(hiddenInput("startAt")).toHaveValue("2026-07-11T14:30");
+
+    rerender(
+      <ThemeProvider theme={theme}>
+        <LocalizationProvider dateAdapter={AdapterDateFns}>
+          <DateTimeField label="Starts at" name="startAt" value="2026-12-25T09:00" />
+        </LocalizationProvider>
+      </ThemeProvider>
+    );
+    expect(hiddenInput("startAt")).toHaveValue("2026-12-25T09:00");
+
+    rerender(
+      <ThemeProvider theme={theme}>
+        <LocalizationProvider dateAdapter={AdapterDateFns}>
+          <DateTimeField label="Starts at" name="startAt" value="" />
+        </LocalizationProvider>
+      </ThemeProvider>
+    );
+    expect(hiddenInput("startAt")).toHaveValue("");
+  });
+
+  it("emits the canonical string when a day is picked", () => {
+    const onChange = vi.fn();
+    renderField(
+      <DateTimeField
+        label="Starts at"
+        name="startAt"
+        defaultValue="2026-07-11T14:30"
+        onChange={onChange}
+      />
+    );
+
+    const dialog = openPicker();
+    fireEvent.click(within(dialog).getByRole("gridcell", { name: "12" }));
+
+    expect(onChange).toHaveBeenCalledWith("2026-07-12T14:30");
+    expect(hiddenInput("startAt")).toHaveValue("2026-07-12T14:30");
+  });
+
+  it("offers minutes in 5-minute steps by default", () => {
+    renderField(<DateTimeField label="Starts at" defaultValue="2026-07-11T14:30" />);
+
+    const dialog = openPicker();
+    const minuteLabels = within(dialog)
+      .getAllByRole("option", { name: /minutes/ })
+      .map((option) => option.getAttribute("aria-label"));
+
+    expect(minuteLabels).toContain("5 minutes");
+    expect(minuteLabels).not.toContain("1 minutes");
+  });
+});
+
+describe("DateField", () => {
+  it("renders the hidden input with the canonical string (uncontrolled)", () => {
+    renderField(<DateField label="Start date" name="startDate" defaultValue="2026-07-11" />);
+
+    expect(hiddenInput("startDate")).toHaveValue("2026-07-11");
+  });
+
+  it("renders empty when no value is given", () => {
+    renderField(<DateField label="Start date" name="startDate" />);
+
+    expect(hiddenInput("startDate")).toHaveValue("");
+  });
+
+  it("emits the canonical string when a day is picked", () => {
+    const onChange = vi.fn();
+    renderField(
+      <DateField label="Start date" name="startDate" defaultValue="2026-07-11" onChange={onChange} />
+    );
+
+    const dialog = openPicker();
+    fireEvent.click(within(dialog).getByRole("gridcell", { name: "12" }));
+
+    expect(onChange).toHaveBeenCalledWith("2026-07-12");
+    expect(hiddenInput("startDate")).toHaveValue("2026-07-12");
+  });
+});
+
+describe("TimeField", () => {
+  it("renders the hidden input with the canonical string (uncontrolled)", () => {
+    renderField(<TimeField label="Start time" name="startTime" defaultValue="14:30" />);
+
+    expect(hiddenInput("startTime")).toHaveValue("14:30");
+  });
+
+  it("renders empty when no value is given", () => {
+    renderField(<TimeField label="Start time" name="startTime" />);
+
+    expect(hiddenInput("startTime")).toHaveValue("");
+  });
+
+  it("emits the canonical string when an hour is picked", () => {
+    const onChange = vi.fn();
+    renderField(
+      <TimeField label="Start time" name="startTime" defaultValue="14:30" onChange={onChange} />
+    );
+
+    // 14:30 renders as 02:30 PM; picking hour 3 (PM) yields 15:30.
+    const dialog = openPicker();
+    fireEvent.click(within(dialog).getByRole("option", { name: "3 hours" }));
+
+    expect(onChange).toHaveBeenCalledWith("15:30");
+    expect(hiddenInput("startTime")).toHaveValue("15:30");
+  });
+});

--- a/app/(dashboard)/admin/users/page.tsx
+++ b/app/(dashboard)/admin/users/page.tsx
@@ -1,10 +1,7 @@
 import { Suspense } from "react";
-import {
-  Container,
-  Typography,
-  Box,
-  CircularProgress,
-} from "@mui/material";
+import { Typography, Box, CircularProgress } from "@mui/material";
+import { PageContainer } from "@/components/ui/PageContainer";
+import { PageHeader } from "@/components/ui/PageHeader";
 import { isSystemAdmin, requireUserId } from "@/lib/auth/session";
 import { getAllUsers } from "@/lib/actions/admin";
 import UserApprovalList from "@/components/features/admin/UserApprovalList";
@@ -17,14 +14,12 @@ async function UserManagementContent() {
 
   if (!isAdmin) {
     return (
-      <Container maxWidth="lg" sx={{ mt: 4, mb: 4 }}>
-        <Typography variant="h4" component="h1" gutterBottom>
-          Access Denied
-        </Typography>
+      <PageContainer>
+        <PageHeader title="Access Denied" />
         <Typography variant="body1">
           You do not have permission to access this page. Only system administrators can manage user approvals.
         </Typography>
-      </Container>
+      </PageContainer>
     );
   }
 
@@ -32,30 +27,22 @@ async function UserManagementContent() {
 
   if (result.error || !result.data) {
     return (
-      <Container maxWidth="lg" sx={{ mt: 4, mb: 4 }}>
-        <Typography variant="h4" component="h1" gutterBottom>
-          Error
-        </Typography>
+      <PageContainer>
+        <PageHeader title="Error" />
         <Typography variant="body1">
           {result.error || "Failed to load users"}
         </Typography>
-      </Container>
+      </PageContainer>
     );
   }
 
   const users = result.data;
 
   return (
-    <Container maxWidth="lg" sx={{ mt: 4, mb: 4 }}>
-      <Typography variant="h4" component="h1" gutterBottom>
-        User Management
-      </Typography>
-      <Typography variant="body1" color="text.secondary" sx={{ mb: 3 }}>
-        Approve or reject user accounts
-      </Typography>
-
+    <PageContainer>
+      <PageHeader title="User Management" subtitle="Approve or reject user accounts" />
       <UserApprovalList users={users} />
-    </Container>
+    </PageContainer>
   );
 }
 
@@ -63,11 +50,11 @@ export default function UserManagementPage() {
   return (
     <Suspense
       fallback={
-        <Container maxWidth="lg" sx={{ mt: 4, mb: 4 }}>
+        <PageContainer>
           <Box sx={{ display: "flex", justifyContent: "center", alignItems: "center", minHeight: "50vh" }}>
             <CircularProgress />
           </Box>
-        </Container>
+        </PageContainer>
       }
     >
       <UserManagementContent />

--- a/app/(dashboard)/calendar/loading.tsx
+++ b/app/(dashboard)/calendar/loading.tsx
@@ -1,0 +1,17 @@
+import { Skeleton, Stack } from "@mui/material";
+import { PageContainer } from "@/components/ui/PageContainer";
+
+export default function CalendarLoading() {
+  return (
+    <PageContainer>
+      <Skeleton variant="text" width={200} sx={{ fontSize: "2.125rem" }} />
+      <Skeleton variant="text" width={240} sx={{ mb: 3 }} />
+      <Skeleton variant="text" width={200} sx={{ fontSize: "1.5rem", mb: 2 }} />
+      <Stack spacing={2}>
+        <Skeleton variant="rounded" height={112} />
+        <Skeleton variant="rounded" height={112} />
+        <Skeleton variant="rounded" height={112} />
+      </Stack>
+    </PageContainer>
+  );
+}

--- a/app/(dashboard)/calendar/page.tsx
+++ b/app/(dashboard)/calendar/page.tsx
@@ -1,60 +1,69 @@
-import { Container, Typography, Box, Divider } from "@mui/material";
+import { Box, Divider, Typography } from "@mui/material";
+import {
+  CalendarMonth as CalendarMonthIcon,
+  Event as EventIcon,
+} from "@mui/icons-material";
 import EventList from "@/components/features/calendar/EventList";
 import { getCalendarData } from "@/lib/actions/team-context";
+import { PageContainer } from "@/components/ui/PageContainer";
+import { PageHeader } from "@/components/ui/PageHeader";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { LinkButton } from "@/components/ui/NextLinkComposites";
 
 export default async function CalendarPage() {
   const data = await getCalendarData();
 
   if (!data) {
     return (
-      <Container maxWidth="lg">
-        <Box sx={{ py: 4 }}>
-          <Typography variant="h4" component="h1" gutterBottom>
-            Calendar
-          </Typography>
-          <Typography variant="body1" color="text.secondary">
-            You are not a member of any team yet.
-          </Typography>
-        </Box>
-      </Container>
+      <PageContainer>
+        <PageHeader title="Calendar" />
+        <EmptyState
+          icon={<CalendarMonthIcon />}
+          title="No team yet"
+          description="You are not a member of any team yet. Join or create a team to see its schedule here."
+          action={
+            <LinkButton href="/dashboard" variant="contained">
+              Go to dashboard
+            </LinkButton>
+          }
+        />
+      </PageContainer>
     );
   }
 
   return (
-    <Container maxWidth="lg">
-      <Box sx={{ py: 4 }}>
-        <Typography variant="h4" component="h1" gutterBottom>
-          Calendar
-        </Typography>
-        <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
-          {data.teamName}
-        </Typography>
+    <PageContainer>
+      <PageHeader title="Calendar" subtitle={data.teamName} />
 
-        <Box sx={{ mb: 4 }}>
-          <Typography variant="h5" component="h2" gutterBottom>
-            Upcoming Events
-          </Typography>
-          <EventList
-            events={data.upcomingEvents}
-            emptyMessage="No upcoming events scheduled"
+      <Box sx={{ mb: 4 }}>
+        <Typography variant="h5" component="h2" gutterBottom>
+          Upcoming Events
+        </Typography>
+        {data.upcomingEvents.length === 0 ? (
+          <EmptyState
+            icon={<EventIcon />}
+            title="No upcoming events"
+            description="Games and practices will appear here once they are scheduled."
           />
-        </Box>
-
-        {data.pastEvents.length > 0 && (
-          <>
-            <Divider sx={{ my: 4 }} />
-            <Box>
-              <Typography variant="h5" component="h2" gutterBottom>
-                Past Events
-              </Typography>
-              <EventList
-                events={data.pastEvents}
-                emptyMessage="No past events"
-              />
-            </Box>
-          </>
+        ) : (
+          <EventList events={data.upcomingEvents} />
         )}
       </Box>
-    </Container>
+
+      {data.pastEvents.length > 0 && (
+        <>
+          <Divider sx={{ my: 4 }} />
+          <Box>
+            <Typography variant="h5" component="h2" gutterBottom>
+              Past Events
+            </Typography>
+            <EventList
+              events={data.pastEvents}
+              emptyMessage="No past events"
+            />
+          </Box>
+        </>
+      )}
+    </PageContainer>
   );
 }

--- a/app/(dashboard)/dashboard/loading.tsx
+++ b/app/(dashboard)/dashboard/loading.tsx
@@ -1,0 +1,29 @@
+import { Box, Container, Skeleton } from "@mui/material";
+
+export default function DashboardLoading() {
+  return (
+    <Container maxWidth="lg">
+      <Box sx={{ py: 4 }}>
+        <Skeleton variant="text" width={240} sx={{ fontSize: "2rem", mb: 3 }} />
+        <Box
+          sx={{
+            display: "grid",
+            gridTemplateColumns: {
+              xs: "1fr",
+              sm: "repeat(2, 1fr)",
+              md: "repeat(3, 1fr)",
+            },
+            gap: 3,
+          }}
+        >
+          <Skeleton variant="rounded" height={220} />
+          <Skeleton variant="rounded" height={220} />
+          <Skeleton variant="rounded" height={220} />
+        </Box>
+        <Skeleton variant="text" width={220} sx={{ fontSize: "1.5rem", mt: 4, mb: 2 }} />
+        <Skeleton variant="rounded" height={64} sx={{ mb: 1.5 }} />
+        <Skeleton variant="rounded" height={64} />
+      </Box>
+    </Container>
+  );
+}

--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -1,47 +1,30 @@
+import { Suspense } from "react";
 import { Box, Container, Typography, Card, CardContent, Chip, Stack } from "@mui/material";
-import { LinkButton, LinkCard } from "@/components/ui/NextLinkComposites";
-import {
-  SportsHockey as SportsHockeyIcon,
-  AccessTime as ClockIcon,
-  CalendarToday as CalendarIcon,
-  ArrowForward as ArrowForwardIcon,
-} from "@mui/icons-material";
+import { LinkButton } from "@/components/ui/NextLinkComposites";
 import OnboardingFlow from "@/components/features/onboarding/OnboardingFlow";
 import CreateTeamDisclosure from "@/components/features/dashboard/CreateTeamDisclosure";
 import TeamCard from "@/components/features/dashboard/TeamCard";
-import { getUserMode } from "@/lib/utils/league-mode";
-import { getDashboardData } from "@/lib/actions/team-context";
+import UpcomingScheduleWidget, {
+  UpcomingScheduleWidgetSkeleton,
+} from "@/components/features/dashboard/widgets/UpcomingScheduleWidget";
+import NeedsRsvpWidget, {
+  NeedsRsvpWidgetSkeleton,
+} from "@/components/features/dashboard/widgets/NeedsRsvpWidget";
+import AdminAttentionWidget, {
+  AdminAttentionWidgetSkeleton,
+} from "@/components/features/dashboard/widgets/AdminAttentionWidget";
+import MyLeaguesWidget, {
+  MyLeaguesWidgetSkeleton,
+} from "@/components/features/dashboard/widgets/MyLeaguesWidget";
+import { getViewerMemberships } from "@/lib/data/dashboard";
 import { getTeamVenueRelationships } from "@/lib/actions/venue-relationships";
 import { requireUserId } from "@/lib/auth/session";
-import { formatSport } from "@/lib/utils/validation";
-import type { LeagueRole } from "@prisma/client";
-
-const LEAGUE_ROLE_LABELS: Record<LeagueRole, string> = {
-  LEAGUE_ADMIN: "League Admin",
-  TEAM_ADMIN: "Team Admin",
-  MEMBER: "Member",
-};
-
-const LEAGUE_ROLE_COLORS: Record<LeagueRole, "primary" | "secondary" | "default"> = {
-  LEAGUE_ADMIN: "primary",
-  TEAM_ADMIN: "secondary",
-  MEMBER: "default",
-};
 
 export default async function DashboardPage() {
   const userId = await requireUserId();
+  const { teams, leagues } = await getViewerMemberships(userId);
 
-  const [userMode, { teams, upcomingPractices, venueRelationships }] = await Promise.all([
-    getUserMode(userId),
-    getDashboardData().then(async (data) => ({
-      ...data,
-      venueRelationships: await getTeamVenueRelationships(
-        data.teams.map((teamMember) => teamMember.team.id)
-      ),
-    })),
-  ]);
-
-  if (teams.length === 0 && userMode.leagues.length === 0) {
+  if (teams.length === 0 && leagues.length === 0) {
     return (
       <Container maxWidth="md">
         <OnboardingFlow />
@@ -49,70 +32,23 @@ export default async function DashboardPage() {
     );
   }
 
+  const isLeagueMode = leagues.length > 0;
+  const teamIds = teams.map((membership) => membership.team.id);
+
   return (
     <Container maxWidth="lg">
       <Box sx={{ py: 4 }}>
-        {userMode.isLeagueMode ? (
+        <Typography variant="h4" component="h1" gutterBottom>
+          {isLeagueMode ? "League Dashboard" : "My Teams"}
+        </Typography>
+
+        {teams.length > 0 && (
           <>
-            <Typography variant="h4" component="h1" gutterBottom>
-              League Dashboard
-            </Typography>
-
-            {userMode.leagues.length > 0 && (
-              <Box sx={{ mb: 4 }}>
-                <Typography variant="h5" component="h2" gutterBottom>
-                  My Leagues
-                </Typography>
-                <Box
-                  sx={{
-                    display: "grid",
-                    gridTemplateColumns: {
-                      xs: "1fr",
-                      sm: "repeat(2, 1fr)",
-                      md: "repeat(3, 1fr)",
-                    },
-                    gap: 2,
-                    mb: 3,
-                  }}
-                >
-                  {userMode.leagues.map((league) => (
-                    <LinkCard
-                      key={league.id}
-                      variant="outlined"
-                      href={`/league/${league.id}/dashboard`}
-                      sx={{
-                        textDecoration: "none",
-                        color: "inherit",
-                        transition: "all 0.2s",
-                        "&:hover": {
-                          borderColor: "primary.main",
-                          boxShadow: 1,
-                        },
-                      }}
-                    >
-                      <CardContent>
-                        <Typography variant="h6" component="h3" gutterBottom>
-                          {league.name}
-                        </Typography>
-                        <Typography variant="body2" color="text.secondary">
-                          {formatSport(league.sport)}
-                        </Typography>
-                        <Chip
-                          label={LEAGUE_ROLE_LABELS[league.role]}
-                          size="small"
-                          color={LEAGUE_ROLE_COLORS[league.role]}
-                          sx={{ mt: 1 }}
-                        />
-                      </CardContent>
-                    </LinkCard>
-                  ))}
-                </Box>
-              </Box>
+            {isLeagueMode && (
+              <Typography variant="h5" component="h2" gutterBottom>
+                My Teams
+              </Typography>
             )}
-
-            <Typography variant="h5" component="h2" gutterBottom>
-              My Teams
-            </Typography>
             <Box
               sx={{
                 display: "grid",
@@ -125,139 +61,38 @@ export default async function DashboardPage() {
                 mt: 2,
               }}
             >
-              {teams.map((teamMember) => (
+              {teams.map((membership) => (
                 <TeamCard
-                  key={teamMember.team.id}
-                  team={teamMember.team}
-                  role={teamMember.role}
-                  showLeagueInfo={true}
-                />
-              ))}
-            </Box>
-          </>
-        ) : (
-          <>
-            <Typography variant="h4" component="h1" gutterBottom>
-              My Teams
-            </Typography>
-
-            <Box
-              sx={{
-                display: "grid",
-                gridTemplateColumns: {
-                  xs: "1fr",
-                  sm: "repeat(2, 1fr)",
-                  md: "repeat(3, 1fr)",
-                },
-                gap: 3,
-                mt: 3,
-              }}
-            >
-              {teams.map((teamMember) => (
-                <TeamCard
-                  key={teamMember.team.id}
-                  team={teamMember.team}
-                  role={teamMember.role}
-                  showLeagueInfo={false}
+                  key={membership.team.id}
+                  team={membership.team}
+                  role={membership.role}
+                  showLeagueInfo={isLeagueMode}
+                  showStats
                 />
               ))}
             </Box>
           </>
         )}
 
-        {!userMode.isLeagueMode && upcomingPractices.length > 0 && (
-          <Box sx={{ mt: 4 }}>
-            <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 2 }}>
-              <Typography variant="h5" component="h2">
-                Upcoming Practices
-              </Typography>
-              <LinkButton
-                href="/practice-planner"
-                endIcon={<ArrowForwardIcon />}
-                size="small"
-              >
-                View All
-              </LinkButton>
-            </Stack>
-            <Stack spacing={1.5}>
-              {upcomingPractices.map((practice) => (
-                <LinkCard
-                  key={practice.id}
-                  variant="outlined"
-                  href={`/practice-planner/${practice.id}`}
-                  sx={{
-                    textDecoration: "none",
-                    color: "inherit",
-                    transition: "all 0.2s",
-                    "&:hover": {
-                      borderColor: "primary.main",
-                      boxShadow: 1,
-                    },
-                  }}
-                >
-                  <CardContent sx={{ py: 1.5, "&:last-child": { pb: 1.5 } }}>
-                    <Stack direction="row" justifyContent="space-between" alignItems="center">
-                      <Stack direction="row" alignItems="center" spacing={1.5}>
-                        <SportsHockeyIcon sx={{ color: "primary.main", fontSize: 20 }} />
-                        <Box>
-                          <Typography variant="subtitle2" fontWeight={600}>
-                            {practice.title}
-                          </Typography>
-                          <Stack direction="row" spacing={1.5} sx={{ color: "text.secondary" }}>
-                            <Stack direction="row" alignItems="center" spacing={0.5}>
-                              <CalendarIcon sx={{ fontSize: 13 }} />
-                              <Typography variant="caption">
-                                {new Date(practice.date).toLocaleDateString("en-US", {
-                                  weekday: "short",
-                                  month: "short",
-                                  day: "numeric",
-                                })}
-                              </Typography>
-                            </Stack>
-                            <Stack direction="row" alignItems="center" spacing={0.5}>
-                              <ClockIcon sx={{ fontSize: 13 }} />
-                              <Typography variant="caption">
-                                {practice.duration} min
-                              </Typography>
-                            </Stack>
-                            <Typography variant="caption">
-                              {practice.playCount} play{practice.playCount !== 1 ? "s" : ""}
-                            </Typography>
-                          </Stack>
-                        </Box>
-                      </Stack>
-                    </Stack>
-                  </CardContent>
-                </LinkCard>
-              ))}
-            </Stack>
-          </Box>
-        )}
-
-        {venueRelationships.length > 0 && (
-          <Box sx={{ mt: 4 }}>
-            <Typography variant="h5" component="h2" gutterBottom>
-              Preferred and home rinks
-            </Typography>
-            <Stack spacing={1.5}>
-              {venueRelationships.map((relationship) => (
-                <Card key={relationship.id} variant="outlined">
-                  <CardContent>
-                    <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap" useFlexGap>
-                      <Typography variant="subtitle1">{relationship.venue.name}</Typography>
-                      <Chip size="small" label={relationship.relationshipType} />
-                      {relationship.venue.slug ? (
-                        <LinkButton href={`/rinks/${relationship.venue.slug}`} size="small">
-                          View rink
-                        </LinkButton>
-                      ) : null}
-                    </Stack>
-                  </CardContent>
-                </Card>
-              ))}
-            </Stack>
-          </Box>
-        )}
+        {/* Widget stack (decision D7 order). Each widget is an independent
+            async RSC that streams in behind its own Suspense fallback. */}
+        <Stack spacing={4} sx={{ mt: 4 }}>
+          <Suspense fallback={<UpcomingScheduleWidgetSkeleton />}>
+            <UpcomingScheduleWidget userId={userId} />
+          </Suspense>
+          <Suspense fallback={<NeedsRsvpWidgetSkeleton />}>
+            <NeedsRsvpWidget userId={userId} />
+          </Suspense>
+          <Suspense fallback={<AdminAttentionWidgetSkeleton />}>
+            <AdminAttentionWidget userId={userId} />
+          </Suspense>
+          <Suspense fallback={<MyLeaguesWidgetSkeleton />}>
+            <MyLeaguesWidget userId={userId} />
+          </Suspense>
+          <Suspense fallback={null}>
+            <VenueRelationshipsSection teamIds={teamIds} />
+          </Suspense>
+        </Stack>
 
         <Box sx={{ mt: 4 }}>
           <CreateTeamDisclosure
@@ -266,5 +101,35 @@ export default async function DashboardPage() {
         </Box>
       </Box>
     </Container>
+  );
+}
+
+async function VenueRelationshipsSection({ teamIds }: { teamIds: string[] }) {
+  const venueRelationships = await getTeamVenueRelationships(teamIds);
+  if (venueRelationships.length === 0) return null;
+
+  return (
+    <Box component="section">
+      <Typography variant="h5" component="h2" gutterBottom>
+        Preferred and home rinks
+      </Typography>
+      <Stack spacing={1.5}>
+        {venueRelationships.map((relationship) => (
+          <Card key={relationship.id} variant="outlined">
+            <CardContent>
+              <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap" useFlexGap>
+                <Typography variant="subtitle1">{relationship.venue.name}</Typography>
+                <Chip size="small" label={relationship.relationshipType} />
+                {relationship.venue.slug ? (
+                  <LinkButton href={`/rinks/${relationship.venue.slug}`} size="small">
+                    View rink
+                  </LinkButton>
+                ) : null}
+              </Stack>
+            </CardContent>
+          </Card>
+        ))}
+      </Stack>
+    </Box>
   );
 }

--- a/app/(dashboard)/error.tsx
+++ b/app/(dashboard)/error.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect } from "react";
+import { Alert, AlertTitle, Button, Container } from "@mui/material";
+
+export default function DashboardError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error("Dashboard route error:", error);
+  }, [error]);
+
+  return (
+    <Container maxWidth="md" sx={{ py: 4 }}>
+      <Alert
+        severity="error"
+        action={
+          <Button color="inherit" size="small" onClick={reset} sx={{ alignSelf: "center" }}>
+            Try again
+          </Button>
+        }
+      >
+        <AlertTitle>Something went wrong</AlertTitle>
+        We hit an unexpected error while loading this page. Try again, and if the problem
+        persists, refresh the page or come back later.
+      </Alert>
+    </Container>
+  );
+}

--- a/app/(dashboard)/events/[id]/edit/page.tsx
+++ b/app/(dashboard)/events/[id]/edit/page.tsx
@@ -1,8 +1,9 @@
 import { requireUserId } from "@/lib/auth/session";
 import { getEvent } from "@/lib/actions/events";
-import { Box, Container } from "@mui/material";
+import { Box } from "@mui/material";
 import { redirect, notFound } from "next/navigation";
 import EventForm from "@/components/features/events/EventForm";
+import { PageContainer } from "@/components/ui/PageContainer";
 
 interface EditEventPageProps {
   params: Promise<{
@@ -27,32 +28,31 @@ export default async function EditEventPage({ params }: EditEventPageProps) {
     redirect(`/events/${id}`);
   }
 
-    return (
-      <Container maxWidth="md">
-        <Box
-          sx={{
-            py: 4,
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "center",
+  return (
+    <PageContainer maxWidth="md">
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+        }}
+      >
+        <EventForm
+          teamId={event.teamId}
+          eventId={event.id}
+          initialData={{
+            type: event.type as "GAME" | "PRACTICE",
+            title: event.title,
+            startAt: event.startAt,
+            endAt: event.endAt ?? undefined,
+            timezone: event.timezone,
+            location: event.location,
+            venueId: event.venueId ?? undefined,
+            opponent: event.opponent || "",
+            notes: event.notes || "",
           }}
-        >
-          <EventForm
-            teamId={event.teamId}
-            eventId={event.id}
-            initialData={{
-              type: event.type as "GAME" | "PRACTICE",
-              title: event.title,
-              startAt: event.startAt,
-              endAt: event.endAt ?? undefined,
-              timezone: event.timezone,
-              location: event.location,
-              venueId: event.venueId ?? undefined,
-              opponent: event.opponent || "",
-              notes: event.notes || "",
-            }}
-          />
-        </Box>
-      </Container>
-    );
+        />
+      </Box>
+    </PageContainer>
+  );
 }

--- a/app/(dashboard)/events/[id]/page.tsx
+++ b/app/(dashboard)/events/[id]/page.tsx
@@ -1,8 +1,8 @@
 import { requireUserId } from "@/lib/auth/session";
 import { getEvent } from "@/lib/actions/events";
-import { Box, Container } from "@mui/material";
 import { notFound } from "next/navigation";
 import EventDetail from "@/components/features/events/EventDetail";
+import { PageContainer } from "@/components/ui/PageContainer";
 
 interface EventPageProps {
   params: Promise<{
@@ -23,14 +23,12 @@ export default async function EventPage({ params }: EventPageProps) {
   }
 
   return (
-    <Container maxWidth="lg">
-      <Box sx={{ py: 4 }}>
-        <EventDetail
-          event={event}
-          userRole={event.userRole}
-          currentUserId={userId}
-        />
-      </Box>
-    </Container>
+    <PageContainer>
+      <EventDetail
+        event={event}
+        userRole={event.userRole}
+        currentUserId={userId}
+      />
+    </PageContainer>
   );
 }

--- a/app/(dashboard)/events/new/page.tsx
+++ b/app/(dashboard)/events/new/page.tsx
@@ -1,7 +1,8 @@
-import { Box, Container } from "@mui/material";
+import { Box } from "@mui/material";
 import { redirect } from "next/navigation";
 import EventForm from "@/components/features/events/EventForm";
 import { getUserTeamContext } from "@/lib/actions/team-context";
+import { PageContainer } from "@/components/ui/PageContainer";
 
 export default async function NewEventPage() {
   const context = await getUserTeamContext();
@@ -15,10 +16,9 @@ export default async function NewEventPage() {
   }
 
   return (
-    <Container maxWidth="md">
+    <PageContainer maxWidth="md">
       <Box
         sx={{
-          py: 4,
           display: "flex",
           flexDirection: "column",
           alignItems: "center",
@@ -26,6 +26,6 @@ export default async function NewEventPage() {
       >
         <EventForm teamId={context.teamId} />
       </Box>
-    </Container>
+    </PageContainer>
   );
 }

--- a/app/(dashboard)/league/[leagueId]/invitations/page.tsx
+++ b/app/(dashboard)/league/[leagueId]/invitations/page.tsx
@@ -1,5 +1,6 @@
-import { Box, Container, Typography } from "@mui/material";
 import { notFound } from "next/navigation";
+import { PageContainer } from "@/components/ui/PageContainer";
+import { PageHeader } from "@/components/ui/PageHeader";
 import LeagueInvitationManager from "@/components/features/roster/LeagueInvitationManager";
 import { getLeagueInvitationsData } from "@/lib/actions/league-context";
 
@@ -16,28 +17,15 @@ export default async function LeagueInvitationsPage({ params }: LeagueInvitation
   }
 
   return (
-    <Container maxWidth="lg">
-      <Box sx={{ py: 4 }}>
-        <Box
-          sx={{
-            display: "flex",
-            justifyContent: "space-between",
-            alignItems: "center",
-            mb: 3,
-          }}
-        >
-          <Typography variant="h4" component="h1">
-            Invitations - {data.league.name}
-          </Typography>
-        </Box>
+    <PageContainer>
+      <PageHeader title="Invitations" subtitle={data.league.name} />
 
-        <LeagueInvitationManager
-          teams={data.teams}
-          invitations={data.invitations}
-          leagueId={leagueId}
-          isLeagueAdmin={data.isLeagueAdmin}
-        />
-      </Box>
-    </Container>
+      <LeagueInvitationManager
+        teams={data.teams}
+        invitations={data.invitations}
+        leagueId={leagueId}
+        isLeagueAdmin={data.isLeagueAdmin}
+      />
+    </PageContainer>
   );
 }

--- a/app/(dashboard)/league/[leagueId]/messages/page.tsx
+++ b/app/(dashboard)/league/[leagueId]/messages/page.tsx
@@ -1,5 +1,7 @@
-import { Box, Typography, Card, CardContent } from "@mui/material";
+import { Card, CardContent, Typography } from "@mui/material";
 import { notFound } from "next/navigation";
+import { PageContainer } from "@/components/ui/PageContainer";
+import { PageHeader } from "@/components/ui/PageHeader";
 import { LeagueMessagesView } from "@/components/features/communication/LeagueMessagesView";
 import { getLeagueMessagesData } from "@/lib/actions/league-context";
 
@@ -16,16 +18,11 @@ export default async function LeagueMessagesPage({ params }: LeagueMessagesPageP
   }
 
   return (
-    <Box>
-      <Box display="flex" justifyContent="space-between" alignItems="center" mb={3}>
-        <Typography variant="h4" component="h1">
-          League Messages
-        </Typography>
-      </Box>
-
-      <Typography variant="body1" color="text.secondary" mb={3}>
-        Send targeted messages and announcements to league members, divisions, or specific teams.
-      </Typography>
+    <PageContainer>
+      <PageHeader
+        title="League Messages"
+        subtitle="Send targeted messages and announcements to league members, divisions, or specific teams."
+      />
 
       {!data.canSendMessages && (
         <Card sx={{ mb: 3 }}>
@@ -41,6 +38,6 @@ export default async function LeagueMessagesPage({ params }: LeagueMessagesPageP
         leagueData={data.leagueData}
         canSendMessages={data.canSendMessages}
       />
-    </Box>
+    </PageContainer>
   );
 }

--- a/app/(dashboard)/league/[leagueId]/payments/page.tsx
+++ b/app/(dashboard)/league/[leagueId]/payments/page.tsx
@@ -1,4 +1,6 @@
-import { Alert, Card, CardContent, Container, Stack, Typography } from "@mui/material";
+import { Alert, Card, CardContent, Stack, Typography } from "@mui/material";
+import { PageContainer } from "@/components/ui/PageContainer";
+import { PageHeader } from "@/components/ui/PageHeader";
 import { getLeaguePaymentsOverview } from "@/lib/actions/league-payments";
 import { LeagueStripeConnectCard } from "@/components/features/signup-events/LeagueStripeConnectCard";
 import { formatCurrencyFromCents } from "@/lib/utils/currency";
@@ -16,12 +18,10 @@ export default async function LeaguePaymentsPage({
   const overview = await getLeaguePaymentsOverview(leagueId);
 
   return (
-    <Container maxWidth="md">
-      <Stack spacing={3} sx={{ py: { xs: 3, md: 5 } }}>
-        <Typography variant="h4" component="h1">
-          Payments
-        </Typography>
+    <PageContainer maxWidth="md">
+      <PageHeader title="Payments" />
 
+      <Stack spacing={3}>
         {onboarding === "complete" ? (
           <Alert severity="success">Welcome back — checking your Stripe account status…</Alert>
         ) : null}
@@ -87,6 +87,6 @@ export default async function LeaguePaymentsPage({
           </>
         )}
       </Stack>
-    </Container>
+    </PageContainer>
   );
 }

--- a/app/(dashboard)/league/[leagueId]/roster/page.tsx
+++ b/app/(dashboard)/league/[leagueId]/roster/page.tsx
@@ -1,5 +1,7 @@
-import { Box, Container, Typography, Divider } from "@mui/material";
+import { Divider } from "@mui/material";
 import { notFound } from "next/navigation";
+import { PageContainer } from "@/components/ui/PageContainer";
+import { PageHeader } from "@/components/ui/PageHeader";
 import LeagueRosterView from "@/components/features/roster/LeagueRosterView";
 import LeagueInvitationManager from "@/components/features/roster/LeagueInvitationManager";
 import { getLeagueRosterData } from "@/lib/actions/league-context";
@@ -17,41 +19,28 @@ export default async function LeagueRosterPage({ params }: LeagueRosterPageProps
   }
 
   return (
-    <Container maxWidth="lg">
-      <Box sx={{ py: 4 }}>
-        <Box
-          sx={{
-            display: "flex",
-            justifyContent: "space-between",
-            alignItems: "center",
-            mb: 3,
-          }}
-        >
-          <Typography variant="h4" component="h1">
-            League Roster - {data.league.name}
-          </Typography>
-        </Box>
+    <PageContainer>
+      <PageHeader title="League Roster" subtitle={data.league.name} />
 
-        {data.isLeagueAdmin && (
-          <>
-            <LeagueInvitationManager
-              teams={data.teams}
-              invitations={data.invitations}
-              leagueId={leagueId}
-              isLeagueAdmin={data.isLeagueAdmin}
-            />
-            <Divider sx={{ my: 4 }} />
-          </>
-        )}
+      {data.isLeagueAdmin && (
+        <>
+          <LeagueInvitationManager
+            teams={data.teams}
+            invitations={data.invitations}
+            leagueId={leagueId}
+            isLeagueAdmin={data.isLeagueAdmin}
+          />
+          <Divider sx={{ my: 4 }} />
+        </>
+      )}
 
-        <LeagueRosterView
-          players={data.players}
-          teams={data.teams}
-          divisions={data.divisions}
-          leagueId={leagueId}
-          isLeagueAdmin={data.isLeagueAdmin}
-        />
-      </Box>
-    </Container>
+      <LeagueRosterView
+        players={data.players}
+        teams={data.teams}
+        divisions={data.divisions}
+        leagueId={leagueId}
+        isLeagueAdmin={data.isLeagueAdmin}
+      />
+    </PageContainer>
   );
 }

--- a/app/(dashboard)/league/[leagueId]/schedule/new-game/page.tsx
+++ b/app/(dashboard)/league/[leagueId]/schedule/new-game/page.tsx
@@ -1,5 +1,9 @@
-import { Container, Box, Typography } from "@mui/material";
+import GroupsIcon from "@mui/icons-material/Groups";
 import { notFound } from "next/navigation";
+import { LinkButton } from "@/components/ui/NextLinkComposites";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { PageContainer } from "@/components/ui/PageContainer";
+import { PageHeader } from "@/components/ui/PageHeader";
 import InterTeamGameForm from "@/components/features/events/InterTeamGameForm";
 import { getNewLeagueGameContext } from "@/lib/actions/league-context";
 
@@ -18,34 +22,33 @@ export default async function NewGamePage({ params }: NewGamePageProps) {
 
   if (data.teams.length < 2) {
     return (
-      <Container maxWidth="md">
-        <Box sx={{ py: 4 }}>
-          <Typography variant="h4" component="h1" gutterBottom>
-            Schedule Inter-Team Game
-          </Typography>
-          <Typography variant="body1" color="text.secondary">
-            You need at least 2 teams in the league to schedule inter-team games.
-          </Typography>
-        </Box>
-      </Container>
+      <PageContainer maxWidth="md">
+        <PageHeader title="Schedule Inter-Team Game" />
+        <EmptyState
+          icon={<GroupsIcon />}
+          title="Not enough teams"
+          description="You need at least 2 teams in the league to schedule inter-team games."
+          action={
+            <LinkButton href={`/league/${leagueId}/teams/new`} variant="contained">
+              Add a team
+            </LinkButton>
+          }
+        />
+      </PageContainer>
     );
   }
 
   return (
-    <Container maxWidth="md">
-      <Box sx={{ py: 4 }}>
-        <Typography variant="h4" component="h1" gutterBottom>
-          Schedule Inter-Team Game
-        </Typography>
-        <Typography variant="body2" color="text.secondary" sx={{ mb: 4 }}>
-          {data.league.name} • Create a game between two teams
-        </Typography>
+    <PageContainer maxWidth="md">
+      <PageHeader
+        title="Schedule Inter-Team Game"
+        subtitle={`${data.league.name} • Create a game between two teams`}
+      />
 
-        <InterTeamGameForm
-          leagueId={leagueId}
-          teams={data.teams}
-        />
-      </Box>
-    </Container>
+      <InterTeamGameForm
+        leagueId={leagueId}
+        teams={data.teams}
+      />
+    </PageContainer>
   );
 }

--- a/app/(dashboard)/league/[leagueId]/schedule/page.tsx
+++ b/app/(dashboard)/league/[leagueId]/schedule/page.tsx
@@ -1,7 +1,8 @@
-import { Container, Box, Typography } from "@mui/material";
 import { Add } from "@mui/icons-material";
 import { notFound } from "next/navigation";
 import { LinkButton } from "@/components/ui/NextLinkComposites";
+import { PageContainer } from "@/components/ui/PageContainer";
+import { PageHeader } from "@/components/ui/PageHeader";
 import LeagueCalendar from "@/components/features/calendar/LeagueCalendar";
 import { getLeagueScheduleData } from "@/lib/actions/league-context";
 import { formatSport } from "@/lib/utils/validation";
@@ -19,26 +20,12 @@ export default async function LeagueSchedulePage({ params }: LeagueSchedulePageP
   }
 
   return (
-    <Container maxWidth="lg">
-      <Box sx={{ py: 4 }}>
-        <Box sx={{
-          display: "flex",
-          justifyContent: "space-between",
-          alignItems: "flex-start",
-          mb: 3,
-          flexWrap: "wrap",
-          gap: 2,
-        }}>
-          <Box>
-            <Typography variant="h4" component="h1" gutterBottom>
-              League Schedule
-            </Typography>
-            <Typography variant="body2" color="text.secondary">
-              {data.league.name} • {formatSport(data.league.sport)}
-            </Typography>
-          </Box>
-
-          {data.canCreateGames && (
+    <PageContainer>
+      <PageHeader
+        title="League Schedule"
+        subtitle={`${data.league.name} • ${formatSport(data.league.sport)}`}
+        actions={
+          data.canCreateGames ? (
             <LinkButton
               href={`/league/${leagueId}/schedule/new-game`}
               variant="contained"
@@ -46,17 +33,17 @@ export default async function LeagueSchedulePage({ params }: LeagueSchedulePageP
             >
               Schedule Game
             </LinkButton>
-          )}
-        </Box>
+          ) : undefined
+        }
+      />
 
-        <LeagueCalendar
-          events={data.events}
-          teams={data.teams}
-          divisions={data.divisions}
-          leagueId={leagueId}
-          leagueName={data.league.name}
-        />
-      </Box>
-    </Container>
+      <LeagueCalendar
+        events={data.events}
+        teams={data.teams}
+        divisions={data.divisions}
+        leagueId={leagueId}
+        leagueName={data.league.name}
+      />
+    </PageContainer>
   );
 }

--- a/app/(dashboard)/league/[leagueId]/statistics/page.tsx
+++ b/app/(dashboard)/league/[leagueId]/statistics/page.tsx
@@ -2,7 +2,8 @@ import { requireUserId } from "@/lib/auth/session";
 import { notFound } from "next/navigation";
 import { hasLeagueAccess, getLeagueStatisticsData } from "@/lib/actions/league";
 import LeagueStatisticsDashboard from "@/components/features/dashboard/LeagueStatisticsDashboard";
-import { Box, Alert } from "@mui/material";
+import { Alert } from "@mui/material";
+import { PageContainer } from "@/components/ui/PageContainer";
 
 interface LeagueStatisticsPageProps {
     params: Promise<{
@@ -25,11 +26,11 @@ export default async function LeagueStatisticsPage({ params }: LeagueStatisticsP
 
     if (!result.success) {
         return (
-            <Box sx={{ p: 3 }}>
+            <PageContainer>
                 <Alert severity="error">
                     {result.error}
                 </Alert>
-            </Box>
+            </PageContainer>
         );
     }
 

--- a/app/(dashboard)/league/loading.tsx
+++ b/app/(dashboard)/league/loading.tsx
@@ -1,0 +1,15 @@
+import { Skeleton, Stack } from "@mui/material";
+import { PageContainer } from "@/components/ui/PageContainer";
+
+export default function LeagueLoading() {
+  return (
+    <PageContainer>
+      <Skeleton variant="text" width={240} sx={{ fontSize: "2.125rem", mb: 3 }} />
+      <Stack spacing={2}>
+        <Skeleton variant="rounded" height={120} />
+        <Skeleton variant="rounded" height={120} />
+        <Skeleton variant="rounded" height={120} />
+      </Stack>
+    </PageContainer>
+  );
+}

--- a/app/(dashboard)/my-registrations/loading.tsx
+++ b/app/(dashboard)/my-registrations/loading.tsx
@@ -1,0 +1,15 @@
+import { Skeleton, Stack } from "@mui/material";
+import { PageContainer } from "@/components/ui/PageContainer";
+
+export default function MyRegistrationsLoading() {
+  return (
+    <PageContainer maxWidth="md">
+      <Skeleton variant="text" width={240} sx={{ fontSize: "2.125rem", mb: 3 }} />
+      <Stack spacing={2}>
+        <Skeleton variant="rounded" height={120} />
+        <Skeleton variant="rounded" height={120} />
+        <Skeleton variant="rounded" height={120} />
+      </Stack>
+    </PageContainer>
+  );
+}

--- a/app/(dashboard)/my-registrations/page.tsx
+++ b/app/(dashboard)/my-registrations/page.tsx
@@ -1,5 +1,11 @@
 import Link from "next/link";
-import { Card, CardContent, Chip, Container, Divider, Stack, Typography } from "@mui/material";
+import { Card, CardContent, Chip, Divider, Stack, Typography } from "@mui/material";
+import ReceiptLongIcon from "@mui/icons-material/ReceiptLong";
+import EventAvailableIcon from "@mui/icons-material/EventAvailable";
+import { LinkButton } from "@/components/ui/NextLinkComposites";
+import { PageContainer } from "@/components/ui/PageContainer";
+import { PageHeader } from "@/components/ui/PageHeader";
+import { EmptyState } from "@/components/ui/EmptyState";
 import { getMyRegistrations } from "@/lib/actions/session-registrations";
 import { getMyEventRegistrations } from "@/lib/actions/event-registrations";
 import { CancelRegistrationButton } from "@/components/features/venue-admin";
@@ -44,19 +50,23 @@ export default async function MyRegistrationsPage() {
   ]);
 
   return (
-    <Container maxWidth="md">
-      <Stack spacing={3} sx={{ py: { xs: 4, md: 6 } }}>
-        <Typography variant="h4" component="h1">
-          My registrations
-        </Typography>
-
+    <PageContainer maxWidth="md">
+      <PageHeader title="My registrations" />
+      <Stack spacing={3}>
         <Typography variant="h5" component="h2">
           Rink sessions &amp; lessons
         </Typography>
         {registrations.length === 0 ? (
-          <Typography color="text.secondary">
-            You haven&apos;t registered for any sessions yet. Browse a rink&apos;s schedule to get started.
-          </Typography>
+          <EmptyState
+            icon={<ReceiptLongIcon />}
+            title="No session registrations yet"
+            description="Browse a rink's schedule to register for public sessions and lessons."
+            action={
+              <LinkButton href="/rinks" variant="outlined">
+                Browse rinks
+              </LinkButton>
+            }
+          />
         ) : (
           <Stack spacing={2}>
             {registrations.map((reg) => {
@@ -113,9 +123,16 @@ export default async function MyRegistrationsPage() {
           Event signups
         </Typography>
         {eventRegistrations.length === 0 ? (
-          <Typography color="text.secondary">
-            No event signups yet. Browse <Link href="/signups">upcoming events</Link> to join one.
-          </Typography>
+          <EmptyState
+            icon={<EventAvailableIcon />}
+            title="No event signups yet"
+            description="Browse upcoming events to join one."
+            action={
+              <LinkButton href="/signups" variant="outlined">
+                Browse upcoming events
+              </LinkButton>
+            }
+          />
         ) : (
           <Stack spacing={2}>
             {eventRegistrations.map((reg) => {
@@ -213,6 +230,6 @@ export default async function MyRegistrationsPage() {
           </Stack>
         )}
       </Stack>
-    </Container>
+    </PageContainer>
   );
 }

--- a/app/(dashboard)/not-found.tsx
+++ b/app/(dashboard)/not-found.tsx
@@ -1,0 +1,21 @@
+import SearchOffIcon from "@mui/icons-material/SearchOff";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { PageContainer } from "@/components/ui/PageContainer";
+import { LinkButton } from "@/components/ui/NextLinkComposites";
+
+export default function DashboardNotFound() {
+  return (
+    <PageContainer maxWidth="md">
+      <EmptyState
+        icon={<SearchOffIcon />}
+        title="Page not found"
+        description="The page you are looking for does not exist or may have been moved."
+        action={
+          <LinkButton href="/dashboard" variant="contained" sx={{ minHeight: 44 }}>
+            Back to dashboard
+          </LinkButton>
+        }
+      />
+    </PageContainer>
+  );
+}

--- a/app/(dashboard)/practice-planner/PracticePlannerList.tsx
+++ b/app/(dashboard)/practice-planner/PracticePlannerList.tsx
@@ -23,6 +23,8 @@ import { useTheme } from "@mui/material/styles";
 import useMediaQuery from "@mui/material/useMediaQuery";
 import Link from "next/link";
 import Image from "next/image";
+import { PageHeader } from "@/components/ui/PageHeader";
+import { EmptyState } from "@/components/ui/EmptyState";
 import AddIcon from "@mui/icons-material/Add";
 import LibraryBooksIcon from "@mui/icons-material/LibraryBooks";
 import SearchIcon from "@mui/icons-material/Search";
@@ -121,44 +123,34 @@ export default function PracticePlannerList({
   return (
     <>
       {/* Header */}
-      <Stack
-        direction={{ xs: "column", sm: "row" }}
-        justifyContent="space-between"
-        alignItems={{ xs: "stretch", sm: "center" }}
-        spacing={2}
-        sx={{ mb: 3 }}
-      >
-        <Box>
-          <Typography variant="h4" component="h1" sx={{ fontWeight: 800 }}>
-            Practice Planner
-          </Typography>
-          <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
-            {teamName}
-          </Typography>
-        </Box>
-        {isAdmin && (
-          <Stack direction="row" spacing={1.5}>
-            <Button
-              component={Link}
-              href="/practice-planner/library"
-              variant="outlined"
-              startIcon={<LibraryBooksIcon />}
-              size={isMobile ? "small" : "medium"}
-            >
-              Play Library
-            </Button>
-            <Button
-              component={Link}
-              href="/practice-planner/new"
-              variant="contained"
-              startIcon={<AddIcon />}
-              size={isMobile ? "small" : "medium"}
-            >
-              New Session
-            </Button>
-          </Stack>
-        )}
-      </Stack>
+      <PageHeader
+        title="Practice Planner"
+        subtitle={teamName}
+        actions={
+          isAdmin ? (
+            <>
+              <Button
+                component={Link}
+                href="/practice-planner/library"
+                variant="outlined"
+                startIcon={<LibraryBooksIcon />}
+                size={isMobile ? "small" : "medium"}
+              >
+                Play Library
+              </Button>
+              <Button
+                component={Link}
+                href="/practice-planner/new"
+                variant="contained"
+                startIcon={<AddIcon />}
+                size={isMobile ? "small" : "medium"}
+              >
+                New Session
+              </Button>
+            </>
+          ) : undefined
+        }
+      />
 
       {!isAdmin && (
         <Alert
@@ -250,7 +242,7 @@ export default function PracticePlannerList({
 
       {/* Session Grid */}
       {filteredSessions.length === 0 ? (
-        <EmptyState
+        <SessionsEmptyState
           isAdmin={isAdmin}
           hasSearch={!!search.trim()}
           timeFilter={timeFilter}
@@ -419,7 +411,7 @@ function SessionCard({
   );
 }
 
-function EmptyState({
+function SessionsEmptyState({
   isAdmin,
   hasSearch,
   timeFilter,
@@ -430,21 +422,11 @@ function EmptyState({
 }) {
   if (hasSearch) {
     return (
-      <Box
-        sx={{
-          textAlign: "center",
-          py: 8,
-          px: 3,
-        }}
-      >
-        <SearchIcon sx={{ fontSize: 56, color: "grey.300", mb: 2 }} />
-        <Typography variant="h6" color="text.secondary" gutterBottom>
-          No matching sessions
-        </Typography>
-        <Typography variant="body2" color="text.secondary">
-          Try a different search term or adjust your filters.
-        </Typography>
-      </Box>
+      <EmptyState
+        icon={<SearchIcon />}
+        title="No matching sessions"
+        description="Try a different search term or adjust your filters."
+      />
     );
   }
 
@@ -464,36 +446,26 @@ function EmptyState({
   };
 
   return (
-    <Box
-      sx={{
-        textAlign: "center",
-        py: 8,
-        px: 3,
-        bgcolor: "background.paper",
-        borderRadius: 3,
-        border: "2px dashed",
-        borderColor: "divider",
-      }}
-    >
-      <SportsHockeyIcon sx={{ fontSize: 56, color: "grey.300", mb: 2 }} />
-      <Typography variant="h6" color="text.secondary" gutterBottom>
-        {timeFilter === "all"
+    <EmptyState
+      icon={<SportsHockeyIcon />}
+      title={
+        timeFilter === "all"
           ? "No practice sessions yet"
-          : `No ${timeFilter} sessions`}
-      </Typography>
-      <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
-        {messages[timeFilter][isAdmin ? "admin" : "member"]}
-      </Typography>
-      {isAdmin && timeFilter !== "past" && (
-        <Button
-          component={Link}
-          href="/practice-planner/new"
-          variant="contained"
-          startIcon={<AddIcon />}
-        >
-          Create Practice Session
-        </Button>
-      )}
-    </Box>
+          : `No ${timeFilter} sessions`
+      }
+      description={messages[timeFilter][isAdmin ? "admin" : "member"]}
+      action={
+        isAdmin && timeFilter !== "past" ? (
+          <Button
+            component={Link}
+            href="/practice-planner/new"
+            variant="contained"
+            startIcon={<AddIcon />}
+          >
+            Create Practice Session
+          </Button>
+        ) : undefined
+      }
+    />
   );
 }

--- a/app/(dashboard)/practice-planner/[sessionId]/SessionDetailView.tsx
+++ b/app/(dashboard)/practice-planner/[sessionId]/SessionDetailView.tsx
@@ -41,6 +41,7 @@ import {
   PlayArrow as PlayIcon,
   Place as PlaceIcon,
 } from "@mui/icons-material";
+import { EmptyState } from "@/components/ui/EmptyState";
 import {
   deletePracticeSession,
   sharePracticeSession,
@@ -340,26 +341,28 @@ export function SessionDetailView({ session, isAdmin }: SessionDetailViewProps) 
 
       {/* Content area */}
       {session.plays.length === 0 ? (
-        <Paper sx={{ p: 6, textAlign: "center" }}>
-          <HockeyIcon sx={{ fontSize: 56, color: "grey.300", mb: 2 }} />
-          <Typography variant="h6" color="text.secondary" gutterBottom>
-            No plays in this session
-          </Typography>
-          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-            {isAdmin
-              ? "Edit the session to add plays from the library."
-              : "The coach hasn't added any plays yet."}
-          </Typography>
-          {isAdmin && (
-            <Button
-              component={Link}
-              href={`/practice-planner/${session.id}/edit`}
-              variant="contained"
-              startIcon={<EditIcon />}
-            >
-              Edit Session
-            </Button>
-          )}
+        <Paper>
+          <EmptyState
+            icon={<HockeyIcon />}
+            title="No plays in this session"
+            description={
+              isAdmin
+                ? "Edit the session to add plays from the library."
+                : "The coach hasn't added any plays yet."
+            }
+            action={
+              isAdmin ? (
+                <Button
+                  component={Link}
+                  href={`/practice-planner/${session.id}/edit`}
+                  variant="contained"
+                  startIcon={<EditIcon />}
+                >
+                  Edit Session
+                </Button>
+              ) : undefined
+            }
+          />
         </Paper>
       ) : (
         <Stack direction={{ xs: "column", md: "row" }} spacing={3}>

--- a/app/(dashboard)/practice-planner/[sessionId]/edit/page.tsx
+++ b/app/(dashboard)/practice-planner/[sessionId]/edit/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
-import { Container, Box } from "@mui/material";
+import { PageContainer } from "@/components/ui/PageContainer";
 import { EditSessionWrapper } from "./EditSessionWrapper";
 import { getPracticeSessionForEdit } from "@/lib/actions/practice-session-queries";
 import { getVenueBookingOptions } from "../../venue-booking-options";
@@ -29,15 +29,13 @@ export default async function EditPracticeSessionPage({ params }: PageProps) {
   const bookingOptions = await getVenueBookingOptions();
 
   return (
-    <Container maxWidth="lg">
-      <Box sx={{ py: 4 }}>
-        <EditSessionWrapper
-          sessionId={data.sessionId}
-          teamId={data.teamId}
-          initialData={data.initialData}
-          bookingOptions={bookingOptions}
-        />
-      </Box>
-    </Container>
+    <PageContainer>
+      <EditSessionWrapper
+        sessionId={data.sessionId}
+        teamId={data.teamId}
+        initialData={data.initialData}
+        bookingOptions={bookingOptions}
+      />
+    </PageContainer>
   );
 }

--- a/app/(dashboard)/practice-planner/[sessionId]/page.tsx
+++ b/app/(dashboard)/practice-planner/[sessionId]/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
-import { Container, Box } from "@mui/material";
+import { PageContainer } from "@/components/ui/PageContainer";
 import { SessionDetailView } from "@/app/(dashboard)/practice-planner/[sessionId]/SessionDetailView";
 import { getPracticeSessionDetail } from "@/lib/actions/practice-session-queries";
 
@@ -25,10 +25,8 @@ export default async function PracticeSessionDetailPage({ params }: PageProps) {
   }
 
   return (
-    <Container maxWidth="lg">
-      <Box sx={{ py: 4 }}>
-        <SessionDetailView session={data.session} isAdmin={data.isAdmin} />
-      </Box>
-    </Container>
+    <PageContainer>
+      <SessionDetailView session={data.session} isAdmin={data.isAdmin} />
+    </PageContainer>
   );
 }

--- a/app/(dashboard)/practice-planner/library/[playId]/edit/page.tsx
+++ b/app/(dashboard)/practice-planner/library/[playId]/edit/page.tsx
@@ -1,7 +1,8 @@
-import { Box, Container, Alert } from "@mui/material";
+import { Alert } from "@mui/material";
 import { notFound, redirect } from "next/navigation";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import { LinkButton } from "@/components/ui/NextLinkComposites";
+import { PageContainer } from "@/components/ui/PageContainer";
 import { getPlayLibraryContext } from "@/lib/actions/practice-session-queries";
 import { getPlayById } from "@/lib/actions/plays";
 import { PlayEditorWrapper } from "../../PlayEditorWrapper";
@@ -27,20 +28,18 @@ export default async function EditPlayPage({ params }: PageProps) {
 
   if (!context.isAdmin) {
     return (
-      <Container maxWidth="lg">
-        <Box sx={{ py: 4 }}>
-          <Alert severity="warning">
-            Only team admins can edit plays.
-          </Alert>
-          <LinkButton
-            href="/practice-planner/library"
-            startIcon={<ArrowBackIcon />}
-            sx={{ mt: 2 }}
-          >
-            Back to Play Library
-          </LinkButton>
-        </Box>
-      </Container>
+      <PageContainer>
+        <Alert severity="warning">
+          Only team admins can edit plays.
+        </Alert>
+        <LinkButton
+          href="/practice-planner/library"
+          startIcon={<ArrowBackIcon />}
+          sx={{ mt: 2 }}
+        >
+          Back to Play Library
+        </LinkButton>
+      </PageContainer>
     );
   }
 
@@ -62,10 +61,8 @@ export default async function EditPlayPage({ params }: PageProps) {
   };
 
   return (
-    <Container maxWidth="lg">
-      <Box sx={{ py: 4 }}>
-        <PlayEditorWrapper teamId={context.teamId} play={play} />
-      </Box>
-    </Container>
+    <PageContainer>
+      <PlayEditorWrapper teamId={context.teamId} play={play} />
+    </PageContainer>
   );
 }

--- a/app/(dashboard)/practice-planner/library/new/page.tsx
+++ b/app/(dashboard)/practice-planner/library/new/page.tsx
@@ -1,7 +1,8 @@
-import { Box, Container, Alert } from "@mui/material";
+import { Alert } from "@mui/material";
 import { redirect } from "next/navigation";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import { LinkButton } from "@/components/ui/NextLinkComposites";
+import { PageContainer } from "@/components/ui/PageContainer";
 import { getPlayLibraryContext } from "@/lib/actions/practice-session-queries";
 import { PlayEditorWrapper } from "../PlayEditorWrapper";
 import type { Metadata } from "next";
@@ -20,28 +21,24 @@ export default async function NewPlayPage() {
 
   if (!context.isAdmin) {
     return (
-      <Container maxWidth="lg">
-        <Box sx={{ py: 4 }}>
-          <Alert severity="warning">
-            Only team admins can create plays.
-          </Alert>
-          <LinkButton
-            href="/practice-planner/library"
-            startIcon={<ArrowBackIcon />}
-            sx={{ mt: 2 }}
-          >
-            Back to Play Library
-          </LinkButton>
-        </Box>
-      </Container>
+      <PageContainer>
+        <Alert severity="warning">
+          Only team admins can create plays.
+        </Alert>
+        <LinkButton
+          href="/practice-planner/library"
+          startIcon={<ArrowBackIcon />}
+          sx={{ mt: 2 }}
+        >
+          Back to Play Library
+        </LinkButton>
+      </PageContainer>
     );
   }
 
   return (
-    <Container maxWidth="lg">
-      <Box sx={{ py: 4 }}>
-        <PlayEditorWrapper teamId={context.teamId} />
-      </Box>
-    </Container>
+    <PageContainer>
+      <PlayEditorWrapper teamId={context.teamId} />
+    </PageContainer>
   );
 }

--- a/app/(dashboard)/practice-planner/library/page.tsx
+++ b/app/(dashboard)/practice-planner/library/page.tsx
@@ -1,7 +1,9 @@
-import { Box, Container, Typography, Stack, Alert } from "@mui/material";
+import { Alert } from "@mui/material";
 import { redirect } from "next/navigation";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import { LinkButton } from "@/components/ui/NextLinkComposites";
+import { PageContainer } from "@/components/ui/PageContainer";
+import { PageHeader } from "@/components/ui/PageHeader";
 import { PlayLibrary } from "@/components/features/practice-planner/PlayLibrary";
 import { getPlayLibraryContext } from "@/lib/actions/practice-session-queries";
 import type { Metadata } from "next";
@@ -20,48 +22,36 @@ export default async function PlayLibraryPage() {
 
   if (!context.isAdmin) {
     return (
-      <Container maxWidth="lg">
-        <Box sx={{ py: 4 }}>
-          <Alert severity="warning">
-            Only team admins can access the play library.
-          </Alert>
-          <LinkButton
-            href="/practice-planner"
-            startIcon={<ArrowBackIcon />}
-            sx={{ mt: 2 }}
-          >
-            Back to Practice Planner
-          </LinkButton>
-        </Box>
-      </Container>
+      <PageContainer>
+        <Alert severity="warning">
+          Only team admins can access the play library.
+        </Alert>
+        <LinkButton
+          href="/practice-planner"
+          startIcon={<ArrowBackIcon />}
+          sx={{ mt: 2 }}
+        >
+          Back to Practice Planner
+        </LinkButton>
+      </PageContainer>
     );
   }
 
   return (
-    <Container maxWidth="lg">
-      <Box sx={{ py: 4 }}>
-        <Stack
-          direction="row"
-          justifyContent="space-between"
-          alignItems="center"
-          sx={{ mb: 3 }}
-        >
-          <Stack direction="row" alignItems="center" spacing={2}>
-            <LinkButton
-              href="/practice-planner"
-              startIcon={<ArrowBackIcon />}
-              size="small"
-            >
-              Back
-            </LinkButton>
-            <Typography variant="h4" component="h1">
-              Play Library
-            </Typography>
-          </Stack>
-        </Stack>
-
-        <PlayLibrary teamId={context.teamId} mode="manage" />
-      </Box>
-    </Container>
+    <PageContainer>
+      <PageHeader
+        title="Play Library"
+        breadcrumbs={
+          <LinkButton
+            href="/practice-planner"
+            startIcon={<ArrowBackIcon />}
+            size="small"
+          >
+            Back
+          </LinkButton>
+        }
+      />
+      <PlayLibrary teamId={context.teamId} mode="manage" />
+    </PageContainer>
   );
 }

--- a/app/(dashboard)/practice-planner/loading.tsx
+++ b/app/(dashboard)/practice-planner/loading.tsx
@@ -1,0 +1,18 @@
+import { Skeleton, Stack } from "@mui/material";
+import { PageContainer } from "@/components/ui/PageContainer";
+
+export default function PracticePlannerLoading() {
+  return (
+    <PageContainer>
+      <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 3 }}>
+        <Skeleton variant="text" width={240} sx={{ fontSize: "2.125rem" }} />
+        <Skeleton variant="rounded" width={150} height={44} />
+      </Stack>
+      <Stack spacing={2}>
+        <Skeleton variant="rounded" height={104} />
+        <Skeleton variant="rounded" height={104} />
+        <Skeleton variant="rounded" height={104} />
+      </Stack>
+    </PageContainer>
+  );
+}

--- a/app/(dashboard)/practice-planner/new/page.tsx
+++ b/app/(dashboard)/practice-planner/new/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import { redirect } from "next/navigation";
-import { Container, Box } from "@mui/material";
+import { PageContainer } from "@/components/ui/PageContainer";
 import { PracticeSessionEditorWrapper } from "./PracticeSessionEditorWrapper";
 import { getUserAdminTeamContext } from "@/lib/actions/team-context";
 import { getVenueBookingOptions } from "../venue-booking-options";
@@ -21,13 +21,11 @@ export default async function NewPracticeSessionPage() {
   const bookingOptions = await getVenueBookingOptions();
 
   return (
-    <Container maxWidth="lg">
-      <Box sx={{ py: 4 }}>
-        <PracticeSessionEditorWrapper
-          teamId={context.teamId}
-          bookingOptions={bookingOptions}
-        />
-      </Box>
-    </Container>
+    <PageContainer>
+      <PracticeSessionEditorWrapper
+        teamId={context.teamId}
+        bookingOptions={bookingOptions}
+      />
+    </PageContainer>
   );
 }

--- a/app/(dashboard)/practice-planner/page.tsx
+++ b/app/(dashboard)/practice-planner/page.tsx
@@ -1,6 +1,6 @@
-import { Container, Box } from "@mui/material";
 import { redirect } from "next/navigation";
 import type { Metadata } from "next";
+import { PageContainer } from "@/components/ui/PageContainer";
 import PracticePlannerList from "@/app/(dashboard)/practice-planner/PracticePlannerList";
 import { getPracticePlannerListData } from "@/lib/actions/practice-session-queries";
 
@@ -17,14 +17,12 @@ export default async function PracticePlannerPage() {
   }
 
   return (
-    <Container maxWidth="lg">
-      <Box sx={{ py: 4 }}>
-        <PracticePlannerList
-          sessions={data.sessions}
-          isAdmin={data.isAdmin}
-          teamName={data.teamName}
-        />
-      </Box>
-    </Container>
+    <PageContainer>
+      <PracticePlannerList
+        sessions={data.sessions}
+        isAdmin={data.isAdmin}
+        teamName={data.teamName}
+      />
+    </PageContainer>
   );
 }

--- a/app/(dashboard)/roster/loading.tsx
+++ b/app/(dashboard)/roster/loading.tsx
@@ -1,0 +1,15 @@
+import { Skeleton, Stack } from "@mui/material";
+import { PageContainer } from "@/components/ui/PageContainer";
+
+export default function RosterLoading() {
+  return (
+    <PageContainer>
+      <Skeleton variant="text" width={180} sx={{ fontSize: "2.125rem", mb: 3 }} />
+      <Stack spacing={2}>
+        <Skeleton variant="rounded" height={96} />
+        <Skeleton variant="rounded" height={96} />
+        <Skeleton variant="rounded" height={96} />
+      </Stack>
+    </PageContainer>
+  );
+}

--- a/app/(dashboard)/roster/page.tsx
+++ b/app/(dashboard)/roster/page.tsx
@@ -1,8 +1,10 @@
-import { Box, Container, Typography, Divider } from "@mui/material";
+import { Divider } from "@mui/material";
 import { redirect } from "next/navigation";
 import RosterList from "@/components/features/roster/RosterList";
 import InvitationManager from "@/components/features/roster/InvitationManager";
 import { getRosterData } from "@/lib/actions/team-context";
+import { PageContainer } from "@/components/ui/PageContainer";
+import { PageHeader } from "@/components/ui/PageHeader";
 
 export default async function RosterPage() {
   const data = await getRosterData();
@@ -12,35 +14,22 @@ export default async function RosterPage() {
   }
 
   return (
-    <Container maxWidth="lg">
-      <Box sx={{ py: 4 }}>
-        <Box
-          sx={{
-            display: "flex",
-            justifyContent: "space-between",
-            alignItems: "center",
-            mb: 3,
-          }}
-        >
-          <Typography variant="h4" component="h1">
-            Roster
-          </Typography>
-        </Box>
+    <PageContainer>
+      <PageHeader title="Roster" />
 
-        {data.isAdmin && (
-          <>
-            <InvitationManager invitations={data.invitations} teamId={data.teamId} />
-            <Divider sx={{ my: 4 }} />
-          </>
-        )}
+      {data.isAdmin && (
+        <>
+          <InvitationManager invitations={data.invitations} teamId={data.teamId} />
+          <Divider sx={{ my: 4 }} />
+        </>
+      )}
 
-        <RosterList
-          players={data.players}
-          teamMembers={data.teamMembers}
-          teamId={data.teamId}
-          isAdmin={data.isAdmin}
-        />
-      </Box>
-    </Container>
+      <RosterList
+        players={data.players}
+        teamMembers={data.teamMembers}
+        teamId={data.teamId}
+        isAdmin={data.isAdmin}
+      />
+    </PageContainer>
   );
 }

--- a/app/(dashboard)/seasons/[seasonId]/page.tsx
+++ b/app/(dashboard)/seasons/[seasonId]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from "next/navigation";
-import { Container, Stack } from "@mui/material";
+import { Stack } from "@mui/material";
 import { LinkButton } from "@/components/ui/NextLinkComposites";
+import { PageContainer } from "@/components/ui/PageContainer";
 import { getSeasonDetail } from "@/lib/actions/seasons";
 import { getAvailableVenues } from "@/lib/actions/venues";
 import { prisma } from "@/lib/db/prisma";
@@ -196,64 +197,62 @@ export default async function SeasonDetailPage({
   }));
 
   return (
-    <Container maxWidth="lg">
-      <Stack sx={{ py: { xs: 3, md: 5 } }}>
-        <SeasonDetail
-          season={{
-            id: season.id,
-            name: season.name,
-            description: season.description,
-            startDate: season.startDate,
-            endDate: season.endDate,
-            archivedAt: season.archivedAt,
-            format: season.format,
-            formatRounds: season.formatRounds,
-            ownerName: season.league?.name ?? season.team?.name ?? "",
-          }}
-          games={games}
-          teams={teams}
-          venues={venues}
-          surfacesByVenue={surfacesByVenue}
-          segmentsBySurface={segmentsBySurface}
-          wholeLabelBySurface={wholeLabelBySurface}
-          sport={sport}
-          canManage={canManage}
-          extraSections={
-            <>
-              {canManage && season.leagueId ? (
-                <Stack direction="row" justifyContent="flex-end">
-                  <LinkButton
-                    href={`/seasons/${season.id}/placement`}
-                    sx={{ minHeight: 44 }}
-                  >
-                    Pre-season placement
-                  </LinkButton>
-                </Stack>
-              ) : null}
-              {canManage ? (
-                <PhaseEditor
-                  seasonId={season.id}
-                  seasonStartDate={season.startDate}
-                  seasonEndDate={season.endDate}
-                  phases={phases}
-                />
-              ) : null}
-              {canManage ? (
-                <GenerationWizard
-                  seasonId={season.id}
-                  seasonStartDate={season.startDate}
-                  seasonEndDate={season.endDate}
-                  phases={phases.map((phase) => ({ id: phase.id, name: phase.name }))}
-                  teams={teams}
-                  divisions={divisions}
-                  venues={venues}
-                />
-              ) : null}
-              <SeasonStandingsTable rows={standingsRows} gated={standingsGated} />
-            </>
-          }
-        />
-      </Stack>
-    </Container>
+    <PageContainer>
+      <SeasonDetail
+        season={{
+          id: season.id,
+          name: season.name,
+          description: season.description,
+          startDate: season.startDate,
+          endDate: season.endDate,
+          archivedAt: season.archivedAt,
+          format: season.format,
+          formatRounds: season.formatRounds,
+          ownerName: season.league?.name ?? season.team?.name ?? "",
+        }}
+        games={games}
+        teams={teams}
+        venues={venues}
+        surfacesByVenue={surfacesByVenue}
+        segmentsBySurface={segmentsBySurface}
+        wholeLabelBySurface={wholeLabelBySurface}
+        sport={sport}
+        canManage={canManage}
+        extraSections={
+          <>
+            {canManage && season.leagueId ? (
+              <Stack direction="row" justifyContent="flex-end">
+                <LinkButton
+                  href={`/seasons/${season.id}/placement`}
+                  sx={{ minHeight: 44 }}
+                >
+                  Pre-season placement
+                </LinkButton>
+              </Stack>
+            ) : null}
+            {canManage ? (
+              <PhaseEditor
+                seasonId={season.id}
+                seasonStartDate={season.startDate}
+                seasonEndDate={season.endDate}
+                phases={phases}
+              />
+            ) : null}
+            {canManage ? (
+              <GenerationWizard
+                seasonId={season.id}
+                seasonStartDate={season.startDate}
+                seasonEndDate={season.endDate}
+                phases={phases.map((phase) => ({ id: phase.id, name: phase.name }))}
+                teams={teams}
+                divisions={divisions}
+                venues={venues}
+              />
+            ) : null}
+            <SeasonStandingsTable rows={standingsRows} gated={standingsGated} />
+          </>
+        }
+      />
+    </PageContainer>
   );
 }

--- a/app/(dashboard)/seasons/[seasonId]/placement/page.tsx
+++ b/app/(dashboard)/seasons/[seasonId]/placement/page.tsx
@@ -1,6 +1,8 @@
-import { Alert, Container, Stack, Typography } from "@mui/material";
+import { Alert, Stack } from "@mui/material";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import { LinkButton, LinkChip } from "@/components/ui/NextLinkComposites";
+import { PageContainer } from "@/components/ui/PageContainer";
+import { PageHeader } from "@/components/ui/PageHeader";
 import { prisma } from "@/lib/db/prisma";
 import { requireUserId } from "@/lib/auth/session";
 import { getPlacementBoard } from "@/lib/actions/placements";
@@ -30,28 +32,21 @@ export default async function PlacementPage({
   const board = await getPlacementBoard({ seasonId, ...(phaseId ? { phaseId } : {}) });
 
   const backLink = (
-    <Stack direction="row">
-      <LinkButton
-        href={`/seasons/${seasonId}`}
-        startIcon={<ArrowBackIcon />}
-        sx={{ minHeight: 44 }}
-      >
-        Back to season
-      </LinkButton>
-    </Stack>
+    <LinkButton
+      href={`/seasons/${seasonId}`}
+      startIcon={<ArrowBackIcon />}
+      sx={{ minHeight: 44 }}
+    >
+      Back to season
+    </LinkButton>
   );
 
   if (!board.success) {
     return (
-      <Container maxWidth="lg">
-        <Stack spacing={3} sx={{ py: { xs: 3, md: 5 } }}>
-          {backLink}
-          <Typography variant="h4" component="h1">
-            Pre-season placement
-          </Typography>
-          <Alert severity="error">{board.error}</Alert>
-        </Stack>
-      </Container>
+      <PageContainer>
+        <PageHeader title="Pre-season placement" breadcrumbs={backLink} />
+        <Alert severity="error">{board.error}</Alert>
+      </PageContainer>
     );
   }
 
@@ -79,17 +74,14 @@ export default async function PlacementPage({
   ]);
 
   return (
-    <Container maxWidth="lg">
-      <Stack spacing={3} sx={{ py: { xs: 3, md: 5 } }}>
-        {backLink}
+    <PageContainer>
+      <PageHeader
+        title="Pre-season placement"
+        subtitle={season?.name}
+        breadcrumbs={backLink}
+      />
 
-        <Stack spacing={0.5}>
-          <Typography variant="h4" component="h1">
-            Pre-season placement
-          </Typography>
-          {season ? <Typography color="text.secondary">{season.name}</Typography> : null}
-        </Stack>
-
+      <Stack spacing={3}>
         {phases.length > 0 ? (
           <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
             <LinkChip
@@ -123,6 +115,6 @@ export default async function PlacementPage({
           <Alert severity="error">Placement is available for league seasons</Alert>
         )}
       </Stack>
-    </Container>
+    </PageContainer>
   );
 }

--- a/app/(dashboard)/seasons/loading.tsx
+++ b/app/(dashboard)/seasons/loading.tsx
@@ -1,0 +1,21 @@
+import { Skeleton, Stack } from "@mui/material";
+import { PageContainer } from "@/components/ui/PageContainer";
+
+export default function SeasonsLoading() {
+  return (
+    <PageContainer maxWidth="md">
+      <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 3 }}>
+        <Skeleton variant="text" width={160} sx={{ fontSize: "2.125rem" }} />
+        <Stack direction="row" spacing={1}>
+          <Skeleton variant="rounded" width={132} height={44} />
+          <Skeleton variant="rounded" width={132} height={44} />
+        </Stack>
+      </Stack>
+      <Stack spacing={2}>
+        <Skeleton variant="rounded" height={88} />
+        <Skeleton variant="rounded" height={88} />
+        <Skeleton variant="rounded" height={88} />
+      </Stack>
+    </PageContainer>
+  );
+}

--- a/app/(dashboard)/seasons/new/page.tsx
+++ b/app/(dashboard)/seasons/new/page.tsx
@@ -1,6 +1,8 @@
-import { Alert, Card, CardContent, Container, Stack, Typography } from "@mui/material";
+import { Alert, Card, CardContent } from "@mui/material";
 import { prisma } from "@/lib/db/prisma";
 import { requireUserId } from "@/lib/auth/session";
+import { PageContainer } from "@/components/ui/PageContainer";
+import { PageHeader } from "@/components/ui/PageHeader";
 import { SeasonForm, type SeasonOwnerOption } from "@/components/features/seasons/SeasonForm";
 
 export const dynamic = "force-dynamic";
@@ -35,31 +37,24 @@ export default async function NewSeasonPage() {
   ];
 
   return (
-    <Container maxWidth="sm">
-      <Stack spacing={3} sx={{ py: { xs: 3, md: 5 } }}>
-        <Stack spacing={0.5}>
-          <Typography variant="h4" component="h1">
-            New season
-          </Typography>
-          <Typography color="text.secondary">
-            Just a name and dates — you can schedule games one at a time. No format or rotation
-            scheme is ever required.
-          </Typography>
-        </Stack>
+    <PageContainer maxWidth="sm">
+      <PageHeader
+        title="New season"
+        subtitle="Just a name and dates — you can schedule games one at a time. No format or rotation scheme is ever required."
+      />
 
-        {ownerOptions.length === 0 ? (
-          <Alert severity="info">
-            You need to be a league administrator or a standalone team&apos;s administrator to
-            create seasons.
-          </Alert>
-        ) : (
-          <Card>
-            <CardContent>
-              <SeasonForm ownerOptions={ownerOptions} />
-            </CardContent>
-          </Card>
-        )}
-      </Stack>
-    </Container>
+      {ownerOptions.length === 0 ? (
+        <Alert severity="info">
+          You need to be a league administrator or a standalone team&apos;s administrator to
+          create seasons.
+        </Alert>
+      ) : (
+        <Card>
+          <CardContent>
+            <SeasonForm ownerOptions={ownerOptions} />
+          </CardContent>
+        </Card>
+      )}
+    </PageContainer>
   );
 }

--- a/app/(dashboard)/seasons/page.tsx
+++ b/app/(dashboard)/seasons/page.tsx
@@ -1,6 +1,9 @@
-import { Container, Stack, Typography } from "@mui/material";
 import AddIcon from "@mui/icons-material/Add";
+import CalendarMonthIcon from "@mui/icons-material/CalendarMonth";
 import { LinkButton } from "@/components/ui/NextLinkComposites";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { PageContainer } from "@/components/ui/PageContainer";
+import { PageHeader } from "@/components/ui/PageHeader";
 import { getSeasons } from "@/lib/actions/seasons";
 import { SeasonList, type SeasonListItem } from "@/components/features/seasons/SeasonList";
 
@@ -28,13 +31,11 @@ export default async function SeasonsPage({
   }));
 
   return (
-    <Container maxWidth="md">
-      <Stack spacing={3} sx={{ py: { xs: 3, md: 5 } }}>
-        <Stack direction="row" alignItems="center" justifyContent="space-between">
-          <Typography variant="h4" component="h1">
-            Seasons
-          </Typography>
-          <Stack direction="row" spacing={1}>
+    <PageContainer maxWidth="md">
+      <PageHeader
+        title="Seasons"
+        actions={
+          <>
             <LinkButton href="/seasons/proposals" sx={{ minHeight: 44 }}>
               Game proposals
             </LinkButton>
@@ -46,19 +47,24 @@ export default async function SeasonsPage({
             >
               New season
             </LinkButton>
-          </Stack>
-        </Stack>
+          </>
+        }
+      />
 
-        {items.length === 0 ? (
-          <Typography color="text.secondary">
-            No seasons yet. Create one with just a name and dates — no format or rotation scheme
-            required — then schedule games one at a time. Each game lands on both teams&apos;
-            calendars with RSVP requests.
-          </Typography>
-        ) : null}
+      {items.length === 0 ? (
+        <EmptyState
+          icon={<CalendarMonthIcon />}
+          title="No seasons yet"
+          description="Create one with just a name and dates — no format or rotation scheme required — then schedule games one at a time. Each game lands on both teams' calendars with RSVP requests."
+          action={
+            <LinkButton href="/seasons/new" variant="contained" startIcon={<AddIcon />}>
+              New season
+            </LinkButton>
+          }
+        />
+      ) : null}
 
-        <SeasonList seasons={items} showArchived={showArchived} />
-      </Stack>
-    </Container>
+      <SeasonList seasons={items} showArchived={showArchived} />
+    </PageContainer>
   );
 }

--- a/app/(dashboard)/seasons/proposals/page.tsx
+++ b/app/(dashboard)/seasons/proposals/page.tsx
@@ -1,8 +1,9 @@
-import { Container, Stack, Typography } from "@mui/material";
 import { prisma } from "@/lib/db/prisma";
 import { requireUserId } from "@/lib/auth/session";
 import { getProposalsForLeague, getProposalsForTeam } from "@/lib/actions/game-proposals";
 import { getAvailableVenues } from "@/lib/actions/venues";
+import { PageContainer } from "@/components/ui/PageContainer";
+import { PageHeader } from "@/components/ui/PageHeader";
 import {
   ProposalInbox,
   type ProposalInboxItem,
@@ -125,19 +126,15 @@ export default async function ProposalsPage() {
   }));
 
   return (
-    <Container maxWidth="md">
-      <Stack spacing={3} sx={{ py: { xs: 3, md: 5 } }}>
-        <Typography variant="h4" component="h1">
-          Game proposals
-        </Typography>
-        <ProposalInbox
-          items={items}
-          leagueView={leagueView}
-          myTeams={myTeams}
-          leagueTeams={leagueTeams}
-          venues={venues}
-        />
-      </Stack>
-    </Container>
+    <PageContainer maxWidth="md">
+      <PageHeader title="Game proposals" />
+      <ProposalInbox
+        items={items}
+        leagueView={leagueView}
+        myTeams={myTeams}
+        leagueTeams={leagueTeams}
+        venues={venues}
+      />
+    </PageContainer>
   );
 }

--- a/app/(dashboard)/signup-events/[eventId]/edit/page.tsx
+++ b/app/(dashboard)/signup-events/[eventId]/edit/page.tsx
@@ -1,7 +1,8 @@
 import { notFound } from "next/navigation";
-import { Container, Stack, Typography } from "@mui/material";
 import { getManagedSignupEvent, listVenueOptions } from "@/lib/actions/signup-events";
 import { EventForm } from "@/components/features/signup-events";
+import { PageContainer } from "@/components/ui/PageContainer";
+import { PageHeader } from "@/components/ui/PageHeader";
 
 export const dynamic = "force-dynamic";
 
@@ -17,68 +18,64 @@ export default async function EditSignupEventPage({
   }
 
   return (
-    <Container maxWidth="md">
-      <Stack spacing={3} sx={{ py: { xs: 3, md: 5 } }}>
-        <Typography variant="h4" component="h1">
-          Edit — {event.title}
-        </Typography>
-        <EventForm
-          hostOptions={[]}
-          venueOptions={venueOptions}
-          host={
-            event.hostOrganization
-              ? { kind: "organization", id: event.hostOrganization.id }
-              : event.hostLeague
-                ? { kind: "league", id: event.hostLeague.id }
-                : { kind: "team", id: event.hostTeam?.id ?? "" }
-          }
-          initialValues={{
-            eventId: event.id,
-            title: event.title,
-            description: event.description,
-            category: event.category,
-            ageClassification: event.ageClassification,
-            visibility: event.visibility,
-            startAt: event.startAt,
-            endAt: event.endAt,
-            timezone: event.timezone,
-            venueId: event.venueId,
-            locationText: event.locationText,
-            registrationOpensAt: event.registrationOpensAt,
-            registrationClosesAt: event.registrationClosesAt,
-            cancellationCutoffAt: event.cancellationCutoffAt,
-            contactName: event.contactName,
-            contactEmail: event.contactEmail,
-            contactPhone: event.contactPhone,
-            acceptsOnlinePayment: event.acceptsOnlinePayment,
-            acceptsManualPayment: event.acceptsManualPayment,
-            venmoHandle: event.venmoHandle,
-            zelleHandle: event.zelleHandle,
-            cashAppHandle: event.cashAppHandle,
-            paymentPhone: event.paymentPhone,
-            paymentInstructions: event.paymentInstructions,
-            galleryEnabled: event.galleryEnabled,
-            publicRoster: event.publicRoster,
-            slots: event.slots.map((slot) => ({
-              id: slot.id,
-              name: slot.name,
-              description: slot.description,
-              capacity: slot.capacity,
-              priceAmount: slot.priceAmount,
-              waitlistEnabled: slot.waitlistEnabled,
-              registrationCount: slot._count.registrations,
-            })),
-            phases: event.phases.map((phase) => ({
-              id: phase.id,
-              name: phase.name,
-              opensAt: phase.opensAt,
-              audience: phase.audience,
-              divisionIds: phase.divisions.map((division) => division.id),
-              teamIds: phase.teams.map((team) => team.id),
-            })),
-          }}
-        />
-      </Stack>
-    </Container>
+    <PageContainer maxWidth="md">
+      <PageHeader title={`Edit — ${event.title}`} />
+      <EventForm
+        hostOptions={[]}
+        venueOptions={venueOptions}
+        host={
+          event.hostOrganization
+            ? { kind: "organization", id: event.hostOrganization.id }
+            : event.hostLeague
+              ? { kind: "league", id: event.hostLeague.id }
+              : { kind: "team", id: event.hostTeam?.id ?? "" }
+        }
+        initialValues={{
+          eventId: event.id,
+          title: event.title,
+          description: event.description,
+          category: event.category,
+          ageClassification: event.ageClassification,
+          visibility: event.visibility,
+          startAt: event.startAt,
+          endAt: event.endAt,
+          timezone: event.timezone,
+          venueId: event.venueId,
+          locationText: event.locationText,
+          registrationOpensAt: event.registrationOpensAt,
+          registrationClosesAt: event.registrationClosesAt,
+          cancellationCutoffAt: event.cancellationCutoffAt,
+          contactName: event.contactName,
+          contactEmail: event.contactEmail,
+          contactPhone: event.contactPhone,
+          acceptsOnlinePayment: event.acceptsOnlinePayment,
+          acceptsManualPayment: event.acceptsManualPayment,
+          venmoHandle: event.venmoHandle,
+          zelleHandle: event.zelleHandle,
+          cashAppHandle: event.cashAppHandle,
+          paymentPhone: event.paymentPhone,
+          paymentInstructions: event.paymentInstructions,
+          galleryEnabled: event.galleryEnabled,
+          publicRoster: event.publicRoster,
+          slots: event.slots.map((slot) => ({
+            id: slot.id,
+            name: slot.name,
+            description: slot.description,
+            capacity: slot.capacity,
+            priceAmount: slot.priceAmount,
+            waitlistEnabled: slot.waitlistEnabled,
+            registrationCount: slot._count.registrations,
+          })),
+          phases: event.phases.map((phase) => ({
+            id: phase.id,
+            name: phase.name,
+            opensAt: phase.opensAt,
+            audience: phase.audience,
+            divisionIds: phase.divisions.map((division) => division.id),
+            teamIds: phase.teams.map((team) => team.id),
+          })),
+        }}
+      />
+    </PageContainer>
   );
 }

--- a/app/(dashboard)/signup-events/[eventId]/page.tsx
+++ b/app/(dashboard)/signup-events/[eventId]/page.tsx
@@ -4,11 +4,11 @@ import {
   Card,
   CardContent,
   Chip,
-  Container,
   Stack,
   Typography,
 } from "@mui/material";
 import { LinkButton } from "@/components/ui/NextLinkComposites";
+import { PageContainer } from "@/components/ui/PageContainer";
 import EditIcon from "@mui/icons-material/Edit";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import { getManagedSignupEvent } from "@/lib/actions/signup-events";
@@ -103,8 +103,8 @@ export default async function ManageSignupEventPage({
         : null;
 
   return (
-    <Container maxWidth="lg">
-      <Stack spacing={3} sx={{ py: { xs: 3, md: 5 } }}>
+    <PageContainer>
+      <Stack spacing={3}>
         <Stack
           direction={{ xs: "column", sm: "row" }}
           spacing={2}
@@ -243,6 +243,6 @@ export default async function ManageSignupEventPage({
           </Card>
         ) : null}
       </Stack>
-    </Container>
+    </PageContainer>
   );
 }

--- a/app/(dashboard)/signup-events/new/page.tsx
+++ b/app/(dashboard)/signup-events/new/page.tsx
@@ -1,6 +1,8 @@
-import { Alert, Container, Stack, Typography } from "@mui/material";
+import { Alert } from "@mui/material";
 import { listMyHostOptions, listVenueOptions } from "@/lib/actions/signup-events";
 import { EventForm } from "@/components/features/signup-events";
+import { PageContainer } from "@/components/ui/PageContainer";
+import { PageHeader } from "@/components/ui/PageHeader";
 import { requireAuth } from "@/lib/auth/session";
 
 export const dynamic = "force-dynamic";
@@ -10,20 +12,16 @@ export default async function NewSignupEventPage() {
   const [hostOptions, venueOptions] = await Promise.all([listMyHostOptions(), listVenueOptions()]);
 
   return (
-    <Container maxWidth="md">
-      <Stack spacing={3} sx={{ py: { xs: 3, md: 5 } }}>
-        <Typography variant="h4" component="h1">
-          New signup event
-        </Typography>
-        {hostOptions.length === 0 ? (
-          <Alert severity="info">
-            You need an admin role in a rink organization, association, or team to host signup
-            events.
-          </Alert>
-        ) : (
-          <EventForm hostOptions={hostOptions} venueOptions={venueOptions} />
-        )}
-      </Stack>
-    </Container>
+    <PageContainer maxWidth="md">
+      <PageHeader title="New signup event" />
+      {hostOptions.length === 0 ? (
+        <Alert severity="info">
+          You need an admin role in a rink organization, association, or team to host signup
+          events.
+        </Alert>
+      ) : (
+        <EventForm hostOptions={hostOptions} venueOptions={venueOptions} />
+      )}
+    </PageContainer>
   );
 }

--- a/app/(dashboard)/signup-events/page.tsx
+++ b/app/(dashboard)/signup-events/page.tsx
@@ -2,12 +2,15 @@ import {
   Card,
   CardContent,
   Chip,
-  Container,
   Stack,
   Typography,
 } from "@mui/material";
 import AddIcon from "@mui/icons-material/Add";
+import EventAvailableIcon from "@mui/icons-material/EventAvailable";
 import { LinkButton, LinkCardActionArea } from "@/components/ui/NextLinkComposites";
+import { PageContainer } from "@/components/ui/PageContainer";
+import { PageHeader } from "@/components/ui/PageHeader";
+import { EmptyState } from "@/components/ui/EmptyState";
 import { listMySignupEvents } from "@/lib/actions/signup-events";
 import { formatDateTime } from "@/lib/utils/date";
 
@@ -24,65 +27,69 @@ export default async function SignupEventsPage() {
   const events = await listMySignupEvents();
 
   return (
-    <Container maxWidth="md">
-      <Stack spacing={3} sx={{ py: { xs: 3, md: 5 } }}>
-        <Stack direction="row" alignItems="center" justifyContent="space-between">
-          <Typography variant="h4" component="h1">
-            Signup events
-          </Typography>
+    <PageContainer maxWidth="md">
+      <PageHeader
+        title="Signup events"
+        actions={
           <LinkButton href="/signup-events/new" variant="contained" startIcon={<AddIcon />}>
             New event
           </LinkButton>
-        </Stack>
+        }
+      />
 
-        {events.length === 0 ? (
-          <Typography color="text.secondary">
-            No signup events yet. Create one to run clinics, scrimmage nights, tryouts, volunteer
-            signups, and more — with per-role capacity limits.
-          </Typography>
-        ) : (
-          <Stack spacing={2}>
-            {events.map((event) => {
-              const hostName =
-                event.hostOrganization?.name ?? event.hostLeague?.name ?? event.hostTeam?.name ?? "";
-              return (
-                <Card key={event.id}>
-                  <LinkCardActionArea href={`/signup-events/${event.id}`}>
-                    <CardContent>
-                      <Stack
-                        direction={{ xs: "column", sm: "row" }}
-                        spacing={1}
-                        justifyContent="space-between"
-                        alignItems={{ sm: "center" }}
-                      >
-                        <Stack spacing={0.5}>
-                          <Typography variant="h6">{event.title}</Typography>
-                          <Typography variant="body2" color="text.secondary">
-                            {formatDateTime(event.startAt, event.timezone)} · {event.venue?.name ?? event.locationText ?? "TBD"} ·{" "}
-                            {hostName}
-                          </Typography>
-                        </Stack>
-                        <Stack direction="row" spacing={1}>
-                          <Chip
-                            size="small"
-                            label={event.status.toLowerCase()}
-                            color={STATUS_COLORS[event.status] ?? "default"}
-                          />
-                          <Chip
-                            size="small"
-                            variant="outlined"
-                            label={`${event._count.registrations} signup${event._count.registrations === 1 ? "" : "s"}`}
-                          />
-                        </Stack>
+      {events.length === 0 ? (
+        <EmptyState
+          icon={<EventAvailableIcon />}
+          title="No signup events yet"
+          description="Create one to run clinics, scrimmage nights, tryouts, volunteer signups, and more — with per-role capacity limits."
+          action={
+            <LinkButton href="/signup-events/new" variant="contained" startIcon={<AddIcon />}>
+              Create your first event
+            </LinkButton>
+          }
+        />
+      ) : (
+        <Stack spacing={2}>
+          {events.map((event) => {
+            const hostName =
+              event.hostOrganization?.name ?? event.hostLeague?.name ?? event.hostTeam?.name ?? "";
+            return (
+              <Card key={event.id}>
+                <LinkCardActionArea href={`/signup-events/${event.id}`}>
+                  <CardContent>
+                    <Stack
+                      direction={{ xs: "column", sm: "row" }}
+                      spacing={1}
+                      justifyContent="space-between"
+                      alignItems={{ sm: "center" }}
+                    >
+                      <Stack spacing={0.5}>
+                        <Typography variant="h6">{event.title}</Typography>
+                        <Typography variant="body2" color="text.secondary">
+                          {formatDateTime(event.startAt, event.timezone)} · {event.venue?.name ?? event.locationText ?? "TBD"} ·{" "}
+                          {hostName}
+                        </Typography>
                       </Stack>
-                    </CardContent>
-                  </LinkCardActionArea>
-                </Card>
-              );
-            })}
-          </Stack>
-        )}
-      </Stack>
-    </Container>
+                      <Stack direction="row" spacing={1}>
+                        <Chip
+                          size="small"
+                          label={event.status.toLowerCase()}
+                          color={STATUS_COLORS[event.status] ?? "default"}
+                        />
+                        <Chip
+                          size="small"
+                          variant="outlined"
+                          label={`${event._count.registrations} signup${event._count.registrations === 1 ? "" : "s"}`}
+                        />
+                      </Stack>
+                    </Stack>
+                  </CardContent>
+                </LinkCardActionArea>
+              </Card>
+            );
+          })}
+        </Stack>
+      )}
+    </PageContainer>
   );
 }

--- a/app/(dashboard)/team/[teamId]/page.tsx
+++ b/app/(dashboard)/team/[teamId]/page.tsx
@@ -5,7 +5,6 @@ import {
   Card,
   CardContent,
   Chip,
-  Container,
   Stack,
   Typography,
 } from "@mui/material";
@@ -19,7 +18,9 @@ import {
 } from "@mui/icons-material";
 import { getTeamOverviewData } from "@/lib/actions/team-context";
 import { formatSport } from "@/lib/utils/validation";
-import { NextLinkButton, NextLinkCard } from "@/components/ui/NextLinkComponents";
+import { LinkButton, LinkCard } from "@/components/ui/NextLinkComposites";
+import { PageContainer } from "@/components/ui/PageContainer";
+import { EmptyState } from "@/components/ui/EmptyState";
 
 interface TeamPageProps {
   params: Promise<{ teamId: string }>;
@@ -65,172 +66,172 @@ export default async function TeamPage({ params }: TeamPageProps) {
   }
 
   return (
-    <Container maxWidth="lg">
-      <Box sx={{ py: 4 }}>
-        <NextLinkButton
-          href="/dashboard"
-          startIcon={<ArrowBackIcon />}
-          sx={{ mb: 3 }}
-        >
-          Back to dashboard
-        </NextLinkButton>
+    <PageContainer>
+      <LinkButton
+        href="/dashboard"
+        startIcon={<ArrowBackIcon />}
+        sx={{ mb: 3 }}
+      >
+        Back to dashboard
+      </LinkButton>
 
-        <Card
-          sx={{
-            mb: 3,
-            overflow: "hidden",
-            border: "1px solid",
-            borderColor: "divider",
-          }}
-        >
-          <CardContent sx={{ p: { xs: 3, md: 4 } }}>
-            <Stack
-              direction={{ xs: "column", md: "row" }}
-              justifyContent="space-between"
-              alignItems={{ xs: "flex-start", md: "center" }}
-              spacing={3}
-            >
-              <Stack direction="row" spacing={2} alignItems="center">
-                <Avatar
-                  sx={{
-                    width: 64,
-                    height: 64,
-                    bgcolor: "primary.main",
-                    fontSize: "1.25rem",
-                    fontWeight: 800,
-                  }}
-                >
-                  {getTeamInitials(team.name)}
-                </Avatar>
-                <Box>
-                  <Typography variant="h4" component="h1" fontWeight={800} gutterBottom>
-                    {team.name}
-                  </Typography>
-                  <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
-                    <Chip icon={<SportsIcon />} label={formatSport(team.sport)} />
-                    <Chip label={team.season} variant="outlined" />
-                    <Chip
-                      label={formatAccessRole(team.role, team.isAdmin)}
-                      color={team.isAdmin ? "primary" : "default"}
-                      variant={team.isAdmin ? "filled" : "outlined"}
-                    />
-                    {team.league ? <Chip label={team.league.name} color="secondary" variant="outlined" /> : null}
-                    {team.division ? <Chip label={`Division: ${team.division.name}`} variant="outlined" /> : null}
-                  </Stack>
-                </Box>
-              </Stack>
+      <Card
+        sx={{
+          mb: 3,
+          overflow: "hidden",
+          border: "1px solid",
+          borderColor: "divider",
+        }}
+      >
+        <CardContent sx={{ p: { xs: 3, md: 4 } }}>
+          <Stack
+            direction={{ xs: "column", md: "row" }}
+            justifyContent="space-between"
+            alignItems={{ xs: "flex-start", md: "center" }}
+            spacing={3}
+          >
+            <Stack direction="row" spacing={2} alignItems="center">
+              <Avatar
+                sx={{
+                  width: 64,
+                  height: 64,
+                  bgcolor: "primary.main",
+                  fontSize: "1.25rem",
+                  fontWeight: 800,
+                }}
+              >
+                {getTeamInitials(team.name)}
+              </Avatar>
+              <Box>
+                <Typography variant="h4" component="h1" fontWeight={800} gutterBottom>
+                  {team.name}
+                </Typography>
+                <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+                  <Chip icon={<SportsIcon />} label={formatSport(team.sport)} />
+                  <Chip label={team.season} variant="outlined" />
+                  <Chip
+                    label={formatAccessRole(team.role, team.isAdmin)}
+                    color={team.isAdmin ? "primary" : "default"}
+                    variant={team.isAdmin ? "filled" : "outlined"}
+                  />
+                  {team.league ? <Chip label={team.league.name} color="secondary" variant="outlined" /> : null}
+                  {team.division ? <Chip label={`Division: ${team.division.name}`} variant="outlined" /> : null}
+                </Stack>
+              </Box>
+            </Stack>
 
-              <Stack direction={{ xs: "column", sm: "row" }} spacing={1} sx={{ width: { xs: "100%", md: "auto" } }}>
-                <NextLinkButton
-                  href={`/team/${team.id}/roster`}
-                  variant="contained"
-                  startIcon={<PeopleIcon />}
+            <Stack direction={{ xs: "column", sm: "row" }} spacing={1} sx={{ width: { xs: "100%", md: "auto" } }}>
+              <LinkButton
+                href={`/team/${team.id}/roster`}
+                variant="contained"
+                startIcon={<PeopleIcon />}
+                fullWidth
+              >
+                {team.isAdmin ? "Manage roster" : "View roster"}
+              </LinkButton>
+              {team.league ? (
+                <LinkButton
+                  href={`/league/${team.league.id}/teams`}
+                  variant="outlined"
+                  startIcon={<GroupsIcon />}
                   fullWidth
                 >
-                  {team.isAdmin ? "Manage roster" : "View roster"}
-                </NextLinkButton>
-                {team.league ? (
-                  <NextLinkButton
-                    href={`/league/${team.league.id}/teams`}
-                    variant="outlined"
-                    startIcon={<GroupsIcon />}
-                    fullWidth
-                  >
-                    League teams
-                  </NextLinkButton>
-                ) : null}
-              </Stack>
+                  League teams
+                </LinkButton>
+              ) : null}
             </Stack>
-          </CardContent>
-        </Card>
+          </Stack>
+        </CardContent>
+      </Card>
 
-        <Box
-          sx={{
-            display: "grid",
-            gridTemplateColumns: { xs: "1fr", sm: "repeat(3, 1fr)" },
-            gap: 2,
-            mb: 3,
-          }}
-        >
-          <StatCard icon={<PeopleIcon color="primary" />} label="Players" value={team.stats.players} />
-          <StatCard icon={<EventIcon color="primary" />} label="Events" value={team.stats.events} />
-          <StatCard icon={<GroupsIcon color="primary" />} label="Members" value={team.stats.members} />
-        </Box>
-
-        <Card variant="outlined">
-          <CardContent>
-            <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 2 }}>
-              <CalendarIcon color="primary" />
-              <Typography variant="h5" component="h2" fontWeight={700}>
-                Upcoming events
-              </Typography>
-            </Stack>
-
-            {team.upcomingEvents.length === 0 ? (
-              <Typography variant="body2" color="text.secondary">
-                No upcoming games or practices are scheduled for this team yet.
-              </Typography>
-            ) : (
-              <Stack spacing={1.5}>
-                {team.upcomingEvents.map((event) => {
-                  const eventCardProps = {
-                    variant: "outlined" as const,
-                    sx: {
-                      color: "inherit",
-                      textDecoration: "none",
-                      transition: "border-color 0.2s, box-shadow 0.2s",
-                      ...(team.canOpenEventDetails && {
-                        cursor: "pointer",
-                      }),
-                      "&:hover": team.canOpenEventDetails ? {
-                        borderColor: "primary.main",
-                        boxShadow: 1,
-                      } : undefined,
-                    },
-                  };
-
-                  const eventCardContent = (
-                    <CardContent sx={{ py: 1.5, "&:last-child": { pb: 1.5 } }}>
-                      <Stack
-                        direction={{ xs: "column", sm: "row" }}
-                        justifyContent="space-between"
-                        spacing={1}
-                      >
-                        <Box>
-                          <Typography variant="subtitle1" fontWeight={700}>
-                            {event.title}
-                          </Typography>
-                          <Typography variant="body2" color="text.secondary">
-                            {event.location || "Location TBD"}
-                            {event.opponent ? ` • vs. ${event.opponent}` : ""}
-                          </Typography>
-                        </Box>
-                        <Stack direction="row" spacing={1} alignItems="center">
-                          <Chip size="small" label={event.type === "GAME" ? "Game" : "Practice"} />
-                          <Typography variant="body2" color="text.secondary">
-                            {formatEventDate(event.startAt)}
-                          </Typography>
-                        </Stack>
-                      </Stack>
-                    </CardContent>
-                  );
-
-                  return team.canOpenEventDetails ? (
-                    <NextLinkCard key={event.id} href={`/events/${event.id}`} {...eventCardProps}>
-                      {eventCardContent}
-                    </NextLinkCard>
-                  ) : (
-                    <Card key={event.id} {...eventCardProps}>
-                      {eventCardContent}
-                    </Card>
-                  );
-                })}
-              </Stack>
-            )}
-          </CardContent>
-        </Card>
+      <Box
+        sx={{
+          display: "grid",
+          gridTemplateColumns: { xs: "1fr", sm: "repeat(3, 1fr)" },
+          gap: 2,
+          mb: 3,
+        }}
+      >
+        <StatCard icon={<PeopleIcon color="primary" />} label="Players" value={team.stats.players} />
+        <StatCard icon={<EventIcon color="primary" />} label="Events" value={team.stats.events} />
+        <StatCard icon={<GroupsIcon color="primary" />} label="Members" value={team.stats.members} />
       </Box>
-    </Container>
+
+      <Card variant="outlined">
+        <CardContent>
+          <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 2 }}>
+            <CalendarIcon color="primary" />
+            <Typography variant="h5" component="h2" fontWeight={700}>
+              Upcoming events
+            </Typography>
+          </Stack>
+
+          {team.upcomingEvents.length === 0 ? (
+            <EmptyState
+              icon={<EventIcon />}
+              title="No upcoming events"
+              description="No upcoming games or practices are scheduled for this team yet."
+            />
+          ) : (
+            <Stack spacing={1.5}>
+              {team.upcomingEvents.map((event) => {
+                const eventCardProps = {
+                  variant: "outlined" as const,
+                  sx: {
+                    color: "inherit",
+                    textDecoration: "none",
+                    transition: "border-color 0.2s, box-shadow 0.2s",
+                    ...(team.canOpenEventDetails && {
+                      cursor: "pointer",
+                    }),
+                    "&:hover": team.canOpenEventDetails ? {
+                      borderColor: "primary.main",
+                      boxShadow: 1,
+                    } : undefined,
+                  },
+                };
+
+                const eventCardContent = (
+                  <CardContent sx={{ py: 1.5, "&:last-child": { pb: 1.5 } }}>
+                    <Stack
+                      direction={{ xs: "column", sm: "row" }}
+                      justifyContent="space-between"
+                      spacing={1}
+                    >
+                      <Box>
+                        <Typography variant="subtitle1" fontWeight={700}>
+                          {event.title}
+                        </Typography>
+                        <Typography variant="body2" color="text.secondary">
+                          {event.location || "Location TBD"}
+                          {event.opponent ? ` • vs. ${event.opponent}` : ""}
+                        </Typography>
+                      </Box>
+                      <Stack direction="row" spacing={1} alignItems="center">
+                        <Chip size="small" label={event.type === "GAME" ? "Game" : "Practice"} />
+                        <Typography variant="body2" color="text.secondary">
+                          {formatEventDate(event.startAt)}
+                        </Typography>
+                      </Stack>
+                    </Stack>
+                  </CardContent>
+                );
+
+                return team.canOpenEventDetails ? (
+                  <LinkCard key={event.id} href={`/events/${event.id}`} {...eventCardProps}>
+                    {eventCardContent}
+                  </LinkCard>
+                ) : (
+                  <Card key={event.id} {...eventCardProps}>
+                    {eventCardContent}
+                  </Card>
+                );
+              })}
+            </Stack>
+          )}
+        </CardContent>
+      </Card>
+    </PageContainer>
   );
 }
 

--- a/app/(dashboard)/team/[teamId]/roster/page.tsx
+++ b/app/(dashboard)/team/[teamId]/roster/page.tsx
@@ -1,10 +1,12 @@
 import { notFound } from "next/navigation";
-import { Box, Container, Divider, Stack, Typography } from "@mui/material";
+import { Divider } from "@mui/material";
 import { ArrowBack as ArrowBackIcon } from "@mui/icons-material";
 import RosterList from "@/components/features/roster/RosterList";
 import InvitationManager from "@/components/features/roster/InvitationManager";
 import { getTeamRosterDataById } from "@/lib/actions/team-context";
-import { NextLinkButton } from "@/components/ui/NextLinkComponents";
+import { LinkButton } from "@/components/ui/NextLinkComposites";
+import { PageContainer } from "@/components/ui/PageContainer";
+import { PageHeader } from "@/components/ui/PageHeader";
 
 interface TeamRosterPageProps {
   params: Promise<{ teamId: string }>;
@@ -19,47 +21,33 @@ export default async function TeamRosterPage({ params }: TeamRosterPageProps) {
   }
 
   return (
-    <Container maxWidth="lg">
-      <Box sx={{ py: 4 }}>
-        <NextLinkButton
-          href={`/team/${teamId}`}
-          startIcon={<ArrowBackIcon />}
-          sx={{ mb: 3 }}
-        >
-          Back to team
-        </NextLinkButton>
+    <PageContainer>
+      <LinkButton
+        href={`/team/${teamId}`}
+        startIcon={<ArrowBackIcon />}
+        sx={{ mb: 3 }}
+      >
+        Back to team
+      </LinkButton>
 
-        <Stack
-          direction={{ xs: "column", sm: "row" }}
-          justifyContent="space-between"
-          alignItems={{ xs: "flex-start", sm: "center" }}
-          spacing={2}
-          sx={{ mb: 3 }}
-        >
-          <Box>
-            <Typography variant="h4" component="h1" fontWeight={800}>
-              {data.teamName} roster
-            </Typography>
-            <Typography variant="body2" color="text.secondary">
-              {data.isAdmin ? "Manage players, invitations, and team official IDs." : "View players and team officials."}
-            </Typography>
-          </Box>
-        </Stack>
+      <PageHeader
+        title={`${data.teamName} roster`}
+        subtitle={data.isAdmin ? "Manage players, invitations, and team official IDs." : "View players and team officials."}
+      />
 
-        {data.isAdmin && (
-          <>
-            <InvitationManager invitations={data.invitations} teamId={data.teamId} />
-            <Divider sx={{ my: 4 }} />
-          </>
-        )}
+      {data.isAdmin && (
+        <>
+          <InvitationManager invitations={data.invitations} teamId={data.teamId} />
+          <Divider sx={{ my: 4 }} />
+        </>
+      )}
 
-        <RosterList
-          players={data.players}
-          teamMembers={data.teamMembers}
-          teamId={data.teamId}
-          isAdmin={data.isAdmin}
-        />
-      </Box>
-    </Container>
+      <RosterList
+        players={data.players}
+        teamMembers={data.teamMembers}
+        teamId={data.teamId}
+        isAdmin={data.isAdmin}
+      />
+    </PageContainer>
   );
 }

--- a/app/(dashboard)/venue-admin/[organizationId]/payments/page.tsx
+++ b/app/(dashboard)/venue-admin/[organizationId]/payments/page.tsx
@@ -1,5 +1,7 @@
 import { notFound } from "next/navigation";
-import { Box, Card, CardContent, Container, Stack, Typography } from "@mui/material";
+import { Box, Card, CardContent, Stack, Typography } from "@mui/material";
+import { PageContainer } from "@/components/ui/PageContainer";
+import { PageHeader } from "@/components/ui/PageHeader";
 import { getOrganizationPaymentsOverview } from "@/lib/actions/venue-payments";
 import { StripeConnectCard } from "@/components/features/venue-admin";
 import { formatCurrencyFromCents } from "@/lib/utils/currency";
@@ -34,17 +36,12 @@ export default async function VenuePaymentsPage({ params, searchParams }: VenueP
   const { status, revenue } = result.data;
 
   return (
-    <Container maxWidth="md">
-      <Stack spacing={3} sx={{ py: 4 }}>
-        <Box>
-          <Typography variant="h4" component="h1" gutterBottom>
-            Payments
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            Accept payments for sessions and lessons through your connected Stripe account.
-          </Typography>
-        </Box>
-
+    <PageContainer maxWidth="md">
+      <PageHeader
+        title="Payments"
+        subtitle="Accept payments for sessions and lessons through your connected Stripe account."
+      />
+      <Stack spacing={3}>
         <StripeConnectCard
           organizationId={organizationId}
           status={status}
@@ -68,6 +65,6 @@ export default async function VenuePaymentsPage({ params, searchParams }: VenueP
           </CardContent>
         </Card>
       </Stack>
-    </Container>
+    </PageContainer>
   );
 }

--- a/app/(dashboard)/venue-admin/[organizationId]/venues/[venueId]/content/page.tsx
+++ b/app/(dashboard)/venue-admin/[organizationId]/venues/[venueId]/content/page.tsx
@@ -1,5 +1,7 @@
 import { notFound } from "next/navigation";
-import { Container, Stack, Typography } from "@mui/material";
+import { Stack } from "@mui/material";
+import { PageContainer } from "@/components/ui/PageContainer";
+import { PageHeader } from "@/components/ui/PageHeader";
 import { getVenueContentAdminData } from "@/lib/actions/venue-content";
 import { LessonOfferingEditor, SpecialtyEventEditor, VenueContentManager } from "@/components/features/venue-admin";
 
@@ -19,15 +21,13 @@ export default async function VenueContentAdminPage({ params }: VenueContentAdmi
   }
 
   return (
-    <Container maxWidth="lg">
-      <Stack spacing={4} sx={{ py: 4 }}>
-        <Typography variant="h4" component="h1">
-          Venue Content
-        </Typography>
+    <PageContainer>
+      <PageHeader title="Venue Content" />
+      <Stack spacing={4}>
         <LessonOfferingEditor organizationId={organizationId} venueId={venueId} />
         <SpecialtyEventEditor organizationId={organizationId} venueId={venueId} />
         <VenueContentManager posts={result.data.posts} />
       </Stack>
-    </Container>
+    </PageContainer>
   );
 }

--- a/app/(dashboard)/venue-admin/[organizationId]/venues/[venueId]/layout/page.tsx
+++ b/app/(dashboard)/venue-admin/[organizationId]/venues/[venueId]/layout/page.tsx
@@ -1,7 +1,8 @@
 import { notFound } from "next/navigation";
-import { Box, Container, Stack, Typography } from "@mui/material";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import { LinkButton } from "@/components/ui/NextLinkComposites";
+import { PageContainer } from "@/components/ui/PageContainer";
+import { PageHeader } from "@/components/ui/PageHeader";
 import { prisma } from "@/lib/db/prisma";
 import { requireVenueProfileManager } from "@/lib/auth/session";
 import { getVenueLayout } from "@/lib/actions/venue-layout";
@@ -32,9 +33,11 @@ export default async function VenueLayoutPage({ params }: VenueLayoutPageProps) 
   }
 
   return (
-    <Container maxWidth="lg">
-      <Stack spacing={3} sx={{ py: 4 }}>
-        <Box>
+    <PageContainer>
+      <PageHeader
+        title={`Facility Layout — ${venue.name}`}
+        subtitle="Arrange surfaces on a schematic map and add landmark labels. A saved layout appears on the public rink profile."
+        breadcrumbs={
           <LinkButton
             href={`/venue-admin/${organizationId}/venues/${venueId}/profile`}
             startIcon={<ArrowBackIcon />}
@@ -42,21 +45,14 @@ export default async function VenueLayoutPage({ params }: VenueLayoutPageProps) 
           >
             Back to venue profile
           </LinkButton>
-          <Typography variant="h4" component="h1" sx={{ mt: 1 }}>
-            Facility Layout — {venue.name}
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            Arrange surfaces on a schematic map and add landmark labels. A saved layout appears on
-            the public rink profile.
-          </Typography>
-        </Box>
-        <VenueLayoutEditor
-          organizationId={organizationId}
-          venueId={venueId}
-          initialLayout={result.data.layout}
-          surfaces={result.data.surfaces}
-        />
-      </Stack>
-    </Container>
+        }
+      />
+      <VenueLayoutEditor
+        organizationId={organizationId}
+        venueId={venueId}
+        initialLayout={result.data.layout}
+        surfaces={result.data.surfaces}
+      />
+    </PageContainer>
   );
 }

--- a/app/(dashboard)/venue-admin/[organizationId]/venues/[venueId]/profile/page.tsx
+++ b/app/(dashboard)/venue-admin/[organizationId]/venues/[venueId]/profile/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from "next/navigation";
-import { Container, Stack, Typography } from "@mui/material";
+import { PageContainer } from "@/components/ui/PageContainer";
+import { PageHeader } from "@/components/ui/PageHeader";
 import { prisma } from "@/lib/db/prisma";
 import { requireVenueProfileManager } from "@/lib/auth/session";
 import { VenueProfileEditor } from "@/components/features/venue-admin";
@@ -46,13 +47,9 @@ export default async function VenueProfilePage({ params }: VenueProfilePageProps
   }
 
   return (
-    <Container maxWidth="lg">
-      <Stack spacing={3} sx={{ py: 4 }}>
-        <Typography variant="h4" component="h1">
-          Manage Venue Profile
-        </Typography>
-        <VenueProfileEditor organizationId={organizationId} venue={venue} />
-      </Stack>
-    </Container>
+    <PageContainer>
+      <PageHeader title="Manage Venue Profile" />
+      <VenueProfileEditor organizationId={organizationId} venue={venue} />
+    </PageContainer>
   );
 }

--- a/app/(dashboard)/venue-admin/[organizationId]/venues/[venueId]/registrations/page.tsx
+++ b/app/(dashboard)/venue-admin/[organizationId]/venues/[venueId]/registrations/page.tsx
@@ -1,4 +1,8 @@
-import { Box, Card, CardContent, Chip, Container, Divider, Stack, Typography } from "@mui/material";
+import { Box, Card, CardContent, Chip, Divider, Stack, Typography } from "@mui/material";
+import ReceiptLongIcon from "@mui/icons-material/ReceiptLong";
+import { PageContainer } from "@/components/ui/PageContainer";
+import { PageHeader } from "@/components/ui/PageHeader";
+import { EmptyState } from "@/components/ui/EmptyState";
 import { getVenueRegistrations } from "@/lib/actions/session-registrations";
 import { RefundRegistrationButton } from "@/components/features/venue-admin";
 import { formatCurrencyFromCents } from "@/lib/utils/currency";
@@ -34,12 +38,9 @@ export default async function VenueRegistrationsPage({ params }: VenueRegistrati
   const { registrations, summary } = await getVenueRegistrations({ organizationId, venueId });
 
   return (
-    <Container maxWidth="lg">
-      <Stack spacing={3} sx={{ py: 4 }}>
-        <Typography variant="h4" component="h1">
-          Registrations
-        </Typography>
-
+    <PageContainer>
+      <PageHeader title="Registrations" />
+      <Stack spacing={3}>
         <Card variant="outlined">
           <CardContent>
             <Stack direction="row" spacing={4} flexWrap="wrap" useFlexGap>
@@ -52,7 +53,11 @@ export default async function VenueRegistrationsPage({ params }: VenueRegistrati
         </Card>
 
         {registrations.length === 0 ? (
-          <Typography color="text.secondary">No registrations yet.</Typography>
+          <EmptyState
+            icon={<ReceiptLongIcon />}
+            title="No registrations yet"
+            description="Registrations appear here once skaters sign up for your sessions and lessons."
+          />
         ) : (
           <Stack spacing={1.5}>
             {registrations.map((reg) => {
@@ -105,6 +110,6 @@ export default async function VenueRegistrationsPage({ params }: VenueRegistrati
           </Stack>
         )}
       </Stack>
-    </Container>
+    </PageContainer>
   );
 }

--- a/app/(dashboard)/venue-admin/[organizationId]/venues/[venueId]/relationships/page.tsx
+++ b/app/(dashboard)/venue-admin/[organizationId]/venues/[venueId]/relationships/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from "next/navigation";
-import { Container, Stack, Typography } from "@mui/material";
+import { PageContainer } from "@/components/ui/PageContainer";
+import { PageHeader } from "@/components/ui/PageHeader";
 import { getVenueRelationshipAdminData } from "@/lib/actions/venue-relationships";
 import { VenueRelationshipManager } from "@/components/features/venue-admin";
 
@@ -19,13 +20,9 @@ export default async function VenueRelationshipsAdminPage({ params }: VenueRelat
   }
 
   return (
-    <Container maxWidth="lg">
-      <Stack spacing={4} sx={{ py: 4 }}>
-        <Typography variant="h4" component="h1">
-          Venue Relationships
-        </Typography>
-        <VenueRelationshipManager relationships={result.data.relationships} />
-      </Stack>
-    </Container>
+    <PageContainer>
+      <PageHeader title="Venue Relationships" />
+      <VenueRelationshipManager relationships={result.data.relationships} />
+    </PageContainer>
   );
 }

--- a/app/(dashboard)/venue-admin/[organizationId]/venues/[venueId]/requests/page.tsx
+++ b/app/(dashboard)/venue-admin/[organizationId]/venues/[venueId]/requests/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from "next/navigation";
-import { Container, Stack, Typography } from "@mui/material";
+import { PageContainer } from "@/components/ui/PageContainer";
+import { PageHeader } from "@/components/ui/PageHeader";
 import { getVenueRequestQueue } from "@/lib/actions/venue-requests";
 import { IceTimeRequestQueue } from "@/components/features/venue-admin";
 
@@ -19,13 +20,9 @@ export default async function VenueRequestsPage({ params }: VenueRequestsPagePro
   }
 
   return (
-    <Container maxWidth="lg">
-      <Stack spacing={4} sx={{ py: 4 }}>
-        <Typography variant="h4" component="h1">
-          Ice Time Requests
-        </Typography>
-        <IceTimeRequestQueue requests={result.data.requests} />
-      </Stack>
-    </Container>
+    <PageContainer>
+      <PageHeader title="Ice Time Requests" />
+      <IceTimeRequestQueue requests={result.data.requests} />
+    </PageContainer>
   );
 }

--- a/app/(dashboard)/venue-admin/[organizationId]/venues/[venueId]/schedule/page.tsx
+++ b/app/(dashboard)/venue-admin/[organizationId]/venues/[venueId]/schedule/page.tsx
@@ -1,6 +1,8 @@
 import { notFound } from "next/navigation";
 import { TZDate } from "@date-fns/tz";
-import { Container, Stack, Typography } from "@mui/material";
+import { Stack } from "@mui/material";
+import { PageContainer } from "@/components/ui/PageContainer";
+import { PageHeader } from "@/components/ui/PageHeader";
 import {
   getVenueScheduleAdminData,
   getVenueScheduleBoard,
@@ -81,11 +83,9 @@ export default async function VenueSchedulePage({ params }: VenueSchedulePagePro
   });
 
   return (
-    <Container maxWidth="lg">
-      <Stack spacing={3} sx={{ py: 4 }}>
-        <Typography variant="h4" component="h1">
-          Manage Venue Schedule
-        </Typography>
+    <PageContainer>
+      <PageHeader title="Manage Venue Schedule" />
+      <Stack spacing={3}>
         <IceSurfaceManager organizationId={organizationId} venueId={venueId} surfaces={surfaces} />
         <OperatingHoursEditor organizationId={organizationId} venueId={venueId} operatingHours={operatingHours} />
         <VenueScheduleBoard
@@ -98,6 +98,6 @@ export default async function VenueSchedulePage({ params }: VenueSchedulePagePro
           initialBlocks={board.success ? board.data.blocks : []}
         />
       </Stack>
-    </Container>
+    </PageContainer>
   );
 }

--- a/app/(dashboard)/venue-admin/[organizationId]/venues/[venueId]/surfaces/page.tsx
+++ b/app/(dashboard)/venue-admin/[organizationId]/venues/[venueId]/surfaces/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from "next/navigation";
-import { Container, Stack, Typography } from "@mui/material";
+import { PageContainer } from "@/components/ui/PageContainer";
+import { PageHeader } from "@/components/ui/PageHeader";
 import { getVenueScheduleAdminData } from "@/lib/actions/venue-schedules";
 import { prisma } from "@/lib/db/prisma";
 import { getWholeSurfaceDefaultLabel } from "@/lib/utils/segment-presets";
@@ -124,18 +125,14 @@ export default async function VenueSurfacesPage({ params }: VenueSurfacesPagePro
   const operatingHours: OperatingHourView[] = hourRows;
 
   return (
-    <Container maxWidth="lg">
-      <Stack spacing={4} sx={{ py: 4 }}>
-        <Typography variant="h4" component="h1">
-          Surfaces and Operating Hours
-        </Typography>
-        <SurfaceManager
-          organizationId={organizationId}
-          venueId={venueId}
-          surfaces={surfaces}
-          operatingHours={operatingHours}
-        />
-      </Stack>
-    </Container>
+    <PageContainer>
+      <PageHeader title="Surfaces and Operating Hours" />
+      <SurfaceManager
+        organizationId={organizationId}
+        venueId={venueId}
+        surfaces={surfaces}
+        operatingHours={operatingHours}
+      />
+    </PageContainer>
   );
 }

--- a/app/(dashboard)/venue-admin/loading.tsx
+++ b/app/(dashboard)/venue-admin/loading.tsx
@@ -1,0 +1,16 @@
+import { Skeleton, Stack } from "@mui/material";
+import { PageContainer } from "@/components/ui/PageContainer";
+
+export default function VenueAdminLoading() {
+  return (
+    <PageContainer>
+      <Skeleton variant="text" width={260} sx={{ fontSize: "2.125rem" }} />
+      <Skeleton variant="text" width={320} sx={{ mb: 3 }} />
+      <Stack spacing={2}>
+        <Skeleton variant="rounded" height={140} />
+        <Skeleton variant="rounded" height={140} />
+        <Skeleton variant="rounded" height={140} />
+      </Stack>
+    </PageContainer>
+  );
+}

--- a/app/(dashboard)/venue-admin/new/page.tsx
+++ b/app/(dashboard)/venue-admin/new/page.tsx
@@ -1,15 +1,12 @@
-import { Container, Stack, Typography } from "@mui/material";
 import { VenueOrganizationOnboarding } from "@/components/features/venue-admin";
+import { PageContainer } from "@/components/ui/PageContainer";
+import { PageHeader } from "@/components/ui/PageHeader";
 
 export default function NewVenueOrganizationPage() {
   return (
-    <Container maxWidth="md">
-      <Stack spacing={3} sx={{ py: 4 }}>
-        <Typography variant="h4" component="h1">
-          New Venue Organization
-        </Typography>
-        <VenueOrganizationOnboarding />
-      </Stack>
-    </Container>
+    <PageContainer maxWidth="md">
+      <PageHeader title="New Venue Organization" />
+      <VenueOrganizationOnboarding />
+    </PageContainer>
   );
 }

--- a/app/(dashboard)/venue-admin/page.tsx
+++ b/app/(dashboard)/venue-admin/page.tsx
@@ -1,32 +1,34 @@
-import { Box, Card, CardContent, Container, Stack, Typography } from "@mui/material";
+import { Box, Card, CardContent, Stack, Typography } from "@mui/material";
+import BusinessIcon from "@mui/icons-material/Business";
 import { LinkButton } from "@/components/ui/NextLinkComposites";
+import { PageContainer } from "@/components/ui/PageContainer";
+import { PageHeader } from "@/components/ui/PageHeader";
+import { EmptyState } from "@/components/ui/EmptyState";
 import { getVenueAdminDashboard } from "@/lib/actions/venue-organizations";
 
 export default async function VenueAdminPage() {
   const { organizations } = await getVenueAdminDashboard();
 
   return (
-    <Container maxWidth="lg">
-      <Stack spacing={3} sx={{ py: 4 }}>
-        <Box>
-          <Typography variant="h4" component="h1" gutterBottom>
-            Venue Admin
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            Manage rink profiles, staff, schedules, requests, content, and team relationships.
-          </Typography>
-        </Box>
+    <PageContainer>
+      <PageHeader
+        title="Venue Admin"
+        subtitle="Manage rink profiles, staff, schedules, requests, content, and team relationships."
+        actions={
+          organizations.length > 0 ? (
+            <LinkButton href="/venue-admin/new" variant="outlined" size="small">
+              New organization
+            </LinkButton>
+          ) : undefined
+        }
+      />
 
-        {organizations.length === 0 ? (
-          <Stack spacing={2} sx={{ maxWidth: 560 }}>
-            <Typography variant="body1">
-              Venue Admin is for rink and venue operators who run facilities: publish a branded
-              public profile, manage staff, and schedule ice time across your surfaces.
-            </Typography>
-            <Typography variant="body2" color="text.secondary">
-              Managing a facility your team or league books for games and practices? Those are
-              handled under Venues instead.
-            </Typography>
+      {organizations.length === 0 ? (
+        <EmptyState
+          icon={<BusinessIcon />}
+          title="No venue organizations yet"
+          description="Venue Admin is for rink and venue operators who run facilities: publish a branded public profile, manage staff, and schedule ice time across your surfaces. Facilities your team or league books for games and practices are handled under Venues instead."
+          action={
             <Stack direction={{ xs: "column", sm: "row" }} spacing={1}>
               <LinkButton href="/venue-admin/new" variant="contained">
                 Create Venue Organization
@@ -35,70 +37,65 @@ export default async function VenueAdminPage() {
                 Go to Venues
               </LinkButton>
             </Stack>
-          </Stack>
-        ) : (
-          <Stack spacing={2}>
-            <Box>
-              <LinkButton href="/venue-admin/new" variant="outlined" size="small">
-                New organization
-              </LinkButton>
-            </Box>
-            {organizations.map((organization) => (
-              <Card key={organization.id}>
-                <CardContent>
-                  <Stack spacing={2}>
-                    <Box>
-                      <Typography variant="h6">{organization.name}</Typography>
-                      <Typography variant="body2" color="text.secondary">
-                        {organization.type} - {organization.status}
-                      </Typography>
-                    </Box>
-                    <Box>
-                      <LinkButton
-                        href={`/venue-admin/${organization.id}/payments`}
-                        variant="text"
-                        size="small"
-                      >
-                        Payments &amp; payouts
-                      </LinkButton>
-                    </Box>
-                      <Stack spacing={1}>
-                      {organization.venues.map((venue) => (
-                          <Stack key={venue.id} direction={{ xs: "column", sm: "row" }} spacing={1}>
-                            <LinkButton
-                              href={`/venue-admin/${organization.id}/venues/${venue.id}/profile`}
-                              variant="outlined"
-                            >
-                              Manage {venue.name}
-                            </LinkButton>
-                            <LinkButton
-                              href={`/venue-admin/${organization.id}/venues/${venue.id}/schedule`}
-                              variant="text"
-                            >
-                              Schedule
-                            </LinkButton>
-                            <LinkButton
-                              href={`/venue-admin/${organization.id}/venues/${venue.id}/layout`}
-                              variant="text"
-                            >
-                              Layout
-                            </LinkButton>
-                            <LinkButton
-                              href={`/venue-admin/${organization.id}/venues/${venue.id}/registrations`}
-                              variant="text"
-                            >
-                              Registrations
-                            </LinkButton>
-                          </Stack>
-                      ))}
-                    </Stack>
+          }
+        />
+      ) : (
+        <Stack spacing={2}>
+          {organizations.map((organization) => (
+            <Card key={organization.id}>
+              <CardContent>
+                <Stack spacing={2}>
+                  <Box>
+                    <Typography variant="h6">{organization.name}</Typography>
+                    <Typography variant="body2" color="text.secondary">
+                      {organization.type} - {organization.status}
+                    </Typography>
+                  </Box>
+                  <Box>
+                    <LinkButton
+                      href={`/venue-admin/${organization.id}/payments`}
+                      variant="text"
+                      size="small"
+                    >
+                      Payments &amp; payouts
+                    </LinkButton>
+                  </Box>
+                  <Stack spacing={1}>
+                    {organization.venues.map((venue) => (
+                      <Stack key={venue.id} direction={{ xs: "column", sm: "row" }} spacing={1}>
+                        <LinkButton
+                          href={`/venue-admin/${organization.id}/venues/${venue.id}/profile`}
+                          variant="outlined"
+                        >
+                          Manage {venue.name}
+                        </LinkButton>
+                        <LinkButton
+                          href={`/venue-admin/${organization.id}/venues/${venue.id}/schedule`}
+                          variant="text"
+                        >
+                          Schedule
+                        </LinkButton>
+                        <LinkButton
+                          href={`/venue-admin/${organization.id}/venues/${venue.id}/layout`}
+                          variant="text"
+                        >
+                          Layout
+                        </LinkButton>
+                        <LinkButton
+                          href={`/venue-admin/${organization.id}/venues/${venue.id}/registrations`}
+                          variant="text"
+                        >
+                          Registrations
+                        </LinkButton>
+                      </Stack>
+                    ))}
                   </Stack>
-                </CardContent>
-              </Card>
-            ))}
-          </Stack>
-        )}
-      </Stack>
-    </Container>
+                </Stack>
+              </CardContent>
+            </Card>
+          ))}
+        </Stack>
+      )}
+    </PageContainer>
   );
 }

--- a/app/(dashboard)/venues/[id]/edit/page.tsx
+++ b/app/(dashboard)/venues/[id]/edit/page.tsx
@@ -1,7 +1,7 @@
-import { Container, Box } from "@mui/material";
 import { notFound, redirect } from "next/navigation";
 import { getVenuePageData, getVenueFormContext } from "@/lib/actions/venues";
 import VenueForm from "@/components/features/venues/VenueForm";
+import { PageContainer } from "@/components/ui/PageContainer";
 
 export default async function EditVenuePage({
   params,
@@ -26,30 +26,28 @@ export default async function EditVenuePage({
   const venue = data.venue!;
 
   return (
-    <Container maxWidth="md">
-      <Box sx={{ py: 4 }}>
-        <VenueForm
-          venueId={venue.id}
-          initialData={{
-            name: venue.name,
-            address: venue.address || "",
-            city: venue.city || "",
-            state: venue.state || "",
-            zipCode: venue.zipCode || "",
-            surfaceType: venue.surfaceType,
-            capacity: venue.capacity,
-            amenities: venue.amenities,
-            phone: venue.phone || "",
-            website: venue.website || "",
-            notes: venue.notes || "",
-            visibility: venue.visibility,
-            teamId: venue.teamId || "",
-            leagueId: venue.leagueId || "",
-          }}
-          teams={formContext?.teams ?? []}
-          leagues={formContext?.leagues ?? []}
-        />
-      </Box>
-    </Container>
+    <PageContainer maxWidth="md">
+      <VenueForm
+        venueId={venue.id}
+        initialData={{
+          name: venue.name,
+          address: venue.address || "",
+          city: venue.city || "",
+          state: venue.state || "",
+          zipCode: venue.zipCode || "",
+          surfaceType: venue.surfaceType,
+          capacity: venue.capacity,
+          amenities: venue.amenities,
+          phone: venue.phone || "",
+          website: venue.website || "",
+          notes: venue.notes || "",
+          visibility: venue.visibility,
+          teamId: venue.teamId || "",
+          leagueId: venue.leagueId || "",
+        }}
+        teams={formContext?.teams ?? []}
+        leagues={formContext?.leagues ?? []}
+      />
+    </PageContainer>
   );
 }

--- a/app/(dashboard)/venues/[id]/page.tsx
+++ b/app/(dashboard)/venues/[id]/page.tsx
@@ -1,7 +1,7 @@
-import { Container, Box } from "@mui/material";
 import { notFound } from "next/navigation";
 import { getVenuePageData } from "@/lib/actions/venues";
 import VenueDetail from "@/components/features/venues/VenueDetail";
+import { PageContainer } from "@/components/ui/PageContainer";
 
 export default async function VenueDetailPage({
   params,
@@ -16,14 +16,12 @@ export default async function VenueDetailPage({
   }
 
   return (
-    <Container maxWidth="md">
-      <Box sx={{ py: 4 }}>
-        <VenueDetail
-          venue={data.venue!}
-          canEdit={data.canEdit}
-          upcomingEvents={data.upcomingEvents}
-        />
-      </Box>
-    </Container>
+    <PageContainer maxWidth="md">
+      <VenueDetail
+        venue={data.venue!}
+        canEdit={data.canEdit}
+        upcomingEvents={data.upcomingEvents}
+      />
+    </PageContainer>
   );
 }

--- a/app/(dashboard)/venues/loading.tsx
+++ b/app/(dashboard)/venues/loading.tsx
@@ -1,0 +1,23 @@
+import { Box, Skeleton } from "@mui/material";
+import { PageContainer } from "@/components/ui/PageContainer";
+
+export default function VenuesLoading() {
+  return (
+    <PageContainer>
+      <Skeleton variant="text" width={180} sx={{ fontSize: "2.125rem" }} />
+      <Skeleton variant="text" width={320} sx={{ mb: 3 }} />
+      <Box
+        sx={{
+          display: "grid",
+          gridTemplateColumns: { xs: "1fr", sm: "repeat(2, 1fr)" },
+          gap: 2,
+        }}
+      >
+        <Skeleton variant="rounded" height={160} />
+        <Skeleton variant="rounded" height={160} />
+        <Skeleton variant="rounded" height={160} />
+        <Skeleton variant="rounded" height={160} />
+      </Box>
+    </PageContainer>
+  );
+}

--- a/app/(dashboard)/venues/new/page.tsx
+++ b/app/(dashboard)/venues/new/page.tsx
@@ -1,7 +1,7 @@
-import { Container, Box } from "@mui/material";
 import { redirect } from "next/navigation";
 import { getVenueFormContext } from "@/lib/actions/venues";
 import VenueForm from "@/components/features/venues/VenueForm";
+import { PageContainer } from "@/components/ui/PageContainer";
 
 export default async function NewVenuePage() {
   const context = await getVenueFormContext();
@@ -10,10 +10,8 @@ export default async function NewVenuePage() {
   }
 
   return (
-    <Container maxWidth="md">
-      <Box sx={{ py: 4 }}>
-        <VenueForm teams={context.teams} leagues={context.leagues} />
-      </Box>
-    </Container>
+    <PageContainer maxWidth="md">
+      <VenueForm teams={context.teams} leagues={context.leagues} />
+    </PageContainer>
   );
 }

--- a/app/(dashboard)/venues/page.tsx
+++ b/app/(dashboard)/venues/page.tsx
@@ -1,7 +1,8 @@
-import { Container, Box, Typography } from "@mui/material";
 import { redirect } from "next/navigation";
 import { getAvailableVenues, getVenuesPageAccess } from "@/lib/actions/venues";
 import VenueList from "@/components/features/venues/VenueList";
+import { PageContainer } from "@/components/ui/PageContainer";
+import { PageHeader } from "@/components/ui/PageHeader";
 
 export default async function VenuesPage() {
   const access = await getVenuesPageAccess();
@@ -12,16 +13,12 @@ export default async function VenuesPage() {
   const venues = await getAvailableVenues();
 
   return (
-    <Container maxWidth="lg">
-      <Box sx={{ py: 4 }}>
-        <Typography variant="h4" component="h1" gutterBottom>
-          Venues
-        </Typography>
-        <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
-          Manage rinks, fields, and facilities for scheduling games and practices.
-        </Typography>
-        <VenueList venues={venues} isAdmin={access.isAdmin} />
-      </Box>
-    </Container>
+    <PageContainer>
+      <PageHeader
+        title="Venues"
+        subtitle="Manage rinks, fields, and facilities for scheduling games and practices."
+      />
+      <VenueList venues={venues} isAdmin={access.isAdmin} />
+    </PageContainer>
   );
 }

--- a/components/features/calendar/EventCard.tsx
+++ b/components/features/calendar/EventCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Card, CardContent, Typography, Box, Chip } from "@mui/material";
-import { useRouter } from "next/navigation";
+import Link from "next/link";
 import type { Event } from "@/types/events";
 
 // EventCard can accept either simple Event or extended with league/team info
@@ -29,8 +29,6 @@ export default function EventCard({
   awayTeam,
   teamName,
 }: EventCardProps) {
-  const router = useRouter();
-
   // Convert UTC date to local timezone
   const localDate = new Date(startAt);
   const dateStr = localDate.toLocaleDateString(undefined, {
@@ -46,16 +44,16 @@ export default function EventCard({
   // Event type badge colors
   const badgeColor = type === "GAME" ? "primary" : "secondary";
 
-  const handleClick = () => {
+  return (
     // Always use the team event detail route; repoint league events to
     // /league/[leagueId]/events/[id] when that route ships (roadmap D1)
-    router.push(`/events/${id}`);
-  };
-
-  return (
     <Card
-      onClick={handleClick}
+      component={Link}
+      href={`/events/${id}`}
       sx={{
+        display: "block",
+        color: "inherit",
+        textDecoration: "none",
         cursor: "pointer",
         minHeight: 44,
         transition: "all 0.2s ease-in-out",

--- a/components/features/dashboard/DashboardNav.tsx
+++ b/components/features/dashboard/DashboardNav.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { usePathname, useRouter } from "next/navigation";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
 import {
   List,
   ListItem,
@@ -39,7 +40,6 @@ interface DashboardNavProps {
 
 export default function DashboardNav({ isLeagueMode = false }: DashboardNavProps) {
   const pathname = usePathname();
-  const router = useRouter();
 
   // Use league context if available
   let currentLeague = null;
@@ -86,10 +86,6 @@ export default function DashboardNav({ isLeagueMode = false }: DashboardNavProps
 
   const navItems = getNavItems();
 
-  const handleNavigation = (path: string) => {
-    router.push(path);
-  };
-
   const handleLogout = async () => {
     await logout();
   };
@@ -100,8 +96,9 @@ export default function DashboardNav({ isLeagueMode = false }: DashboardNavProps
       {navItems.map((item) => (
         <ListItem key={item.path} disablePadding>
           <ListItemButton
+            component={Link}
+            href={item.path}
             selected={pathname === item.path || pathname.startsWith(`${item.path}/`)}
-            onClick={() => handleNavigation(item.path)}
           >
             <ListItemIcon>{item.icon}</ListItemIcon>
             <ListItemText primary={item.label} />

--- a/components/features/dashboard/LeagueOverviewCard.tsx
+++ b/components/features/dashboard/LeagueOverviewCard.tsx
@@ -46,7 +46,8 @@ export default function LeagueOverviewCard({
   const router = useRouter();
 
   const handleViewLeague = () => {
-    router.push(`/league/${league.id}`);
+    // No /league/[leagueId] index route exists — dashboard is the canonical view.
+    router.push(`/league/${league.id}/dashboard`);
   };
 
   const handleManageLeague = () => {

--- a/components/features/dashboard/widgets/AdminAttentionWidget.tsx
+++ b/components/features/dashboard/widgets/AdminAttentionWidget.tsx
@@ -1,0 +1,140 @@
+import { Box, CardContent, Chip, Skeleton, Stack, Typography } from "@mui/material";
+import {
+  MailOutline as MailOutlineIcon,
+  HelpOutline as HelpOutlineIcon,
+} from "@mui/icons-material";
+import { LinkCard } from "@/components/ui/NextLinkComposites";
+import { getAdminAttention } from "@/lib/data/dashboard";
+import { formatDateTimeInZone } from "@/lib/utils/date";
+
+/**
+ * Admin-only attention items: upcoming events with unanswered RSVPs and
+ * pending invitations, for teams the viewer administers. Renders nothing for
+ * non-admins or when nothing needs attention. Async RSC — wrap in
+ * <Suspense fallback={<AdminAttentionWidgetSkeleton />}>.
+ */
+export default async function AdminAttentionWidget({ userId }: { userId: string }) {
+  const attention = await getAdminAttention(userId);
+  if (!attention) return null;
+
+  const { events, pendingInvitations } = attention;
+  if (events.length === 0 && pendingInvitations.length === 0) return null;
+
+  return (
+    <Box component="section">
+      <Typography variant="h5" component="h2" sx={{ mb: 2 }}>
+        Needs Your Attention
+      </Typography>
+
+      <Stack spacing={1.5}>
+        {events.map((event) => (
+          <LinkCard
+            key={event.id}
+            variant="outlined"
+            href={`/events/${event.id}`}
+            sx={{
+              textDecoration: "none",
+              color: "inherit",
+              transition: "all 0.2s",
+              "&:hover": {
+                borderColor: "primary.main",
+                boxShadow: 1,
+              },
+            }}
+          >
+            <CardContent sx={{ py: 1.5, "&:last-child": { pb: 1.5 } }}>
+              <Stack
+                direction="row"
+                justifyContent="space-between"
+                alignItems="center"
+                spacing={1}
+              >
+                <Stack direction="row" alignItems="center" spacing={1.5} sx={{ minWidth: 0 }}>
+                  <HelpOutlineIcon sx={{ color: "warning.main", fontSize: 20 }} />
+                  <Box sx={{ minWidth: 0 }}>
+                    <Typography variant="subtitle2" fontWeight={600} noWrap>
+                      {event.title}
+                    </Typography>
+                    <Stack
+                      direction="row"
+                      spacing={1.5}
+                      sx={{ color: "text.secondary" }}
+                      flexWrap="wrap"
+                      useFlexGap
+                    >
+                      <Typography variant="caption">{event.teamName}</Typography>
+                      <Typography variant="caption">
+                        {formatDateTimeInZone(event.startAt, event.timezone)}
+                      </Typography>
+                    </Stack>
+                  </Box>
+                </Stack>
+                <Chip
+                  label={`${event.noResponseCount} unanswered RSVP${
+                    event.noResponseCount !== 1 ? "s" : ""
+                  }`}
+                  color="warning"
+                  size="small"
+                  variant="outlined"
+                />
+              </Stack>
+            </CardContent>
+          </LinkCard>
+        ))}
+
+        {pendingInvitations.map((invitation) => (
+          <LinkCard
+            key={invitation.teamId}
+            variant="outlined"
+            href={`/team/${invitation.teamId}/roster`}
+            sx={{
+              textDecoration: "none",
+              color: "inherit",
+              transition: "all 0.2s",
+              "&:hover": {
+                borderColor: "primary.main",
+                boxShadow: 1,
+              },
+            }}
+          >
+            <CardContent sx={{ py: 1.5, "&:last-child": { pb: 1.5 } }}>
+              <Stack
+                direction="row"
+                justifyContent="space-between"
+                alignItems="center"
+                spacing={1}
+              >
+                <Stack direction="row" alignItems="center" spacing={1.5}>
+                  <MailOutlineIcon sx={{ color: "primary.main", fontSize: 20 }} />
+                  <Typography variant="subtitle2" fontWeight={600}>
+                    {invitation.teamName}
+                  </Typography>
+                </Stack>
+                <Chip
+                  label={`${invitation.count} pending invitation${
+                    invitation.count !== 1 ? "s" : ""
+                  }`}
+                  color="primary"
+                  size="small"
+                  variant="outlined"
+                />
+              </Stack>
+            </CardContent>
+          </LinkCard>
+        ))}
+      </Stack>
+    </Box>
+  );
+}
+
+export function AdminAttentionWidgetSkeleton() {
+  return (
+    <Box component="section">
+      <Skeleton variant="text" width={230} sx={{ fontSize: "1.5rem", mb: 2 }} />
+      <Stack spacing={1.5}>
+        <Skeleton variant="rounded" height={64} />
+        <Skeleton variant="rounded" height={64} />
+      </Stack>
+    </Box>
+  );
+}

--- a/components/features/dashboard/widgets/MyLeaguesWidget.tsx
+++ b/components/features/dashboard/widgets/MyLeaguesWidget.tsx
@@ -1,0 +1,63 @@
+import { Box, Skeleton, Typography } from "@mui/material";
+import LeagueOverviewCard from "@/components/features/dashboard/LeagueOverviewCard";
+import { getViewerMemberships } from "@/lib/data/dashboard";
+
+/**
+ * Role-aware league cards for every league the viewer belongs to. Renders
+ * nothing when the viewer has no league memberships. Async RSC — shares the
+ * cache()-deduped memberships fetch; wrap in
+ * <Suspense fallback={<MyLeaguesWidgetSkeleton />}>.
+ */
+export default async function MyLeaguesWidget({ userId }: { userId: string }) {
+  const { leagues } = await getViewerMemberships(userId);
+  if (leagues.length === 0) return null;
+
+  return (
+    <Box component="section">
+      <Typography variant="h5" component="h2" sx={{ mb: 2 }}>
+        My Leagues
+      </Typography>
+      <Box
+        sx={{
+          display: "grid",
+          gridTemplateColumns: {
+            xs: "1fr",
+            sm: "repeat(2, 1fr)",
+            md: "repeat(3, 1fr)",
+          },
+          gap: 2,
+        }}
+      >
+        {leagues.map((membership) => (
+          <LeagueOverviewCard
+            key={membership.league.id}
+            league={membership.league}
+            userRole={membership.role}
+          />
+        ))}
+      </Box>
+    </Box>
+  );
+}
+
+export function MyLeaguesWidgetSkeleton() {
+  return (
+    <Box component="section">
+      <Skeleton variant="text" width={160} sx={{ fontSize: "1.5rem", mb: 2 }} />
+      <Box
+        sx={{
+          display: "grid",
+          gridTemplateColumns: {
+            xs: "1fr",
+            sm: "repeat(2, 1fr)",
+            md: "repeat(3, 1fr)",
+          },
+          gap: 2,
+        }}
+      >
+        <Skeleton variant="rounded" height={200} />
+        <Skeleton variant="rounded" height={200} />
+      </Box>
+    </Box>
+  );
+}

--- a/components/features/dashboard/widgets/NeedsRsvpWidget.tsx
+++ b/components/features/dashboard/widgets/NeedsRsvpWidget.tsx
@@ -1,0 +1,84 @@
+import { Box, Card, CardContent, Skeleton, Stack, Typography } from "@mui/material";
+import { CheckCircleOutline as CheckCircleOutlineIcon } from "@mui/icons-material";
+import { LinkMuiLink } from "@/components/ui/NextLinkComposites";
+import { RSVPButtons } from "@/components/features/events/RSVPButtons";
+import { getNeedsRsvp } from "@/lib/data/dashboard";
+import { formatDateTimeInZone } from "@/lib/utils/date";
+
+/**
+ * The viewer's unanswered RSVPs on future events, with inline RSVP response.
+ * Async RSC — the only client leaf is the reused RSVPButtons component (all
+ * props crossing that boundary are serializable strings). Wrap in
+ * <Suspense fallback={<NeedsRsvpWidgetSkeleton />}>.
+ */
+export default async function NeedsRsvpWidget({ userId }: { userId: string }) {
+  const items = await getNeedsRsvp(userId);
+
+  return (
+    <Box component="section">
+      <Typography variant="h5" component="h2" sx={{ mb: 2 }}>
+        Needs Your RSVP
+      </Typography>
+
+      {items.length === 0 ? (
+        <Stack direction="row" alignItems="center" spacing={1} sx={{ color: "text.secondary" }}>
+          <CheckCircleOutlineIcon fontSize="small" color="success" />
+          <Typography variant="body2">
+            You&apos;re all caught up — no RSVPs waiting.
+          </Typography>
+        </Stack>
+      ) : (
+        <Stack spacing={1.5}>
+          {items.map((item) => (
+            <Card key={item.eventId} variant="outlined">
+              <CardContent sx={{ py: 1.5, "&:last-child": { pb: 1.5 } }}>
+                <Stack spacing={1.5}>
+                  <Box>
+                    <LinkMuiLink
+                      href={`/events/${item.eventId}`}
+                      variant="subtitle2"
+                      color="inherit"
+                      underline="hover"
+                      sx={{ fontWeight: 600 }}
+                    >
+                      {item.title}
+                      {item.opponent ? ` vs ${item.opponent}` : ""}
+                    </LinkMuiLink>
+                    <Stack
+                      direction="row"
+                      spacing={1.5}
+                      sx={{ color: "text.secondary" }}
+                      flexWrap="wrap"
+                      useFlexGap
+                    >
+                      <Typography variant="caption">{item.teamName}</Typography>
+                      <Typography variant="caption">
+                        {formatDateTimeInZone(item.startAt, item.timezone)}
+                      </Typography>
+                      {item.location ? (
+                        <Typography variant="caption">{item.location}</Typography>
+                      ) : null}
+                    </Stack>
+                  </Box>
+                  <RSVPButtons eventId={item.eventId} currentStatus="NO_RESPONSE" />
+                </Stack>
+              </CardContent>
+            </Card>
+          ))}
+        </Stack>
+      )}
+    </Box>
+  );
+}
+
+export function NeedsRsvpWidgetSkeleton() {
+  return (
+    <Box component="section">
+      <Skeleton variant="text" width={200} sx={{ fontSize: "1.5rem", mb: 2 }} />
+      <Stack spacing={1.5}>
+        <Skeleton variant="rounded" height={120} />
+        <Skeleton variant="rounded" height={120} />
+      </Stack>
+    </Box>
+  );
+}

--- a/components/features/dashboard/widgets/UpcomingScheduleWidget.tsx
+++ b/components/features/dashboard/widgets/UpcomingScheduleWidget.tsx
@@ -1,0 +1,143 @@
+import { Box, Chip, Skeleton, Stack, Typography, CardContent } from "@mui/material";
+import {
+  SportsHockey as SportsHockeyIcon,
+  Event as EventIcon,
+  ArrowForward as ArrowForwardIcon,
+  Place as PlaceIcon,
+} from "@mui/icons-material";
+import { LinkButton, LinkCard } from "@/components/ui/NextLinkComposites";
+import { getUpcomingSchedule, type UpcomingEventItem } from "@/lib/data/dashboard";
+import { formatDateTimeInZone } from "@/lib/utils/date";
+
+const RSVP_CHIP: Record<
+  UpcomingEventItem["rsvpStatus"],
+  { label: string; color: "success" | "warning" | "error" | "default" }
+> = {
+  GOING: { label: "Going", color: "success" },
+  MAYBE: { label: "Maybe", color: "warning" },
+  NOT_GOING: { label: "Not going", color: "error" },
+  NO_RESPONSE: { label: "RSVP needed", color: "default" },
+};
+
+/**
+ * Schedule-first dashboard widget: events across all the viewer's teams merged
+ * with upcoming practice sessions for the next 14 days. Async RSC — fetches its
+ * own data; wrap in <Suspense fallback={<UpcomingScheduleWidgetSkeleton />}>.
+ */
+export default async function UpcomingScheduleWidget({ userId }: { userId: string }) {
+  const items = await getUpcomingSchedule(userId);
+
+  return (
+    <Box component="section">
+      <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 2 }}>
+        <Typography variant="h5" component="h2">
+          Upcoming Schedule
+        </Typography>
+        <LinkButton href="/calendar" endIcon={<ArrowForwardIcon />} size="small">
+          View Calendar
+        </LinkButton>
+      </Stack>
+
+      {items.length === 0 ? (
+        <Typography variant="body2" color="text.secondary">
+          Nothing scheduled in the next 14 days.
+        </Typography>
+      ) : (
+        <Stack spacing={1.5}>
+          {items.map((item) => (
+            <LinkCard
+              key={`${item.kind}-${item.id}`}
+              variant="outlined"
+              href={item.kind === "event" ? `/events/${item.id}` : `/practice-planner/${item.id}`}
+              sx={{
+                textDecoration: "none",
+                color: "inherit",
+                transition: "all 0.2s",
+                "&:hover": {
+                  borderColor: "primary.main",
+                  boxShadow: 1,
+                },
+              }}
+            >
+              <CardContent sx={{ py: 1.5, "&:last-child": { pb: 1.5 } }}>
+                <Stack
+                  direction="row"
+                  justifyContent="space-between"
+                  alignItems="center"
+                  spacing={1}
+                >
+                  <Stack direction="row" alignItems="center" spacing={1.5} sx={{ minWidth: 0 }}>
+                    {item.kind === "event" && item.eventType === "GAME" ? (
+                      <EventIcon sx={{ color: "primary.main", fontSize: 20 }} />
+                    ) : (
+                      <SportsHockeyIcon sx={{ color: "primary.main", fontSize: 20 }} />
+                    )}
+                    <Box sx={{ minWidth: 0 }}>
+                      <Typography variant="subtitle2" fontWeight={600} noWrap>
+                        {item.title}
+                        {item.kind === "event" && item.opponent ? ` vs ${item.opponent}` : ""}
+                      </Typography>
+                      <Stack
+                        direction="row"
+                        spacing={1.5}
+                        sx={{ color: "text.secondary" }}
+                        flexWrap="wrap"
+                        useFlexGap
+                      >
+                        <Typography variant="caption">{item.teamName}</Typography>
+                        <Typography variant="caption">
+                          {item.kind === "event"
+                            ? formatDateTimeInZone(item.startAt, item.timezone)
+                            : new Date(item.startAt).toLocaleDateString("en-US", {
+                                weekday: "short",
+                                month: "short",
+                                day: "numeric",
+                              })}
+                        </Typography>
+                        {item.kind === "event" && item.location ? (
+                          <Stack direction="row" alignItems="center" spacing={0.5}>
+                            <PlaceIcon sx={{ fontSize: 13 }} />
+                            <Typography variant="caption">{item.location}</Typography>
+                          </Stack>
+                        ) : null}
+                        {item.kind === "practice" ? (
+                          <Typography variant="caption">
+                            {item.duration} min · {item.playCount} play
+                            {item.playCount !== 1 ? "s" : ""}
+                          </Typography>
+                        ) : null}
+                      </Stack>
+                    </Box>
+                  </Stack>
+                  {item.kind === "event" ? (
+                    <Chip
+                      label={RSVP_CHIP[item.rsvpStatus].label}
+                      color={RSVP_CHIP[item.rsvpStatus].color}
+                      size="small"
+                      variant={item.rsvpStatus === "NO_RESPONSE" ? "outlined" : "filled"}
+                    />
+                  ) : (
+                    <Chip label="Practice plan" size="small" variant="outlined" />
+                  )}
+                </Stack>
+              </CardContent>
+            </LinkCard>
+          ))}
+        </Stack>
+      )}
+    </Box>
+  );
+}
+
+export function UpcomingScheduleWidgetSkeleton() {
+  return (
+    <Box component="section">
+      <Skeleton variant="text" width={220} sx={{ fontSize: "1.5rem", mb: 2 }} />
+      <Stack spacing={1.5}>
+        <Skeleton variant="rounded" height={64} />
+        <Skeleton variant="rounded" height={64} />
+        <Skeleton variant="rounded" height={64} />
+      </Stack>
+    </Box>
+  );
+}

--- a/components/features/events/EventForm.tsx
+++ b/components/features/events/EventForm.tsx
@@ -28,6 +28,7 @@ import {
 } from "@/lib/utils/date";
 import { trackEventAction } from "@/lib/analytics/umami";
 import VenueSelector from "@/components/features/venues/VenueSelector";
+import { DateTimeField } from "@/components/ui/date";
 import type { BookingConflict } from "@/types/segments";
 
 interface EventFormProps {
@@ -125,8 +126,7 @@ export default function EventForm({
     setFieldErrors((prev) => ({ ...prev, [name]: undefined }));
   };
 
-  const handleDateChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const { name, value } = e.target;
+  const handleDateChange = (name: "startAt" | "endAt") => (value: string) => {
     if (name === "endAt") {
       setEndAtLocal(value);
       setFieldErrors((prev) => ({ ...prev, endAt: undefined }));
@@ -340,31 +340,27 @@ export default function EventForm({
         helperText={fieldErrors.title}
       />
 
-      <TextField
+      <DateTimeField
         label="Start Date & Time"
         name="startAt"
-        type="datetime-local"
         value={startAtLocal}
-        onChange={handleDateChange}
+        onChange={handleDateChange("startAt")}
         required
         fullWidth
         disabled={isSubmitting}
         error={!!fieldErrors.startAt}
         helperText={fieldErrors.startAt || `Times are in ${timeZone}`}
-        slotProps={{ inputLabel: { shrink: true } }}
       />
 
-      <TextField
+      <DateTimeField
         label="End Date & Time (optional)"
         name="endAt"
-        type="datetime-local"
         value={endAtLocal}
-        onChange={handleDateChange}
+        onChange={handleDateChange("endAt")}
         fullWidth
         disabled={isSubmitting}
         error={!!fieldErrors.endAt}
         helperText={fieldErrors.endAt || `Times are in ${timeZone}`}
-        slotProps={{ inputLabel: { shrink: true } }}
       />
 
       <VenueSelector

--- a/components/features/events/InterTeamGameForm.tsx
+++ b/components/features/events/InterTeamGameForm.tsx
@@ -20,6 +20,7 @@ import { createInterTeamGame } from "@/lib/actions/events";
 import type { CreateInterTeamGameInput } from "@/lib/utils/validation";
 import { createInterTeamGameSchema } from "@/lib/utils/validation";
 import { formatDateTimeLocalInput, parseDateTimeLocalToUtc, resolveTimeZone } from "@/lib/utils/date";
+import { DateTimeField } from "@/components/ui/date";
 
 interface InterTeamGameFormProps {
   leagueId: string;
@@ -116,8 +117,7 @@ export default function InterTeamGameForm({
     setFieldErrors((prev) => ({ ...prev, [name]: undefined }));
   };
 
-  const handleDateChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const { value } = e.target;
+  const handleDateChange = (value: string) => {
     const parsed = parseDateTimeLocalToUtc(value, timeZone);
     setFormData((prev) => ({ ...prev, startAt: parsed ?? new Date(NaN) }));
     setError(null);
@@ -316,10 +316,9 @@ export default function InterTeamGameForm({
         helperText={fieldErrors.title || "Auto-generated when teams are selected"}
       />
 
-      <TextField
+      <DateTimeField
         label="Date & Time"
         name="startAt"
-        type="datetime-local"
         value={formatDateTimeLocalInput(formData.startAt, timeZone)}
         onChange={handleDateChange}
         required
@@ -327,9 +326,6 @@ export default function InterTeamGameForm({
         disabled={isSubmitting}
         error={!!fieldErrors.startAt}
         helperText={fieldErrors.startAt || `Times are in ${timeZone}`}
-        InputLabelProps={{
-          shrink: true,
-        }}
       />
 
       <TextField

--- a/components/features/navigation/MobileNavigation.tsx
+++ b/components/features/navigation/MobileNavigation.tsx
@@ -20,7 +20,8 @@ import {
   SportsHockey as SportsHockeyIcon,
   HowToReg as HowToRegIcon,
 } from '@mui/icons-material';
-import { usePathname, useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 import { logout } from '@/lib/actions/logout';
 import { useLeague } from '@/components/providers/LeagueProvider';
 
@@ -30,7 +31,6 @@ interface MobileNavigationProps {
 
 export default function MobileNavigation({ isLeagueMode = false }: MobileNavigationProps) {
   const pathname = usePathname();
-  const router = useRouter();
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const menuOpen = Boolean(anchorEl);
 
@@ -72,10 +72,6 @@ export default function MobileNavigation({ isLeagueMode = false }: MobileNavigat
 
   const navItems = getNavItems();
 
-  const handleNavigation = (path: string) => {
-    router.push(path);
-  };
-
   const handleMenuOpen = (event: React.MouseEvent<HTMLElement>) => {
     setAnchorEl(event.currentTarget);
   };
@@ -115,11 +111,6 @@ export default function MobileNavigation({ isLeagueMode = false }: MobileNavigat
       >
         <BottomNavigation
           value={getCurrentValue()}
-          onChange={(_event, newValue) => {
-            if (newValue !== "more") {
-              handleNavigation(newValue);
-            }
-          }}
           showLabels
           sx={{
             '& .MuiBottomNavigationAction-root': {
@@ -134,6 +125,8 @@ export default function MobileNavigation({ isLeagueMode = false }: MobileNavigat
           {navItems.map((item) => (
             <BottomNavigationAction
               key={item.path}
+              component={Link}
+              href={item.path}
               label={item.label}
               value={item.path}
               icon={item.icon}
@@ -176,10 +169,9 @@ export default function MobileNavigation({ isLeagueMode = false }: MobileNavigat
       >
         {!isLeagueMode && (
           <MenuItem
-            onClick={() => {
-              handleMenuClose();
-              handleNavigation('/practice-planner');
-            }}
+            component={Link}
+            href="/practice-planner"
+            onClick={handleMenuClose}
           >
             <ListItemIcon>
               <SportsHockeyIcon />
@@ -188,10 +180,9 @@ export default function MobileNavigation({ isLeagueMode = false }: MobileNavigat
           </MenuItem>
         )}
         <MenuItem
-          onClick={() => {
-            handleMenuClose();
-            handleNavigation('/signup-events');
-          }}
+          component={Link}
+          href="/signup-events"
+          onClick={handleMenuClose}
         >
           <ListItemIcon>
             <HowToRegIcon />

--- a/components/features/practice-planner/PracticeSessionEditor.tsx
+++ b/components/features/practice-planner/PracticeSessionEditor.tsx
@@ -42,8 +42,6 @@ import {
     Edit as EditIcon,
 } from "@mui/icons-material";
 import { DateTimePicker } from "@mui/x-date-pickers/DateTimePicker";
-import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
-import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFns";
 import Image from "next/image";
 import {
     PracticeSessionData,
@@ -608,8 +606,10 @@ export function PracticeSessionEditor({
         // the venue's timezone to form the booking instant (FR-019).
         let startAt: Date | null = null;
         if (venueId) {
-            const pad = (value: number) => String(value).padStart(2, "0");
-            const dateStr = `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
+            // Derive the booking day in the venue's zone — not via browser-local
+            // getFullYear/getMonth/getDate — so the day doesn't shift across
+            // midnight between zones (matches the initial startTime derivation).
+            const dateStr = formatDateTimeLocalInput(date, selectedVenueTimeZone).slice(0, 10);
             startAt = parseDateTimeLocalToUtc(`${dateStr}T${startTime}`, selectedVenueTimeZone);
             if (!startAt) {
                 setValidationErrors((prev) => ({
@@ -932,191 +932,93 @@ export function PracticeSessionEditor({
     const wholeSurfaceLabel = (surfaceId && wholeLabelBySurface[surfaceId]) || "Whole surface";
 
     return (
-        <LocalizationProvider dateAdapter={AdapterDateFns}>
-            <Box
-                sx={{
-                    display: "flex",
-                    flexDirection: "column",
-                    gap: 2,
-                    p: isMobile ? 2 : 3,
-                    maxWidth: "1400px",
-                    margin: "0 auto",
-                }}
-            >
-                {/* Header */}
-                <Typography variant="h4" component="h1">
-                    {sessionId ? "Edit Practice Session" : "Create New Practice Session"}
-                </Typography>
+        <Box
+            sx={{
+                display: "flex",
+                flexDirection: "column",
+                gap: 2,
+                p: isMobile ? 2 : 3,
+                maxWidth: "1400px",
+                margin: "0 auto",
+            }}
+        >
+            {/* Header */}
+            <Typography variant="h4" component="h1">
+                {sessionId ? "Edit Practice Session" : "Create New Practice Session"}
+            </Typography>
 
-                {/* Session Metadata Form */}
-                {/* Requirements: 2.1 - Form fields for title, date, and duration */}
-                <Paper elevation={2} sx={{ p: 2 }}>
-                    <Stack spacing={2}>
-                        <Typography variant="h6" component="h2">
-                            Session Details
-                        </Typography>
+            {/* Session Metadata Form */}
+            {/* Requirements: 2.1 - Form fields for title, date, and duration */}
+            <Paper elevation={2} sx={{ p: 2 }}>
+                <Stack spacing={2}>
+                    <Typography variant="h6" component="h2">
+                        Session Details
+                    </Typography>
 
-                        {/* Title Field */}
-                        <TextField
-                            label="Session Title"
-                            value={title}
-                            onChange={handleTitleChange}
-                            fullWidth
-                            required
-                            placeholder="Enter session title"
-                            inputProps={{ maxLength: 100 }}
-                            helperText={
-                                validationErrors.title ||
-                                `${title.length}/100 characters`
-                            }
-                            error={!!validationErrors.title}
-                        />
+                    {/* Title Field */}
+                    <TextField
+                        label="Session Title"
+                        value={title}
+                        onChange={handleTitleChange}
+                        fullWidth
+                        required
+                        placeholder="Enter session title"
+                        inputProps={{ maxLength: 100 }}
+                        helperText={
+                            validationErrors.title ||
+                            `${title.length}/100 characters`
+                        }
+                        error={!!validationErrors.title}
+                    />
 
-                        {/* Date Field */}
-                        <DateTimePicker
-                            label="Practice Date & Time"
-                            value={date}
-                            onChange={handleDateChange}
-                            slotProps={{
-                                textField: {
-                                    fullWidth: true,
-                                    required: true,
-                                    error: !!validationErrors.date,
-                                    helperText: validationErrors.date,
-                                },
-                            }}
-                        />
+                    {/* Date Field */}
+                    <DateTimePicker
+                        label="Practice Date & Time"
+                        value={date}
+                        onChange={handleDateChange}
+                        slotProps={{
+                            textField: {
+                                fullWidth: true,
+                                required: true,
+                                error: !!validationErrors.date,
+                                helperText: validationErrors.date,
+                            },
+                        }}
+                    />
 
-                        {/* Duration Field */}
-                        {/* Requirements: 2.1 - Duration validation (1-300 minutes) */}
-                        <TextField
-                            label="Session Duration (minutes)"
-                            type="number"
-                            value={duration}
-                            onChange={handleDurationChange}
-                            fullWidth
-                            required
-                            inputProps={{
-                                min: VALIDATION_CONSTRAINTS.MIN_DURATION,
-                                max: VALIDATION_CONSTRAINTS.MAX_DURATION,
-                            }}
-                            helperText={
-                                validationErrors.duration ||
-                                `Duration must be between ${VALIDATION_CONSTRAINTS.MIN_DURATION} and ${VALIDATION_CONSTRAINTS.MAX_DURATION} minutes`
-                            }
-                            error={!!validationErrors.duration}
-                        />
+                    {/* Duration Field */}
+                    {/* Requirements: 2.1 - Duration validation (1-300 minutes) */}
+                    <TextField
+                        label="Session Duration (minutes)"
+                        type="number"
+                        value={duration}
+                        onChange={handleDurationChange}
+                        fullWidth
+                        required
+                        inputProps={{
+                            min: VALIDATION_CONSTRAINTS.MIN_DURATION,
+                            max: VALIDATION_CONSTRAINTS.MAX_DURATION,
+                        }}
+                        helperText={
+                            validationErrors.duration ||
+                            `Duration must be between ${VALIDATION_CONSTRAINTS.MIN_DURATION} and ${VALIDATION_CONSTRAINTS.MAX_DURATION} minutes`
+                        }
+                        error={!!validationErrors.duration}
+                    />
 
-                        {/* Shared Status Indicator */}
-                        {/* Requirements: 3.1 - Show shared status indicator */}
-                        {isShared && (
-                            <Alert severity="info">
-                                This session is shared with your team members
-                            </Alert>
-                        )}
-                    </Stack>
-                </Paper>
+                    {/* Shared Status Indicator */}
+                    {/* Requirements: 3.1 - Show shared status indicator */}
+                    {isShared && (
+                        <Alert severity="info">
+                            This session is shared with your team members
+                        </Alert>
+                    )}
+                </Stack>
+            </Paper>
 
-                {/* Ice Booking (feature 006, FR-019) */}
-                {/* Optional venue attachment: venue → surface → segment + start time. */}
-                {venues.length > 0 && (
-                    <Paper elevation={2} sx={{ p: 2 }}>
-                        <Stack spacing={2}>
-                            <Stack
-                                direction="row"
-                                justifyContent="space-between"
-                                alignItems="center"
-                            >
-                                <Typography variant="h6" component="h2">
-                                    Ice Booking (optional)
-                                </Typography>
-                                {venueId && (
-                                    <Button
-                                        size="small"
-                                        color="inherit"
-                                        onClick={handleClearBooking}
-                                        disabled={isSaving || isSharing}
-                                    >
-                                        Clear booking
-                                    </Button>
-                                )}
-                            </Stack>
-                            <Typography variant="body2" color="text.secondary">
-                                Book a venue for this practice so it appears on the venue&apos;s
-                                schedule and other bookings warn against it.
-                            </Typography>
-                            <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
-                                <TextField
-                                    select
-                                    label="Venue"
-                                    fullWidth
-                                    value={venueId}
-                                    onChange={(event) => handleVenueChange(event.target.value)}
-                                >
-                                    <MenuItem value="">No venue booking</MenuItem>
-                                    {venues.map((venue) => (
-                                        <MenuItem key={venue.id} value={venue.id}>
-                                            {venue.name}
-                                        </MenuItem>
-                                    ))}
-                                </TextField>
-                                {venueId && (
-                                    <TextField
-                                        label="Start time"
-                                        type="time"
-                                        required
-                                        fullWidth
-                                        value={startTime}
-                                        onChange={handleStartTimeChange}
-                                        error={!!validationErrors.startTime}
-                                        helperText={
-                                            validationErrors.startTime ||
-                                            `On the practice date, in ${selectedVenueTimeZone} (the venue's timezone); runs ${duration} min`
-                                        }
-                                        slotProps={{ inputLabel: { shrink: true } }}
-                                    />
-                                )}
-                            </Stack>
-                            {venueId && venueSurfaces.length > 0 && (
-                                <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
-                                    <TextField
-                                        select
-                                        label="Surface (optional)"
-                                        fullWidth
-                                        value={surfaceId}
-                                        onChange={(event) => handleSurfaceChange(event.target.value)}
-                                    >
-                                        <MenuItem value="">Any surface</MenuItem>
-                                        {venueSurfaces.map((surface) => (
-                                            <MenuItem key={surface.id} value={surface.id}>
-                                                {surface.name}
-                                            </MenuItem>
-                                        ))}
-                                    </TextField>
-                                    {surfaceId && surfaceSegments.length > 0 && (
-                                        <TextField
-                                            select
-                                            label="Segment (optional)"
-                                            fullWidth
-                                            value={segmentId}
-                                            onChange={(event) => handleSegmentChange(event.target.value)}
-                                        >
-                                            <MenuItem value="">{wholeSurfaceLabel}</MenuItem>
-                                            {surfaceSegments.map((segment) => (
-                                                <MenuItem key={segment.id} value={segment.id}>
-                                                    {segment.name}
-                                                </MenuItem>
-                                            ))}
-                                        </TextField>
-                                    )}
-                                </Stack>
-                            )}
-                        </Stack>
-                    </Paper>
-                )}
-
-                {/* Play List Management */}
-                {/* Requirements: 2.2, 2.3 - List view for plays in session */}
+            {/* Ice Booking (feature 006, FR-019) */}
+            {/* Optional venue attachment: venue → surface → segment + start time. */}
+            {venues.length > 0 && (
                 <Paper elevation={2} sx={{ p: 2 }}>
                     <Stack spacing={2}>
                         <Stack
@@ -1125,288 +1027,384 @@ export function PracticeSessionEditor({
                             alignItems="center"
                         >
                             <Typography variant="h6" component="h2">
-                                Plays in Session
+                                Ice Booking (optional)
                             </Typography>
-                            {/* Requirements: 4.3 - Add play button to open library */}
-                            <Button
-                                variant="outlined"
-                                startIcon={<AddIcon />}
-                                onClick={handleOpenLibrary}
-                                disabled={isSaving || isSharing}
-                            >
-                                Add Play
-                            </Button>
-                        </Stack>
-
-                        {/* Total Session Time */}
-                        {/* Requirements: 2.3 - Display total session time with validation */}
-                        {plays.length > 0 && (
-                            <Box>
-                                <Stack direction="row" spacing={2} alignItems="center">
-                                    <Typography variant="body2" color="text.secondary">
-                                        Total Play Time: {calculateTotalPlayTime()} minutes
-                                    </Typography>
-                                    <Typography variant="body2" color="text.secondary">
-                                        Session Duration: {duration} minutes
-                                    </Typography>
-                                </Stack>
-                                {/* Requirements: 2.3 - Show warning when total exceeds session duration */}
-                                {calculateTotalPlayTime() > duration && (
-                                    <Alert severity="warning" sx={{ mt: 1 }}>
-                                        Total play time ({calculateTotalPlayTime()} min) exceeds
-                                        session duration ({duration} min)
-                                    </Alert>
-                                )}
-                            </Box>
-                        )}
-
-                        {/* Empty State */}
-                        {plays.length === 0 && (
-                            <Box
-                                sx={{
-                                    display: "flex",
-                                    flexDirection: "column",
-                                    alignItems: "center",
-                                    justifyContent: "center",
-                                    minHeight: 200,
-                                    textAlign: "center",
-                                    p: 3,
-                                }}
-                            >
-                                <Typography variant="h6" color="text.secondary" gutterBottom>
-                                    No plays added yet
-                                </Typography>
-                                <Typography variant="body2" color="text.secondary">
-                                    Add plays from your library to build your practice session
-                                </Typography>
-                            </Box>
-                        )}
-
-                        {/* Play Cards */}
-                        {/* Requirements: 2.2 - Play card showing thumbnail, duration, and instructions */}
-                        {plays.length > 0 && (
-                            <Stack spacing={2}>
-                                {plays.map((play, index) => (
-                                    <PlayCard
-                                        key={play.id}
-                                        play={play}
-                                        index={index}
-                                        totalPlays={plays.length}
-                                        isEditing={editingPlayId === play.id}
-                                        onDelete={handleDeletePlay}
-                                        onEdit={handleEditPlay}
-                                        onUpdate={handleUpdatePlayInSession}
-                                        onCancelEdit={handleCancelEdit}
-                                        onMoveUp={handleMovePlayUp}
-                                        onMoveDown={handleMovePlayDown}
-                                    />
-                                ))}
-                            </Stack>
-                        )}
-                    </Stack>
-                </Paper>
-
-                {/* Save Status and Actions */}
-                <Paper elevation={2} sx={{ p: 2 }}>
-                    <Stack spacing={2}>
-                        {/* Error Message */}
-                        {saveError && (
-                            <Alert severity="error" onClose={() => setSaveError(null)}>
-                                {saveError}
-                            </Alert>
-                        )}
-
-                        {/* Venue booking conflicts (FR-019/US5): warn and allow an
-                            explicit override that resubmits with overrideConflicts. */}
-                        {bookingConflicts && (
-                            <Alert
-                                severity="warning"
-                                action={
-                                    <Button
-                                        color="inherit"
-                                        size="small"
-                                        disabled={isSaving || isSharing}
-                                        onClick={() => handleSave(true)}
-                                    >
-                                        Book anyway
-                                    </Button>
-                                }
-                            >
-                                <AlertTitle>
-                                    This time overlaps {bookingConflicts.length} existing booking
-                                    {bookingConflicts.length === 1 ? "" : "s"} at the venue
-                                </AlertTitle>
-                                {bookingConflicts.map((conflict, index) => (
-                                    <Typography key={`${conflict.title}-${index}`} variant="body2">
-                                        {conflict.title} —{" "}
-                                        {formatDateTimeInZone(conflict.startAt, selectedVenueTimeZone)}
-                                        {conflict.endAt
-                                            ? ` – ${formatDateTimeInZone(conflict.endAt, selectedVenueTimeZone)}`
-                                            : ""}
-                                    </Typography>
-                                ))}
-                            </Alert>
-                        )}
-
-                        {/* Success Message */}
-                        {saveSuccess && (
-                            <Alert severity="success" onClose={() => setSaveSuccess(false)}>
-                                {isShared
-                                    ? "Session shared successfully!"
-                                    : "Session saved successfully!"}
-                            </Alert>
-                        )}
-
-                        {/* Save Status Indicator */}
-                        {isSaving && (
-                            <Stack direction="row" spacing={1} alignItems="center">
-                                <CircularProgress size={16} />
-                                <Typography variant="body2" color="text.secondary">
-                                    Saving...
-                                </Typography>
-                            </Stack>
-                        )}
-                        {hasUnsavedChanges && !isSaving && (
-                            <Typography variant="body2" color="text.secondary">
-                                Unsaved changes
-                            </Typography>
-                        )}
-
-                        {/* Action Buttons */}
-                        <Stack direction="row" spacing={2} justifyContent="flex-end">
-                            {onCancel && (
+                            {venueId && (
                                 <Button
-                                    variant="outlined"
-                                    onClick={onCancel}
+                                    size="small"
+                                    color="inherit"
+                                    onClick={handleClearBooking}
                                     disabled={isSaving || isSharing}
                                 >
-                                    Cancel
-                                </Button>
-                            )}
-
-                            <Button
-                                variant="contained"
-                                color="primary"
-                                onClick={() => handleSave()}
-                                disabled={isSaving || isSharing || !title.trim()}
-                                startIcon={
-                                    isSaving ? (
-                                        <CircularProgress size={20} color="inherit" />
-                                    ) : (
-                                        <SaveIcon />
-                                    )
-                                }
-                            >
-                                {isSaving ? "Saving..." : "Save Session"}
-                            </Button>
-
-                            {/* Share Button */}
-                            {/* Requirements: 3.1 - Share button with confirmation */}
-                            {sessionId && (
-                                <Button
-                                    variant="contained"
-                                    color="secondary"
-                                    onClick={handleOpenShareDialog}
-                                    disabled={isSaving || isSharing || hasUnsavedChanges}
-                                    startIcon={
-                                        isSharing ? (
-                                            <CircularProgress size={20} color="inherit" />
-                                        ) : (
-                                            <ShareIcon />
-                                        )
-                                    }
-                                >
-                                    {isSharing ? "Sharing..." : isShared ? "Shared" : "Share with Team"}
+                                    Clear booking
                                 </Button>
                             )}
                         </Stack>
+                        <Typography variant="body2" color="text.secondary">
+                            Book a venue for this practice so it appears on the venue&apos;s
+                            schedule and other bookings warn against it.
+                        </Typography>
+                        <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
+                            <TextField
+                                select
+                                label="Venue"
+                                fullWidth
+                                value={venueId}
+                                onChange={(event) => handleVenueChange(event.target.value)}
+                            >
+                                <MenuItem value="">No venue booking</MenuItem>
+                                {venues.map((venue) => (
+                                    <MenuItem key={venue.id} value={venue.id}>
+                                        {venue.name}
+                                    </MenuItem>
+                                ))}
+                            </TextField>
+                            {venueId && (
+                                <TextField
+                                    label="Start time"
+                                    type="time"
+                                    required
+                                    fullWidth
+                                    value={startTime}
+                                    onChange={handleStartTimeChange}
+                                    error={!!validationErrors.startTime}
+                                    helperText={
+                                        validationErrors.startTime ||
+                                        `On the practice date, in ${selectedVenueTimeZone} (the venue's timezone); runs ${duration} min`
+                                    }
+                                    slotProps={{ inputLabel: { shrink: true } }}
+                                />
+                            )}
+                        </Stack>
+                        {venueId && venueSurfaces.length > 0 && (
+                            <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
+                                <TextField
+                                    select
+                                    label="Surface (optional)"
+                                    fullWidth
+                                    value={surfaceId}
+                                    onChange={(event) => handleSurfaceChange(event.target.value)}
+                                >
+                                    <MenuItem value="">Any surface</MenuItem>
+                                    {venueSurfaces.map((surface) => (
+                                        <MenuItem key={surface.id} value={surface.id}>
+                                            {surface.name}
+                                        </MenuItem>
+                                    ))}
+                                </TextField>
+                                {surfaceId && surfaceSegments.length > 0 && (
+                                    <TextField
+                                        select
+                                        label="Segment (optional)"
+                                        fullWidth
+                                        value={segmentId}
+                                        onChange={(event) => handleSegmentChange(event.target.value)}
+                                    >
+                                        <MenuItem value="">{wholeSurfaceLabel}</MenuItem>
+                                        {surfaceSegments.map((segment) => (
+                                            <MenuItem key={segment.id} value={segment.id}>
+                                                {segment.name}
+                                            </MenuItem>
+                                        ))}
+                                    </TextField>
+                                )}
+                            </Stack>
+                        )}
                     </Stack>
                 </Paper>
+            )}
 
-                {/* Play Library Dialog */}
-                {/* Requirements: 4.3 - Integrate PlayLibrary component in selection mode */}
-                {/* Using MUI Dialog for accessibility: focus trapping, scroll locking, Escape key handling */}
-                <Dialog
-                    open={showLibrary}
-                    onClose={handleCloseLibrary}
-                    fullScreen={isMobile}
-                    maxWidth="lg"
-                    fullWidth
-                    aria-labelledby="play-library-dialog-title"
-                >
-                    <DialogTitle id="play-library-dialog-title">
-                        <Stack
-                            direction="row"
-                            justifyContent="space-between"
-                            alignItems="center"
-                        >
-                            <Typography variant="h5" component="span">
-                                Select Play from Library
-                            </Typography>
-                            <Button variant="outlined" onClick={handleCloseLibrary}>
-                                Close
-                            </Button>
-                        </Stack>
-                    </DialogTitle>
-                    <DialogContent dividers>
-                        <PlayLibrary
-                            teamId={teamId}
-                            onSelectPlay={handleAddPlayFromLibrary}
-                            mode="select"
-                        />
-                    </DialogContent>
-                </Dialog>
-
-                {/* Share Confirmation Dialog */}
-                {/* Requirements: 3.1 - Share button with confirmation */}
-                <Dialog
-                    open={showShareDialog}
-                    onClose={handleCloseShareDialog}
-                    aria-labelledby="share-dialog-title"
-                    aria-describedby="share-dialog-description"
-                >
-                    <DialogTitle id="share-dialog-title">
-                        Share Practice Session?
-                    </DialogTitle>
-                    <DialogContent>
-                        <DialogContentText id="share-dialog-description">
-                            This will share the practice session with all team members. They
-                            will receive an email notification with a link to view the
-                            session.
-                            {isShared && (
-                                <>
-                                    <br />
-                                    <br />
-                                    <strong>
-                                        Note: This session is already shared. Sharing again will
-                                        send update notifications to team members.
-                                    </strong>
-                                </>
-                            )}
-                        </DialogContentText>
-                    </DialogContent>
-                    <DialogActions>
-                        <Button onClick={handleCloseShareDialog} disabled={isSharing}>
-                            Cancel
-                        </Button>
+            {/* Play List Management */}
+            {/* Requirements: 2.2, 2.3 - List view for plays in session */}
+            <Paper elevation={2} sx={{ p: 2 }}>
+                <Stack spacing={2}>
+                    <Stack
+                        direction="row"
+                        justifyContent="space-between"
+                        alignItems="center"
+                    >
+                        <Typography variant="h6" component="h2">
+                            Plays in Session
+                        </Typography>
+                        {/* Requirements: 4.3 - Add play button to open library */}
                         <Button
-                            onClick={handleShare}
-                            color="primary"
+                            variant="outlined"
+                            startIcon={<AddIcon />}
+                            onClick={handleOpenLibrary}
+                            disabled={isSaving || isSharing}
+                        >
+                            Add Play
+                        </Button>
+                    </Stack>
+
+                    {/* Total Session Time */}
+                    {/* Requirements: 2.3 - Display total session time with validation */}
+                    {plays.length > 0 && (
+                        <Box>
+                            <Stack direction="row" spacing={2} alignItems="center">
+                                <Typography variant="body2" color="text.secondary">
+                                    Total Play Time: {calculateTotalPlayTime()} minutes
+                                </Typography>
+                                <Typography variant="body2" color="text.secondary">
+                                    Session Duration: {duration} minutes
+                                </Typography>
+                            </Stack>
+                            {/* Requirements: 2.3 - Show warning when total exceeds session duration */}
+                            {calculateTotalPlayTime() > duration && (
+                                <Alert severity="warning" sx={{ mt: 1 }}>
+                                    Total play time ({calculateTotalPlayTime()} min) exceeds
+                                    session duration ({duration} min)
+                                </Alert>
+                            )}
+                        </Box>
+                    )}
+
+                    {/* Empty State */}
+                    {plays.length === 0 && (
+                        <Box
+                            sx={{
+                                display: "flex",
+                                flexDirection: "column",
+                                alignItems: "center",
+                                justifyContent: "center",
+                                minHeight: 200,
+                                textAlign: "center",
+                                p: 3,
+                            }}
+                        >
+                            <Typography variant="h6" color="text.secondary" gutterBottom>
+                                No plays added yet
+                            </Typography>
+                            <Typography variant="body2" color="text.secondary">
+                                Add plays from your library to build your practice session
+                            </Typography>
+                        </Box>
+                    )}
+
+                    {/* Play Cards */}
+                    {/* Requirements: 2.2 - Play card showing thumbnail, duration, and instructions */}
+                    {plays.length > 0 && (
+                        <Stack spacing={2}>
+                            {plays.map((play, index) => (
+                                <PlayCard
+                                    key={play.id}
+                                    play={play}
+                                    index={index}
+                                    totalPlays={plays.length}
+                                    isEditing={editingPlayId === play.id}
+                                    onDelete={handleDeletePlay}
+                                    onEdit={handleEditPlay}
+                                    onUpdate={handleUpdatePlayInSession}
+                                    onCancelEdit={handleCancelEdit}
+                                    onMoveUp={handleMovePlayUp}
+                                    onMoveDown={handleMovePlayDown}
+                                />
+                            ))}
+                        </Stack>
+                    )}
+                </Stack>
+            </Paper>
+
+            {/* Save Status and Actions */}
+            <Paper elevation={2} sx={{ p: 2 }}>
+                <Stack spacing={2}>
+                    {/* Error Message */}
+                    {saveError && (
+                        <Alert severity="error" onClose={() => setSaveError(null)}>
+                            {saveError}
+                        </Alert>
+                    )}
+
+                    {/* Venue booking conflicts (FR-019/US5): warn and allow an
+                        explicit override that resubmits with overrideConflicts. */}
+                    {bookingConflicts && (
+                        <Alert
+                            severity="warning"
+                            action={
+                                <Button
+                                    color="inherit"
+                                    size="small"
+                                    disabled={isSaving || isSharing}
+                                    onClick={() => handleSave(true)}
+                                >
+                                    Book anyway
+                                </Button>
+                            }
+                        >
+                            <AlertTitle>
+                                This time overlaps {bookingConflicts.length} existing booking
+                                {bookingConflicts.length === 1 ? "" : "s"} at the venue
+                            </AlertTitle>
+                            {bookingConflicts.map((conflict, index) => (
+                                <Typography key={`${conflict.title}-${index}`} variant="body2">
+                                    {conflict.title} —{" "}
+                                    {formatDateTimeInZone(conflict.startAt, selectedVenueTimeZone)}
+                                    {conflict.endAt
+                                        ? ` – ${formatDateTimeInZone(conflict.endAt, selectedVenueTimeZone)}`
+                                        : ""}
+                                </Typography>
+                            ))}
+                        </Alert>
+                    )}
+
+                    {/* Success Message */}
+                    {saveSuccess && (
+                        <Alert severity="success" onClose={() => setSaveSuccess(false)}>
+                            {isShared
+                                ? "Session shared successfully!"
+                                : "Session saved successfully!"}
+                        </Alert>
+                    )}
+
+                    {/* Save Status Indicator */}
+                    {isSaving && (
+                        <Stack direction="row" spacing={1} alignItems="center">
+                            <CircularProgress size={16} />
+                            <Typography variant="body2" color="text.secondary">
+                                Saving...
+                            </Typography>
+                        </Stack>
+                    )}
+                    {hasUnsavedChanges && !isSaving && (
+                        <Typography variant="body2" color="text.secondary">
+                            Unsaved changes
+                        </Typography>
+                    )}
+
+                    {/* Action Buttons */}
+                    <Stack direction="row" spacing={2} justifyContent="flex-end">
+                        {onCancel && (
+                            <Button
+                                variant="outlined"
+                                onClick={onCancel}
+                                disabled={isSaving || isSharing}
+                            >
+                                Cancel
+                            </Button>
+                        )}
+
+                        <Button
                             variant="contained"
-                            disabled={isSharing}
+                            color="primary"
+                            onClick={() => handleSave()}
+                            disabled={isSaving || isSharing || !title.trim()}
                             startIcon={
-                                isSharing ? (
+                                isSaving ? (
                                     <CircularProgress size={20} color="inherit" />
                                 ) : (
-                                    <ShareIcon />
+                                    <SaveIcon />
                                 )
                             }
                         >
-                            {isSharing ? "Sharing..." : "Share"}
+                            {isSaving ? "Saving..." : "Save Session"}
                         </Button>
-                    </DialogActions>
-                </Dialog>
-            </Box>
-        </LocalizationProvider>
+
+                        {/* Share Button */}
+                        {/* Requirements: 3.1 - Share button with confirmation */}
+                        {sessionId && (
+                            <Button
+                                variant="contained"
+                                color="secondary"
+                                onClick={handleOpenShareDialog}
+                                disabled={isSaving || isSharing || hasUnsavedChanges}
+                                startIcon={
+                                    isSharing ? (
+                                        <CircularProgress size={20} color="inherit" />
+                                    ) : (
+                                        <ShareIcon />
+                                    )
+                                }
+                            >
+                                {isSharing ? "Sharing..." : isShared ? "Shared" : "Share with Team"}
+                            </Button>
+                        )}
+                    </Stack>
+                </Stack>
+            </Paper>
+
+            {/* Play Library Dialog */}
+            {/* Requirements: 4.3 - Integrate PlayLibrary component in selection mode */}
+            {/* Using MUI Dialog for accessibility: focus trapping, scroll locking, Escape key handling */}
+            <Dialog
+                open={showLibrary}
+                onClose={handleCloseLibrary}
+                fullScreen={isMobile}
+                maxWidth="lg"
+                fullWidth
+                aria-labelledby="play-library-dialog-title"
+            >
+                <DialogTitle id="play-library-dialog-title">
+                    <Stack
+                        direction="row"
+                        justifyContent="space-between"
+                        alignItems="center"
+                    >
+                        <Typography variant="h5" component="span">
+                            Select Play from Library
+                        </Typography>
+                        <Button variant="outlined" onClick={handleCloseLibrary}>
+                            Close
+                        </Button>
+                    </Stack>
+                </DialogTitle>
+                <DialogContent dividers>
+                    <PlayLibrary
+                        teamId={teamId}
+                        onSelectPlay={handleAddPlayFromLibrary}
+                        mode="select"
+                    />
+                </DialogContent>
+            </Dialog>
+
+            {/* Share Confirmation Dialog */}
+            {/* Requirements: 3.1 - Share button with confirmation */}
+            <Dialog
+                open={showShareDialog}
+                onClose={handleCloseShareDialog}
+                aria-labelledby="share-dialog-title"
+                aria-describedby="share-dialog-description"
+            >
+                <DialogTitle id="share-dialog-title">
+                    Share Practice Session?
+                </DialogTitle>
+                <DialogContent>
+                    <DialogContentText id="share-dialog-description">
+                        This will share the practice session with all team members. They
+                        will receive an email notification with a link to view the
+                        session.
+                        {isShared && (
+                            <>
+                                <br />
+                                <br />
+                                <strong>
+                                    Note: This session is already shared. Sharing again will
+                                    send update notifications to team members.
+                                </strong>
+                            </>
+                        )}
+                    </DialogContentText>
+                </DialogContent>
+                <DialogActions>
+                    <Button onClick={handleCloseShareDialog} disabled={isSharing}>
+                        Cancel
+                    </Button>
+                    <Button
+                        onClick={handleShare}
+                        color="primary"
+                        variant="contained"
+                        disabled={isSharing}
+                        startIcon={
+                            isSharing ? (
+                                <CircularProgress size={20} color="inherit" />
+                            ) : (
+                                <ShareIcon />
+                            )
+                        }
+                    >
+                        {isSharing ? "Sharing..." : "Share"}
+                    </Button>
+                </DialogActions>
+            </Dialog>
+        </Box>
     );
 }

--- a/components/features/seasons/GameForm.tsx
+++ b/components/features/seasons/GameForm.tsx
@@ -16,6 +16,7 @@ import {
   Typography,
 } from "@mui/material";
 import type { Sport } from "@prisma/client";
+import { DateTimeField } from "@/components/ui/date";
 import { createSeasonGame, updateSeasonGame } from "@/lib/actions/season-games";
 import { getSportCapabilities } from "@/lib/utils/sport-catalog";
 import {
@@ -290,25 +291,21 @@ function GameFormBody({
             </Stack>
 
             <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
-              <TextField
+              <DateTimeField
                 name="startAt"
                 label="Starts"
-                type="datetime-local"
                 required
                 fullWidth
                 defaultValue={
                   game ? formatDateTimeLocalInput(game.startAt, initialTimeZone) : ""
                 }
-                slotProps={{ inputLabel: { shrink: true } }}
               />
-              <TextField
+              <DateTimeField
                 name="endAt"
                 label="Ends"
-                type="datetime-local"
                 required
                 fullWidth
                 defaultValue={game ? formatDateTimeLocalInput(game.endAt, initialTimeZone) : ""}
-                slotProps={{ inputLabel: { shrink: true } }}
               />
             </Stack>
             <Typography variant="caption" color="text.secondary">

--- a/components/features/seasons/GenerationWizard.tsx
+++ b/components/features/seasons/GenerationWizard.tsx
@@ -34,6 +34,7 @@ import {
 } from "@mui/material";
 import AutoFixHighIcon from "@mui/icons-material/AutoFixHigh";
 import type { ScheduleFormat } from "@prisma/client";
+import { DateField, TimeField } from "@/components/ui/date";
 import {
   generateRoundRobin,
   previewRoundRobin,
@@ -458,23 +459,19 @@ function WizardBody({
                     </MenuItem>
                   ))}
                 </TextField>
-                <TextField
+                <DateField
                   label="First game day"
-                  type="date"
                   required
                   fullWidth
                   value={startDateText}
-                  onChange={(event) => setStartDateText(event.target.value)}
-                  slotProps={{ inputLabel: { shrink: true } }}
+                  onChange={setStartDateText}
                 />
-                <TextField
+                <DateField
                   label="Last game day"
-                  type="date"
                   required
                   fullWidth
                   value={endDateText}
-                  onChange={(event) => setEndDateText(event.target.value)}
-                  slotProps={{ inputLabel: { shrink: true } }}
+                  onChange={setEndDateText}
                 />
               </Stack>
 
@@ -498,14 +495,12 @@ function WizardBody({
               </Stack>
 
               <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
-                <TextField
+                <TimeField
                   label="Start time"
-                  type="time"
                   required
                   fullWidth
                   value={startTime}
-                  onChange={(event) => setStartTime(event.target.value)}
-                  slotProps={{ inputLabel: { shrink: true } }}
+                  onChange={setStartTime}
                 />
                 <TextField
                   label="Game duration (minutes)"

--- a/components/features/seasons/PhaseEditor.tsx
+++ b/components/features/seasons/PhaseEditor.tsx
@@ -21,6 +21,7 @@ import {
 } from "@mui/material";
 import AddIcon from "@mui/icons-material/Add";
 import type { ScheduleFormat, SeasonPhaseType } from "@prisma/client";
+import { DateField } from "@/components/ui/date";
 import {
   createSeasonPhase,
   deleteSeasonPhase,
@@ -353,36 +354,24 @@ function PhaseFormBody({
                 </MenuItem>
               ))}
             </TextField>
+            {/* The season-end upper bound (former native `max`) is enforced by
+                handleSubmit and the server; DateField exposes only `min`. */}
             <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
-              <TextField
+              <DateField
                 name="startDate"
                 label="Starts"
-                type="date"
                 required
                 fullWidth
                 defaultValue={phase ? dateInputValue(phase.startDate) : ""}
-                slotProps={{
-                  inputLabel: { shrink: true },
-                  htmlInput: {
-                    min: dateInputValue(seasonStartDate),
-                    max: dateInputValue(seasonEndDate),
-                  },
-                }}
+                min={dateInputValue(seasonStartDate)}
               />
-              <TextField
+              <DateField
                 name="endDate"
                 label="Ends"
-                type="date"
                 required
                 fullWidth
                 defaultValue={phase ? dateInputValue(phase.endDate) : ""}
-                slotProps={{
-                  inputLabel: { shrink: true },
-                  htmlInput: {
-                    min: dateInputValue(seasonStartDate),
-                    max: dateInputValue(seasonEndDate),
-                  },
-                }}
+                min={dateInputValue(seasonStartDate)}
               />
             </Stack>
             <TextField

--- a/components/features/seasons/ProposalForm.tsx
+++ b/components/features/seasons/ProposalForm.tsx
@@ -14,6 +14,7 @@ import {
   TextField,
   Typography,
 } from "@mui/material";
+import { DateTimeField } from "@/components/ui/date";
 import { createGameProposal } from "@/lib/actions/game-proposals";
 import {
   isValidTimeZone,
@@ -175,22 +176,8 @@ function ProposalFormBody({
             </Stack>
 
             <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
-              <TextField
-                name="startAt"
-                label="Proposed start"
-                type="datetime-local"
-                required
-                fullWidth
-                slotProps={{ inputLabel: { shrink: true } }}
-              />
-              <TextField
-                name="endAt"
-                label="Proposed end"
-                type="datetime-local"
-                required
-                fullWidth
-                slotProps={{ inputLabel: { shrink: true } }}
-              />
+              <DateTimeField name="startAt" label="Proposed start" required fullWidth />
+              <DateTimeField name="endAt" label="Proposed end" required fullWidth />
             </Stack>
             <Typography variant="caption" color="text.secondary">
               Times are entered in {effectiveTimeZone}

--- a/components/features/seasons/ProposalThread.tsx
+++ b/components/features/seasons/ProposalThread.tsx
@@ -19,6 +19,7 @@ import {
   Typography,
 } from "@mui/material";
 import type { GameProposalEntryKind, GameProposalStatus } from "@prisma/client";
+import { DateTimeField } from "@/components/ui/date";
 import {
   acceptGameProposal,
   counterGameProposal,
@@ -323,22 +324,8 @@ export function ProposalThread({ proposal, canAct, canWithdraw, venues }: Propos
         >
           <Typography variant="subtitle2">Counter-propose new terms</Typography>
           <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
-            <TextField
-              name="startAt"
-              label="New start"
-              type="datetime-local"
-              required
-              fullWidth
-              slotProps={{ inputLabel: { shrink: true } }}
-            />
-            <TextField
-              name="endAt"
-              label="New end"
-              type="datetime-local"
-              required
-              fullWidth
-              slotProps={{ inputLabel: { shrink: true } }}
-            />
+            <DateTimeField name="startAt" label="New start" required fullWidth />
+            <DateTimeField name="endAt" label="New end" required fullWidth />
           </Stack>
           <TextField
             select

--- a/components/features/seasons/SeasonForm.tsx
+++ b/components/features/seasons/SeasonForm.tsx
@@ -4,6 +4,7 @@ import { type FormEvent, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { Alert, Button, MenuItem, Stack, TextField } from "@mui/material";
 import type { ScheduleFormat } from "@prisma/client";
+import { DateField } from "@/components/ui/date";
 import { createSeason, updateSeason } from "@/lib/actions/seasons";
 import { SCHEDULE_FORMAT_LABELS } from "@/lib/utils/sport-catalog";
 import { SCHEDULE_FORMATS } from "@/lib/utils/validation";
@@ -156,23 +157,19 @@ export function SeasonForm({ ownerOptions = [], initialValues, onSaved, onCancel
         slotProps={{ htmlInput: { maxLength: 1000 } }}
       />
       <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
-        <TextField
+        <DateField
           name="startDate"
           label="Starts"
-          type="date"
           required
           fullWidth
           defaultValue={initialValues ? dateInputValue(initialValues.startDate) : ""}
-          slotProps={{ inputLabel: { shrink: true } }}
         />
-        <TextField
+        <DateField
           name="endDate"
           label="Ends"
-          type="date"
           required
           fullWidth
           defaultValue={initialValues ? dateInputValue(initialValues.endDate) : ""}
-          slotProps={{ inputLabel: { shrink: true } }}
         />
       </Stack>
 

--- a/components/features/signup-events/EventForm.tsx
+++ b/components/features/signup-events/EventForm.tsx
@@ -39,6 +39,7 @@ import {
   resolveTimeZone,
   isValidTimeZone,
 } from "@/lib/utils/date";
+import { DateTimeField } from "@/components/ui/date";
 
 const CATEGORY_LABELS: Record<(typeof SIGNUP_EVENT_CATEGORIES)[number], string> = {
   CLINIC: "Clinic / skills",
@@ -382,23 +383,19 @@ export function EventForm({ hostOptions, venueOptions, initialValues, host }: Ev
               </TextField>
             </Stack>
             <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
-              <TextField
+              <DateTimeField
                 name="startAt"
                 label="Starts"
-                type="datetime-local"
                 required
                 fullWidth
                 defaultValue={formatDateTimeLocalInput(initialValues?.startAt, initialTimeZone)}
-                slotProps={{ inputLabel: { shrink: true } }}
               />
-              <TextField
+              <DateTimeField
                 name="endAt"
                 label="Ends"
-                type="datetime-local"
                 required
                 fullWidth
                 defaultValue={formatDateTimeLocalInput(initialValues?.endAt, initialTimeZone)}
-                slotProps={{ inputLabel: { shrink: true } }}
               />
             </Stack>
             <Typography variant="caption" color="text.secondary">
@@ -530,29 +527,23 @@ export function EventForm({ hostOptions, venueOptions, initialValues, host }: Ev
               ))}
             </TextField>
             <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
-              <TextField
+              <DateTimeField
                 name="registrationOpensAt"
                 label="Registration opens (optional)"
-                type="datetime-local"
                 fullWidth
                 defaultValue={formatDateTimeLocalInput(initialValues?.registrationOpensAt, initialTimeZone)}
-                slotProps={{ inputLabel: { shrink: true } }}
               />
-              <TextField
+              <DateTimeField
                 name="registrationClosesAt"
                 label="Registration closes (optional)"
-                type="datetime-local"
                 fullWidth
                 defaultValue={formatDateTimeLocalInput(initialValues?.registrationClosesAt, initialTimeZone)}
-                slotProps={{ inputLabel: { shrink: true } }}
               />
-              <TextField
+              <DateTimeField
                 name="cancellationCutoffAt"
                 label="Cancellation cutoff (optional)"
-                type="datetime-local"
                 fullWidth
                 defaultValue={formatDateTimeLocalInput(initialValues?.cancellationCutoffAt, initialTimeZone)}
-                slotProps={{ inputLabel: { shrink: true } }}
               />
             </Stack>
             <FormControlLabel

--- a/components/features/signup-events/GameScheduler.tsx
+++ b/components/features/signup-events/GameScheduler.tsx
@@ -26,6 +26,7 @@ import CloseIcon from "@mui/icons-material/Close";
 import { deleteEventGame, setGameRotation, upsertEventGame } from "@/lib/actions/event-teams";
 import { GameResultForm } from "./GameResultForm";
 import { formatDateTime, parseDateTimeLocalToUtc, resolveTimeZone } from "@/lib/utils/date";
+import { DateTimeField } from "@/components/ui/date";
 import type { BookingConflict } from "@/types/segments";
 
 type GameParticipant = {
@@ -370,27 +371,23 @@ export function GameScheduler({
                 </TextField>
               </Stack>
               <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
-                <TextField
+                <DateTimeField
                   name="startAt"
                   label="Starts"
-                  type="datetime-local"
                   required
                   fullWidth
                   defaultValue=""
                   helperText={`Times are in ${tz}`}
                   onChange={clearStaleConflicts}
-                  slotProps={{ inputLabel: { shrink: true } }}
                 />
-                <TextField
+                <DateTimeField
                   name="endAt"
                   label="Ends"
-                  type="datetime-local"
                   required
                   fullWidth
                   defaultValue=""
                   helperText={`Times are in ${tz}`}
                   onChange={clearStaleConflicts}
-                  slotProps={{ inputLabel: { shrink: true } }}
                 />
               </Stack>
               <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>

--- a/components/features/signup-events/PhaseEditor.tsx
+++ b/components/features/signup-events/PhaseEditor.tsx
@@ -15,6 +15,7 @@ import AddIcon from "@mui/icons-material/Add";
 import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
 import type { HostGroupOptions } from "@/lib/actions/signup-events";
 import { PHASE_AUDIENCES } from "@/lib/utils/validation";
+import { DateTimeField } from "@/components/ui/date";
 
 export type PhaseRow = {
   id?: string;
@@ -85,15 +86,15 @@ export function PhaseEditor({ phases, onChange, groupOptions }: PhaseEditorProps
                 sx={{ flex: 1 }}
                 slotProps={{ htmlInput: { maxLength: 100 } }}
               />
-              <TextField
-                label="Opens at"
-                type="datetime-local"
-                required
-                value={phase.opensAt}
-                onChange={(event) => updatePhase(index, { opensAt: event.target.value })}
-                sx={{ flex: 1 }}
-                slotProps={{ inputLabel: { shrink: true } }}
-              />
+              {/* The shared field takes no sx; a Box carries the row's flex sizing. */}
+              <Box sx={{ flex: 1 }}>
+                <DateTimeField
+                  label="Opens at"
+                  required
+                  value={phase.opensAt}
+                  onChange={(value) => updatePhase(index, { opensAt: value })}
+                />
+              </Box>
               <IconButton
                 aria-label={`Remove phase ${phase.name || index + 1}`}
                 onClick={() => onChange(phases.filter((_, i) => i !== index))}

--- a/components/features/venue-admin/IceTimeRequestForm.tsx
+++ b/components/features/venue-admin/IceTimeRequestForm.tsx
@@ -2,6 +2,7 @@
 
 import { type FormEvent, useMemo, useState, useTransition } from "react";
 import { Alert, Button, Stack, TextField, Typography } from "@mui/material";
+import { DateTimeField } from "@/components/ui/date";
 import { submitIceTimeRequest } from "@/lib/actions/venue-requests";
 import {
   formatDateTimeLocalInput,
@@ -77,22 +78,18 @@ export function IceTimeRequestForm({ scheduleBlockId, venueId, venueName, starts
       <TextField label="Contact name" name="contactName" required />
       <TextField label="Contact email" name="contactEmail" type="email" required />
       <TextField label="Contact phone" name="contactPhone" type="tel" autoComplete="tel" />
-      <TextField
+      <DateTimeField
         label="Requested start"
         name="requestedStartAt"
-        type="datetime-local"
         required
         defaultValue={defaultStartAt}
-        slotProps={{ inputLabel: { shrink: true } }}
       />
-      <TextField
+      <DateTimeField
         label="Requested end"
         name="requestedEndAt"
-        type="datetime-local"
         required
         defaultValue={defaultEndAt}
         helperText={`Times are in ${tz}`}
-        slotProps={{ inputLabel: { shrink: true } }}
       />
       <TextField label="Notes" name="notes" multiline minRows={3} />
       <Button type="submit" variant="contained" disabled={isPending}>

--- a/components/features/venue-admin/SpecialtyEventEditor.tsx
+++ b/components/features/venue-admin/SpecialtyEventEditor.tsx
@@ -1,16 +1,29 @@
 "use client";
 
-import { Button, Card, CardContent, Stack, TextField, Typography } from "@mui/material";
+import { Button, Card, CardContent, Chip, Stack, Typography } from "@mui/material";
 
+/**
+ * Placeholder for the specialty-event publishing flow (feature 002). The
+ * backing Server Action does not exist yet, so this renders an explicit
+ * "coming soon" state instead of inert form controls — see the Tier 1
+ * foundations design (workstream B1).
+ */
 export function SpecialtyEventEditor({ organizationId: _organizationId, venueId: _venueId }: { organizationId: string; venueId: string }) {
   return (
     <Card>
       <CardContent>
         <Stack spacing={2}>
-          <Typography variant="h5">Specialty event</Typography>
-          <TextField label="Event title" />
-          <TextField label="Starts at" type="datetime-local" InputLabelProps={{ shrink: true }} />
-          <Button variant="contained">Publish event</Button>
+          <Stack direction="row" spacing={1} alignItems="center">
+            <Typography variant="h5">Specialty event</Typography>
+            <Chip label="Coming soon" size="small" color="default" />
+          </Stack>
+          <Typography variant="body2" color="text.secondary">
+            Publishing one-off specialty events (holiday skates, tournaments, exhibitions)
+            to your public rink page isn&apos;t available yet.
+          </Typography>
+          <Button variant="contained" disabled sx={{ alignSelf: "flex-start" }}>
+            Publish event
+          </Button>
         </Stack>
       </CardContent>
     </Card>

--- a/components/features/venue-admin/SurfaceManager.tsx
+++ b/components/features/venue-admin/SurfaceManager.tsx
@@ -45,6 +45,7 @@ import {
 } from "@mui/material";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
+import { TimeField } from "@/components/ui/date";
 import {
   archiveIceSurface,
   createIceSurface,
@@ -735,22 +736,10 @@ function HoursSection({ organizationId, venueId, surfaceId, rows }: HoursSection
             </MenuItem>
           ))}
         </TextField>
-        <TextField
-          name="opensAt"
-          label="Opens"
-          type="time"
-          required
-          size="small"
-          slotProps={{ inputLabel: { shrink: true } }}
-        />
-        <TextField
-          name="closesAt"
-          label="Closes"
-          type="time"
-          required
-          size="small"
-          slotProps={{ inputLabel: { shrink: true } }}
-        />
+        {/* TimeField has no `size` prop — fullWidth={false} keeps the inline
+            wrap-row layout; the pickers render at medium height. */}
+        <TimeField name="opensAt" label="Opens" required fullWidth={false} />
+        <TimeField name="closesAt" label="Closes" required fullWidth={false} />
         <Button type="submit" variant="outlined" disabled={pending} sx={{ minHeight: 44 }}>
           Add hours
         </Button>

--- a/components/features/venue-admin/VenueScheduleBoard.tsx
+++ b/components/features/venue-admin/VenueScheduleBoard.tsx
@@ -24,6 +24,7 @@ import AddIcon from "@mui/icons-material/Add";
 import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
 import ChevronRightIcon from "@mui/icons-material/ChevronRight";
 import { TZDate } from "@date-fns/tz";
+import { DateTimeField } from "@/components/ui/date";
 import {
   createScheduleBlock,
   getVenueScheduleBoard,
@@ -610,25 +611,21 @@ function BlockDialogBody({
             </Stack>
 
             <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
-              <TextField
+              <DateTimeField
                 name="startsAt"
                 label="Starts"
-                type="datetime-local"
                 required
                 fullWidth
                 defaultValue={block ? formatDateTimeLocalInput(block.startsAt, timeZone) : ""}
                 helperText={`Times are in ${timeZone}`}
-                slotProps={{ inputLabel: { shrink: true } }}
               />
-              <TextField
+              <DateTimeField
                 name="endsAt"
                 label="Ends"
-                type="datetime-local"
                 required
                 fullWidth
                 defaultValue={block ? formatDateTimeLocalInput(block.endsAt, timeZone) : ""}
                 helperText={`Times are in ${timeZone}`}
-                slotProps={{ inputLabel: { shrink: true } }}
               />
             </Stack>
 

--- a/components/providers/ThemeProvider.tsx
+++ b/components/providers/ThemeProvider.tsx
@@ -3,14 +3,19 @@
 import { ThemeProvider as MuiThemeProvider } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';
 import { AppRouterCacheProvider } from '@mui/material-nextjs/v15-appRouter';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import theme from '@/lib/theme';
 
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
   return (
     <AppRouterCacheProvider>
       <MuiThemeProvider theme={theme}>
-        <CssBaseline />
-        {children}
+        {/* Single app-wide MUI X pickers provider (AdapterDateFns = date-fns v3/v4). */}
+        <LocalizationProvider dateAdapter={AdapterDateFns}>
+          <CssBaseline />
+          {children}
+        </LocalizationProvider>
       </MuiThemeProvider>
     </AppRouterCacheProvider>
   );

--- a/components/ui/EmptyState.tsx
+++ b/components/ui/EmptyState.tsx
@@ -1,0 +1,44 @@
+import type { ReactNode } from "react";
+import { Box, Typography } from "@mui/material";
+
+export interface EmptyStateProps {
+  /** Usually an MUI SvgIcon element; sized and muted automatically. */
+  icon?: ReactNode;
+  title: string;
+  description?: string;
+  /** Call-to-action slot (Button, or LinkButton from NextLinkComposites in RSC contexts). */
+  action?: ReactNode;
+}
+
+/**
+ * Centered, muted empty-state block. Server-safe.
+ */
+export function EmptyState({ icon, title, description, action }: EmptyStateProps) {
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        textAlign: "center",
+        py: 6,
+        px: 2,
+      }}
+    >
+      {icon ? (
+        <Box aria-hidden sx={{ mb: 2, color: "text.disabled", "& svg": { fontSize: 48 } }}>
+          {icon}
+        </Box>
+      ) : null}
+      <Typography variant="h6" component="p" gutterBottom>
+        {title}
+      </Typography>
+      {description ? (
+        <Typography variant="body2" color="text.secondary" sx={{ maxWidth: 480 }}>
+          {description}
+        </Typography>
+      ) : null}
+      {action ? <Box sx={{ mt: 3 }}>{action}</Box> : null}
+    </Box>
+  );
+}

--- a/components/ui/PageContainer.tsx
+++ b/components/ui/PageContainer.tsx
@@ -1,0 +1,26 @@
+import type { ReactNode } from "react";
+import { Container, type ContainerProps } from "@mui/material";
+
+export interface PageContainerProps {
+  children: ReactNode;
+  /** Override the dashboard-wide default width ("lg"). */
+  maxWidth?: ContainerProps["maxWidth"];
+  /** Remove the standard vertical padding (e.g. for full-bleed editors). */
+  disablePadding?: boolean;
+}
+
+/**
+ * Standard dashboard page container: Container maxWidth="lg" with py: 4 —
+ * the dominant convention across existing dashboard pages. Server-safe.
+ */
+export function PageContainer({
+  children,
+  maxWidth = "lg",
+  disablePadding = false,
+}: PageContainerProps) {
+  return (
+    <Container maxWidth={maxWidth} sx={{ py: disablePadding ? 0 : 4 }}>
+      {children}
+    </Container>
+  );
+}

--- a/components/ui/PageHeader.tsx
+++ b/components/ui/PageHeader.tsx
@@ -1,0 +1,46 @@
+import type { ReactNode } from "react";
+import { Box, Stack, Typography } from "@mui/material";
+
+export interface PageHeaderProps {
+  title: string;
+  subtitle?: string;
+  /** Right-aligned action slot. From Server Components pass RSC-safe elements
+   *  (e.g. LinkButton from components/ui/NextLinkComposites). */
+  actions?: ReactNode;
+  /** Rendered above the title row (e.g. a Breadcrumbs element). */
+  breadcrumbs?: ReactNode;
+}
+
+/**
+ * Standard dashboard page header: h4/h1 title, optional muted subtitle,
+ * optional action buttons. Server-safe (no hooks, no client directive).
+ */
+export function PageHeader({ title, subtitle, actions, breadcrumbs }: PageHeaderProps) {
+  return (
+    <Box sx={{ mb: 3 }}>
+      {breadcrumbs ? <Box sx={{ mb: 1 }}>{breadcrumbs}</Box> : null}
+      <Stack
+        direction={{ xs: "column", sm: "row" }}
+        alignItems={{ xs: "flex-start", sm: "center" }}
+        justifyContent="space-between"
+        spacing={2}
+      >
+        <Box>
+          <Typography variant="h4" component="h1">
+            {title}
+          </Typography>
+          {subtitle ? (
+            <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+              {subtitle}
+            </Typography>
+          ) : null}
+        </Box>
+        {actions ? (
+          <Stack direction="row" spacing={1} sx={{ flexShrink: 0 }}>
+            {actions}
+          </Stack>
+        ) : null}
+      </Stack>
+    </Box>
+  );
+}

--- a/components/ui/date/DateField.tsx
+++ b/components/ui/date/DateField.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+/**
+ * DateField — shared wrapper over MUI X's responsive DatePicker (popover on
+ * desktop, dialog on touch). Self-contained: carries its own
+ * LocalizationProvider so isolated renders (tests, storybook) work without
+ * the app-wide provider in ThemeProvider; nesting is supported by MUI X.
+ *
+ * Public API speaks the calendar-date string 'YYYY-MM-DD' (same format as
+ * native date inputs). Supports both controlled (value + onChange) and
+ * uncontrolled (defaultValue + hidden input) usage; when `name` is given a
+ * hidden input carries the canonical string so FormData-based forms work
+ * unchanged.
+ */
+
+import { DatePicker } from "@mui/x-date-pickers/DatePicker";
+import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
+import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFns";
+import {
+  type BaseFieldProps,
+  formatDateValue,
+  parseDateValue,
+  useDateFieldState,
+} from "./internal";
+
+export interface DateFieldProps extends BaseFieldProps {
+  /** Earliest selectable day, as 'YYYY-MM-DD'. */
+  min?: string;
+}
+
+export function DateField({
+  label,
+  name,
+  value,
+  defaultValue,
+  onChange,
+  required,
+  disabled,
+  error,
+  helperText,
+  min,
+  fullWidth = true,
+}: DateFieldProps) {
+  const { displayValue, canonicalValue, handleChange } = useDateFieldState(
+    parseDateValue,
+    formatDateValue,
+    { value, defaultValue, onChange }
+  );
+
+  return (
+    <LocalizationProvider dateAdapter={AdapterDateFns}>
+      <DatePicker
+        label={label}
+        value={displayValue}
+        onChange={handleChange}
+        disabled={disabled}
+        minDate={parseDateValue(min) ?? undefined}
+        slotProps={{
+          textField: {
+            fullWidth,
+            required,
+            error,
+            helperText,
+          },
+        }}
+      />
+      {name && <input type="hidden" name={name} value={canonicalValue} />}
+    </LocalizationProvider>
+  );
+}

--- a/components/ui/date/DateTimeField.tsx
+++ b/components/ui/date/DateTimeField.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+/**
+ * DateTimeField — shared wrapper over MUI X's responsive DateTimePicker
+ * (popover on desktop, dialog on touch). Self-contained: carries its own
+ * LocalizationProvider so isolated renders (tests, storybook) work without
+ * the app-wide provider in ThemeProvider; nesting is supported by MUI X.
+ *
+ * Public API speaks the wall-clock string 'YYYY-MM-DDTHH:MM' (same format as
+ * native datetime-local inputs and lib/utils/date.ts helpers). Supports both
+ * controlled (value + onChange) and uncontrolled (defaultValue + hidden
+ * input) usage; when `name` is given a hidden input carries the canonical
+ * string so FormData-based forms work unchanged.
+ */
+
+import { DateTimePicker } from "@mui/x-date-pickers/DateTimePicker";
+import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
+import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFns";
+import {
+  type BaseFieldProps,
+  formatDateTimeValue,
+  parseDateTimeValue,
+  useDateFieldState,
+} from "./internal";
+
+export interface DateTimeFieldProps extends BaseFieldProps {
+  /** Earliest selectable instant, as 'YYYY-MM-DDTHH:MM'. */
+  minDateTime?: string;
+  /** @default 5 */
+  minutesStep?: number;
+}
+
+export function DateTimeField({
+  label,
+  name,
+  value,
+  defaultValue,
+  onChange,
+  required,
+  disabled,
+  error,
+  helperText,
+  minDateTime,
+  fullWidth = true,
+  minutesStep = 5,
+}: DateTimeFieldProps) {
+  const { displayValue, canonicalValue, handleChange } = useDateFieldState(
+    parseDateTimeValue,
+    formatDateTimeValue,
+    { value, defaultValue, onChange }
+  );
+
+  return (
+    <LocalizationProvider dateAdapter={AdapterDateFns}>
+      <DateTimePicker
+        label={label}
+        value={displayValue}
+        onChange={handleChange}
+        disabled={disabled}
+        minDateTime={parseDateTimeValue(minDateTime) ?? undefined}
+        minutesStep={minutesStep}
+        slotProps={{
+          textField: {
+            fullWidth,
+            required,
+            error,
+            helperText,
+          },
+        }}
+      />
+      {name && <input type="hidden" name={name} value={canonicalValue} />}
+    </LocalizationProvider>
+  );
+}

--- a/components/ui/date/TimeField.tsx
+++ b/components/ui/date/TimeField.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+/**
+ * TimeField — shared wrapper over MUI X's responsive TimePicker (popover on
+ * desktop, dialog on touch). Self-contained: carries its own
+ * LocalizationProvider so isolated renders (tests, storybook) work without
+ * the app-wide provider in ThemeProvider; nesting is supported by MUI X.
+ *
+ * Public API speaks the wall-clock string 'HH:MM' (same format as native time
+ * inputs). Supports both controlled (value + onChange) and uncontrolled
+ * (defaultValue + hidden input) usage; when `name` is given a hidden input
+ * carries the canonical string so FormData-based forms work unchanged.
+ */
+
+import { TimePicker } from "@mui/x-date-pickers/TimePicker";
+import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
+import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFns";
+import {
+  type BaseFieldProps,
+  formatTimeValue,
+  parseTimeValue,
+  useDateFieldState,
+} from "./internal";
+
+export interface TimeFieldProps extends BaseFieldProps {
+  /** Earliest selectable time of day, as 'HH:MM'. */
+  min?: string;
+  /** @default 5 */
+  minutesStep?: number;
+}
+
+export function TimeField({
+  label,
+  name,
+  value,
+  defaultValue,
+  onChange,
+  required,
+  disabled,
+  error,
+  helperText,
+  min,
+  fullWidth = true,
+  minutesStep = 5,
+}: TimeFieldProps) {
+  const { displayValue, canonicalValue, handleChange } = useDateFieldState(
+    parseTimeValue,
+    formatTimeValue,
+    { value, defaultValue, onChange }
+  );
+
+  return (
+    <LocalizationProvider dateAdapter={AdapterDateFns}>
+      <TimePicker
+        label={label}
+        value={displayValue}
+        onChange={handleChange}
+        disabled={disabled}
+        minTime={parseTimeValue(min) ?? undefined}
+        minutesStep={minutesStep}
+        slotProps={{
+          textField: {
+            fullWidth,
+            required,
+            error,
+            helperText,
+          },
+        }}
+      />
+      {name && <input type="hidden" name={name} value={canonicalValue} />}
+    </LocalizationProvider>
+  );
+}

--- a/components/ui/date/index.ts
+++ b/components/ui/date/index.ts
@@ -1,0 +1,3 @@
+export { DateTimeField, type DateTimeFieldProps } from "./DateTimeField";
+export { DateField, type DateFieldProps } from "./DateField";
+export { TimeField, type TimeFieldProps } from "./TimeField";

--- a/components/ui/date/internal.ts
+++ b/components/ui/date/internal.ts
@@ -29,15 +29,21 @@ export function parseDateTimeValue(value: string | null | undefined): Date | nul
   if (!value) return null;
   const match = DATETIME_VALUE_RE.exec(value.trim());
   if (!match) return null;
-  const [, year, month, day, hour, minute] = match;
-  const date = new Date(
-    Number(year),
-    Number(month) - 1,
-    Number(day),
-    Number(hour),
-    Number(minute)
-  );
-  return Number.isNaN(date.getTime()) ? null : date;
+  const [, year, month, day, hour, minute] = match.map(Number);
+  const date = new Date(year, month - 1, day, hour, minute);
+  // The Date constructor silently rolls invalid components over (Feb 31 →
+  // Mar 3, 25:00 → the next day); reject anything that doesn't round-trip
+  // rather than display — and later re-serialize — a shifted value.
+  if (
+    date.getFullYear() !== year ||
+    date.getMonth() !== month - 1 ||
+    date.getDate() !== day ||
+    date.getHours() !== hour ||
+    date.getMinutes() !== minute
+  ) {
+    return null;
+  }
+  return date;
 }
 
 /** Display Date → 'YYYY-MM-DDTHH:MM'. Null/invalid → ''. */
@@ -53,9 +59,15 @@ export function parseDateValue(value: string | null | undefined): Date | null {
   if (!value) return null;
   const match = DATE_VALUE_RE.exec(value.trim());
   if (!match) return null;
-  const [, year, month, day] = match;
-  const date = new Date(Number(year), Number(month) - 1, Number(day));
-  return Number.isNaN(date.getTime()) ? null : date;
+  const [, year, month, day] = match.map(Number);
+  const date = new Date(year, month - 1, day);
+  // Reject constructor rollover (Feb 31 → Mar 3). Only the date components
+  // are checked: in zones where DST skips midnight the constructor
+  // legitimately lands on 01:00 of the same (valid) day.
+  if (date.getFullYear() !== year || date.getMonth() !== month - 1 || date.getDate() !== day) {
+    return null;
+  }
+  return date;
 }
 
 /** Display Date → 'YYYY-MM-DD'. Null/invalid → ''. */

--- a/components/ui/date/internal.ts
+++ b/components/ui/date/internal.ts
@@ -1,0 +1,147 @@
+/**
+ * Shared internals for the DateTimeField/DateField/TimeField wrappers.
+ *
+ * The public API of the field components speaks the canonical wall-clock
+ * strings the forms already serialize ('YYYY-MM-DDTHH:MM', 'YYYY-MM-DD',
+ * 'HH:MM'). The `Date` objects produced here are presentation-only — they are
+ * composed in the runtime's local zone purely so MUI X can render the picker,
+ * and are never serialized. Timezone interpretation (venue zone vs browser
+ * zone) stays in the forms via lib/utils/date.ts, exactly as today.
+ */
+
+import { useState } from "react";
+
+const DATETIME_VALUE_RE = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})(?::\d{2})?$/;
+const DATE_VALUE_RE = /^(\d{4})-(\d{2})-(\d{2})$/;
+const TIME_VALUE_RE = /^(\d{2}):(\d{2})(?::\d{2})?$/;
+
+/**
+ * Fixed reference day used to carry time-only values in a `Date`. Any date
+ * works — only the hour/minute sections are shown — but a stable one keeps
+ * minTime comparisons and tests deterministic.
+ */
+const TIME_REFERENCE = { year: 2000, monthIndex: 0, day: 1 } as const;
+
+const pad = (value: number) => String(value).padStart(2, "0");
+
+/** 'YYYY-MM-DDTHH:MM' → display Date (local composition). Invalid/empty → null. */
+export function parseDateTimeValue(value: string | null | undefined): Date | null {
+  if (!value) return null;
+  const match = DATETIME_VALUE_RE.exec(value.trim());
+  if (!match) return null;
+  const [, year, month, day, hour, minute] = match;
+  const date = new Date(
+    Number(year),
+    Number(month) - 1,
+    Number(day),
+    Number(hour),
+    Number(minute)
+  );
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+/** Display Date → 'YYYY-MM-DDTHH:MM'. Null/invalid → ''. */
+export function formatDateTimeValue(date: Date | null): string {
+  if (!date || Number.isNaN(date.getTime())) return "";
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(
+    date.getDate()
+  )}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+}
+
+/** 'YYYY-MM-DD' → display Date (local midnight). Invalid/empty → null. */
+export function parseDateValue(value: string | null | undefined): Date | null {
+  if (!value) return null;
+  const match = DATE_VALUE_RE.exec(value.trim());
+  if (!match) return null;
+  const [, year, month, day] = match;
+  const date = new Date(Number(year), Number(month) - 1, Number(day));
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+/** Display Date → 'YYYY-MM-DD'. Null/invalid → ''. */
+export function formatDateValue(date: Date | null): string {
+  if (!date || Number.isNaN(date.getTime())) return "";
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
+}
+
+/** 'HH:MM' → display Date on a fixed reference day. Invalid/empty → null. */
+export function parseTimeValue(value: string | null | undefined): Date | null {
+  if (!value) return null;
+  const match = TIME_VALUE_RE.exec(value.trim());
+  if (!match) return null;
+  const [, hour, minute] = match;
+  if (Number(hour) > 23 || Number(minute) > 59) return null;
+  const date = new Date(
+    TIME_REFERENCE.year,
+    TIME_REFERENCE.monthIndex,
+    TIME_REFERENCE.day,
+    Number(hour),
+    Number(minute)
+  );
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+/** Display Date → 'HH:MM'. Null/invalid → ''. */
+export function formatTimeValue(date: Date | null): string {
+  if (!date || Number.isNaN(date.getTime())) return "";
+  return `${pad(date.getHours())}:${pad(date.getMinutes())}`;
+}
+
+/** Props every field wrapper shares (see the concrete components for docs). */
+export interface BaseFieldProps {
+  label: string;
+  /** When set, a hidden `<input name>` carries the canonical string for FormData forms. */
+  name?: string;
+  /** Controlled canonical string ('' = empty). */
+  value?: string;
+  /** Uncontrolled initial canonical string. */
+  defaultValue?: string;
+  /** Fires with the canonical string, or '' when cleared/invalid. */
+  onChange?: (value: string) => void;
+  required?: boolean;
+  disabled?: boolean;
+  error?: boolean;
+  helperText?: React.ReactNode;
+  /** @default true */
+  fullWidth?: boolean;
+}
+
+/**
+ * Semi-controlled state shared by the three fields.
+ *
+ * The picker always renders from internal `Date` state so partially typed
+ * (invalid) input is not clobbered when a controlled parent echoes back the
+ * '' we emitted for it; a genuinely new `value` prop re-derives the display.
+ */
+export function useDateFieldState(
+  parse: (value: string | null | undefined) => Date | null,
+  format: (date: Date | null) => string,
+  { value, defaultValue, onChange }: Pick<BaseFieldProps, "value" | "defaultValue" | "onChange">
+): {
+  displayValue: Date | null;
+  canonicalValue: string;
+  handleChange: (next: Date | null) => void;
+} {
+  const [displayValue, setDisplayValue] = useState<Date | null>(() =>
+    parse(value ?? defaultValue)
+  );
+  const [lastValueProp, setLastValueProp] = useState(value);
+
+  // Controlled sync (render-phase derived state, per React's "storing
+  // information from previous renders" guidance): only re-derive when the
+  // prop no longer matches what the display serializes to.
+  if (value !== undefined && value !== lastValueProp) {
+    setLastValueProp(value);
+    if (value !== format(displayValue)) {
+      setDisplayValue(parse(value));
+    }
+  }
+
+  const handleChange = (next: Date | null) => {
+    setDisplayValue(next);
+    // Invalid/partial input serializes to '' — never emit garbage.
+    onChange?.(format(next));
+  };
+
+  return { displayValue, canonicalValue: format(displayValue), handleChange };
+}

--- a/docs/superpowers/specs/2026-07-11-tier1-foundations-design.md
+++ b/docs/superpowers/specs/2026-07-11-tier1-foundations-design.md
@@ -1,0 +1,139 @@
+# Tier 1 — Foundations: Design
+
+**Date:** 2026-07-11
+**Status:** Approved direction (roadmap D1–D8); this doc specifies the four Tier 1 workstreams
+**Parent:** `2026-07-11-observation-audit-roadmap-design.md`
+**Branch:** `feat/audit-tier1-foundations` (stacked on `feat/audit-tier0-fixes`, PR #263)
+
+Four independently shippable workstreams. A and B each have a foundation stage
+(build the primitives) followed by an adoption stage (sweep consumers). C and D
+are single-stage. File ownership is disjoint across concurrent streams.
+
+## Workstream A — App shell
+
+**A1 — Primitives + route states**
+
+- `components/ui/PageHeader.tsx`: server-safe presentational component —
+  `{ title, subtitle?, actions?, breadcrumbs? }`. Actions is a ReactNode slot
+  (callers pass RSC-safe links via `NextLinkComposites`). Typography scales per
+  the existing theme (athletic headline for title).
+- `components/ui/PageContainer.tsx`: standardizes `Container maxWidth` + vertical
+  padding (today three different `py` values and two widths exist across pages).
+- `components/ui/EmptyState.tsx`: `{ icon?, title, description?, action? }` —
+  MUI-styled, replaces bare-text empty states; action slot takes a
+  LinkButton/Button.
+- Route states for the `(dashboard)` group: `error.tsx` (client, MUI Alert +
+  reset button), `not-found.tsx`, and per-section `loading.tsx` skeletons for the
+  heaviest routes: roster, calendar, seasons, venues, venue-admin, league,
+  practice-planner, my-registrations. Skeletons approximate each section's
+  layout (header bar + card/list placeholders).
+
+**A2 — Adoption sweep (three parallel sub-streams, disjoint page sets)**
+
+- A2a: roster, calendar, events, team pages.
+- A2b: seasons, league pages.
+- A2c: venues, venue-admin, practice-planner, signup-events, my-registrations,
+  admin pages.
+- Each page: wrap content in `PageContainer`, replace ad-hoc header rows with
+  `PageHeader`, replace bare empty states with `EmptyState`. Convert non-link
+  navigation (`onClick` + `router.push`) to real links where encountered in
+  owned files (client components use `next/link`; RSC contexts use
+  `NextLinkComposites`).
+- Explicitly excluded: `app/(dashboard)/dashboard/**` (workstream D owns) and
+  form components (workstream B owns).
+
+## Workstream B — Date/time fields (decision D6)
+
+**B1 — Provider + field components**
+
+- Hoist a single `LocalizationProvider` (AdapterDateFns, date-fns v4) into
+  `components/providers/ThemeProvider.tsx` (already `"use client"`); delete the
+  local provider in `PracticeSessionEditor`.
+- `components/ui/date/DateTimeField.tsx`, `DateField.tsx`, `TimeField.tsx`:
+  thin `"use client"` wrappers over MUI X `DateTimePicker`/`DatePicker`/
+  `TimePicker` (responsive: popover desktop, dialog touch). API speaks the
+  wall-clock strings forms already use — `'YYYY-MM-DDTHH:MM'`, `'YYYY-MM-DD'`,
+  `'HH:MM'` — converting to/from a display `Date` internally; the `Date` object
+  is never serialized. Each renders a hidden `<input name={...}>` with the
+  canonical string so uncontrolled FormData-based forms keep working unchanged.
+  Support `label`, `required`, `disabled`, `minDateTime`/`min`, `helperText`,
+  `error`. 5-minute time step default.
+- Unit tests mirroring `__tests__/lib/utils/date.test.ts` formats: round-trip
+  string↔display, hidden-input emission, empty/invalid handling.
+- Fix the `PracticeSessionEditor` zone mix: derive the booking day via
+  `formatDateTimeLocalInput(date, selectedVenueTimeZone).slice(0, 10)` instead
+  of browser-local `getFullYear/getMonth/getDate`.
+- `SpecialtyEventEditor` dead stub: delete it if nothing renders it; if
+  rendered, replace its inert fields with the new components and wire submit or
+  gate it behind a "coming soon" state — investigate first.
+
+**B2 — Form conversion (two parallel sub-streams, disjoint files)**
+
+- B2a: `events/EventForm`, `events/InterTeamGameForm`, `signup-events/EventForm`,
+  `signup-events/GameScheduler`, `signup-events/PhaseEditor`.
+- B2b: `seasons/GameForm`, `seasons/ProposalForm`, `seasons/ProposalThread`,
+  `seasons/SeasonForm`, `seasons/PhaseEditor`, `seasons/GenerationWizard`,
+  `venue-admin/VenueScheduleBoard`, `venue-admin/IceTimeRequestForm`,
+  `venue-admin/SurfaceManager`.
+- Local swaps only: native `type="datetime-local|date|time"` TextFields become
+  the shared fields. No serialization, Zod, or Server Action changes. Season
+  date-only forms keep their UTC-calendar-date convention. Timezone stays
+  implicit (venue zone > browser zone) with existing helper text.
+
+## Workstream C — Dev fixture graph
+
+Extend `prisma/seed.ts` (single entry, small named upsert helpers so it can
+split into scenario modules later):
+
+- `Metro Hockey League` (HOCKEY) with 2 divisions.
+- 4 league teams (`isActive`, `leagueId`, `divisionId`) with cuid-shaped fixed
+  IDs; keep the existing standalone teams untouched.
+- Role-matrix users (all documented in the seed summary output):
+  `league-admin@test.com` (LeagueUser LEAGUE_ADMIN), two team admins holding
+  BOTH TeamMember ADMIN and LeagueUser TEAM_ADMIN rows, one plain member.
+- One venue with a timezone; one league-owned season spanning now−30d…now+120d
+  with 3 phases (pre-season/regular/playoffs) where one phase covers "now".
+- Game proposals exercising the inbox: PENDING incoming, PENDING outgoing,
+  DECLINED, EXPIRED (accept/counter flows left to manual testing).
+- Production guard: refuse to run when `DATABASE_URL` doesn't look local/dev
+  unless `FORCE_SEED=1`.
+- Idempotent via upsert with fixed IDs; re-runs shift relative dates
+  (acceptable for dev).
+
+## Workstream D — Dashboard v1 (decision D7: schedule-first)
+
+- `app/(dashboard)/dashboard/page.tsx` becomes a thin RSC shell: header +
+  My Teams grid paint immediately; each widget is an independent async RSC in
+  `components/features/dashboard/widgets/`, wrapped in `<Suspense>` with an MUI
+  Skeleton card fallback.
+- Widget order (D7): **UpcomingSchedule** (Events for ALL the user's teams +
+  upcoming practice sessions, next 14 days, with the viewer's RSVP status
+  chips) → **NeedsYourRSVP** (NO_RESPONSE RSVPs on future events, inline
+  RSVPButtons reuse) → **AdminAttention** (admin-only: events with unanswered
+  RSVPs, pending invitations) → **MyLeagues** (role-aware league cards via
+  `LeagueOverviewCard` where data allows).
+- Data layer: `lib/data/dashboard.ts` — read-only RSC queries (not Server
+  Actions), all starting from one `cache()`-deduped memberships fetch (teams +
+  roles, leagues + roles). Every query filters strictly by the viewer's own
+  memberships. Widen `getDashboardData`/practices to all teams
+  (`teamId: { in: [...] }`) — `lib/actions/team-context.ts` is owned by this
+  stream.
+- `TeamCard`: feed the existing `showStats` capability with `_count`
+  (players, events).
+- Deferred: RecentMessages widget (needs `MessageRecipient @@index([userId,
+  sentAt])` migration — lands with the next schema migration), venue-admin
+  panel, per-team feed tabs.
+
+## Verification
+
+Single pass after all streams land: `bun run type-check`, `bun run lint`,
+`bun run test` (new date-field tests included), `bun run build` (new routes:
+none expected beyond loading/error files — build validates the Suspense/RSC
+composition). Manual smoke: dashboard streams under throttled network;
+EventForm picker on desktop + touch emulation.
+
+## Out of scope (later tiers)
+
+Unified calendar (Tier 2), TeamOfficial model (Tier 2), venue staff invites
+(Tier 2), league route build-out (Tier 2, D1), dark mode (Tier 2, D8),
+PlayerGuardian/per-child RSVP (Tier 3, D5).

--- a/lib/actions/team-context.ts
+++ b/lib/actions/team-context.ts
@@ -64,58 +64,6 @@ export async function getUserAdminTeamContext(): Promise<TeamContext | null> {
 }
 
 /**
- * Get the user's dashboard data: all team memberships and upcoming practice sessions.
- */
-export async function getDashboardData() {
-  const userId = await requireUserId();
-
-  const teams = await prisma.teamMember.findMany({
-    where: { userId },
-    select: {
-      id: true,
-      role: true,
-      joinedAt: true,
-      team: {
-        select: {
-          id: true,
-          name: true,
-          sport: true,
-          season: true,
-          leagueId: true,
-          league: { select: { id: true, name: true } },
-          division: { select: { id: true, name: true } },
-        },
-      },
-    },
-    orderBy: { joinedAt: "desc" },
-  });
-
-  const firstTeam = teams[0]?.team;
-  const upcomingPractices = firstTeam
-    ? await prisma.practiceSession.findMany({
-        where: {
-          teamId: firstTeam.id,
-          date: { gte: new Date() },
-          OR: [{ isShared: true }, { createdById: userId }],
-        },
-        orderBy: { date: "asc" },
-        take: 3,
-        include: { _count: { select: { plays: true } } },
-      })
-    : [];
-
-  const serializedPractices = upcomingPractices.map((p) => ({
-    id: p.id,
-    title: p.title,
-    date: p.date.toISOString(),
-    duration: p.duration,
-    playCount: p._count.plays,
-  }));
-
-  return { teams, upcomingPractices: serializedPractices };
-}
-
-/**
  * Get the calendar events for the user's primary team.
  */
 export async function getCalendarData(): Promise<{

--- a/lib/data/dashboard.ts
+++ b/lib/data/dashboard.ts
@@ -1,0 +1,332 @@
+// Server-only read layer for the dashboard. These are RSC data-fetching
+// helpers (NOT Server Actions — no "use server"): they must never be imported
+// from Client Components. Every query scopes strictly to the viewer's own
+// memberships, which come from one cache()-deduped fetch per request.
+import { cache } from "react";
+import { addDays } from "date-fns";
+import { prisma } from "@/lib/db/prisma";
+import type { EventType, LeagueRole, Role, RSVPStatus } from "@prisma/client";
+
+const SCHEDULE_WINDOW_DAYS = 14;
+const SCHEDULE_LIMIT = 10;
+const NEEDS_RSVP_LIMIT = 5;
+const ADMIN_EVENTS_LIMIT = 5;
+
+export type ViewerTeamMembership = {
+  role: Role;
+  team: {
+    id: string;
+    name: string;
+    sport: string;
+    season: string;
+    leagueId: string | null;
+    league: { id: string; name: string } | null;
+    division: { id: string; name: string } | null;
+    _count: { players: number; events: number };
+  };
+};
+
+export type ViewerLeagueMembership = {
+  role: LeagueRole;
+  league: {
+    id: string;
+    name: string;
+    sport: string;
+    _count: { teams: number; players: number; events: number; divisions: number };
+  };
+};
+
+export type ViewerMemberships = {
+  teams: ViewerTeamMembership[];
+  leagues: ViewerLeagueMembership[];
+};
+
+/**
+ * The viewer's active team + league memberships (with roles). Deduped with
+ * React cache() so the page shell and every widget share one fetch per request.
+ */
+export const getViewerMemberships = cache(
+  async (userId: string): Promise<ViewerMemberships> => {
+    const [teams, leagues] = await Promise.all([
+      prisma.teamMember.findMany({
+        where: { userId, team: { isActive: true } },
+        select: {
+          role: true,
+          team: {
+            select: {
+              id: true,
+              name: true,
+              sport: true,
+              season: true,
+              leagueId: true,
+              league: { select: { id: true, name: true } },
+              division: { select: { id: true, name: true } },
+              _count: { select: { players: true, events: true } },
+            },
+          },
+        },
+        orderBy: { joinedAt: "desc" },
+      }),
+      prisma.leagueUser.findMany({
+        where: { userId, league: { isActive: true } },
+        select: {
+          role: true,
+          league: {
+            select: {
+              id: true,
+              name: true,
+              sport: true,
+              _count: {
+                select: { teams: true, players: true, events: true, divisions: true },
+              },
+            },
+          },
+        },
+        orderBy: { joinedAt: "desc" },
+      }),
+    ]);
+
+    return { teams, leagues };
+  }
+);
+
+export type UpcomingEventItem = {
+  kind: "event";
+  id: string;
+  eventType: EventType;
+  title: string;
+  startAt: string; // ISO string — serialized before crossing to any client leaf
+  timezone: string;
+  location: string;
+  opponent: string | null;
+  teamId: string;
+  teamName: string;
+  rsvpStatus: RSVPStatus;
+};
+
+export type UpcomingPracticeItem = {
+  kind: "practice";
+  id: string;
+  title: string;
+  startAt: string; // ISO string
+  duration: number;
+  playCount: number;
+  teamId: string;
+  teamName: string;
+};
+
+export type ScheduleItem = UpcomingEventItem | UpcomingPracticeItem;
+
+/**
+ * Events across ALL the viewer's teams (next 14 days, with the viewer's own
+ * RSVP status) merged with upcoming shared/own practice sessions, sorted by
+ * start and capped at 10 items.
+ */
+export async function getUpcomingSchedule(userId: string): Promise<ScheduleItem[]> {
+  const { teams } = await getViewerMemberships(userId);
+  const teamIds = teams.map((membership) => membership.team.id);
+  if (teamIds.length === 0) return [];
+
+  const now = new Date();
+  const horizon = addDays(now, SCHEDULE_WINDOW_DAYS);
+
+  const [events, practices] = await Promise.all([
+    prisma.event.findMany({
+      where: { teamId: { in: teamIds }, startAt: { gte: now, lte: horizon } },
+      orderBy: { startAt: "asc" },
+      take: SCHEDULE_LIMIT,
+      select: {
+        id: true,
+        type: true,
+        title: true,
+        startAt: true,
+        timezone: true,
+        location: true,
+        opponent: true,
+        team: { select: { id: true, name: true } },
+        rsvps: { where: { userId }, select: { status: true } },
+      },
+    }),
+    prisma.practiceSession.findMany({
+      where: {
+        teamId: { in: teamIds },
+        date: { gte: now, lte: horizon },
+        OR: [{ isShared: true }, { createdById: userId }],
+      },
+      orderBy: { date: "asc" },
+      take: SCHEDULE_LIMIT,
+      select: {
+        id: true,
+        title: true,
+        date: true,
+        duration: true,
+        teamId: true,
+        team: { select: { name: true } },
+        _count: { select: { plays: true } },
+      },
+    }),
+  ]);
+
+  const items: ScheduleItem[] = [
+    ...events.map(
+      (event): UpcomingEventItem => ({
+        kind: "event",
+        id: event.id,
+        eventType: event.type,
+        title: event.title,
+        startAt: event.startAt.toISOString(),
+        timezone: event.timezone,
+        location: event.location,
+        opponent: event.opponent,
+        teamId: event.team.id,
+        teamName: event.team.name,
+        rsvpStatus: event.rsvps[0]?.status ?? "NO_RESPONSE",
+      })
+    ),
+    ...practices.map(
+      (practice): UpcomingPracticeItem => ({
+        kind: "practice",
+        id: practice.id,
+        title: practice.title,
+        startAt: practice.date.toISOString(),
+        duration: practice.duration,
+        playCount: practice._count.plays,
+        teamId: practice.teamId,
+        teamName: practice.team.name,
+      })
+    ),
+  ];
+
+  // ISO-8601 UTC strings sort correctly lexicographically.
+  return items.sort((a, b) => a.startAt.localeCompare(b.startAt)).slice(0, SCHEDULE_LIMIT);
+}
+
+export type NeedsRsvpItem = {
+  eventId: string;
+  eventType: EventType;
+  title: string;
+  startAt: string; // ISO string
+  timezone: string;
+  location: string;
+  opponent: string | null;
+  teamName: string;
+};
+
+/**
+ * The viewer's own NO_RESPONSE RSVPs on future events (soonest first, max 5).
+ */
+export async function getNeedsRsvp(userId: string): Promise<NeedsRsvpItem[]> {
+  const rsvps = await prisma.rSVP.findMany({
+    where: {
+      userId,
+      status: "NO_RESPONSE",
+      event: { startAt: { gte: new Date() } },
+    },
+    orderBy: { event: { startAt: "asc" } },
+    take: NEEDS_RSVP_LIMIT,
+    select: {
+      event: {
+        select: {
+          id: true,
+          type: true,
+          title: true,
+          startAt: true,
+          timezone: true,
+          location: true,
+          opponent: true,
+          team: { select: { name: true } },
+        },
+      },
+    },
+  });
+
+  return rsvps.map(({ event }) => ({
+    eventId: event.id,
+    eventType: event.type,
+    title: event.title,
+    startAt: event.startAt.toISOString(),
+    timezone: event.timezone,
+    location: event.location,
+    opponent: event.opponent,
+    teamName: event.team.name,
+  }));
+}
+
+export type AdminAttentionData = {
+  events: Array<{
+    id: string;
+    eventType: EventType;
+    title: string;
+    startAt: string; // ISO string
+    timezone: string;
+    teamId: string;
+    teamName: string;
+    noResponseCount: number;
+  }>;
+  pendingInvitations: Array<{ teamId: string; teamName: string; count: number }>;
+};
+
+/**
+ * Admin-only attention items for teams the viewer administers: upcoming events
+ * with unanswered RSVPs and pending (non-expired) invitations per team.
+ * Returns null when the viewer administers no teams.
+ */
+export async function getAdminAttention(userId: string): Promise<AdminAttentionData | null> {
+  const { teams } = await getViewerMemberships(userId);
+  const adminTeams = teams.filter((membership) => membership.role === "ADMIN");
+  if (adminTeams.length === 0) return null;
+
+  const adminTeamIds = adminTeams.map((membership) => membership.team.id);
+  const teamNames = new Map(
+    adminTeams.map((membership) => [membership.team.id, membership.team.name])
+  );
+  const now = new Date();
+
+  const [events, invitationGroups] = await Promise.all([
+    prisma.event.findMany({
+      where: {
+        teamId: { in: adminTeamIds },
+        startAt: { gte: now },
+        rsvps: { some: { status: "NO_RESPONSE" } },
+      },
+      orderBy: { startAt: "asc" },
+      take: ADMIN_EVENTS_LIMIT,
+      select: {
+        id: true,
+        type: true,
+        title: true,
+        startAt: true,
+        timezone: true,
+        teamId: true,
+        _count: { select: { rsvps: { where: { status: "NO_RESPONSE" } } } },
+      },
+    }),
+    prisma.invitation.groupBy({
+      by: ["teamId"],
+      where: {
+        teamId: { in: adminTeamIds },
+        status: "PENDING",
+        expiresAt: { gt: now },
+      },
+      _count: { _all: true },
+    }),
+  ]);
+
+  return {
+    events: events.map((event) => ({
+      id: event.id,
+      eventType: event.type,
+      title: event.title,
+      startAt: event.startAt.toISOString(),
+      timezone: event.timezone,
+      teamId: event.teamId,
+      teamName: teamNames.get(event.teamId) ?? "",
+      noResponseCount: event._count.rsvps,
+    })),
+    pendingInvitations: invitationGroups.map((group) => ({
+      teamId: group.teamId,
+      teamName: teamNames.get(group.teamId) ?? "",
+      count: group._count._all,
+    })),
+  };
+}

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,7 +1,392 @@
 import { PrismaClient } from '@prisma/client'
+import { PrismaNeon } from '@prisma/adapter-neon'
+import { PrismaPg } from '@prisma/adapter-pg'
 import bcrypt from 'bcryptjs'
 
-const prisma = new PrismaClient()
+// Guard before constructing the client so a refused run never attempts a
+// connection (calls the hoisted declaration below).
+assertSeedTargetIsDev()
+
+// Mirrors lib/db/prisma.ts: Neon's serverless driver only speaks to Neon
+// endpoints; any other PostgreSQL goes through the standard pg adapter.
+function createSeedAdapter() {
+  const connectionString = process.env.DATABASE_URL!
+  if (/\.neon\.tech[/:]/.test(connectionString)) {
+    return new PrismaNeon({ connectionString })
+  }
+  return new PrismaPg({ connectionString })
+}
+
+const prisma = new PrismaClient({ adapter: createSeedAdapter() })
+
+const DAY_MS = 24 * 60 * 60 * 1000
+const HOUR_MS = 60 * 60 * 1000
+
+function daysFromNow(days: number): Date {
+  return new Date(Date.now() + days * DAY_MS)
+}
+
+function hoursAfter(date: Date, hours: number): Date {
+  return new Date(date.getTime() + hours * HOUR_MS)
+}
+
+/**
+ * Refuse to seed anything that doesn't look like a local/dev database.
+ * Neon hostnames are identical between production and dev branches, so
+ * remote hosts always require an explicit FORCE_SEED=1 opt-in.
+ */
+function assertSeedTargetIsDev(): void {
+  if (process.env.FORCE_SEED === '1') {
+    console.warn('⚠️  FORCE_SEED=1 — skipping DATABASE_URL safety check')
+    return
+  }
+  const url = process.env.DATABASE_URL
+  if (!url) {
+    console.error('❌ DATABASE_URL is not set — refusing to seed')
+    process.exit(1)
+  }
+  let host: string
+  try {
+    host = new URL(url).hostname.toLowerCase()
+  } catch {
+    console.error('❌ DATABASE_URL is not a parseable URL — refusing to seed')
+    process.exit(1)
+  }
+  const isLocal =
+    host === 'localhost' || host === '127.0.0.1' || host === '::1' || host.endsWith('.local')
+  if (!isLocal) {
+    console.error(`❌ Refusing to seed non-local database host "${host}"`)
+    console.error('   Re-run with FORCE_SEED=1 only if this is a disposable dev database')
+    console.error('   (e.g. a Neon dev branch — prod and dev branch hostnames are indistinguishable).')
+    process.exit(1)
+  }
+}
+
+// --- Metro Hockey League fixtures (league mode, role matrix, proposal inbox) ---
+
+async function seedMetroLeague() {
+  const league = await prisma.league.upsert({
+    where: { id: 'cseedleague00000000000001' },
+    update: { isActive: true },
+    create: {
+      id: 'cseedleague00000000000001',
+      name: 'Metro Hockey League',
+      sport: 'HOCKEY',
+      contactEmail: 'league-admin@test.com',
+    },
+  })
+
+  const u12Division = await prisma.division.upsert({
+    where: { id: 'cseeddivision000000000001' },
+    update: { isActive: true },
+    create: {
+      id: 'cseeddivision000000000001',
+      name: 'U12 Recreational',
+      ageGroup: 'U12',
+      skillLevel: 'Recreational',
+      leagueId: league.id,
+    },
+  })
+
+  const adultDivision = await prisma.division.upsert({
+    where: { id: 'cseeddivision000000000002' },
+    update: { isActive: true },
+    create: {
+      id: 'cseeddivision000000000002',
+      name: 'Adult Competitive',
+      ageGroup: 'Adult',
+      skillLevel: 'Competitive',
+      leagueId: league.id,
+    },
+  })
+
+  return { league, u12Division, adultDivision }
+}
+
+async function seedLeagueTeams(leagueId: string, u12DivisionId: string, adultDivisionId: string) {
+  const upsertLeagueTeam = (id: string, name: string, divisionId: string) =>
+    prisma.team.upsert({
+      where: { id },
+      // Re-runs repair league/division links if they drifted during manual testing.
+      update: { leagueId, divisionId, isActive: true },
+      create: {
+        id,
+        name,
+        sport: 'HOCKEY',
+        season: 'Winter 2026-27',
+        isActive: true,
+        leagueId,
+        divisionId,
+      },
+    })
+
+  const blades = await upsertLeagueTeam('cseedlgteam00000000000001', 'Metro Blades', u12DivisionId)
+  const hawks = await upsertLeagueTeam('cseedlgteam00000000000002', 'Harbor Hawks', u12DivisionId)
+  const flyers = await upsertLeagueTeam('cseedlgteam00000000000003', 'Foundry Flyers', adultDivisionId)
+  const storm = await upsertLeagueTeam('cseedlgteam00000000000004', 'Summit Storm', adultDivisionId)
+
+  return { blades, hawks, flyers, storm }
+}
+
+async function seedLeagueRoleMatrix(leagueId: string, bladesTeamId: string, hawksTeamId: string) {
+  const adminPassword = await bcrypt.hash('admin123', 12)
+  const memberPassword = await bcrypt.hash('member123', 12)
+
+  const upsertUser = (email: string, name: string, passwordHash: string) =>
+    prisma.user.upsert({
+      where: { email },
+      update: { approved: true }, // Ensure existing users are approved
+      create: { email, passwordHash, name, approved: true },
+    })
+
+  const leagueAdmin = await upsertUser('league-admin@test.com', 'Test League Admin', adminPassword)
+  const teamAdmin1 = await upsertUser('team-admin1@test.com', 'Test Team Admin One', adminPassword)
+  const teamAdmin2 = await upsertUser('team-admin2@test.com', 'Test Team Admin Two', adminPassword)
+  const leagueMember = await upsertUser('league-member@test.com', 'Test League Member', memberPassword)
+
+  const upsertLeagueUser = (userId: string, role: 'LEAGUE_ADMIN' | 'TEAM_ADMIN' | 'MEMBER') =>
+    prisma.leagueUser.upsert({
+      where: { userId_leagueId: { userId, leagueId } },
+      update: { role },
+      create: { userId, leagueId, role },
+    })
+
+  await upsertLeagueUser(leagueAdmin.id, 'LEAGUE_ADMIN')
+  await upsertLeagueUser(teamAdmin1.id, 'TEAM_ADMIN')
+  await upsertLeagueUser(teamAdmin2.id, 'TEAM_ADMIN')
+  await upsertLeagueUser(leagueMember.id, 'MEMBER')
+
+  const upsertTeamMember = (userId: string, teamId: string, role: 'ADMIN' | 'MEMBER') =>
+    prisma.teamMember.upsert({
+      where: { userId_teamId: { userId, teamId } },
+      update: { role },
+      create: { userId, teamId, role },
+    })
+
+  // Team admins hold BOTH a TeamMember ADMIN row and a LeagueUser TEAM_ADMIN row.
+  await upsertTeamMember(teamAdmin1.id, bladesTeamId, 'ADMIN')
+  await upsertTeamMember(teamAdmin2.id, hawksTeamId, 'ADMIN')
+  await upsertTeamMember(leagueMember.id, bladesTeamId, 'MEMBER')
+
+  return { leagueAdmin, teamAdmin1, teamAdmin2, leagueMember }
+}
+
+async function seedLeagueVenue(leagueId: string, createdById: string) {
+  return prisma.venue.upsert({
+    where: { id: 'cseedvenue000000000000001' },
+    update: { timezone: 'America/Chicago', isActive: true },
+    create: {
+      id: 'cseedvenue000000000000001',
+      name: 'Metro Ice Center',
+      address: '400 Rinkside Drive',
+      city: 'Chicago',
+      state: 'IL',
+      surfaceType: 'ICE',
+      timezone: 'America/Chicago',
+      leagueId,
+      createdById,
+    },
+  })
+}
+
+async function seedLeagueSeason(leagueId: string, createdById: string) {
+  // Relative dates are recomputed each run so the regular phase always covers "now".
+  const season = await prisma.season.upsert({
+    where: { id: 'cseedseason00000000000001' },
+    update: { startDate: daysFromNow(-30), endDate: daysFromNow(120), archivedAt: null },
+    create: {
+      id: 'cseedseason00000000000001',
+      name: 'Metro Winter Season',
+      startDate: daysFromNow(-30),
+      endDate: daysFromNow(120),
+      leagueId,
+      createdById,
+    },
+  })
+
+  const upsertPhase = (
+    id: string,
+    name: string,
+    type: 'PRE_SEASON' | 'REGULAR_SEASON' | 'PLAYOFFS',
+    sortOrder: number,
+    startDays: number,
+    endDays: number
+  ) =>
+    prisma.seasonPhase.upsert({
+      where: { id },
+      update: { startDate: daysFromNow(startDays), endDate: daysFromNow(endDays), sortOrder },
+      create: {
+        id,
+        name,
+        type,
+        sortOrder,
+        startDate: daysFromNow(startDays),
+        endDate: daysFromNow(endDays),
+        seasonId: season.id,
+      },
+    })
+
+  await upsertPhase('cseedphase000000000000001', 'Pre-Season', 'PRE_SEASON', 0, -30, -8)
+  await upsertPhase('cseedphase000000000000002', 'Regular Season', 'REGULAR_SEASON', 1, -7, 60)
+  await upsertPhase('cseedphase000000000000003', 'Playoffs', 'PLAYOFFS', 2, 61, 120)
+
+  return season
+}
+
+async function seedProposalInbox(opts: {
+  leagueId: string
+  seasonId: string
+  venueId: string
+  bladesTeamId: string
+  hawksTeamId: string
+  flyersTeamId: string
+  teamAdmin1Id: string
+  teamAdmin2Id: string
+}) {
+  const upsertProposal = (args: {
+    id: string
+    status: 'PENDING' | 'DECLINED' | 'EXPIRED'
+    proposingTeamId: string
+    receivingTeamId: string
+    createdById: string
+    resolvedAt?: Date
+  }) =>
+    prisma.gameProposal.upsert({
+      where: { id: args.id },
+      // Re-runs reset status/resolution so the four inbox states stay canonical.
+      update: { status: args.status, resolvedAt: args.resolvedAt ?? null },
+      create: {
+        id: args.id,
+        status: args.status,
+        leagueId: opts.leagueId,
+        seasonId: opts.seasonId,
+        proposingTeamId: args.proposingTeamId,
+        receivingTeamId: args.receivingTeamId,
+        createdById: args.createdById,
+        resolvedAt: args.resolvedAt ?? null,
+      },
+    })
+
+  const upsertEntry = (args: {
+    id: string
+    proposalId: string
+    kind: 'PROPOSE' | 'DECLINE'
+    startAt: Date | null
+    endAt: Date | null
+    venueId?: string
+    note?: string
+    actorTeamId: string
+    actorUserId: string
+  }) =>
+    prisma.gameProposalEntry.upsert({
+      where: { id: args.id },
+      // The latest PROPOSE entry's startAt drives lazy expiry, so re-runs must
+      // shift it to keep PENDING fixtures unexpired (and the EXPIRED one past).
+      update: { startAt: args.startAt, endAt: args.endAt },
+      create: {
+        id: args.id,
+        proposalId: args.proposalId,
+        kind: args.kind,
+        startAt: args.startAt,
+        endAt: args.endAt,
+        venueId: args.venueId ?? null,
+        note: args.note ?? null,
+        actorTeamId: args.actorTeamId,
+        actorUserId: args.actorUserId,
+      },
+    })
+
+  // 1. PENDING incoming for Metro Blades: Harbor Hawks proposed to team-admin1's team.
+  const incomingStart = daysFromNow(14)
+  await upsertProposal({
+    id: 'cseedproposal000000000001',
+    status: 'PENDING',
+    proposingTeamId: opts.hawksTeamId,
+    receivingTeamId: opts.bladesTeamId,
+    createdById: opts.teamAdmin2Id,
+  })
+  await upsertEntry({
+    id: 'cseedpropentry00000000001',
+    proposalId: 'cseedproposal000000000001',
+    kind: 'PROPOSE',
+    startAt: incomingStart,
+    endAt: hoursAfter(incomingStart, 2),
+    venueId: opts.venueId,
+    note: 'Saturday matchup at Metro Ice Center?',
+    actorTeamId: opts.hawksTeamId,
+    actorUserId: opts.teamAdmin2Id,
+  })
+
+  // 2. PENDING outgoing from Metro Blades to Foundry Flyers.
+  const outgoingStart = daysFromNow(21)
+  await upsertProposal({
+    id: 'cseedproposal000000000002',
+    status: 'PENDING',
+    proposingTeamId: opts.bladesTeamId,
+    receivingTeamId: opts.flyersTeamId,
+    createdById: opts.teamAdmin1Id,
+  })
+  await upsertEntry({
+    id: 'cseedpropentry00000000002',
+    proposalId: 'cseedproposal000000000002',
+    kind: 'PROPOSE',
+    startAt: outgoingStart,
+    endAt: hoursAfter(outgoingStart, 2),
+    note: 'Cross-division exhibition game — open to a weeknight.',
+    actorTeamId: opts.bladesTeamId,
+    actorUserId: opts.teamAdmin1Id,
+  })
+
+  // 3. DECLINED: Metro Blades proposed to Harbor Hawks; Hawks declined.
+  const declinedStart = daysFromNow(10)
+  await upsertProposal({
+    id: 'cseedproposal000000000003',
+    status: 'DECLINED',
+    proposingTeamId: opts.bladesTeamId,
+    receivingTeamId: opts.hawksTeamId,
+    createdById: opts.teamAdmin1Id,
+    resolvedAt: daysFromNow(-1),
+  })
+  await upsertEntry({
+    id: 'cseedpropentry00000000003',
+    proposalId: 'cseedproposal000000000003',
+    kind: 'PROPOSE',
+    startAt: declinedStart,
+    endAt: hoursAfter(declinedStart, 2),
+    actorTeamId: opts.bladesTeamId,
+    actorUserId: opts.teamAdmin1Id,
+  })
+  await upsertEntry({
+    id: 'cseedpropentry00000000004',
+    proposalId: 'cseedproposal000000000003',
+    kind: 'DECLINE',
+    startAt: null,
+    endAt: null,
+    note: 'That date clashes with our tournament weekend.',
+    actorTeamId: opts.hawksTeamId,
+    actorUserId: opts.teamAdmin2Id,
+  })
+
+  // 4. EXPIRED: Hawks → Blades with the proposed start already in the past.
+  // Lazy expiry (FR-022) only flips status, so resolvedAt stays null.
+  const expiredStart = daysFromNow(-3)
+  await upsertProposal({
+    id: 'cseedproposal000000000004',
+    status: 'EXPIRED',
+    proposingTeamId: opts.hawksTeamId,
+    receivingTeamId: opts.bladesTeamId,
+    createdById: opts.teamAdmin2Id,
+  })
+  await upsertEntry({
+    id: 'cseedpropentry00000000005',
+    proposalId: 'cseedproposal000000000004',
+    kind: 'PROPOSE',
+    startAt: expiredStart,
+    endAt: hoursAfter(expiredStart, 2),
+    actorTeamId: opts.hawksTeamId,
+    actorUserId: opts.teamAdmin2Id,
+  })
+}
 
 async function main() {
   console.log('🌱 Starting database seed...')
@@ -310,13 +695,47 @@ async function main() {
     },
   })
 
+  // League-mode fixtures: Metro Hockey League role matrix + proposal inbox
+  const { league, u12Division, adultDivision } = await seedMetroLeague()
+  const teams = await seedLeagueTeams(league.id, u12Division.id, adultDivision.id)
+  const users = await seedLeagueRoleMatrix(league.id, teams.blades.id, teams.hawks.id)
+  const venue = await seedLeagueVenue(league.id, users.leagueAdmin.id)
+  const season = await seedLeagueSeason(league.id, users.leagueAdmin.id)
+  await seedProposalInbox({
+    leagueId: league.id,
+    seasonId: season.id,
+    venueId: venue.id,
+    bladesTeamId: teams.blades.id,
+    hawksTeamId: teams.hawks.id,
+    flyersTeamId: teams.flyers.id,
+    teamAdmin1Id: users.teamAdmin1.id,
+    teamAdmin2Id: users.teamAdmin2.id,
+  })
+
   console.log('✅ Database seeded successfully!')
-  console.log('📧 Test accounts:')
-  console.log('   Admin: admin@test.com / admin123')
-  console.log('   Member: member@test.com / member123')
+  console.log('📧 Standalone-team accounts:')
+  console.log('   Admin: admin@test.com / admin123 — ADMIN of both standalone teams')
+  console.log('   Member: member@test.com / member123 — MEMBER of Northside Ice Hawks')
   console.log('🏒 Hockey: Northside Ice Hawks (Winter 2026-27) — 4 players')
   console.log('🥍 Lacrosse: Eastside Thunder (Spring 2026) — 2 players')
   console.log('📅 Events: 2 games + 2 practices scheduled')
+  console.log('')
+  console.log('🏆 Metro Hockey League (HOCKEY)')
+  console.log('   Divisions: U12 Recreational, Adult Competitive')
+  console.log('   Teams: Metro Blades + Harbor Hawks (U12 Rec); Foundry Flyers + Summit Storm (Adult Comp)')
+  console.log('🏟️  Venue: Metro Ice Center (America/Chicago)')
+  console.log('📆 Season: Metro Winter Season, now−30d → now+120d')
+  console.log('   Phases: Pre-Season / Regular Season (covers today) / Playoffs')
+  console.log('📧 League accounts (role matrix):')
+  console.log('   league-admin@test.com / admin123 — LeagueUser LEAGUE_ADMIN')
+  console.log('   team-admin1@test.com / admin123 — TeamMember ADMIN (Metro Blades) + LeagueUser TEAM_ADMIN')
+  console.log('   team-admin2@test.com / admin123 — TeamMember ADMIN (Harbor Hawks) + LeagueUser TEAM_ADMIN')
+  console.log('   league-member@test.com / member123 — TeamMember MEMBER (Metro Blades) + LeagueUser MEMBER')
+  console.log('📨 Proposal inbox states (log in as team-admin1@test.com unless noted):')
+  console.log('   PENDING incoming: Harbor Hawks → Metro Blades (team-admin2 sees it as outgoing)')
+  console.log('   PENDING outgoing: Metro Blades → Foundry Flyers')
+  console.log('   DECLINED:         Metro Blades → Harbor Hawks (declined by team-admin2)')
+  console.log('   EXPIRED:          Harbor Hawks → Metro Blades (proposed start already passed)')
 }
 
 main()


### PR DESCRIPTION
## Summary

Tier 1 of the observation-audit roadmap (spec: `docs/superpowers/specs/2026-07-11-tier1-foundations-design.md`; parent design + decisions D1–D8: `2026-07-11-observation-audit-roadmap-design.md`). Follows #263. Four workstreams:

### A — App shell
- New shared primitives: `PageHeader`, `PageContainer`, `EmptyState` (`components/ui/`), matched to the dominant existing conventions so adoption is a near visual no-op
- `error.tsx` + `not-found.tsx` for the `(dashboard)` group; per-section `loading.tsx` skeletons for roster, calendar, seasons, venues, venue-admin, league, practice-planner, my-registrations — navigations now show feedback during Neon cold starts
- ~30 pages swept onto the primitives; bare-text empty states replaced with actionable `EmptyState`s; onClick+router.push navigation converted to real links (prefetch, cmd-click)

### B — Date/time fields (decision D6)
- `DateTimeField` / `DateField` / `TimeField` (`components/ui/date/`): responsive MUI X pickers speaking the exact wall-clock strings forms already use (`YYYY-MM-DDTHH:MM`, `YYYY-MM-DD`, `HH:MM`); hidden inputs keep FormData forms working unchanged; self-contained `LocalizationProvider` (nesting-safe) plus one app-level provider in `ThemeProvider`
- All 14 remaining forms converted off native `datetime-local`/`date`/`time` inputs — zero serialization/Zod/Server Action changes
- Fixed `PracticeSessionEditor` composing the booking day in browser-local time while interpreting it in the venue zone (wrong day across midnight)
- New unit tests for the field wrappers (round-trip, hidden-input emission, clearing)

### C — Dev fixture graph
- `prisma/seed.ts`: Metro Hockey League + 2 divisions + 4 league-linked teams, role-matrix users (league admin / team admins holding both TeamMember ADMIN and LeagueUser TEAM_ADMIN rows / plain member), venue with timezone, league season spanning now with 3 phases, and game proposals in PENDING (in/out), DECLINED, EXPIRED states — the proposals feature is now fully testable locally
- Refuses to run against non-local `DATABASE_URL` unless `FORCE_SEED=1`; prints a role/team/login matrix

### D — Dashboard v1 (decision D7, schedule-first)
- `app/(dashboard)/dashboard/page.tsx` is now a streaming shell: header + My Teams paint immediately; widgets stream in under Suspense
- Widgets: **UpcomingSchedule** (events + practices across ALL the user's teams, with RSVP status), **NeedsYourRSVP** (inline responses), **AdminAttention** (unanswered RSVPs, pending invitations), **MyLeagues**
- `lib/data/dashboard.ts` read layer with a `cache()`-deduped memberships fetch; every query scoped to the viewer's own memberships; TeamCard stats wired via `_count`

## Verification
- `bun run type-check` ✅ (including post-rebase onto v0.59.3 main)
- `bun run lint` ✅ (project code clean; remaining noise confined to git-ignored `ds-bundle/`)
- `bun run test` ✅ 1361/1361 (suite +23 from new date-field tests; SeasonForm tests updated to the MUI picker accessible contract)
- `bun run build` ✅