### PR TITLE
feat: Tier 3 — identity graph: guardians, per-child RSVP, unified invitations, league-identity sync

### DIFF
--- a/__tests__/lib/actions/guardians.test.ts
+++ b/__tests__/lib/actions/guardians.test.ts
@@ -1,0 +1,417 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const {
+  mockPrismaPlayer,
+  mockPrismaUser,
+  mockPrismaPlayerGuardian,
+  mockPrismaEvent,
+  mockPrismaRsvp,
+  mockRequireUserId,
+  mockRequireTeamAdmin,
+  mockIsTeamAdmin,
+} = vi.hoisted(() => ({
+  mockPrismaPlayer: {
+    findUnique: vi.fn(),
+  },
+  mockPrismaUser: {
+    findUnique: vi.fn(),
+  },
+  mockPrismaPlayerGuardian: {
+    findUnique: vi.fn(),
+    findMany: vi.fn(),
+    create: vi.fn(),
+    delete: vi.fn(),
+  },
+  mockPrismaEvent: {
+    findMany: vi.fn(),
+  },
+  mockPrismaRsvp: {
+    findMany: vi.fn(),
+  },
+  mockRequireUserId: vi.fn(),
+  mockRequireTeamAdmin: vi.fn(),
+  mockIsTeamAdmin: vi.fn(),
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/session", () => ({
+  requireUserId: (...args: unknown[]) => mockRequireUserId(...args),
+  requireTeamAdmin: (...args: unknown[]) => mockRequireTeamAdmin(...args),
+  isTeamAdmin: (...args: unknown[]) => mockIsTeamAdmin(...args),
+}));
+
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: {
+    player: mockPrismaPlayer,
+    user: mockPrismaUser,
+    playerGuardian: mockPrismaPlayerGuardian,
+    event: mockPrismaEvent,
+    rSVP: mockPrismaRsvp,
+  },
+}));
+
+import {
+  addGuardian,
+  removeGuardian,
+  listGuardians,
+  getMyPlayers,
+} from "@/lib/actions/guardians";
+
+const USER_ID = "user-123";
+const GUARDIAN_USER_ID = "user-guardian";
+const TEAM_ID = "cteam00000000000000000001";
+const PLAYER_ID = "cplayer000000000000000001";
+const GUARDIAN_ID = "cguardian0000000000000001";
+const EVENT_ID = "cevent0000000000000000001";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockRequireUserId.mockResolvedValue(USER_ID);
+  mockRequireTeamAdmin.mockResolvedValue(USER_ID);
+  mockIsTeamAdmin.mockResolvedValue(false);
+});
+
+describe("addGuardian", () => {
+  beforeEach(() => {
+    mockPrismaPlayer.findUnique.mockResolvedValue({ id: PLAYER_ID, teamId: TEAM_ID });
+    mockPrismaUser.findUnique.mockResolvedValue({ id: GUARDIAN_USER_ID });
+    mockPrismaPlayerGuardian.findUnique.mockResolvedValue(null);
+  });
+
+  it("creates a guardian link for an existing account (team admin only)", async () => {
+    const created = {
+      id: GUARDIAN_ID,
+      playerId: PLAYER_ID,
+      userId: GUARDIAN_USER_ID,
+      relationship: "Mother",
+      canRsvp: true,
+      createdAt: new Date(),
+      user: { id: GUARDIAN_USER_ID, name: "Paula Parent", email: "paula@test.com" },
+    };
+    mockPrismaPlayerGuardian.create.mockResolvedValue(created);
+
+    const result = await addGuardian({
+      playerId: PLAYER_ID,
+      email: "Paula@Test.com",
+      relationship: "Mother",
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockRequireTeamAdmin).toHaveBeenCalledWith(TEAM_ID);
+    // Email is normalized to lowercase by the schema before lookup
+    expect(mockPrismaUser.findUnique).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { email: "paula@test.com" },
+      })
+    );
+    expect(mockPrismaPlayerGuardian.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: {
+          playerId: PLAYER_ID,
+          userId: GUARDIAN_USER_ID,
+          relationship: "Mother",
+        },
+      })
+    );
+  });
+
+  it("returns a friendly error when no account exists for the email", async () => {
+    mockPrismaUser.findUnique.mockResolvedValue(null);
+
+    const result = await addGuardian({
+      playerId: PLAYER_ID,
+      email: "nobody@test.com",
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toMatch(/sign up/i);
+    expect(mockPrismaPlayerGuardian.create).not.toHaveBeenCalled();
+  });
+
+  it("rejects duplicate guardian links", async () => {
+    mockPrismaPlayerGuardian.findUnique.mockResolvedValue({ id: GUARDIAN_ID });
+
+    const result = await addGuardian({
+      playerId: PLAYER_ID,
+      email: "paula@test.com",
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toMatch(/already a guardian/i);
+    expect(mockPrismaPlayerGuardian.create).not.toHaveBeenCalled();
+  });
+
+  it("returns error when the player does not exist", async () => {
+    mockPrismaPlayer.findUnique.mockResolvedValue(null);
+
+    const result = await addGuardian({
+      playerId: PLAYER_ID,
+      email: "paula@test.com",
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toMatch(/player not found/i);
+    expect(mockRequireTeamAdmin).not.toHaveBeenCalled();
+  });
+
+  it("fails when the caller is not a team admin", async () => {
+    mockRequireTeamAdmin.mockRejectedValue(new Error("Unauthorized"));
+
+    const result = await addGuardian({
+      playerId: PLAYER_ID,
+      email: "paula@test.com",
+    });
+
+    expect(result.success).toBe(false);
+    expect(mockPrismaPlayerGuardian.create).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid input (bad email)", async () => {
+    const result = await addGuardian({
+      playerId: PLAYER_ID,
+      email: "not-an-email",
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toMatch(/validation failed/i);
+  });
+});
+
+describe("removeGuardian", () => {
+  const guardianRow = {
+    id: GUARDIAN_ID,
+    userId: GUARDIAN_USER_ID,
+    player: { teamId: TEAM_ID },
+  };
+
+  it("allows the guardian to remove themself", async () => {
+    mockRequireUserId.mockResolvedValue(GUARDIAN_USER_ID);
+    mockPrismaPlayerGuardian.findUnique.mockResolvedValue(guardianRow);
+
+    const result = await removeGuardian({ guardianId: GUARDIAN_ID });
+
+    expect(result.success).toBe(true);
+    expect(mockPrismaPlayerGuardian.delete).toHaveBeenCalledWith({
+      where: { id: GUARDIAN_ID },
+    });
+    // Self-removal short-circuits — no admin lookup needed.
+    expect(mockIsTeamAdmin).not.toHaveBeenCalled();
+  });
+
+  it("allows a team ADMIN of the player's team", async () => {
+    mockPrismaPlayerGuardian.findUnique.mockResolvedValue(guardianRow);
+    mockIsTeamAdmin.mockResolvedValue(true);
+
+    const result = await removeGuardian({ guardianId: GUARDIAN_ID });
+
+    expect(result.success).toBe(true);
+    expect(mockIsTeamAdmin).toHaveBeenCalledWith(USER_ID, TEAM_ID);
+    expect(mockPrismaPlayerGuardian.delete).toHaveBeenCalled();
+  });
+
+  it("rejects a viewer who is neither the guardian nor a team admin", async () => {
+    mockPrismaPlayerGuardian.findUnique.mockResolvedValue(guardianRow);
+    mockIsTeamAdmin.mockResolvedValue(false);
+
+    const result = await removeGuardian({ guardianId: GUARDIAN_ID });
+
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toMatch(/not authorized/i);
+    expect(mockPrismaPlayerGuardian.delete).not.toHaveBeenCalled();
+  });
+
+  it("returns error when the guardian link does not exist", async () => {
+    mockPrismaPlayerGuardian.findUnique.mockResolvedValue(null);
+
+    const result = await removeGuardian({ guardianId: GUARDIAN_ID });
+
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toMatch(/not found/i);
+  });
+});
+
+describe("listGuardians", () => {
+  beforeEach(() => {
+    mockPrismaPlayer.findUnique.mockResolvedValue({ id: PLAYER_ID, teamId: TEAM_ID });
+  });
+
+  it("allows a team ADMIN", async () => {
+    mockPrismaPlayerGuardian.findUnique.mockResolvedValue(null);
+    mockIsTeamAdmin.mockResolvedValue(true);
+    mockPrismaPlayerGuardian.findMany.mockResolvedValue([]);
+
+    const result = await listGuardians(PLAYER_ID);
+
+    expect(result.success).toBe(true);
+    expect(mockPrismaPlayerGuardian.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { playerId: PLAYER_ID },
+      })
+    );
+  });
+
+  it("allows a guardian of the player", async () => {
+    mockPrismaPlayerGuardian.findUnique.mockResolvedValue({ id: GUARDIAN_ID });
+    mockPrismaPlayerGuardian.findMany.mockResolvedValue([]);
+
+    const result = await listGuardians(PLAYER_ID);
+
+    expect(result.success).toBe(true);
+    expect(mockIsTeamAdmin).not.toHaveBeenCalled();
+  });
+
+  it("rejects other viewers", async () => {
+    mockPrismaPlayerGuardian.findUnique.mockResolvedValue(null);
+    mockIsTeamAdmin.mockResolvedValue(false);
+
+    const result = await listGuardians(PLAYER_ID);
+
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toMatch(/not authorized/i);
+    expect(mockPrismaPlayerGuardian.findMany).not.toHaveBeenCalled();
+  });
+
+  it("rejects malformed player IDs", async () => {
+    const result = await listGuardians("not-a-cuid");
+
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toMatch(/invalid player id/i);
+  });
+});
+
+describe("getMyPlayers", () => {
+  it("returns an empty list when the user guards no players", async () => {
+    mockPrismaPlayerGuardian.findMany.mockResolvedValue([]);
+
+    const result = await getMyPlayers();
+
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data).toEqual([]);
+    expect(mockPrismaEvent.findMany).not.toHaveBeenCalled();
+  });
+
+  it("returns guarded players with upcoming events and per-child statuses", async () => {
+    const startAt = new Date(Date.now() + 3 * 24 * 60 * 60 * 1000);
+    mockPrismaPlayerGuardian.findMany.mockResolvedValue([
+      {
+        canRsvp: true,
+        player: {
+          id: PLAYER_ID,
+          name: "Kid One",
+          teamId: TEAM_ID,
+          team: { name: "Ice Hawks" },
+        },
+      },
+      {
+        canRsvp: false,
+        player: {
+          id: "cplayer000000000000000002",
+          name: "Kid Two",
+          teamId: TEAM_ID,
+          team: { name: "Ice Hawks" },
+        },
+      },
+    ]);
+    mockPrismaEvent.findMany.mockResolvedValue([
+      { id: EVENT_ID, title: "vs Wolves", startAt, teamId: TEAM_ID },
+    ]);
+    mockPrismaRsvp.findMany.mockResolvedValue([
+      {
+        playerId: PLAYER_ID,
+        eventId: EVENT_ID,
+        status: "GOING",
+        updatedAt: new Date("2026-07-01"),
+      },
+    ]);
+
+    const result = await getMyPlayers();
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    expect(result.data).toHaveLength(2);
+
+    const [kidOne, kidTwo] = result.data;
+    expect(kidOne).toMatchObject({
+      playerId: PLAYER_ID,
+      playerName: "Kid One",
+      teamId: TEAM_ID,
+      teamName: "Ice Hawks",
+      canRsvp: true,
+    });
+    expect(kidOne.upcoming).toEqual([
+      {
+        eventId: EVENT_ID,
+        title: "vs Wolves",
+        startAt,
+        myChildStatus: "GOING",
+      },
+    ]);
+
+    // No per-child row yet — pending shows as NO_RESPONSE
+    expect(kidTwo.canRsvp).toBe(false);
+    expect(kidTwo.upcoming[0].myChildStatus).toBe("NO_RESPONSE");
+  });
+
+  it("uses the latest row when multiple adults answered for the same child", async () => {
+    const startAt = new Date(Date.now() + 24 * 60 * 60 * 1000);
+    mockPrismaPlayerGuardian.findMany.mockResolvedValue([
+      {
+        canRsvp: true,
+        player: {
+          id: PLAYER_ID,
+          name: "Kid One",
+          teamId: TEAM_ID,
+          team: { name: "Ice Hawks" },
+        },
+      },
+    ]);
+    mockPrismaEvent.findMany.mockResolvedValue([
+      { id: EVENT_ID, title: "Practice", startAt, teamId: TEAM_ID },
+    ]);
+    mockPrismaRsvp.findMany.mockResolvedValue([
+      {
+        playerId: PLAYER_ID,
+        eventId: EVENT_ID,
+        status: "NOT_GOING",
+        updatedAt: new Date("2026-07-01"),
+      },
+      {
+        playerId: PLAYER_ID,
+        eventId: EVENT_ID,
+        status: "GOING",
+        updatedAt: new Date("2026-07-05"),
+      },
+    ]);
+
+    const result = await getMyPlayers();
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data[0].upcoming[0].myChildStatus).toBe("GOING");
+  });
+
+  it("skips the RSVP query when there are no upcoming events", async () => {
+    mockPrismaPlayerGuardian.findMany.mockResolvedValue([
+      {
+        canRsvp: true,
+        player: {
+          id: PLAYER_ID,
+          name: "Kid One",
+          teamId: TEAM_ID,
+          team: { name: "Ice Hawks" },
+        },
+      },
+    ]);
+    mockPrismaEvent.findMany.mockResolvedValue([]);
+
+    const result = await getMyPlayers();
+
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data[0].upcoming).toEqual([]);
+    expect(mockPrismaRsvp.findMany).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/lib/actions/league.test.ts
+++ b/__tests__/lib/actions/league.test.ts
@@ -21,12 +21,20 @@ const {
     league: {
       create: vi.fn(),
     },
+    leagueUser: {
+      findUnique: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+    },
     player: {
       updateMany: vi.fn(),
     },
     team: {
       update: vi.fn(),
       updateMany: vi.fn(),
+    },
+    teamMember: {
+      findMany: vi.fn(),
     },
   };
 
@@ -54,6 +62,9 @@ const {
       },
       leagueUser: {
         findFirst: vi.fn(),
+        findUnique: vi.fn(),
+        create: vi.fn(),
+        update: vi.fn(),
       },
       player: {
         count: vi.fn(),
@@ -122,10 +133,12 @@ import {
   createDivision,
   createLeague,
   deleteDivision,
+  ensureLeagueUser,
   getLeagueStatisticsData,
   getLeagueTeamsPaginated,
   migrateTeamToLeague,
 } from "@/lib/actions/league";
+import type { Prisma } from "@prisma/client";
 
 const USER_ID = "user-1";
 const LEAGUE_ID = "clleague00000000000000000";
@@ -148,6 +161,14 @@ beforeEach(() => {
     hasAccess: true,
     userId: USER_ID,
     accessLevel: 3,
+  });
+  // League-identity sync defaults: no team members to backfill, and the
+  // acting league admin already has a LeagueUser row.
+  mockTx.teamMember.findMany.mockResolvedValue([]);
+  mockTx.leagueUser.findUnique.mockResolvedValue(null);
+  mockPrisma.leagueUser.findUnique.mockResolvedValue({
+    id: "league-user-admin",
+    role: "LEAGUE_ADMIN",
   });
 });
 
@@ -243,6 +264,19 @@ describe("league Server Actions", () => {
       mockTx.team.update.mockResolvedValue({ id: TEAM_ID, name: "Sharks" });
       mockTx.event.updateMany.mockResolvedValue({ count: 12 });
       mockTx.player.updateMany.mockResolvedValue({ count: 18 });
+      mockTx.teamMember.findMany.mockResolvedValue([
+        { userId: USER_ID, role: "ADMIN" },
+        { userId: "user-2", role: "ADMIN" },
+        { userId: "user-3", role: "MEMBER" },
+      ]);
+      // The acting admin already got LEAGUE_ADMIN from the league create;
+      // the other members have no LeagueUser row yet.
+      mockTx.leagueUser.findUnique.mockImplementation(
+        async ({ where }: { where: { userId_leagueId: { userId: string } } }) =>
+          where.userId_leagueId.userId === USER_ID
+            ? { id: "league-user-1", role: "LEAGUE_ADMIN" }
+            : null
+      );
 
       const result = await migrateTeamToLeague({
         teamId: TEAM_ID,
@@ -278,6 +312,17 @@ describe("league Server Actions", () => {
         where: { teamId: TEAM_ID },
         data: { leagueId: LEAGUE_ID },
       });
+      // League-identity sync: every existing member gets a LeagueUser row
+      // (TEAM_ADMIN for team ADMINs, MEMBER otherwise); the acting admin's
+      // LEAGUE_ADMIN row is never downgraded.
+      expect(mockTx.leagueUser.create).toHaveBeenCalledWith({
+        data: { userId: "user-2", leagueId: LEAGUE_ID, role: "TEAM_ADMIN" },
+      });
+      expect(mockTx.leagueUser.create).toHaveBeenCalledWith({
+        data: { userId: "user-3", leagueId: LEAGUE_ID, role: "MEMBER" },
+      });
+      expect(mockTx.leagueUser.create).toHaveBeenCalledTimes(2);
+      expect(mockTx.leagueUser.update).not.toHaveBeenCalled();
       expect(mockLogAuditEvent).toHaveBeenCalledWith(
         expect.objectContaining({
           action: "team_migrated",
@@ -577,6 +622,46 @@ describe("league Server Actions", () => {
         error: "Unauthorized - you are not a member of this league",
       });
       expect(mockGetLeagueStatistics).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("ensureLeagueUser", () => {
+    const tx = mockTx as unknown as Prisma.TransactionClient;
+
+    it("creates a MEMBER row (default role) when none exists", async () => {
+      mockTx.leagueUser.findUnique.mockResolvedValue(null);
+
+      await ensureLeagueUser(tx, USER_ID, LEAGUE_ID);
+
+      expect(mockTx.leagueUser.findUnique).toHaveBeenCalledWith({
+        where: { userId_leagueId: { userId: USER_ID, leagueId: LEAGUE_ID } },
+        select: { id: true, role: true },
+      });
+      expect(mockTx.leagueUser.create).toHaveBeenCalledWith({
+        data: { userId: USER_ID, leagueId: LEAGUE_ID, role: "MEMBER" },
+      });
+      expect(mockTx.leagueUser.update).not.toHaveBeenCalled();
+    });
+
+    it("upgrades an existing row when the requested role outranks it", async () => {
+      mockTx.leagueUser.findUnique.mockResolvedValue({ id: "lu-1", role: "MEMBER" });
+
+      await ensureLeagueUser(tx, USER_ID, LEAGUE_ID, "TEAM_ADMIN");
+
+      expect(mockTx.leagueUser.create).not.toHaveBeenCalled();
+      expect(mockTx.leagueUser.update).toHaveBeenCalledWith({
+        where: { id: "lu-1" },
+        data: { role: "TEAM_ADMIN" },
+      });
+    });
+
+    it("never downgrades an existing higher role", async () => {
+      mockTx.leagueUser.findUnique.mockResolvedValue({ id: "lu-1", role: "LEAGUE_ADMIN" });
+
+      await ensureLeagueUser(tx, USER_ID, LEAGUE_ID, "MEMBER");
+
+      expect(mockTx.leagueUser.create).not.toHaveBeenCalled();
+      expect(mockTx.leagueUser.update).not.toHaveBeenCalled();
     });
   });
 });

--- a/__tests__/lib/actions/rsvp.test.ts
+++ b/__tests__/lib/actions/rsvp.test.ts
@@ -1,0 +1,402 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const {
+  mockPrismaEvent,
+  mockPrismaPlayer,
+  mockPrismaPlayerGuardian,
+  mockPrismaRsvp,
+  mockPrismaTeamMember,
+  mockPrismaLeagueUser,
+  mockRequireUserId,
+  mockRequireTeamMember,
+  mockIsTeamAdmin,
+} = vi.hoisted(() => ({
+  mockPrismaEvent: {
+    findUnique: vi.fn(),
+  },
+  mockPrismaPlayer: {
+    findUnique: vi.fn(),
+  },
+  mockPrismaPlayerGuardian: {
+    findUnique: vi.fn(),
+  },
+  mockPrismaRsvp: {
+    upsert: vi.fn(),
+    findFirst: vi.fn(),
+    findMany: vi.fn(),
+    update: vi.fn(),
+    create: vi.fn(),
+  },
+  mockPrismaTeamMember: {
+    findUnique: vi.fn(),
+  },
+  mockPrismaLeagueUser: {
+    findFirst: vi.fn(),
+  },
+  mockRequireUserId: vi.fn(),
+  mockRequireTeamMember: vi.fn(),
+  mockIsTeamAdmin: vi.fn(),
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/session", () => ({
+  requireUserId: (...args: unknown[]) => mockRequireUserId(...args),
+  requireTeamMember: (...args: unknown[]) => mockRequireTeamMember(...args),
+  isTeamAdmin: (...args: unknown[]) => mockIsTeamAdmin(...args),
+}));
+
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: {
+    event: mockPrismaEvent,
+    player: mockPrismaPlayer,
+    playerGuardian: mockPrismaPlayerGuardian,
+    rSVP: mockPrismaRsvp,
+    teamMember: mockPrismaTeamMember,
+    leagueUser: mockPrismaLeagueUser,
+  },
+}));
+
+import { submitRSVP, getEventAttendance } from "@/lib/actions/rsvp";
+
+const USER_ID = "user-123";
+const TEAM_ID = "cteam00000000000000000001";
+const EVENT_ID = "cevent0000000000000000001";
+const PLAYER_ID = "cplayer000000000000000001";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockRequireUserId.mockResolvedValue(USER_ID);
+  mockRequireTeamMember.mockResolvedValue(USER_ID);
+  mockIsTeamAdmin.mockResolvedValue(false);
+  mockPrismaEvent.findUnique.mockResolvedValue({ id: EVENT_ID, teamId: TEAM_ID });
+});
+
+describe("submitRSVP — self/household (no playerId)", () => {
+  it("updates the existing self row via findFirst + update (never upsert)", async () => {
+    mockPrismaRsvp.findFirst.mockResolvedValue({ id: "rsvp-1" });
+    mockPrismaRsvp.update.mockResolvedValue({
+      id: "rsvp-1",
+      status: "GOING",
+      userId: USER_ID,
+      eventId: EVENT_ID,
+      playerId: null,
+    });
+
+    const result = await submitRSVP({ eventId: EVENT_ID, status: "GOING" });
+
+    expect(result.success).toBe(true);
+    expect(mockRequireTeamMember).toHaveBeenCalledWith(TEAM_ID);
+    expect(mockPrismaRsvp.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { userId: USER_ID, eventId: EVENT_ID, playerId: null },
+      })
+    );
+    expect(mockPrismaRsvp.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "rsvp-1" },
+        data: { status: "GOING" },
+      })
+    );
+    // The composite unique rejects null playerId — upsert must not be used here.
+    expect(mockPrismaRsvp.upsert).not.toHaveBeenCalled();
+    expect(mockPrismaRsvp.create).not.toHaveBeenCalled();
+  });
+
+  it("creates a self row when none exists", async () => {
+    mockPrismaRsvp.findFirst.mockResolvedValue(null);
+    mockPrismaRsvp.create.mockResolvedValue({
+      id: "rsvp-2",
+      status: "MAYBE",
+      userId: USER_ID,
+      eventId: EVENT_ID,
+      playerId: null,
+    });
+
+    const result = await submitRSVP({ eventId: EVENT_ID, status: "MAYBE" });
+
+    expect(result.success).toBe(true);
+    expect(mockPrismaRsvp.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: { userId: USER_ID, eventId: EVENT_ID, status: "MAYBE" },
+      })
+    );
+    expect(mockPrismaRsvp.upsert).not.toHaveBeenCalled();
+  });
+
+  it("returns error when the event does not exist", async () => {
+    mockPrismaEvent.findUnique.mockResolvedValue(null);
+
+    const result = await submitRSVP({ eventId: EVENT_ID, status: "GOING" });
+
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toMatch(/not found/i);
+  });
+
+  it("rejects invalid status values", async () => {
+    const result = await submitRSVP({
+      eventId: EVENT_ID,
+      // @ts-expect-error — fan-out-only status must be rejected by the schema
+      status: "NO_RESPONSE",
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toMatch(/validation failed/i);
+  });
+});
+
+describe("submitRSVP — per-child (playerId set)", () => {
+  beforeEach(() => {
+    mockPrismaPlayer.findUnique.mockResolvedValue({ id: PLAYER_ID, teamId: TEAM_ID });
+    mockPrismaRsvp.upsert.mockResolvedValue({
+      id: "rsvp-3",
+      status: "GOING",
+      userId: USER_ID,
+      eventId: EVENT_ID,
+      playerId: PLAYER_ID,
+    });
+  });
+
+  it("allows a guardian with canRsvp and upserts on the composite key", async () => {
+    mockPrismaPlayerGuardian.findUnique.mockResolvedValue({ canRsvp: true });
+
+    const result = await submitRSVP({
+      eventId: EVENT_ID,
+      status: "GOING",
+      playerId: PLAYER_ID,
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockPrismaRsvp.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          userId_eventId_playerId: {
+            userId: USER_ID,
+            eventId: EVENT_ID,
+            playerId: PLAYER_ID,
+          },
+        },
+        create: expect.objectContaining({ playerId: PLAYER_ID, status: "GOING" }),
+      })
+    );
+    // Guardian check short-circuits — no admin lookup needed.
+    expect(mockIsTeamAdmin).not.toHaveBeenCalled();
+  });
+
+  it("allows a team ADMIN without a guardian link", async () => {
+    mockPrismaPlayerGuardian.findUnique.mockResolvedValue(null);
+    mockIsTeamAdmin.mockResolvedValue(true);
+
+    const result = await submitRSVP({
+      eventId: EVENT_ID,
+      status: "NOT_GOING",
+      playerId: PLAYER_ID,
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockIsTeamAdmin).toHaveBeenCalledWith(USER_ID, TEAM_ID);
+    expect(mockPrismaRsvp.upsert).toHaveBeenCalled();
+  });
+
+  it("rejects a guardian whose canRsvp is false (and who is not admin)", async () => {
+    mockPrismaPlayerGuardian.findUnique.mockResolvedValue({ canRsvp: false });
+    mockIsTeamAdmin.mockResolvedValue(false);
+
+    const result = await submitRSVP({
+      eventId: EVENT_ID,
+      status: "GOING",
+      playerId: PLAYER_ID,
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toMatch(/not authorized/i);
+    expect(mockPrismaRsvp.upsert).not.toHaveBeenCalled();
+  });
+
+  it("rejects a non-guardian non-admin viewer", async () => {
+    mockPrismaPlayerGuardian.findUnique.mockResolvedValue(null);
+    mockIsTeamAdmin.mockResolvedValue(false);
+
+    const result = await submitRSVP({
+      eventId: EVENT_ID,
+      status: "GOING",
+      playerId: PLAYER_ID,
+    });
+
+    expect(result.success).toBe(false);
+    expect(mockPrismaRsvp.upsert).not.toHaveBeenCalled();
+  });
+
+  it("rejects a player that belongs to a different team than the event", async () => {
+    mockPrismaPlayer.findUnique.mockResolvedValue({
+      id: PLAYER_ID,
+      teamId: "cotherteam000000000000001",
+    });
+
+    const result = await submitRSVP({
+      eventId: EVENT_ID,
+      status: "GOING",
+      playerId: PLAYER_ID,
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toMatch(/player/i);
+    expect(mockPrismaPlayerGuardian.findUnique).not.toHaveBeenCalled();
+    expect(mockPrismaRsvp.upsert).not.toHaveBeenCalled();
+  });
+
+  it("rejects a playerId for a player that does not exist", async () => {
+    mockPrismaPlayer.findUnique.mockResolvedValue(null);
+
+    const result = await submitRSVP({
+      eventId: EVENT_ID,
+      status: "GOING",
+      playerId: PLAYER_ID,
+    });
+
+    expect(result.success).toBe(false);
+    expect(mockPrismaRsvp.upsert).not.toHaveBeenCalled();
+  });
+});
+
+describe("getEventAttendance", () => {
+  beforeEach(() => {
+    mockPrismaEvent.findUnique.mockResolvedValue({
+      id: EVENT_ID,
+      teamId: TEAM_ID,
+      leagueId: null,
+      team: { leagueId: null },
+    });
+    mockPrismaTeamMember.findUnique.mockResolvedValue({ role: "MEMBER" });
+  });
+
+  it("lists user-level and player-level entries with attribution and counts", async () => {
+    mockPrismaRsvp.findMany.mockResolvedValue([
+      {
+        status: "GOING",
+        playerId: null,
+        updatedAt: new Date("2026-07-01"),
+        user: { name: "Alice Adult", email: "alice@test.com" },
+        player: null,
+      },
+      {
+        status: "MAYBE",
+        playerId: null,
+        updatedAt: new Date("2026-07-01"),
+        user: { name: null, email: "bob@test.com" },
+        player: null,
+      },
+      {
+        status: "GOING",
+        playerId: PLAYER_ID,
+        updatedAt: new Date("2026-07-02"),
+        user: { name: "Paula Parent", email: "paula@test.com" },
+        player: { id: PLAYER_ID, name: "Kid Kowalski" },
+      },
+    ]);
+
+    const result = await getEventAttendance(EVENT_ID);
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    expect(result.data.entries).toHaveLength(3);
+
+    const playerEntry = result.data.entries.find((e) => e.kind === "player");
+    expect(playerEntry).toMatchObject({
+      name: "Kid Kowalski",
+      status: "GOING",
+      respondedByName: "Paula Parent",
+    });
+
+    // User without a display name falls back to email
+    const bobEntry = result.data.entries.find((e) => e.name === "bob@test.com");
+    expect(bobEntry).toMatchObject({ kind: "user", status: "MAYBE" });
+
+    expect(result.data.counts).toEqual({
+      GOING: 2,
+      MAYBE: 1,
+      NOT_GOING: 0,
+      NO_RESPONSE: 0,
+    });
+  });
+
+  it("deduplicates multiple rows for the same player — latest response wins", async () => {
+    mockPrismaRsvp.findMany.mockResolvedValue([
+      {
+        status: "NOT_GOING",
+        playerId: PLAYER_ID,
+        updatedAt: new Date("2026-07-01"),
+        user: { name: "Admin", email: "admin@test.com" },
+        player: { id: PLAYER_ID, name: "Kid Kowalski" },
+      },
+      {
+        status: "GOING",
+        playerId: PLAYER_ID,
+        updatedAt: new Date("2026-07-03"),
+        user: { name: "Paula Parent", email: "paula@test.com" },
+        player: { id: PLAYER_ID, name: "Kid Kowalski" },
+      },
+    ]);
+
+    const result = await getEventAttendance(EVENT_ID);
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    expect(result.data.entries).toHaveLength(1);
+    expect(result.data.entries[0]).toMatchObject({
+      kind: "player",
+      status: "GOING",
+      respondedByName: "Paula Parent",
+    });
+    expect(result.data.counts.GOING).toBe(1);
+    expect(result.data.counts.NOT_GOING).toBe(0);
+  });
+
+  it("denies non-members when the event has no league", async () => {
+    mockPrismaTeamMember.findUnique.mockResolvedValue(null);
+
+    const result = await getEventAttendance(EVENT_ID);
+
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toMatch(/access/i);
+    expect(mockPrismaRsvp.findMany).not.toHaveBeenCalled();
+  });
+
+  it("allows a LEAGUE_ADMIN of the event's league", async () => {
+    mockPrismaEvent.findUnique.mockResolvedValue({
+      id: EVENT_ID,
+      teamId: TEAM_ID,
+      leagueId: "cleague000000000000000001",
+      team: { leagueId: "cleague000000000000000001" },
+    });
+    mockPrismaTeamMember.findUnique.mockResolvedValue(null);
+    mockPrismaLeagueUser.findFirst.mockResolvedValue({ id: "lu-1" });
+    mockPrismaRsvp.findMany.mockResolvedValue([]);
+
+    const result = await getEventAttendance(EVENT_ID);
+
+    expect(result.success).toBe(true);
+    expect(mockPrismaLeagueUser.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          userId: USER_ID,
+          leagueId: "cleague000000000000000001",
+          role: "LEAGUE_ADMIN",
+        }),
+      })
+    );
+  });
+
+  it("returns error for an unknown event", async () => {
+    mockPrismaEvent.findUnique.mockResolvedValue(null);
+
+    const result = await getEventAttendance(EVENT_ID);
+
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toMatch(/not found/i);
+  });
+});

--- a/__tests__/lib/actions/venue-staff.test.ts
+++ b/__tests__/lib/actions/venue-staff.test.ts
@@ -7,15 +7,21 @@ const {
   mockRequireVenueStaffRole,
   mockGetUserVenueStaffRole,
   mockSendVenueStaffInviteEmail,
+  mockSendVenueStaffSignupInviteEmail,
   mockPrisma,
 } = vi.hoisted(() => ({
   mockRequireUserId: vi.fn(),
   mockRequireVenueStaffRole: vi.fn(),
   mockGetUserVenueStaffRole: vi.fn(),
   mockSendVenueStaffInviteEmail: vi.fn(),
+  mockSendVenueStaffSignupInviteEmail: vi.fn(),
   mockPrisma: {
     venueOrganization: { findFirst: vi.fn() },
     user: { findUnique: vi.fn() },
+    invitation: {
+      findFirst: vi.fn(),
+      create: vi.fn(),
+    },
     venueStaff: {
       findFirst: vi.fn(),
       findMany: vi.fn(),
@@ -36,6 +42,8 @@ vi.mock("@/lib/auth/session", () => ({
 vi.mock("@/lib/db/prisma", () => ({ prisma: mockPrisma }));
 vi.mock("@/lib/email/templates", () => ({
   sendVenueStaffInviteEmail: (...args: unknown[]) => mockSendVenueStaffInviteEmail(...args),
+  sendVenueStaffSignupInviteEmail: (...args: unknown[]) =>
+    mockSendVenueStaffSignupInviteEmail(...args),
 }));
 
 import {
@@ -70,6 +78,8 @@ beforeEach(() => {
   mockPrisma.venueStaff.findFirst.mockResolvedValue(null);
   mockPrisma.venueStaff.create.mockResolvedValue({ id: STAFF_ID });
   mockPrisma.venueStaff.update.mockResolvedValue({ id: STAFF_ID, role: "MANAGER" });
+  mockPrisma.invitation.findFirst.mockResolvedValue(null);
+  mockPrisma.invitation.create.mockResolvedValue({ id: "invitation-1" });
   // Transactions run against the same mock client.
   mockPrisma.$transaction.mockImplementation(async (fn: (tx: typeof mockPrisma) => unknown) =>
     fn(mockPrisma)
@@ -106,19 +116,54 @@ describe("inviteVenueStaff", () => {
     );
   });
 
-  it("returns a friendly error when no account matches the email", async () => {
+  it("creates a unified Invitation with the venueRole payload when no account matches", async () => {
+    const result = await inviteVenueStaff({
+      organizationId: ORG_ID,
+      email: "nobody@example.com",
+      role: "SCHEDULER",
+    });
+
+    expect(result).toEqual({ success: true, data: { staffId: null } });
+    expect(mockPrisma.venueStaff.create).not.toHaveBeenCalled();
+    expect(mockPrisma.invitation.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          email: "nobody@example.com",
+          status: "PENDING",
+          organizationId: ORG_ID,
+          venueRole: "SCHEDULER",
+          invitedById: INVITER_ID,
+          token: expect.any(String),
+          expiresAt: expect.any(Date),
+        }),
+      })
+    );
+    expect(mockSendVenueStaffSignupInviteEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        email: "nobody@example.com",
+        organizationName: "North Rink",
+        role: "SCHEDULER",
+        token: expect.any(String),
+      })
+    );
+    expect(mockSendVenueStaffInviteEmail).not.toHaveBeenCalled();
+  });
+
+  it("dedupes a still-pending account-less invitation", async () => {
+    mockPrisma.invitation.findFirst.mockResolvedValue({ id: "invitation-1" });
+
     const result = await inviteVenueStaff({
       organizationId: ORG_ID,
       email: "nobody@example.com",
       role: "VIEWER",
     });
 
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(result.error).toContain("sign up first");
-    }
-    expect(mockPrisma.venueStaff.create).not.toHaveBeenCalled();
-    expect(mockSendVenueStaffInviteEmail).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      success: false,
+      error: "That person already has a pending invitation.",
+    });
+    expect(mockPrisma.invitation.create).not.toHaveBeenCalled();
+    expect(mockSendVenueStaffSignupInviteEmail).not.toHaveBeenCalled();
   });
 
   it("blocks a MANAGER from granting the OWNER role", async () => {

--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -22,10 +22,21 @@ function SignupForm() {
   const router = useRouter();
   const searchParams = useSearchParams();
 
-  // Get invitation parameters from URL
+  // Get invitation parameters from URL (unified invitations target exactly
+  // one of team / league / venue organization)
   const invitationEmail = searchParams.get("email");
   const invitationToken = searchParams.get("invitationToken");
   const teamName = searchParams.get("teamName");
+  const leagueName = searchParams.get("leagueName");
+  const organizationName = searchParams.get("organizationName");
+
+  const invitationSubtitle = teamName
+    ? `Join ${teamName} on openleague`
+    : leagueName
+      ? `Join the ${leagueName} league on openleague`
+      : organizationName
+        ? `Join ${organizationName}'s staff on openleague`
+        : null;
 
   const [formData, setFormData] = useState({
     email: invitationEmail || "",
@@ -160,9 +171,7 @@ function SignupForm() {
           Create Account
         </Typography>
         <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
-          {teamName
-            ? `Join ${teamName} on openleague`
-            : "Sign up to start managing your team"}
+          {invitationSubtitle ?? "Sign up to start managing your team"}
         </Typography>
 
         {generalError && (

--- a/app/(dashboard)/admin/users/page.tsx
+++ b/app/(dashboard)/admin/users/page.tsx
@@ -2,15 +2,15 @@ import { Suspense } from "react";
 import { Typography, Box, CircularProgress } from "@mui/material";
 import { PageContainer } from "@/components/ui/PageContainer";
 import { PageHeader } from "@/components/ui/PageHeader";
-import { isSystemAdmin, requireUserId } from "@/lib/auth/session";
+import { isAnyLeagueAdmin, requireUserId } from "@/lib/auth/session";
 import { getAllUsers } from "@/lib/actions/admin";
 import UserApprovalList from "@/components/features/admin/UserApprovalList";
 
 async function UserManagementContent() {
   const userId = await requireUserId();
 
-  // Check if user is system admin
-  const isAdmin = await isSystemAdmin(userId);
+  // Check if user is an admin (LEAGUE_ADMIN of any league)
+  const isAdmin = await isAnyLeagueAdmin(userId);
 
   if (!isAdmin) {
     return (

--- a/app/(dashboard)/events/[id]/page.tsx
+++ b/app/(dashboard)/events/[id]/page.tsx
@@ -1,7 +1,11 @@
 import { requireUserId } from "@/lib/auth/session";
 import { getEvent } from "@/lib/actions/events";
+import { getEventAttendance } from "@/lib/actions/rsvp";
+import { getMyPlayers } from "@/lib/actions/guardians";
 import { notFound } from "next/navigation";
-import EventDetail from "@/components/features/events/EventDetail";
+import EventDetail, {
+  type GuardedPlayerRsvp,
+} from "@/components/features/events/EventDetail";
 import { PageContainer } from "@/components/ui/PageContainer";
 
 interface EventPageProps {
@@ -22,12 +26,44 @@ export default async function EventPage({ params }: EventPageProps) {
     notFound();
   }
 
+  // Identity graph (Tier 3): guardian context for per-child RSVP rows and the
+  // server-computed attendance view (player-level entries with attribution).
+  const [myPlayersResult, attendanceResult] = await Promise.all([
+    event.canRSVP ? getMyPlayers() : null,
+    event.canManageEvent ? getEventAttendance(id) : null,
+  ]);
+
+  // Players the viewer guards (with canRsvp) on this event's team, each with
+  // their current per-child status for this event. Empty for single-identity
+  // users → EventDetail renders exactly the pre-Tier-3 UI.
+  const guardedPlayers: GuardedPlayerRsvp[] =
+    myPlayersResult?.success
+      ? myPlayersResult.data
+          .filter(
+            (player) => player.teamId === event.team.id && player.canRsvp
+          )
+          .map((player) => ({
+            playerId: player.playerId,
+            playerName: player.playerName,
+            status:
+              player.upcoming.find((entry) => entry.eventId === id)
+                ?.myChildStatus ??
+              event.rsvps.find((rsvp) => rsvp.playerId === player.playerId)
+                ?.status ??
+              "NO_RESPONSE",
+          }))
+      : [];
+
+  const attendance = attendanceResult?.success ? attendanceResult.data : null;
+
   return (
     <PageContainer>
       <EventDetail
         event={event}
         userRole={event.userRole}
         currentUserId={userId}
+        guardedPlayers={guardedPlayers}
+        attendance={attendance}
       />
     </PageContainer>
   );

--- a/app/(dashboard)/venue-admin/[organizationId]/staff/StaffManager.tsx
+++ b/app/(dashboard)/venue-admin/[organizationId]/staff/StaffManager.tsx
@@ -166,7 +166,7 @@ export function StaffManager({
         <EmptyState
           icon={<PersonAddAltIcon />}
           title="No staff members yet"
-          description="Invite a colleague with an OpenLeague account to help manage this organization."
+          description="Invite a colleague by email to help manage this organization."
         />
       ) : (
         <Stack spacing={1.5}>
@@ -250,8 +250,9 @@ export function StaffManager({
           <Dialog.Content>
             <Stack spacing={2} sx={{ mt: 0.5 }}>
               <Typography variant="body2" color="text.secondary">
-                The person must already have an OpenLeague account. They&apos;ll get an email and
-                can accept the invitation from this page.
+                They&apos;ll get an email invitation. Existing OpenLeague users accept it from this
+                page; anyone else can create a free account through the invitation link and join
+                automatically.
               </Typography>
               {inviteError ? <Alert severity="error">{inviteError}</Alert> : null}
               <TextField label="Email" name="email" type="email" required autoFocus />

--- a/app/api/invitations/[token]/route.ts
+++ b/app/api/invitations/[token]/route.ts
@@ -8,7 +8,8 @@ export async function GET(
   try {
     const { token } = await params;
 
-    // Find the invitation by token
+    // Find the invitation by token. Unified invitations target exactly one
+    // of team / league / venue organization.
     const invitation = await prisma.invitation.findUnique({
       where: { token },
       include: {
@@ -18,6 +19,18 @@ export async function GET(
             name: true,
             sport: true,
             season: true,
+          },
+        },
+        league: {
+          select: {
+            id: true,
+            name: true,
+          },
+        },
+        organization: {
+          select: {
+            id: true,
+            name: true,
           },
         },
       },
@@ -50,12 +63,19 @@ export async function GET(
       );
     }
 
-    // Redirect to signup page with pre-filled team information
+    // Redirect to signup page with pre-filled invitation context
     const signupUrl = new URL("/signup", request.url);
     signupUrl.searchParams.set("email", invitation.email);
-    signupUrl.searchParams.set("teamId", invitation.team.id);
-    signupUrl.searchParams.set("teamName", invitation.team.name);
     signupUrl.searchParams.set("invitationToken", token);
+
+    if (invitation.team) {
+      signupUrl.searchParams.set("teamId", invitation.team.id);
+      signupUrl.searchParams.set("teamName", invitation.team.name);
+    } else if (invitation.league) {
+      signupUrl.searchParams.set("leagueName", invitation.league.name);
+    } else if (invitation.organization) {
+      signupUrl.searchParams.set("organizationName", invitation.organization.name);
+    }
 
     return NextResponse.redirect(signupUrl);
   } catch (error) {

--- a/components/features/dashboard/widgets/NeedsRsvpWidget.tsx
+++ b/components/features/dashboard/widgets/NeedsRsvpWidget.tsx
@@ -1,4 +1,4 @@
-import { Box, Card, CardContent, Skeleton, Stack, Typography } from "@mui/material";
+import { Box, Card, CardContent, Chip, Skeleton, Stack, Typography } from "@mui/material";
 import { CheckCircleOutline as CheckCircleOutlineIcon } from "@mui/icons-material";
 import { LinkMuiLink } from "@/components/ui/NextLinkComposites";
 import { RSVPButtons } from "@/components/features/events/RSVPButtons";
@@ -6,10 +6,11 @@ import { getNeedsRsvp } from "@/lib/data/dashboard";
 import { formatDateTimeInZone } from "@/lib/utils/date";
 
 /**
- * The viewer's unanswered RSVPs on future events, with inline RSVP response.
- * Async RSC — the only client leaf is the reused RSVPButtons component (all
- * props crossing that boundary are serializable strings). Wrap in
- * <Suspense fallback={<NeedsRsvpWidgetSkeleton />}>.
+ * The viewer's pending RSVPs on future events, one row per identity (self and
+ * each guarded player, per the getNeedsRsvp contract), with inline RSVP
+ * response. Async RSC — the only client leaf is the reused RSVPButtons
+ * component (all props crossing that boundary are serializable strings). Wrap
+ * in <Suspense fallback={<NeedsRsvpWidgetSkeleton />}>.
  */
 export default async function NeedsRsvpWidget({ userId }: { userId: string }) {
   const items = await getNeedsRsvp(userId);
@@ -29,42 +30,68 @@ export default async function NeedsRsvpWidget({ userId }: { userId: string }) {
         </Stack>
       ) : (
         <Stack spacing={1.5}>
-          {items.map((item) => (
-            <Card key={item.eventId} variant="outlined">
-              <CardContent sx={{ py: 1.5, "&:last-child": { pb: 1.5 } }}>
-                <Stack spacing={1.5}>
-                  <Box>
-                    <LinkMuiLink
-                      href={`/events/${item.eventId}`}
-                      variant="subtitle2"
-                      color="inherit"
-                      underline="hover"
-                      sx={{ fontWeight: 600 }}
-                    >
-                      {item.title}
-                      {item.opponent ? ` vs ${item.opponent}` : ""}
-                    </LinkMuiLink>
-                    <Stack
-                      direction="row"
-                      spacing={1.5}
-                      sx={{ color: "text.secondary" }}
-                      flexWrap="wrap"
-                      useFlexGap
-                    >
-                      <Typography variant="caption">{item.teamName}</Typography>
-                      <Typography variant="caption">
-                        {formatDateTimeInZone(item.startAt, item.timezone)}
-                      </Typography>
-                      {item.location ? (
-                        <Typography variant="caption">{item.location}</Typography>
-                      ) : null}
-                    </Stack>
-                  </Box>
-                  <RSVPButtons eventId={item.eventId} currentStatus="NO_RESPONSE" />
-                </Stack>
-              </CardContent>
-            </Card>
-          ))}
+          {items.map((item) => {
+            const target = item.target;
+            const key = `${item.eventId}:${
+              target.kind === "player" ? target.playerId : "self"
+            }`;
+            return (
+              <Card key={key} variant="outlined">
+                <CardContent sx={{ py: 1.5, "&:last-child": { pb: 1.5 } }}>
+                  <Stack spacing={1.5}>
+                    <Box>
+                      <Stack
+                        direction="row"
+                        alignItems="center"
+                        spacing={1}
+                        flexWrap="wrap"
+                        useFlexGap
+                      >
+                        <LinkMuiLink
+                          href={`/events/${item.eventId}`}
+                          variant="subtitle2"
+                          color="inherit"
+                          underline="hover"
+                          sx={{ fontWeight: 600 }}
+                        >
+                          {item.title}
+                          {item.opponent ? ` vs ${item.opponent}` : ""}
+                        </LinkMuiLink>
+                        {target.kind === "player" && (
+                          <Chip
+                            label={`For ${target.playerName}`}
+                            size="small"
+                            variant="outlined"
+                            color="primary"
+                          />
+                        )}
+                      </Stack>
+                      <Stack
+                        direction="row"
+                        spacing={1.5}
+                        sx={{ color: "text.secondary" }}
+                        flexWrap="wrap"
+                        useFlexGap
+                      >
+                        <Typography variant="caption">{item.teamName}</Typography>
+                        <Typography variant="caption">
+                          {formatDateTimeInZone(item.startAt, item.timezone)}
+                        </Typography>
+                        {item.location ? (
+                          <Typography variant="caption">{item.location}</Typography>
+                        ) : null}
+                      </Stack>
+                    </Box>
+                    <RSVPButtons
+                      eventId={item.eventId}
+                      currentStatus="NO_RESPONSE"
+                      playerId={target.kind === "player" ? target.playerId : undefined}
+                    />
+                  </Stack>
+                </CardContent>
+              </Card>
+            );
+          })}
         </Stack>
       )}
     </Box>

--- a/components/features/events/AttendanceView.tsx
+++ b/components/features/events/AttendanceView.tsx
@@ -14,56 +14,89 @@ import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import CancelIcon from "@mui/icons-material/Cancel";
 import HelpIcon from "@mui/icons-material/Help";
 import QuestionMarkIcon from "@mui/icons-material/QuestionMark";
-
-type RSVPStatus = "GOING" | "NOT_GOING" | "MAYBE" | "NO_RESPONSE";
-
-interface AttendanceMember {
-  id: string;
-  name: string | null;
-  email: string;
-  status: RSVPStatus;
-}
+import type {
+  AttendanceCounts,
+  AttendanceEntry,
+  RSVPStatus,
+} from "@/types/events";
 
 interface AttendanceViewProps {
-  rsvps: Array<{
-    id: string;
-    status: RSVPStatus;
-    user: {
-      id: string;
-      name: string | null;
-      email: string;
-    };
-  }>;
+  /**
+   * Per-identity attendance rows (contract of getEventAttendance): player-level
+   * responses where they exist, user-level otherwise. A user row and their
+   * child rows are distinct entries.
+   */
+  entries: AttendanceEntry[];
+  /** Status counts, deduplicated per entry (not per user). */
+  counts: AttendanceCounts;
 }
 
-export function AttendanceView({ rsvps }: AttendanceViewProps) {
-  // Group RSVPs by status
-  const groupedRSVPs = rsvps.reduce(
-    (acc, rsvp) => {
-      const member: AttendanceMember = {
-        id: rsvp.user.id,
-        name: rsvp.user.name,
-        email: rsvp.user.email,
-        status: rsvp.status,
-      };
-      acc[rsvp.status].push(member);
-      return acc;
-    },
-    {
-      GOING: [] as AttendanceMember[],
-      NOT_GOING: [] as AttendanceMember[],
-      MAYBE: [] as AttendanceMember[],
-      NO_RESPONSE: [] as AttendanceMember[],
-    }
-  );
+const STATUS_SECTIONS: Array<{
+  status: RSVPStatus;
+  label: string;
+  icon: React.ReactNode;
+}> = [
+  {
+    status: "GOING",
+    label: "Going",
+    icon: <CheckCircleIcon color="success" fontSize="small" />,
+  },
+  {
+    status: "MAYBE",
+    label: "Maybe",
+    icon: <HelpIcon color="warning" fontSize="small" />,
+  },
+  {
+    status: "NOT_GOING",
+    label: "Not Going",
+    icon: <CancelIcon color="error" fontSize="small" />,
+  },
+  {
+    status: "NO_RESPONSE",
+    label: "No Response",
+    icon: <QuestionMarkIcon color="disabled" fontSize="small" />,
+  },
+];
 
-  // Calculate counts
-  const counts = {
-    going: groupedRSVPs.GOING.length,
-    notGoing: groupedRSVPs.NOT_GOING.length,
-    maybe: groupedRSVPs.MAYBE.length,
-    noResponse: groupedRSVPs.NO_RESPONSE.length,
+function AttendanceEntryRow({ entry }: { entry: AttendanceEntry }) {
+  return (
+    <Stack
+      direction="row"
+      spacing={1}
+      alignItems="center"
+      flexWrap="wrap"
+      useFlexGap
+      sx={{ minHeight: 32 }}
+    >
+      <Typography variant="body2" sx={{ fontWeight: 500 }}>
+        {entry.name}
+      </Typography>
+      <Chip
+        label={entry.kind === "player" ? "Player" : "Member"}
+        size="small"
+        variant="outlined"
+        color={entry.kind === "player" ? "primary" : "default"}
+      />
+      {entry.kind === "player" && entry.respondedByName && (
+        <Typography variant="caption" color="text.secondary">
+          answered by {entry.respondedByName}
+        </Typography>
+      )}
+    </Stack>
+  );
+}
+
+export function AttendanceView({ entries, counts }: AttendanceViewProps) {
+  // Group entries by status for the detailed lists
+  const grouped: Record<RSVPStatus, AttendanceEntry[]> = {
+    GOING: [],
+    NOT_GOING: [],
+    MAYBE: [],
+    NO_RESPONSE: [],
   };
+  for (const entry of entries) {
+    grouped[entry.status].push(entry);
+  }
 
   return (
     <Card>
@@ -85,7 +118,7 @@ export function AttendanceView({ rsvps }: AttendanceViewProps) {
             >
               <CheckCircleIcon sx={{ fontSize: 32, color: "success.dark" }} />
               <Typography variant="h4" sx={{ fontWeight: 600, mt: 1 }}>
-                {counts.going}
+                {counts.GOING}
               </Typography>
               <Typography variant="body2" color="text.secondary">
                 Going
@@ -104,7 +137,7 @@ export function AttendanceView({ rsvps }: AttendanceViewProps) {
             >
               <HelpIcon sx={{ fontSize: 32, color: "warning.dark" }} />
               <Typography variant="h4" sx={{ fontWeight: 600, mt: 1 }}>
-                {counts.maybe}
+                {counts.MAYBE}
               </Typography>
               <Typography variant="body2" color="text.secondary">
                 Maybe
@@ -123,7 +156,7 @@ export function AttendanceView({ rsvps }: AttendanceViewProps) {
             >
               <CancelIcon sx={{ fontSize: 32, color: "error.dark" }} />
               <Typography variant="h4" sx={{ fontWeight: 600, mt: 1 }}>
-                {counts.notGoing}
+                {counts.NOT_GOING}
               </Typography>
               <Typography variant="body2" color="text.secondary">
                 Not Going
@@ -142,7 +175,7 @@ export function AttendanceView({ rsvps }: AttendanceViewProps) {
             >
               <QuestionMarkIcon sx={{ fontSize: 32, color: "grey.600" }} />
               <Typography variant="h4" sx={{ fontWeight: 600, mt: 1 }}>
-                {counts.noResponse}
+                {counts.NO_RESPONSE}
               </Typography>
               <Typography variant="body2" color="text.secondary">
                 No Response
@@ -155,99 +188,32 @@ export function AttendanceView({ rsvps }: AttendanceViewProps) {
 
         {/* Detailed Lists */}
         <Stack spacing={3}>
-          {/* Going */}
-          {groupedRSVPs.GOING.length > 0 && (
-            <Box>
-              <Typography
-                variant="subtitle1"
-                sx={{ fontWeight: 600, mb: 1, display: "flex", alignItems: "center", gap: 1 }}
-              >
-                <CheckCircleIcon color="success" fontSize="small" />
-                Going ({counts.going})
-              </Typography>
-              <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
-                {groupedRSVPs.GOING.map((member) => (
-                  <Chip
-                    key={member.id}
-                    label={member.name || member.email}
-                    color="success"
-                    variant="outlined"
-                    size="small"
-                  />
-                ))}
-              </Stack>
-            </Box>
-          )}
-
-          {/* Maybe */}
-          {groupedRSVPs.MAYBE.length > 0 && (
-            <Box>
-              <Typography
-                variant="subtitle1"
-                sx={{ fontWeight: 600, mb: 1, display: "flex", alignItems: "center", gap: 1 }}
-              >
-                <HelpIcon color="warning" fontSize="small" />
-                Maybe ({counts.maybe})
-              </Typography>
-              <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
-                {groupedRSVPs.MAYBE.map((member) => (
-                  <Chip
-                    key={member.id}
-                    label={member.name || member.email}
-                    color="warning"
-                    variant="outlined"
-                    size="small"
-                  />
-                ))}
-              </Stack>
-            </Box>
-          )}
-
-          {/* Not Going */}
-          {groupedRSVPs.NOT_GOING.length > 0 && (
-            <Box>
-              <Typography
-                variant="subtitle1"
-                sx={{ fontWeight: 600, mb: 1, display: "flex", alignItems: "center", gap: 1 }}
-              >
-                <CancelIcon color="error" fontSize="small" />
-                Not Going ({counts.notGoing})
-              </Typography>
-              <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
-                {groupedRSVPs.NOT_GOING.map((member) => (
-                  <Chip
-                    key={member.id}
-                    label={member.name || member.email}
-                    color="error"
-                    variant="outlined"
-                    size="small"
-                  />
-                ))}
-              </Stack>
-            </Box>
-          )}
-
-          {/* No Response */}
-          {groupedRSVPs.NO_RESPONSE.length > 0 && (
-            <Box>
-              <Typography
-                variant="subtitle1"
-                sx={{ fontWeight: 600, mb: 1, display: "flex", alignItems: "center", gap: 1 }}
-              >
-                <QuestionMarkIcon color="disabled" fontSize="small" />
-                No Response ({counts.noResponse})
-              </Typography>
-              <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
-                {groupedRSVPs.NO_RESPONSE.map((member) => (
-                  <Chip
-                    key={member.id}
-                    label={member.name || member.email}
-                    variant="outlined"
-                    size="small"
-                  />
-                ))}
-              </Stack>
-            </Box>
+          {STATUS_SECTIONS.map(({ status, label, icon }) =>
+            grouped[status].length > 0 ? (
+              <Box key={status}>
+                <Typography
+                  variant="subtitle1"
+                  sx={{
+                    fontWeight: 600,
+                    mb: 1,
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 1,
+                  }}
+                >
+                  {icon}
+                  {label} ({grouped[status].length})
+                </Typography>
+                <Stack spacing={0.5}>
+                  {grouped[status].map((entry, index) => (
+                    <AttendanceEntryRow
+                      key={`${status}:${entry.kind}:${entry.name}:${index}`}
+                      entry={entry}
+                    />
+                  ))}
+                </Stack>
+              </Box>
+            ) : null
           )}
         </Stack>
       </CardContent>

--- a/components/features/events/EventDetail.tsx
+++ b/components/features/events/EventDetail.tsx
@@ -15,6 +15,7 @@ import {
   DialogActions,
   Alert,
   CircularProgress,
+  Stack,
 } from "@mui/material";
 import {
   CalendarToday,
@@ -28,8 +29,33 @@ import { deleteEvent } from "@/lib/actions/events";
 import { formatDateTime } from "@/lib/utils/date";
 import { RSVPButtons } from "./RSVPButtons";
 import { AttendanceView } from "./AttendanceView";
+import type { AttendanceCounts, AttendanceEntry } from "@/types/events";
 
 type RSVPStatus = "GOING" | "NOT_GOING" | "MAYBE" | "NO_RESPONSE";
+
+type EventRsvp = {
+  id: string;
+  status: RSVPStatus;
+  user: {
+    id: string;
+    name: string | null;
+    email: string;
+  };
+  // Per-child response (identity graph, Tier 3). Absent/null on
+  // self/household rows.
+  playerId?: string | null;
+  player?: {
+    id: string;
+    name: string;
+  } | null;
+};
+
+/** A player the viewer guards (with canRsvp) on this event's team. */
+export interface GuardedPlayerRsvp {
+  playerId: string;
+  playerName: string;
+  status: RSVPStatus;
+}
 
 interface EventDetailProps {
   event: {
@@ -45,23 +71,68 @@ interface EventDetailProps {
       id: string;
       name: string;
     };
-    rsvps: Array<{
-      id: string;
-      status: RSVPStatus;
-      user: {
-        id: string;
-        name: string | null;
-        email: string;
-      };
-    }>;
+    rsvps: EventRsvp[];
     canRSVP?: boolean;
     canManageEvent?: boolean;
   };
   userRole: string;
   currentUserId: string;
+  /**
+   * Guarded players (canRsvp) the viewer answers for on this event's team.
+   * Empty/omitted → single-identity UI, identical to the pre-Tier-3 layout.
+   */
+  guardedPlayers?: GuardedPlayerRsvp[];
+  /**
+   * Server-computed attendance (getEventAttendance contract). When absent the
+   * component derives equivalent entries/counts from event.rsvps.
+   */
+  attendance?: { entries: AttendanceEntry[]; counts: AttendanceCounts } | null;
 }
 
-export default function EventDetail({ event, userRole, currentUserId }: EventDetailProps) {
+/**
+ * Fallback attendance derivation matching the getEventAttendance semantics:
+ * player-level entries where a per-child row exists, user-level otherwise;
+ * every row is a distinct entry.
+ */
+function deriveAttendance(rsvps: EventRsvp[]): {
+  entries: AttendanceEntry[];
+  counts: AttendanceCounts;
+} {
+  const entries: AttendanceEntry[] = rsvps.map((rsvp) =>
+    rsvp.playerId && rsvp.player
+      ? {
+          kind: "player" as const,
+          name: rsvp.player.name,
+          status: rsvp.status,
+          respondedByName: rsvp.user.name ?? rsvp.user.email,
+        }
+      : {
+          kind: "user" as const,
+          name: rsvp.user.name ?? rsvp.user.email,
+          status: rsvp.status,
+        }
+  );
+
+  const counts: AttendanceCounts = {
+    GOING: 0,
+    NOT_GOING: 0,
+    MAYBE: 0,
+    NO_RESPONSE: 0,
+  };
+  for (const entry of entries) {
+    counts[entry.status] += 1;
+  }
+
+  return { entries, counts };
+}
+
+export default function EventDetail({
+  event,
+  userRole,
+  currentUserId,
+  guardedPlayers = [],
+  attendance,
+}: EventDetailProps) {
   const router = useRouter();
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
@@ -70,9 +141,16 @@ export default function EventDetail({ event, userRole, currentUserId }: EventDet
   const isAdmin = event.canManageEvent ?? userRole === "ADMIN";
   const canRSVP = event.canRSVP ?? true;
 
-  // Find current user's RSVP status
-  const currentUserRSVP = event.rsvps.find((rsvp) => rsvp.user.id === currentUserId);
+  // Find current user's own (self/household) RSVP status — per-child rows
+  // carry a playerId and are answered separately below.
+  const currentUserRSVP = event.rsvps.find(
+    (rsvp) => rsvp.user.id === currentUserId && !rsvp.playerId
+  );
   const currentStatus = currentUserRSVP?.status || "NO_RESPONSE";
+
+  const hasGuardedPlayers = guardedPlayers.length > 0;
+  const { entries: attendanceEntries, counts: attendanceCounts } =
+    attendance ?? deriveAttendance(event.rsvps);
 
   const handleDelete = async () => {
     setIsDeleting(true);
@@ -193,20 +271,49 @@ export default function EventDetail({ event, userRole, currentUserId }: EventDet
         </CardContent>
       </Card>
 
-      {/* RSVP Buttons */}
+      {/* RSVP Buttons — one response row per identity for guardians */}
       {canRSVP && (
         <Box sx={{ mt: 3 }}>
           <Typography variant="h6" gutterBottom>
-            Your Response
+            {hasGuardedPlayers ? "Your Responses" : "Your Response"}
           </Typography>
-          <RSVPButtons eventId={event.id} currentStatus={currentStatus} />
+          {hasGuardedPlayers ? (
+            <Stack spacing={2.5}>
+              <Box>
+                <Typography
+                  variant="subtitle2"
+                  sx={{ mb: 1, color: "text.secondary" }}
+                >
+                  You
+                </Typography>
+                <RSVPButtons eventId={event.id} currentStatus={currentStatus} />
+              </Box>
+              {guardedPlayers.map((player) => (
+                <Box key={player.playerId}>
+                  <Typography
+                    variant="subtitle2"
+                    sx={{ mb: 1, color: "text.secondary" }}
+                  >
+                    {player.playerName}
+                  </Typography>
+                  <RSVPButtons
+                    eventId={event.id}
+                    currentStatus={player.status}
+                    playerId={player.playerId}
+                  />
+                </Box>
+              ))}
+            </Stack>
+          ) : (
+            <RSVPButtons eventId={event.id} currentStatus={currentStatus} />
+          )}
         </Box>
       )}
 
       {/* Attendance View (Admin only) */}
       {isAdmin && (
         <Box sx={{ mt: 3 }}>
-          <AttendanceView rsvps={event.rsvps} />
+          <AttendanceView entries={attendanceEntries} counts={attendanceCounts} />
         </Box>
       )}
 

--- a/components/features/events/RSVPButtons.tsx
+++ b/components/features/events/RSVPButtons.tsx
@@ -5,7 +5,7 @@ import { Box, Button, Stack } from "@mui/material";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import CancelIcon from "@mui/icons-material/Cancel";
 import HelpIcon from "@mui/icons-material/Help";
-import { updateRSVP } from "@/lib/actions/rsvp";
+import { submitRSVP } from "@/lib/actions/rsvp";
 import { trackRSVP } from "@/lib/analytics/umami";
 
 type RSVPStatus = "GOING" | "NOT_GOING" | "MAYBE" | "NO_RESPONSE";
@@ -13,12 +13,19 @@ type RSVPStatus = "GOING" | "NOT_GOING" | "MAYBE" | "NO_RESPONSE";
 interface RSVPButtonsProps {
   eventId: string;
   currentStatus: RSVPStatus;
+  /**
+   * When set, responses are recorded for this guarded player (per-child
+   * RSVP row, identity graph Tier 3). Omit/null for the viewer's own
+   * self/household response — the default, unchanged behavior.
+   */
+  playerId?: string | null;
   onStatusChange?: (status: RSVPStatus) => void;
 }
 
 export function RSVPButtons({
   eventId,
   currentStatus,
+  playerId,
   onStatusChange,
 }: RSVPButtonsProps) {
   const [isPending, startTransition] = useTransition();
@@ -30,10 +37,12 @@ export function RSVPButtons({
       // Optimistically update the UI
       setOptimisticStatus(status);
 
-      // Call the server action
-      const result = await updateRSVP({
+      // Call the server action (playerId present → answer on behalf of a
+      // guarded player; absent → the viewer's own self/household response)
+      const result = await submitRSVP({
         eventId,
         status,
+        ...(playerId ? { playerId } : {}),
       });
 
       if (result.success) {

--- a/components/features/roster/ManageGuardiansDialog.tsx
+++ b/components/features/roster/ManageGuardiansDialog.tsx
@@ -1,0 +1,305 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  TextField,
+  Box,
+  List,
+  ListItem,
+  ListItemText,
+  IconButton,
+  Chip,
+  Typography,
+  Alert,
+  CircularProgress,
+  Divider,
+} from "@mui/material";
+import DeleteIcon from "@mui/icons-material/Delete";
+import PersonAddIcon from "@mui/icons-material/PersonAdd";
+import {
+  addGuardian,
+  listGuardians,
+  removeGuardian,
+} from "@/lib/actions/guardians";
+import { useToast } from "@/components/ui/Toast";
+import type { GuardianWithUser } from "@/types/roster";
+
+type ManageGuardiansDialogProps = {
+  open: boolean;
+  onClose: () => void;
+  playerId: string;
+  playerName: string;
+  /**
+   * Fires whenever the guardian list is loaded or mutated so the parent
+   * (PlayerCard chips) can stay in sync without its own fetch.
+   */
+  onGuardiansChange?: (guardians: GuardianWithUser[]) => void;
+};
+
+export default function ManageGuardiansDialog({
+  open,
+  onClose,
+  playerId,
+  playerName,
+  onGuardiansChange,
+}: ManageGuardiansDialogProps) {
+  const { showSuccess, showError } = useToast();
+
+  // Guardian list — loaded lazily when the dialog opens (kept out of the
+  // roster query on purpose).
+  const [guardians, setGuardians] = useState<GuardianWithUser[] | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [removingId, setRemovingId] = useState<string | null>(null);
+
+  // Add-guardian form
+  const [email, setEmail] = useState("");
+  const [relationship, setRelationship] = useState("");
+  const [emailError, setEmailError] = useState<string | null>(null);
+  // Server-side add errors (e.g. "no account with that email") render inline,
+  // not as a toast — account-less guardian invites are out of scope this tier.
+  const [addError, setAddError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const loadGuardians = useCallback(async () => {
+    setIsLoading(true);
+    setLoadError(null);
+    try {
+      const result = await listGuardians(playerId);
+      if (result.success) {
+        setGuardians(result.data);
+        onGuardiansChange?.(result.data);
+      } else {
+        setLoadError(result.error);
+      }
+    } catch (error) {
+      console.error("Error loading guardians:", error);
+      setLoadError("Failed to load guardians. Please try again.");
+    } finally {
+      setIsLoading(false);
+    }
+  }, [playerId, onGuardiansChange]);
+
+  // Reset the form and (re)load the list each time the dialog opens
+  useEffect(() => {
+    if (open) {
+      setEmail("");
+      setRelationship("");
+      setEmailError(null);
+      setAddError(null);
+      void loadGuardians();
+    }
+  }, [open, loadGuardians]);
+
+  const handleAddSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    const trimmedEmail = email.trim();
+    if (!trimmedEmail || !/^\S+@\S+\.\S+$/.test(trimmedEmail)) {
+      setEmailError("Enter a valid email address");
+      return;
+    }
+
+    setIsSubmitting(true);
+    setEmailError(null);
+    setAddError(null);
+
+    try {
+      const result = await addGuardian({
+        playerId,
+        email: trimmedEmail,
+        relationship: relationship.trim() || undefined,
+      });
+
+      if (result.success) {
+        showSuccess("Guardian added");
+        setEmail("");
+        setRelationship("");
+        await loadGuardians();
+      } else {
+        // Friendly server message (no matching account, already linked, ...)
+        setAddError(result.error);
+      }
+    } catch (error) {
+      console.error("Error adding guardian:", error);
+      setAddError("An unexpected error occurred. Please try again.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleRemove = async (guardianId: string) => {
+    setRemovingId(guardianId);
+    try {
+      const result = await removeGuardian({ guardianId });
+      if (result.success) {
+        showSuccess("Guardian removed");
+        setGuardians((prev) => {
+          const next = (prev ?? []).filter((g) => g.id !== guardianId);
+          onGuardiansChange?.(next);
+          return next;
+        });
+      } else {
+        showError(result.error);
+      }
+    } catch (error) {
+      console.error("Error removing guardian:", error);
+      showError("An unexpected error occurred. Please try again.");
+    } finally {
+      setRemovingId(null);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>Guardians — {playerName}</DialogTitle>
+
+      <DialogContent>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+          Guardians can view {playerName}&apos;s schedule and RSVP on their
+          behalf.
+        </Typography>
+
+        {/* Current guardians */}
+        {isLoading ? (
+          <Box sx={{ display: "flex", justifyContent: "center", py: 3 }}>
+            <CircularProgress size={28} aria-label="Loading guardians" />
+          </Box>
+        ) : loadError ? (
+          <Alert
+            severity="error"
+            action={
+              <Button
+                color="inherit"
+                size="small"
+                onClick={() => void loadGuardians()}
+              >
+                Retry
+              </Button>
+            }
+          >
+            {loadError}
+          </Alert>
+        ) : guardians && guardians.length > 0 ? (
+          <List disablePadding>
+            {guardians.map((guardian) => (
+              <ListItem
+                key={guardian.id}
+                disableGutters
+                secondaryAction={
+                  <IconButton
+                    edge="end"
+                    aria-label={`Remove guardian ${guardian.user.name || guardian.user.email}`}
+                    color="error"
+                    disabled={removingId === guardian.id}
+                    onClick={() => void handleRemove(guardian.id)}
+                    sx={{ minWidth: 44, minHeight: 44 }}
+                  >
+                    <DeleteIcon fontSize="small" />
+                  </IconButton>
+                }
+              >
+                <ListItemText
+                  primary={
+                    <Box
+                      sx={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: 1,
+                        flexWrap: "wrap",
+                      }}
+                    >
+                      <Typography variant="body1" component="span">
+                        {guardian.user.name || guardian.user.email}
+                      </Typography>
+                      <Chip
+                        size="small"
+                        variant="outlined"
+                        color={guardian.canRsvp ? "success" : "default"}
+                        label={guardian.canRsvp ? "Can RSVP" : "View only"}
+                      />
+                    </Box>
+                  }
+                  secondary={[guardian.user.email, guardian.relationship]
+                    .filter(Boolean)
+                    .join(" · ")}
+                />
+              </ListItem>
+            ))}
+          </List>
+        ) : (
+          <Typography variant="body2" color="text.secondary" sx={{ py: 1 }}>
+            No guardians linked yet. Add a parent or guardian below so they can
+            RSVP for {playerName}.
+          </Typography>
+        )}
+
+        <Divider sx={{ my: 2 }} />
+
+        {/* Add guardian */}
+        <Typography variant="subtitle2" sx={{ mb: 1 }}>
+          Add a guardian
+        </Typography>
+
+        {addError && (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            {addError}
+          </Alert>
+        )}
+
+        <Box
+          component="form"
+          onSubmit={handleAddSubmit}
+          sx={{ display: "flex", flexDirection: "column", gap: 2 }}
+        >
+          <TextField
+            label="Email"
+            type="email"
+            value={email}
+            onChange={(e) => {
+              setEmail(e.target.value);
+              setEmailError(null);
+              setAddError(null);
+            }}
+            error={!!emailError}
+            helperText={
+              emailError || "Must match an existing OpenLeague account"
+            }
+            required
+            fullWidth
+            inputProps={{ inputMode: "email" }}
+          />
+
+          <TextField
+            label="Relationship"
+            value={relationship}
+            onChange={(e) => setRelationship(e.target.value)}
+            helperText="Optional — e.g. Mother, Father, Grandparent"
+            fullWidth
+            inputProps={{ maxLength: 50 }}
+          />
+
+          <Box sx={{ display: "flex", justifyContent: "flex-end" }}>
+            <Button
+              type="submit"
+              variant="contained"
+              startIcon={<PersonAddIcon />}
+              disabled={isSubmitting || !email.trim()}
+            >
+              {isSubmitting ? "Adding..." : "Add Guardian"}
+            </Button>
+          </Box>
+        </Box>
+      </DialogContent>
+
+      <DialogActions>
+        <Button onClick={onClose}>Close</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/components/features/roster/PlayerCard.tsx
+++ b/components/features/roster/PlayerCard.tsx
@@ -19,9 +19,11 @@ import EditIcon from "@mui/icons-material/Edit";
 import DeleteIcon from "@mui/icons-material/Delete";
 import EmailIcon from "@mui/icons-material/Email";
 import PhoneIcon from "@mui/icons-material/Phone";
+import SupervisorAccountIcon from "@mui/icons-material/SupervisorAccount";
 import Chip from "@mui/material/Chip";
 import { deletePlayer } from "@/lib/actions/roster";
-import type { Player } from "@/types/roster";
+import ManageGuardiansDialog from "./ManageGuardiansDialog";
+import type { GuardianWithUser, Player } from "@/types/roster";
 
 type PlayerCardProps = {
   player: Player;
@@ -37,6 +39,10 @@ export default function PlayerCard({
   onEdit,
 }: PlayerCardProps) {
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [guardiansDialogOpen, setGuardiansDialogOpen] = useState(false);
+  // Guardian names for the chips row. null = not loaded yet — guardians load
+  // lazily inside the manage dialog to keep the roster query lean.
+  const [guardians, setGuardians] = useState<GuardianWithUser[] | null>(null);
   const [snackbar, setSnackbar] = useState<{
     open: boolean;
     message: string;
@@ -214,8 +220,70 @@ export default function PlayerCard({
               )}
             </Box>
           )}
+
+          {/* Guardians (Admin only) */}
+          {isAdmin && (
+            <Box
+              sx={{
+                mt: 2,
+                pt: 1,
+                borderTop: 1,
+                borderColor: "divider",
+              }}
+            >
+              <Box
+                sx={{
+                  display: "flex",
+                  justifyContent: "space-between",
+                  alignItems: "center",
+                  gap: 1,
+                }}
+              >
+                <Typography
+                  variant="caption"
+                  color="text.secondary"
+                  sx={{ fontWeight: 600 }}
+                >
+                  Guardians
+                </Typography>
+                <Button
+                  size="small"
+                  startIcon={<SupervisorAccountIcon />}
+                  onClick={() => setGuardiansDialogOpen(true)}
+                  aria-label={`Manage guardians for ${player.name}`}
+                  sx={{ minHeight: 44 }}
+                >
+                  Manage guardians
+                </Button>
+              </Box>
+              {guardians && guardians.length > 0 && (
+                <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.5, mt: 0.5 }}>
+                  {guardians.map((guardian) => (
+                    <Chip
+                      key={guardian.id}
+                      size="small"
+                      variant="outlined"
+                      icon={<SupervisorAccountIcon />}
+                      label={guardian.user.name || guardian.user.email}
+                    />
+                  ))}
+                </Box>
+              )}
+            </Box>
+          )}
         </CardContent>
       </Card>
+
+      {/* Manage Guardians Dialog (Admin only) */}
+      {isAdmin && (
+        <ManageGuardiansDialog
+          open={guardiansDialogOpen}
+          onClose={() => setGuardiansDialogOpen(false)}
+          playerId={player.id}
+          playerName={player.name}
+          onGuardiansChange={setGuardians}
+        />
+      )}
 
       {/* Delete Confirmation Dialog */}
       <Dialog open={deleteDialogOpen} onClose={handleDeleteCancel}>

--- a/docs/superpowers/specs/2026-07-11-tier3-identity-design.md
+++ b/docs/superpowers/specs/2026-07-11-tier3-identity-design.md
@@ -1,0 +1,136 @@
+# Tier 3 — Identity Graph: Design
+
+**Date:** 2026-07-11
+**Status:** Approved direction (roadmap D5; audit identity-crosscut recommendation)
+**Parent:** `2026-07-11-observation-audit-roadmap-design.md`
+**Branch:** `feat/audit-tier3-identity` (stacked on `feat/audit-tier2-features`, PR #266)
+
+Activates the unwired identity seams. Explicitly NOT a unified-Person refactor —
+`User` remains the hub; all additions are edges and columns.
+
+## Decisions locked here
+
+- **League identity rule (canonical):** explicit `LeagueUser` rows, synced.
+  Every TeamMember of a league team gets a `LeagueUser` MEMBER row (TEAM_ADMIN
+  for team ADMINs) created at: invitation acceptance, `migrateTeamToLeague`,
+  and team-joins-league transitions. One-off backfill in the migration.
+  Derivation checks remain as fallback but the row is the source of truth.
+- **RSVP semantics (D5):** existing `playerId = null` rows remain valid
+  "self/household" responses. Guardians (and admins) answer per child via rows
+  carrying `playerId`. Event fan-out is unchanged (per-user NO_RESPONSE rows);
+  per-child rows are created on response (upsert). Reminders stay user-level
+  in this tier.
+- **Attendance counting:** an event's attendance view lists player-level
+  responses where they exist and user-level otherwise; counts deduplicate
+  (a user row + their child rows are distinct entries — the child rows count
+  as players attending, the user row as the adult's own response).
+
+## X1 — Schema migration (one migration: `identity_graph`)
+
+- `PlayerGuardian { id, playerId → Player (Cascade), userId → User (Cascade),
+  relationship String?, canRsvp Boolean @default(true), createdAt,
+  @@unique([playerId, userId]), @@index([userId]) }`.
+- `RSVP.playerId String?` → Player (Cascade), `@@index([playerId])`.
+  Uniqueness: drop `@@unique([userId, eventId])`; add
+  `@@unique([userId, eventId, playerId])` PLUS a raw-SQL partial unique index
+  `ON "RSVP"(userId, eventId) WHERE "playerId" IS NULL` (Postgres treats NULLs
+  as distinct in composite uniques). Existing rows keep `playerId = null`.
+- `Invitation` unified-target: add `leagueId String?`, `organizationId
+  String?`, `officialRole TeamOfficialRole?`, `venueRole` (existing venue role
+  enum) — `teamId` becomes optional; raw-SQL CHECK constraint: exactly one of
+  (teamId, leagueId, organizationId) non-null (pattern exists on SignupEvent).
+  Existing rows (teamId set) remain valid.
+- LeagueUser backfill (data migration SQL): insert missing LeagueUser rows for
+  every TeamMember of a league-linked team (role MEMBER; TEAM_ADMIN where
+  TeamMember.role = ADMIN), ON CONFLICT DO NOTHING.
+- Apply via `db:wake` + `db:migrate`; fallback hand-authored SQL; always
+  `db:generate`.
+
+## Interface contracts (implement/consume against these — enables parallel work)
+
+```ts
+// lib/actions/rsvp.ts (X2 implements, X3 consumes)
+submitRSVP({ eventId, status, playerId? }): ActionResult<...>
+// playerId present → authz: viewer is guardian with canRsvp of that player
+// (PlayerGuardian) OR team ADMIN; upsert keyed on (userId, eventId, playerId).
+getEventAttendance(eventId): ActionResult<{
+  entries: Array<{ kind: 'user'|'player'; name: string; status: RSVPStatus;
+                   respondedByName?: string }>,
+  counts: Record<RSVPStatus, number>
+}>
+
+// lib/actions/guardians.ts (X2 implements, X6 consumes)
+addGuardian({ playerId, email, relationship? })      // team ADMIN; existing User by email
+removeGuardian({ guardianId })                        // team ADMIN or the guardian themself
+listGuardians(playerId)                               // team ADMIN or guardian
+getMyPlayers(): ActionResult<Array<{ playerId, playerName, teamId, teamName,
+  canRsvp, upcoming: Array<{ eventId, title, startAt, myChildStatus }> }>>
+
+// lib/data/dashboard.ts (X3 owns this tier)
+getNeedsRsvp(...) returns per-identity pending rows:
+  Array<{ eventId, ..., target: { kind: 'self' } | { kind: 'player',
+          playerId, playerName } }>
+```
+
+## X2 — Guardian + per-child RSVP server logic
+
+Owns: `lib/actions/rsvp.ts`, NEW `lib/actions/guardians.ts`,
+`lib/utils/validation.ts`, `lib/actions/events.ts` (fan-out untouched;
+attendance queries updated), `app/api/cron/**` (verify reminders still compile
+against the RSVP shape; behavior unchanged), `prisma/seed.ts` (guardian +
+per-child RSVP fixtures), types file additions.
+
+## X3 — RSVP UI
+
+Owns: `components/features/events/**` (RSVPButtons → per-identity rows for
+guardians: self + one row per linked player with canRsvp; attendance list
+shows player-level entries with "answered by" attribution),
+`components/features/dashboard/widgets/NeedsRsvpWidget.tsx`,
+`lib/data/dashboard.ts`, `app/(dashboard)/events/[id]/**` (attendance
+section). Implements against the X2 contracts.
+
+## X4 — Unified invitation + league-identity sync + account-less invites
+
+Owns: `lib/actions/invitations.ts`, `lib/actions/auth.ts`,
+`lib/actions/league.ts`, `lib/auth/session.ts`, `lib/actions/venue-staff.ts`,
+`lib/actions/team-officials.ts`, `lib/email/templates.ts`,
+`app/api/invitations/**`, invitation acceptance UI touchpoints.
+
+- Extend invitation create/accept for league and venue-org targets with role
+  payloads; acceptance creates the right membership row (LeagueUser /
+  VenueStaff / TeamOfficial link) inside the existing transactions.
+- Account-less venue staff + official invites: Invitation row up front;
+  VenueStaff/TeamOfficial row created (or userId-linked) at acceptance —
+  closes the Tier 2 W3 "sign up first" gap.
+- League-identity sync (canonical rule): `ensureLeagueUser` helper applied at
+  team-invitation acceptance for league teams and inside
+  `migrateTeamToLeague`.
+- Fix `isSystemAdmin` mislabel in `lib/auth/session.ts` (any LEAGUE_ADMIN
+  passes a check named system-wide): rename to what it means
+  (`isAnyLeagueAdmin`) and update call sites.
+
+## X6 — Guardian UI
+
+Owns: `components/features/roster/**` (PlayerCard guardian chips + manage
+dialog, AddGuardianDialog), `app/(dashboard)/roster/**`, NEW "My players"
+surface (section on the dashboard is X3's widget; here: roster-side guardian
+management only).
+
+## Sequencing
+
+X1 first (schema + contracts landed in types). Then X2/X3/X4/X6 in parallel
+against the interface contracts above. X3 consumes X2's module — both
+implement to this spec's signatures; integration pass reconciles drift.
+
+## Out of scope
+
+Person entity/RoleAssignment refactor (rejected), per-child reminder fan-out
+(user-level reminders stay), RSVP.playerId backfill (no historical inference),
+household messaging preferences.
+
+## Verification
+
+`bun run type-check`, `lint`, `test`, `build`; migration applied to dev DB +
+`db:generate` consistency; seed re-run green (guardian fixtures); manual
+smoke: guardian answers per child, attendance shows attribution, league-team
+invite acceptance creates LeagueUser row, account-less staff invite round-trip.

--- a/lib/actions/auth.ts
+++ b/lib/actions/auth.ts
@@ -1,7 +1,9 @@
 "use server";
 
 import { hash } from "bcryptjs";
+import type { Invitation, Prisma } from "@prisma/client";
 import { prisma } from "@/lib/db/prisma";
+import { ensureLeagueUser } from "@/lib/actions/league";
 import { signupSchema, type SignupInput } from "@/lib/utils/validation";
 import { ZodError } from "zod";
 
@@ -50,40 +52,20 @@ export async function signup(data: SignupWithInvitationInput) {
         });
 
         if (invitation && invitation.status === "PENDING" && invitation.expiresAt > new Date()) {
-          // Use transaction to ensure atomicity
-          await prisma.$transaction([
-            // Add user to team as MEMBER
-            prisma.teamMember.create({
-              data: {
-                userId: user.id,
-                teamId: invitation.teamId,
-                role: "MEMBER",
-              },
-            }),
-            // Link unclaimed roster entries matching the invitation email to the new account
-            prisma.player.updateMany({
-              where: {
-                teamId: invitation.teamId,
-                email: { equals: invitation.email, mode: "insensitive" },
-                userId: null,
-              },
-              data: { userId: user.id },
-            }),
-            // Link unclaimed team official entries the same way
-            prisma.teamOfficial.updateMany({
-              where: {
-                teamId: invitation.teamId,
-                email: { equals: invitation.email, mode: "insensitive" },
-                userId: null,
-              },
-              data: { userId: user.id },
-            }),
+          // Use transaction to ensure atomicity. The unified Invitation model
+          // targets exactly one of team / league / venue organization.
+          await prisma.$transaction(async (tx) => {
+            await acceptInvitationMemberships(tx, invitation, {
+              id: user.id,
+              name: user.name,
+            });
+
             // Update invitation status to ACCEPTED
-            prisma.invitation.update({
+            await tx.invitation.update({
               where: { id: invitation.id },
               data: { status: "ACCEPTED" },
-            }),
-          ]);
+            });
+          });
         }
       } catch (inviteError) {
         console.error("Error processing invitation during signup:", inviteError);
@@ -119,5 +101,127 @@ export async function signup(data: SignupWithInvitationInput) {
     // Return a clean, serializable error response
     const errorMessage = error instanceof Error ? error.message : "An unexpected error occurred during signup";
     return { error: errorMessage };
+  }
+}
+
+/**
+ * Create the membership rows an accepted invitation grants, inside the
+ * caller's transaction. The unified Invitation model targets exactly one of:
+ * - team: TeamMember MEMBER + link unclaimed Player/TeamOfficial rows;
+ *   creates-or-links a TeamOfficial when the invite carries an officialRole;
+ *   syncs the LeagueUser row for league-linked teams.
+ * - league: LeagueUser MEMBER row.
+ * - venue organization: ACTIVE VenueStaff row with the invited venueRole.
+ */
+async function acceptInvitationMemberships(
+  tx: Prisma.TransactionClient,
+  invitation: Invitation,
+  user: { id: string; name: string | null }
+): Promise<void> {
+  if (invitation.teamId) {
+    // Add user to team as MEMBER
+    await tx.teamMember.create({
+      data: {
+        userId: user.id,
+        teamId: invitation.teamId,
+        role: "MEMBER",
+      },
+    });
+
+    // Link unclaimed roster entries matching the invitation email to the new account
+    await tx.player.updateMany({
+      where: {
+        teamId: invitation.teamId,
+        email: { equals: invitation.email, mode: "insensitive" },
+        userId: null,
+      },
+      data: { userId: user.id },
+    });
+
+    // Link unclaimed team official entries the same way
+    await tx.teamOfficial.updateMany({
+      where: {
+        teamId: invitation.teamId,
+        email: { equals: invitation.email, mode: "insensitive" },
+        userId: null,
+      },
+      data: { userId: user.id },
+    });
+
+    if (invitation.officialRole) {
+      // Official invite: activate the pending TeamOfficial entry for this
+      // role, or create one if it no longer exists.
+      const official = await tx.teamOfficial.findFirst({
+        where: {
+          teamId: invitation.teamId,
+          email: { equals: invitation.email, mode: "insensitive" },
+          role: invitation.officialRole,
+        },
+        select: { id: true },
+      });
+
+      if (official) {
+        await tx.teamOfficial.update({
+          where: { id: official.id },
+          data: { userId: user.id, status: "ACTIVE" },
+        });
+      } else {
+        await tx.teamOfficial.create({
+          data: {
+            teamId: invitation.teamId,
+            name: user.name || invitation.email,
+            email: invitation.email.toLowerCase(),
+            role: invitation.officialRole,
+            status: "ACTIVE",
+            userId: user.id,
+          },
+        });
+      }
+    }
+
+    // League-identity sync: members of league-linked teams get an explicit
+    // LeagueUser row.
+    const team = await tx.team.findUnique({
+      where: { id: invitation.teamId },
+      select: { leagueId: true },
+    });
+    if (team?.leagueId) {
+      await ensureLeagueUser(tx, user.id, team.leagueId, "MEMBER");
+    }
+  } else if (invitation.leagueId) {
+    await ensureLeagueUser(tx, user.id, invitation.leagueId, "MEMBER");
+  } else if (invitation.organizationId) {
+    // Org-wide staff rows use a null venueId; Postgres treats NULLs as
+    // distinct in the composite unique, so look up any existing row manually.
+    const existing = await tx.venueStaff.findFirst({
+      where: {
+        organizationId: invitation.organizationId,
+        userId: user.id,
+        venueId: null,
+      },
+      select: { id: true },
+    });
+
+    if (existing) {
+      await tx.venueStaff.update({
+        where: { id: existing.id },
+        data: {
+          role: invitation.venueRole ?? "VIEWER",
+          status: "ACTIVE",
+          joinedAt: new Date(),
+        },
+      });
+    } else {
+      await tx.venueStaff.create({
+        data: {
+          organizationId: invitation.organizationId,
+          userId: user.id,
+          role: invitation.venueRole ?? "VIEWER",
+          status: "ACTIVE",
+          joinedAt: new Date(),
+          invitedById: invitation.invitedById,
+        },
+      });
+    }
   }
 }

--- a/lib/actions/events.ts
+++ b/lib/actions/events.ts
@@ -457,6 +457,15 @@ export async function getEvent(eventId: string) {
                 email: true,
               },
             },
+            // Per-child rows (identity graph): playerId is a scalar on the
+            // row; include the player so attendance UIs can render the
+            // child's name with "answered by" attribution.
+            player: {
+              select: {
+                id: true,
+                name: true,
+              },
+            },
           },
         },
       },

--- a/lib/actions/guardians.ts
+++ b/lib/actions/guardians.ts
@@ -1,0 +1,384 @@
+"use server";
+
+import { z } from "zod";
+import { prisma } from "@/lib/db/prisma";
+import { isTeamAdmin, requireTeamAdmin, requireUserId } from "@/lib/auth/session";
+import { revalidatePath } from "next/cache";
+import {
+  addGuardianSchema,
+  removeGuardianSchema,
+  type AddGuardianInput,
+  type RemoveGuardianInput,
+} from "@/lib/utils/validation";
+import type { GuardianWithUser } from "@/types/roster";
+import type { RSVPStatus } from "@/types/events";
+
+export type ActionResult<T> =
+  | { success: true; data: T }
+  | { success: false; error: string; details?: unknown };
+
+const GUARDIAN_WITH_USER_INCLUDE = {
+  user: {
+    select: {
+      id: true,
+      name: true,
+      email: true,
+    },
+  },
+} as const;
+
+/** How many days ahead getMyPlayers looks for upcoming events. */
+const UPCOMING_WINDOW_DAYS = 14;
+
+/** One upcoming event for a guarded player, with the child's RSVP status. */
+export type MyPlayerUpcomingEvent = {
+  eventId: string;
+  title: string;
+  startAt: Date;
+  /** The child's per-player status (latest row regardless of who answered); NO_RESPONSE when unanswered. */
+  myChildStatus: RSVPStatus;
+};
+
+/** A player the current user guards, with team context and upcoming events. */
+export type MyPlayerSummary = {
+  playerId: string;
+  playerName: string;
+  teamId: string;
+  teamName: string;
+  canRsvp: boolean;
+  upcoming: MyPlayerUpcomingEvent[];
+};
+
+/**
+ * Link an existing User account as a guardian of a roster player.
+ * Team ADMIN only. The email must belong to an existing account — guardians
+ * are User edges, not standalone contacts.
+ */
+export async function addGuardian(
+  input: AddGuardianInput
+): Promise<ActionResult<GuardianWithUser>> {
+  try {
+    const validated = addGuardianSchema.parse(input);
+
+    const player = await prisma.player.findUnique({
+      where: { id: validated.playerId },
+      select: { id: true, teamId: true },
+    });
+
+    if (!player) {
+      return { success: false, error: "Player not found" };
+    }
+
+    // Only team admins can manage a player's guardians
+    await requireTeamAdmin(player.teamId);
+
+    const user = await prisma.user.findUnique({
+      where: { email: validated.email },
+      select: { id: true },
+    });
+
+    if (!user) {
+      return {
+        success: false,
+        error:
+          "No account found with that email. Ask them to sign up for OpenLeague first, then add them as a guardian.",
+      };
+    }
+
+    const existing = await prisma.playerGuardian.findUnique({
+      where: {
+        playerId_userId: {
+          playerId: player.id,
+          userId: user.id,
+        },
+      },
+      select: { id: true },
+    });
+
+    if (existing) {
+      return {
+        success: false,
+        error: "That account is already a guardian of this player",
+      };
+    }
+
+    const guardian = await prisma.playerGuardian.create({
+      data: {
+        playerId: player.id,
+        userId: user.id,
+        relationship: validated.relationship || null,
+      },
+      include: GUARDIAN_WITH_USER_INCLUDE,
+    });
+
+    revalidatePath("/roster");
+    revalidatePath("/dashboard");
+
+    return { success: true, data: guardian };
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      const fieldErrors = error.issues
+        .map((issue: z.ZodIssue) => `${issue.path.join(".")}: ${issue.message}`)
+        .join(", ");
+      return {
+        success: false,
+        error: `Validation failed: ${fieldErrors}`,
+        details: error.issues,
+      };
+    }
+
+    console.error("Error adding guardian:", error);
+
+    return {
+      success: false,
+      error: "Failed to add guardian. Please try again.",
+    };
+  }
+}
+
+/**
+ * Remove a guardian link. Allowed for team ADMINs of the player's team and
+ * for the guardian themself (self-removal).
+ */
+export async function removeGuardian(
+  input: RemoveGuardianInput
+): Promise<ActionResult<{ id: string }>> {
+  try {
+    const validated = removeGuardianSchema.parse(input);
+
+    const userId = await requireUserId();
+
+    const guardian = await prisma.playerGuardian.findUnique({
+      where: { id: validated.guardianId },
+      select: {
+        id: true,
+        userId: true,
+        player: { select: { teamId: true } },
+      },
+    });
+
+    if (!guardian) {
+      return { success: false, error: "Guardian link not found" };
+    }
+
+    const authorized =
+      guardian.userId === userId ||
+      (await isTeamAdmin(userId, guardian.player.teamId));
+
+    if (!authorized) {
+      return {
+        success: false,
+        error: "You are not authorized to remove this guardian",
+      };
+    }
+
+    await prisma.playerGuardian.delete({
+      where: { id: guardian.id },
+    });
+
+    revalidatePath("/roster");
+    revalidatePath("/dashboard");
+
+    return { success: true, data: { id: guardian.id } };
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      const fieldErrors = error.issues
+        .map((issue: z.ZodIssue) => `${issue.path.join(".")}: ${issue.message}`)
+        .join(", ");
+      return {
+        success: false,
+        error: `Validation failed: ${fieldErrors}`,
+        details: error.issues,
+      };
+    }
+
+    console.error("Error removing guardian:", error);
+
+    return {
+      success: false,
+      error: "Failed to remove guardian. Please try again.",
+    };
+  }
+}
+
+const playerIdSchema = z.string().cuid("Invalid player ID format");
+
+/**
+ * List a player's guardians. Visible to team ADMINs of the player's team and
+ * to the player's guardians themselves.
+ */
+export async function listGuardians(
+  playerId: string
+): Promise<ActionResult<GuardianWithUser[]>> {
+  try {
+    const validatedPlayerId = playerIdSchema.parse(playerId);
+
+    const player = await prisma.player.findUnique({
+      where: { id: validatedPlayerId },
+      select: { id: true, teamId: true },
+    });
+
+    if (!player) {
+      return { success: false, error: "Player not found" };
+    }
+
+    const userId = await requireUserId();
+
+    const selfLink = await prisma.playerGuardian.findUnique({
+      where: {
+        playerId_userId: {
+          playerId: player.id,
+          userId,
+        },
+      },
+      select: { id: true },
+    });
+
+    const authorized =
+      selfLink !== null || (await isTeamAdmin(userId, player.teamId));
+
+    if (!authorized) {
+      return {
+        success: false,
+        error: "You are not authorized to view this player's guardians",
+      };
+    }
+
+    const guardians = await prisma.playerGuardian.findMany({
+      where: { playerId: player.id },
+      include: GUARDIAN_WITH_USER_INCLUDE,
+      orderBy: { createdAt: "asc" },
+    });
+
+    return { success: true, data: guardians };
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return {
+        success: false,
+        error: "Invalid player ID",
+        details: error.issues,
+      };
+    }
+
+    console.error("Error listing guardians:", error);
+
+    return {
+      success: false,
+      error: "Failed to load guardians. Please try again.",
+    };
+  }
+}
+
+/**
+ * The current user's guarded players with their teams and each team's
+ * upcoming events (next 14 days), carrying the child's per-player RSVP
+ * status (NO_RESPONSE where no per-child row exists — per-child rows are
+ * only created on response).
+ */
+export async function getMyPlayers(): Promise<ActionResult<MyPlayerSummary[]>> {
+  try {
+    const userId = await requireUserId();
+
+    const links = await prisma.playerGuardian.findMany({
+      where: { userId },
+      select: {
+        canRsvp: true,
+        player: {
+          select: {
+            id: true,
+            name: true,
+            teamId: true,
+            team: { select: { name: true } },
+          },
+        },
+      },
+      orderBy: { player: { name: "asc" } },
+    });
+
+    if (links.length === 0) {
+      return { success: true, data: [] };
+    }
+
+    const teamIds = [...new Set(links.map((link) => link.player.teamId))];
+    const playerIds = links.map((link) => link.player.id);
+
+    const now = new Date();
+    const horizon = new Date(
+      now.getTime() + UPCOMING_WINDOW_DAYS * 24 * 60 * 60 * 1000
+    );
+
+    const events = await prisma.event.findMany({
+      where: {
+        teamId: { in: teamIds },
+        startAt: { gte: now, lte: horizon },
+      },
+      select: {
+        id: true,
+        title: true,
+        startAt: true,
+        teamId: true,
+      },
+      orderBy: { startAt: "asc" },
+    });
+
+    const childRsvps = events.length
+      ? await prisma.rSVP.findMany({
+          where: {
+            playerId: { in: playerIds },
+            eventId: { in: events.map((event) => event.id) },
+          },
+          select: {
+            playerId: true,
+            eventId: true,
+            status: true,
+            updatedAt: true,
+          },
+        })
+      : [];
+
+    // Latest status per (playerId, eventId), regardless of who answered
+    // (a guardian and a team admin may each hold a row for the same child).
+    const statusByPlayerEvent = new Map<
+      string,
+      { status: RSVPStatus; updatedAt: Date }
+    >();
+    for (const row of childRsvps) {
+      if (!row.playerId) continue;
+      const key = `${row.playerId}:${row.eventId}`;
+      const current = statusByPlayerEvent.get(key);
+      if (!current || row.updatedAt > current.updatedAt) {
+        statusByPlayerEvent.set(key, {
+          status: row.status as RSVPStatus,
+          updatedAt: row.updatedAt,
+        });
+      }
+    }
+
+    const data: MyPlayerSummary[] = links.map((link) => ({
+      playerId: link.player.id,
+      playerName: link.player.name,
+      teamId: link.player.teamId,
+      teamName: link.player.team.name,
+      canRsvp: link.canRsvp,
+      upcoming: events
+        .filter((event) => event.teamId === link.player.teamId)
+        .map((event) => ({
+          eventId: event.id,
+          title: event.title,
+          startAt: event.startAt,
+          myChildStatus:
+            statusByPlayerEvent.get(`${link.player.id}:${event.id}`)?.status ??
+            "NO_RESPONSE",
+        })),
+    }));
+
+    return { success: true, data };
+  } catch (error) {
+    console.error("Error loading guarded players:", error);
+
+    return {
+      success: false,
+      error: "Failed to load your players. Please try again.",
+    };
+  }
+}

--- a/lib/actions/invitations.ts
+++ b/lib/actions/invitations.ts
@@ -2,17 +2,42 @@
 
 import { z } from "zod";
 import { prisma } from "@/lib/db/prisma";
-import { requireTeamAdmin, requireUserId } from "@/lib/auth/session";
+import {
+  hasVenueStaffRole,
+  requireTeamAdmin,
+  requireUserId,
+  VENUE_STAFF_ADMIN_ROLES,
+} from "@/lib/auth/session";
+import { ensureLeagueUser } from "@/lib/actions/league";
 import { revalidatePath } from "next/cache";
 import { randomBytes } from "crypto";
-import { sendInvitationEmail, sendExistingUserNotification } from "@/lib/email/templates";
+import {
+  sendInvitationEmail,
+  sendExistingUserNotification,
+  sendLeagueInvitationEmail,
+  sendLeagueMemberAddedNotification,
+  sendVenueStaffSignupInviteEmail,
+} from "@/lib/email/templates";
 import { sendInvitationSchema, sendLeagueInvitationSchema, type SendInvitationInput, type SendLeagueInvitationInput } from "@/lib/utils/validation";
 
 export type ActionResult<T> =
   | { success: true; data: T }
   | { success: false; error: string; details?: unknown };
 
+// Local schema: lib/utils/validation.ts is owned by a concurrent workstream
+// this tier.
+const sendLeagueMemberInvitationSchema = z.object({
+  leagueId: z.string().cuid("Invalid league ID format"),
+  email: z
+    .string()
+    .trim()
+    .toLowerCase()
+    .email("Invalid email address")
+    .max(254, "Email must be less than 254 characters"),
+  role: z.enum(["LEAGUE_ADMIN", "TEAM_ADMIN", "MEMBER"]).default("MEMBER"),
+});
 
+export type SendLeagueMemberInvitationInput = z.input<typeof sendLeagueMemberInvitationSchema>;
 
 /**
  * Generate a cryptographically secure random token
@@ -40,7 +65,7 @@ export async function sendInvitation(
     const [team, inviter] = await Promise.all([
       prisma.team.findUnique({
         where: { id: validated.teamId },
-        select: { name: true },
+        select: { name: true, leagueId: true },
       }),
       prisma.user.findUnique({
         where: { id: userId },
@@ -79,33 +104,41 @@ export async function sendInvitation(
       }
 
       // Add user directly to team as MEMBER
-      await prisma.$transaction([
-        prisma.teamMember.create({
+      await prisma.$transaction(async (tx) => {
+        await tx.teamMember.create({
           data: {
             userId: existingUser.id,
             teamId: validated.teamId,
             role: "MEMBER",
           },
-        }),
+        });
+
         // Link unclaimed roster entries matching the invited email to the account
-        prisma.player.updateMany({
+        await tx.player.updateMany({
           where: {
             teamId: validated.teamId,
             email: { equals: validated.email, mode: "insensitive" },
             userId: null,
           },
           data: { userId: existingUser.id },
-        }),
+        });
+
         // Link unclaimed team official entries the same way
-        prisma.teamOfficial.updateMany({
+        await tx.teamOfficial.updateMany({
           where: {
             teamId: validated.teamId,
             email: { equals: validated.email, mode: "insensitive" },
             userId: null,
           },
           data: { userId: existingUser.id },
-        }),
-      ]);
+        });
+
+        // League-identity sync: members of league-linked teams get an
+        // explicit LeagueUser row.
+        if (team.leagueId) {
+          await ensureLeagueUser(tx, existingUser.id, team.leagueId, "MEMBER");
+        }
+      });
 
       // Send notification email to existing user
       try {
@@ -319,23 +352,8 @@ export async function sendLeagueInvitation(
           data: { userId: existingUser.id },
         });
 
-        // Add to league if not already a member
-        const existingLeagueUser = await tx.leagueUser.findFirst({
-          where: {
-            userId: existingUser.id,
-            leagueId: validated.leagueId,
-          },
-        });
-
-        if (!existingLeagueUser) {
-          await tx.leagueUser.create({
-            data: {
-              userId: existingUser.id,
-              leagueId: validated.leagueId,
-              role: "MEMBER",
-            },
-          });
-        }
+        // League-identity sync: add to league if not already a member
+        await ensureLeagueUser(tx, existingUser.id, validated.leagueId, "MEMBER");
       });
 
       // Send notification email to existing user
@@ -441,24 +459,197 @@ export async function sendLeagueInvitation(
 }
 
 /**
- * Resend an expired invitation
+ * Invite someone to a league directly (not to a specific team).
+ * Only LEAGUE_ADMINs of the league may invite.
+ *
+ * Existing accounts are added immediately with the requested role. Emails
+ * without an account get a unified Invitation (league target) and join as
+ * MEMBER at signup acceptance — elevated roles can only be granted to
+ * existing accounts (the invitation carries no league-role payload).
+ */
+export async function sendLeagueMemberInvitation(
+  input: SendLeagueMemberInvitationInput
+): Promise<ActionResult<{ invited: boolean; addedDirectly: boolean }>> {
+  try {
+    const validated = sendLeagueMemberInvitationSchema.parse(input);
+
+    const userId = await requireUserId();
+    const requesterMembership = await prisma.leagueUser.findFirst({
+      where: {
+        userId,
+        leagueId: validated.leagueId,
+        role: "LEAGUE_ADMIN",
+      },
+    });
+
+    if (!requesterMembership) {
+      return {
+        success: false,
+        error: "Unauthorized: Only league admins can invite league members",
+      };
+    }
+
+    const [league, inviter] = await Promise.all([
+      prisma.league.findFirst({
+        where: { id: validated.leagueId, isActive: true },
+        select: { name: true },
+      }),
+      prisma.user.findUnique({
+        where: { id: userId },
+        select: { name: true, email: true },
+      }),
+    ]);
+
+    if (!league || !inviter) {
+      return { success: false, error: "League not found or inactive" };
+    }
+
+    const existingUser = await prisma.user.findUnique({
+      where: { email: validated.email },
+      select: { id: true },
+    });
+
+    if (existingUser) {
+      const existingMembership = await prisma.leagueUser.findUnique({
+        where: {
+          userId_leagueId: {
+            userId: existingUser.id,
+            leagueId: validated.leagueId,
+          },
+        },
+        select: { id: true },
+      });
+
+      if (existingMembership) {
+        return {
+          success: false,
+          error: "User is already a member of this league",
+        };
+      }
+
+      await ensureLeagueUser(prisma, existingUser.id, validated.leagueId, validated.role);
+
+      try {
+        await sendLeagueMemberAddedNotification({
+          email: validated.email,
+          leagueName: league.name,
+          inviterName: inviter.name || inviter.email,
+          role: validated.role,
+        });
+      } catch (error) {
+        console.error("Failed to send league notification email:", error);
+        // Don't fail the entire operation if email fails
+      }
+
+      revalidatePath(`/league/${validated.leagueId}`);
+      revalidatePath(`/league/${validated.leagueId}/roster`);
+
+      return { success: true, data: { invited: true, addedDirectly: true } };
+    }
+
+    // The Invitation row has no league-role payload, so account-less invites
+    // can only grant the default MEMBER role at acceptance.
+    if (validated.role !== "MEMBER") {
+      return {
+        success: false,
+        error:
+          "Elevated league roles can only be granted to existing accounts. Invite them as a member, or ask them to sign up first.",
+      };
+    }
+
+    const existingInvitation = await prisma.invitation.findFirst({
+      where: {
+        email: validated.email,
+        leagueId: validated.leagueId,
+        status: "PENDING",
+        expiresAt: { gt: new Date() },
+      },
+    });
+
+    if (existingInvitation) {
+      return {
+        success: false,
+        error: "An invitation has already been sent to this email",
+      };
+    }
+
+    const token = generateInvitationToken();
+    const expiresAt = new Date();
+    expiresAt.setDate(expiresAt.getDate() + 7);
+
+    await prisma.invitation.create({
+      data: {
+        email: validated.email,
+        token,
+        status: "PENDING",
+        expiresAt,
+        leagueId: validated.leagueId,
+        invitedById: userId,
+      },
+    });
+
+    try {
+      await sendLeagueInvitationEmail({
+        email: validated.email,
+        leagueName: league.name,
+        inviterName: inviter.name || inviter.email,
+        token,
+      });
+    } catch (error) {
+      console.error("Failed to send league invitation email:", error);
+      // Don't fail the entire operation if email fails
+    }
+
+    revalidatePath(`/league/${validated.leagueId}`);
+    revalidatePath(`/league/${validated.leagueId}/roster`);
+
+    return { success: true, data: { invited: true, addedDirectly: false } };
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return {
+        success: false,
+        error: "Invalid input",
+        details: error.issues,
+      };
+    }
+
+    console.error("Error sending league member invitation:", error);
+    return {
+      success: false,
+      error: "Failed to send invitation. Please try again.",
+    };
+  }
+}
+
+/**
+ * Resend an expired invitation (team, league, or venue-organization target).
  */
 export async function resendInvitation(
   invitationId: string
 ): Promise<ActionResult<{ invited: boolean }>> {
   try {
-    // Get the invitation first to get the teamId
+    // Get the invitation first to resolve its target
     const invitation = await prisma.invitation.findUnique({
       where: { id: invitationId },
       select: {
         id: true,
         email: true,
         teamId: true,
+        leagueId: true,
+        organizationId: true,
+        venueRole: true,
+        officialRole: true,
         team: {
           select: {
             name: true,
             leagueId: true,
           },
+        },
+        league: {
+          select: { name: true },
+        },
+        organization: {
+          select: { name: true },
         },
       },
     });
@@ -470,29 +661,50 @@ export async function resendInvitation(
       };
     }
 
-    // Check authentication and authorization
+    // Check authentication and authorization against the invitation's target
     const userId = await requireUserId();
 
-    // Check if user is team admin OR league admin
-    const isTeamAdmin = await prisma.teamMember.findFirst({
-      where: { userId, teamId: invitation.teamId, role: "ADMIN" },
-    });
+    let authorized = false;
+    if (invitation.teamId && invitation.team) {
+      // Team target: team admin OR admin of the team's league
+      const isTeamAdmin = await prisma.teamMember.findFirst({
+        where: { userId, teamId: invitation.teamId, role: "ADMIN" },
+      });
+      authorized = !!isTeamAdmin;
 
-    let isLeagueAdmin = null;
-    if (!isTeamAdmin && invitation.team.leagueId) {
-      isLeagueAdmin = await prisma.leagueUser.findFirst({
+      if (!authorized && invitation.team.leagueId) {
+        const isLeagueAdmin = await prisma.leagueUser.findFirst({
+          where: {
+            userId,
+            leagueId: invitation.team.leagueId,
+            role: "LEAGUE_ADMIN",
+          },
+        });
+        authorized = !!isLeagueAdmin;
+      }
+    } else if (invitation.leagueId) {
+      // League target: league admin
+      const isLeagueAdmin = await prisma.leagueUser.findFirst({
         where: {
           userId,
-          leagueId: invitation.team.leagueId,
+          leagueId: invitation.leagueId,
           role: "LEAGUE_ADMIN",
         },
       });
+      authorized = !!isLeagueAdmin;
+    } else if (invitation.organizationId) {
+      // Venue-organization target: active OWNER/MANAGER staff
+      authorized = await hasVenueStaffRole(
+        userId,
+        invitation.organizationId,
+        VENUE_STAFF_ADMIN_ROLES
+      );
     }
 
-    if (!isTeamAdmin && !isLeagueAdmin) {
+    if (!authorized) {
       return {
         success: false,
-        error: "Unauthorized: Only team or league admins can resend invitations",
+        error: "Unauthorized: Only admins of the invitation's target can resend it",
       };
     }
 
@@ -517,24 +729,48 @@ export async function resendInvitation(
       select: { name: true, email: true },
     });
 
-    // Send invitation email
+    // Send invitation email matching the target
     if (inviter) {
+      const inviterName = inviter.name || inviter.email;
       try {
-        await sendInvitationEmail({
-          email: invitation.email,
-          teamName: invitation.team.name,
-          inviterName: inviter.name || inviter.email,
-          token,
-        });
+        if (invitation.team) {
+          await sendInvitationEmail({
+            email: invitation.email,
+            teamName: invitation.team.name,
+            inviterName,
+            token,
+          });
+        } else if (invitation.league) {
+          await sendLeagueInvitationEmail({
+            email: invitation.email,
+            leagueName: invitation.league.name,
+            inviterName,
+            token,
+          });
+        } else if (invitation.organization) {
+          await sendVenueStaffSignupInviteEmail({
+            email: invitation.email,
+            organizationName: invitation.organization.name,
+            inviterName,
+            role: invitation.venueRole ?? "VIEWER",
+            token,
+          });
+        }
       } catch (error) {
         console.error("Failed to send invitation email:", error);
         // Don't fail the entire operation if email fails
       }
     }
 
-    revalidatePath("/roster");
-    if (invitation.team.leagueId) {
-      revalidatePath(`/league/${invitation.team.leagueId}/roster`);
+    if (invitation.teamId) {
+      revalidatePath("/roster");
+      if (invitation.team?.leagueId) {
+        revalidatePath(`/league/${invitation.team.leagueId}/roster`);
+      }
+    } else if (invitation.leagueId) {
+      revalidatePath(`/league/${invitation.leagueId}/roster`);
+    } else if (invitation.organizationId) {
+      revalidatePath(`/venue-admin/${invitation.organizationId}/staff`);
     }
 
     return {

--- a/lib/actions/league.ts
+++ b/lib/actions/league.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { z } from "zod";
+import type { LeagueRole, Prisma } from "@prisma/client";
 import { prisma } from "@/lib/db/prisma";
 import { requireUserId } from "@/lib/auth/session";
 import { revalidatePath } from "next/cache";
@@ -40,6 +41,50 @@ import { rethrowIfNextRedirectError } from "@/lib/utils/next-errors";
 export type ActionResult<T> =
   | { success: true; data: T }
   | { success: false; error: string; details?: unknown };
+
+const LEAGUE_ROLE_RANK: Record<LeagueRole, number> = {
+  MEMBER: 1,
+  TEAM_ADMIN: 2,
+  LEAGUE_ADMIN: 3,
+};
+
+/**
+ * League-identity sync (Tier 3 canonical rule): every TeamMember of a
+ * league-linked team must have an explicit LeagueUser row. Call this wherever
+ * a TeamMember row is created for a league team (invitation acceptance,
+ * migrateTeamToLeague, team-joins-league transitions).
+ *
+ * Idempotent: creates the row when missing, upgrades the role when the
+ * requested role outranks the existing one, and never downgrades.
+ *
+ * Not a client-callable action — it must run inside a caller-owned Prisma
+ * transaction (any client invocation fails because `tx` is not serializable).
+ */
+export async function ensureLeagueUser(
+  tx: Prisma.TransactionClient,
+  userId: string,
+  leagueId: string,
+  role: LeagueRole = "MEMBER"
+): Promise<void> {
+  const existing = await tx.leagueUser.findUnique({
+    where: { userId_leagueId: { userId, leagueId } },
+    select: { id: true, role: true },
+  });
+
+  if (!existing) {
+    await tx.leagueUser.create({
+      data: { userId, leagueId, role },
+    });
+    return;
+  }
+
+  if (LEAGUE_ROLE_RANK[role] > LEAGUE_ROLE_RANK[existing.role]) {
+    await tx.leagueUser.update({
+      where: { id: existing.id },
+      data: { role },
+    });
+  }
+}
 
 /**
  * Create a new league and assign the creator as LEAGUE_ADMIN
@@ -217,6 +262,23 @@ export async function migrateTeamToLeague(
         data: { leagueId: league.id },
       });
 
+      // League-identity sync: every existing team member gets an explicit
+      // LeagueUser row (TEAM_ADMIN for team ADMINs, MEMBER otherwise). The
+      // acting user already holds LEAGUE_ADMIN from the league create above;
+      // ensureLeagueUser never downgrades, so this is safe for them too.
+      const members = await tx.teamMember.findMany({
+        where: { teamId: validated.teamId },
+        select: { userId: true, role: true },
+      });
+      for (const member of members) {
+        await ensureLeagueUser(
+          tx,
+          member.userId,
+          league.id,
+          member.role === "ADMIN" ? "TEAM_ADMIN" : "MEMBER"
+        );
+      }
+
       return {
         league,
         team,
@@ -354,6 +416,11 @@ export async function addTeamToLeague(
         season: true,
       },
     });
+
+    // League-identity sync: the creator becomes a TeamMember ADMIN of a
+    // league-linked team, so guarantee their LeagueUser row (no-op for the
+    // league admins this action requires, but keeps the invariant explicit).
+    await ensureLeagueUser(prisma, userId, validated.leagueId, "TEAM_ADMIN");
 
     // Log audit event
     await logAuditEvent({

--- a/lib/actions/rsvp.ts
+++ b/lib/actions/rsvp.ts
@@ -2,30 +2,54 @@
 
 import { z } from "zod";
 import { prisma } from "@/lib/db/prisma";
-import { requireTeamMember } from "@/lib/auth/session";
+import { isTeamAdmin, requireTeamMember, requireUserId } from "@/lib/auth/session";
 import { revalidatePath } from "next/cache";
 import {
   updateRSVPSchema,
-  type UpdateRSVPInput
+  type UpdateRSVPInput,
 } from "@/lib/utils/validation";
+import type {
+  AttendanceCounts,
+  AttendanceEntry,
+  RSVPStatus,
+} from "@/types/events";
 
 export type ActionResult<T> =
   | { success: true; data: T }
   | { success: false; error: string; details?: unknown };
 
+type RsvpRow = {
+  id: string;
+  status: string;
+  userId: string;
+  eventId: string;
+  playerId: string | null;
+};
+
+const RSVP_ROW_SELECT = {
+  id: true,
+  status: true,
+  userId: true,
+  eventId: true,
+  playerId: true,
+} as const;
+
 /**
- * Update or create an RSVP for an event
+ * Submit (create or update) an RSVP for an event.
+ *
+ * Identity graph (Tier 3, decision D5):
+ * - No `playerId` → the viewer's own self/household response (RSVP.playerId
+ *   null). Requires team membership; integrity is enforced by the partial
+ *   unique index `RSVP_userId_eventId_self_key` (the composite unique rejects
+ *   null members), so this path uses findFirst + create/update, not upsert.
+ * - `playerId` set → a per-child response. The viewer must be a guardian of
+ *   that player with `canRsvp`, or a team ADMIN of the player's team; the
+ *   player must belong to the event's team. Upserts on
+ *   (userId, eventId, playerId).
  */
-export async function updateRSVP(
+export async function submitRSVP(
   input: UpdateRSVPInput
-): Promise<
-  ActionResult<{
-    id: string;
-    status: string;
-    userId: string;
-    eventId: string;
-  }>
-> {
+): Promise<ActionResult<RsvpRow>> {
   try {
     // Validate input
     const validated = updateRSVPSchema.parse(input);
@@ -46,36 +70,96 @@ export async function updateRSVP(
       };
     }
 
-    // Check authentication and authorization - user must be a team member
-    const userId = await requireTeamMember(event.teamId);
+    let rsvp: RsvpRow;
 
-    // Create or update RSVP
-    const rsvp = await prisma.rSVP.upsert({
-      where: {
-        userId_eventId: {
+    if (validated.playerId) {
+      // Per-child response: authenticate, then authorize as guardian or admin.
+      const userId = await requireUserId();
+
+      const player = await prisma.player.findUnique({
+        where: { id: validated.playerId },
+        select: { id: true, teamId: true },
+      });
+
+      if (!player || player.teamId !== event.teamId) {
+        return {
+          success: false,
+          error: "Player not found on this event's team",
+        };
+      }
+
+      const guardian = await prisma.playerGuardian.findUnique({
+        where: {
+          playerId_userId: {
+            playerId: validated.playerId,
+            userId,
+          },
+        },
+        select: { canRsvp: true },
+      });
+
+      const authorized =
+        guardian?.canRsvp === true || (await isTeamAdmin(userId, event.teamId));
+
+      if (!authorized) {
+        return {
+          success: false,
+          error: "You are not authorized to RSVP for this player",
+        };
+      }
+
+      rsvp = await prisma.rSVP.upsert({
+        where: {
+          userId_eventId_playerId: {
+            userId,
+            eventId: validated.eventId,
+            playerId: validated.playerId,
+          },
+        },
+        update: {
+          status: validated.status,
+        },
+        create: {
           userId,
           eventId: validated.eventId,
+          playerId: validated.playerId,
+          status: validated.status,
         },
-      },
-      update: {
-        status: validated.status,
-      },
-      create: {
-        userId,
-        eventId: validated.eventId,
-        status: validated.status,
-      },
-      select: {
-        id: true,
-        status: true,
-        userId: true,
-        eventId: true,
-      },
-    });
+        select: RSVP_ROW_SELECT,
+      });
+    } else {
+      // Self/household response — user must be a team member.
+      const userId = await requireTeamMember(event.teamId);
 
-    // Revalidate the event detail page and calendar
+      const existing = await prisma.rSVP.findFirst({
+        where: {
+          userId,
+          eventId: validated.eventId,
+          playerId: null,
+        },
+        select: { id: true },
+      });
+
+      rsvp = existing
+        ? await prisma.rSVP.update({
+            where: { id: existing.id },
+            data: { status: validated.status },
+            select: RSVP_ROW_SELECT,
+          })
+        : await prisma.rSVP.create({
+            data: {
+              userId,
+              eventId: validated.eventId,
+              status: validated.status,
+            },
+            select: RSVP_ROW_SELECT,
+          });
+    }
+
+    // Revalidate the event detail page, calendar, and dashboard widgets
     revalidatePath(`/events/${validated.eventId}`);
     revalidatePath("/calendar");
+    revalidatePath("/dashboard");
 
     return {
       success: true,
@@ -93,11 +177,163 @@ export async function updateRSVP(
       };
     }
 
-    console.error("Error updating RSVP:", error);
+    console.error("Error submitting RSVP:", error);
 
     return {
       success: false,
       error: "Failed to update RSVP. Please try again.",
+    };
+  }
+}
+
+/**
+ * Update or create an RSVP for an event.
+ *
+ * @deprecated Use {@link submitRSVP} (same behavior; contract name from the
+ * Tier 3 identity-graph spec). Kept so existing callers compile unchanged.
+ */
+export async function updateRSVP(
+  input: UpdateRSVPInput
+): Promise<ActionResult<RsvpRow>> {
+  return submitRSVP(input);
+}
+
+const eventIdSchema = z.string().cuid("Invalid event ID format");
+
+/**
+ * Per-identity attendance for an event (Tier 3 locked decision):
+ * player-level responses are listed where they exist and user-level rows
+ * otherwise; a user row and their child rows are distinct entries. Counts
+ * treat each entry as one.
+ *
+ * Visible to team members and to LEAGUE_ADMINs of the event's league
+ * (mirrors getEvent's read access).
+ */
+export async function getEventAttendance(
+  eventId: string
+): Promise<ActionResult<{ entries: AttendanceEntry[]; counts: AttendanceCounts }>> {
+  try {
+    const validatedEventId = eventIdSchema.parse(eventId);
+
+    const event = await prisma.event.findUnique({
+      where: { id: validatedEventId },
+      select: {
+        id: true,
+        teamId: true,
+        leagueId: true,
+        team: { select: { leagueId: true } },
+      },
+    });
+
+    if (!event) {
+      return { success: false, error: "Event not found" };
+    }
+
+    const userId = await requireUserId();
+
+    const teamMember = await prisma.teamMember.findUnique({
+      where: {
+        userId_teamId: {
+          userId,
+          teamId: event.teamId,
+        },
+      },
+      select: { role: true },
+    });
+
+    if (!teamMember) {
+      const eventLeagueId = event.leagueId ?? event.team.leagueId;
+      const leagueAdmin = eventLeagueId
+        ? await prisma.leagueUser.findFirst({
+            where: {
+              userId,
+              leagueId: eventLeagueId,
+              role: "LEAGUE_ADMIN",
+            },
+            select: { id: true },
+          })
+        : null;
+
+      if (!leagueAdmin) {
+        return {
+          success: false,
+          error: "You do not have access to this event",
+        };
+      }
+    }
+
+    const rsvps = await prisma.rSVP.findMany({
+      where: { eventId: validatedEventId },
+      select: {
+        status: true,
+        playerId: true,
+        updatedAt: true,
+        user: { select: { name: true, email: true } },
+        player: { select: { id: true, name: true } },
+      },
+    });
+
+    const entries: AttendanceEntry[] = [];
+
+    // Player-level entries: dedupe per player (a child answered by both a
+    // guardian and an admin still counts once — the latest response wins).
+    const latestPerPlayer = new Map<string, (typeof rsvps)[number]>();
+
+    for (const row of rsvps) {
+      if (row.playerId && row.player) {
+        const current = latestPerPlayer.get(row.playerId);
+        if (!current || row.updatedAt > current.updatedAt) {
+          latestPerPlayer.set(row.playerId, row);
+        }
+      } else {
+        // User-level (self/household) entry.
+        entries.push({
+          kind: "user",
+          name: row.user.name ?? row.user.email,
+          status: row.status as RSVPStatus,
+        });
+      }
+    }
+
+    for (const row of latestPerPlayer.values()) {
+      entries.push({
+        kind: "player",
+        name: row.player!.name,
+        status: row.status as RSVPStatus,
+        respondedByName: row.user.name ?? row.user.email,
+      });
+    }
+
+    entries.sort((a, b) => a.name.localeCompare(b.name));
+
+    const counts: AttendanceCounts = {
+      GOING: 0,
+      NOT_GOING: 0,
+      MAYBE: 0,
+      NO_RESPONSE: 0,
+    };
+    for (const entry of entries) {
+      counts[entry.status] += 1;
+    }
+
+    return {
+      success: true,
+      data: { entries, counts },
+    };
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return {
+        success: false,
+        error: "Invalid event ID",
+        details: error.issues,
+      };
+    }
+
+    console.error("Error loading event attendance:", error);
+
+    return {
+      success: false,
+      error: "Failed to load attendance. Please try again.",
     };
   }
 }

--- a/lib/actions/team-officials.ts
+++ b/lib/actions/team-officials.ts
@@ -1,10 +1,16 @@
 "use server";
 
 import { z } from "zod";
+import { randomBytes } from "crypto";
 import { Prisma, type TeamOfficial } from "@prisma/client";
 import { prisma } from "@/lib/db/prisma";
 import { requireTeamAdmin, requireTeamMember } from "@/lib/auth/session";
+import { ensureLeagueUser } from "@/lib/actions/league";
 import { revalidatePath } from "next/cache";
+import {
+  sendExistingUserNotification,
+  sendTeamOfficialInviteEmail,
+} from "@/lib/email/templates";
 import {
   createTeamOfficialSchema,
   updateTeamOfficialSchema,
@@ -17,6 +23,36 @@ import {
 export type ActionResult<T> =
   | { success: true; data: T }
   | { success: false; error: string; details?: unknown };
+
+// Local schema: lib/utils/validation.ts is owned by a concurrent workstream
+// this tier. Mirrors teamOfficialBaseSchema's constraints.
+const inviteTeamOfficialSchema = z
+  .object({
+    teamId: z.string().cuid("Invalid team ID format"),
+    email: z
+      .string()
+      .trim()
+      .toLowerCase()
+      .email("Invalid email address")
+      .max(254, "Email must be less than 254 characters"),
+    name: z.string().trim().min(1, "Name is required").max(100),
+    role: z.enum([
+      "HEAD_COACH",
+      "ASSISTANT_COACH",
+      "MANAGER",
+      "TREASURER",
+      "VOLUNTEER_COORDINATOR",
+      "PARENT_VOLUNTEER",
+      "OTHER",
+    ]),
+    roleDetail: z.string().trim().max(100).optional(),
+  })
+  .refine((data) => data.role !== "OTHER" || !!data.roleDetail, {
+    message: "Please describe the role when selecting Other",
+    path: ["roleDetail"],
+  });
+
+export type InviteTeamOfficialInput = z.input<typeof inviteTeamOfficialSchema>;
 
 function revalidateRosterPaths(teamId: string) {
   revalidatePath("/roster");
@@ -118,6 +154,16 @@ export async function createTeamOfficial(
             role: "ADMIN",
           },
         });
+
+        // League-identity sync: team admins of league-linked teams get an
+        // explicit LeagueUser TEAM_ADMIN row.
+        const team = await tx.team.findUnique({
+          where: { id: validated.teamId },
+          select: { leagueId: true },
+        });
+        if (team?.leagueId) {
+          await ensureLeagueUser(tx, linkedUser.id, team.leagueId, "TEAM_ADMIN");
+        }
       }
 
       return row;
@@ -142,6 +188,202 @@ export async function createTeamOfficial(
     return {
       success: false,
       error: "Failed to add official. Please try again.",
+    };
+  }
+}
+
+/**
+ * Invite someone to join the team as an official (coach, manager, ...).
+ * Only ADMIN role can invite.
+ *
+ * Existing OpenLeague users are linked immediately (ACTIVE entry, fast path).
+ * Emails without an account get an INVITED TeamOfficial entry plus a unified
+ * Invitation carrying the officialRole payload — at signup acceptance the
+ * entry is linked to the new account, they join the team as MEMBER, and
+ * league-linked teams also get their LeagueUser row.
+ */
+export async function inviteTeamOfficial(
+  input: InviteTeamOfficialInput
+): Promise<ActionResult<{ official: TeamOfficial; invited: boolean; addedDirectly: boolean }>> {
+  try {
+    const validated = inviteTeamOfficialSchema.parse(input);
+    const inviterId = await requireTeamAdmin(validated.teamId);
+
+    const [team, inviter, linkedUser] = await Promise.all([
+      prisma.team.findUnique({
+        where: { id: validated.teamId },
+        select: { name: true },
+      }),
+      prisma.user.findUnique({
+        where: { id: inviterId },
+        select: { name: true, email: true },
+      }),
+      findUserByEmail(validated.email),
+    ]);
+
+    if (!team || !inviter) {
+      return {
+        success: false,
+        error: "Internal server error: Team or inviter not found.",
+      };
+    }
+
+    const roleDetail = validated.roleDetail || null;
+
+    // The [teamId, email, role] slot may be held by a live entry (conflict)
+    // or a soft-removed one (reactivate below).
+    const existingOfficial = await prisma.teamOfficial.findFirst({
+      where: {
+        teamId: validated.teamId,
+        email: { equals: validated.email, mode: "insensitive" },
+        role: validated.role,
+      },
+      select: { id: true, status: true },
+    });
+
+    if (existingOfficial && existingOfficial.status !== "REMOVED") {
+      return {
+        success: false,
+        error: "An official with this email and role already exists",
+      };
+    }
+
+    const inviterName = inviter.name || inviter.email;
+
+    if (linkedUser) {
+      // Fast path: existing account — link the official entry immediately.
+      const official = existingOfficial
+        ? await prisma.teamOfficial.update({
+            where: { id: existingOfficial.id },
+            data: {
+              name: validated.name,
+              roleDetail,
+              status: "ACTIVE",
+              userId: linkedUser.id,
+            },
+          })
+        : await prisma.teamOfficial.create({
+            data: {
+              teamId: validated.teamId,
+              name: validated.name,
+              email: validated.email,
+              role: validated.role,
+              roleDetail,
+              status: "ACTIVE",
+              userId: linkedUser.id,
+            },
+          });
+
+      try {
+        await sendExistingUserNotification({
+          email: validated.email,
+          teamName: team.name,
+          inviterName,
+        });
+      } catch (emailError) {
+        console.error("Failed to send official notification email:", emailError);
+      }
+
+      revalidateRosterPaths(validated.teamId);
+      return {
+        success: true,
+        data: { official, invited: true, addedDirectly: true },
+      };
+    }
+
+    // Account-less path: INVITED entry + unified Invitation with the
+    // officialRole payload.
+    const pendingInvitation = await prisma.invitation.findFirst({
+      where: {
+        email: validated.email,
+        teamId: validated.teamId,
+        status: "PENDING",
+        expiresAt: { gt: new Date() },
+      },
+      select: { id: true },
+    });
+
+    if (pendingInvitation) {
+      return {
+        success: false,
+        error: "An invitation has already been sent to this email",
+      };
+    }
+
+    const token = randomBytes(32).toString("hex");
+    const expiresAt = new Date();
+    expiresAt.setDate(expiresAt.getDate() + 7);
+
+    const official = await prisma.$transaction(async (tx) => {
+      const row = existingOfficial
+        ? await tx.teamOfficial.update({
+            where: { id: existingOfficial.id },
+            data: {
+              name: validated.name,
+              roleDetail,
+              status: "INVITED",
+              userId: null,
+            },
+          })
+        : await tx.teamOfficial.create({
+            data: {
+              teamId: validated.teamId,
+              name: validated.name,
+              email: validated.email,
+              role: validated.role,
+              roleDetail,
+              status: "INVITED",
+            },
+          });
+
+      await tx.invitation.create({
+        data: {
+          email: validated.email,
+          token,
+          status: "PENDING",
+          expiresAt,
+          teamId: validated.teamId,
+          officialRole: validated.role,
+          invitedById: inviterId,
+        },
+      });
+
+      return row;
+    });
+
+    try {
+      await sendTeamOfficialInviteEmail({
+        email: validated.email,
+        teamName: team.name,
+        inviterName,
+        role: validated.role,
+        token,
+      });
+    } catch (emailError) {
+      console.error("Failed to send official invite email:", emailError);
+    }
+
+    revalidateRosterPaths(validated.teamId);
+    return {
+      success: true,
+      data: { official, invited: true, addedDirectly: false },
+    };
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return { success: false, error: "Invalid input", details: error.issues };
+    }
+
+    if (isUniqueConstraintError(error)) {
+      return {
+        success: false,
+        error: "An official with this email and role already exists",
+      };
+    }
+
+    console.error("Error inviting team official:", error);
+    return {
+      success: false,
+      error: "Failed to invite official. Please try again.",
     };
   }
 }
@@ -209,6 +451,16 @@ export async function updateTeamOfficial(
           update: { role: "ADMIN" },
           create: { userId, teamId: validated.teamId, role: "ADMIN" },
         });
+
+        // League-identity sync: team admins of league-linked teams get an
+        // explicit LeagueUser TEAM_ADMIN row.
+        const team = await tx.team.findUnique({
+          where: { id: validated.teamId },
+          select: { leagueId: true },
+        });
+        if (team?.leagueId) {
+          await ensureLeagueUser(tx, userId, team.leagueId, "TEAM_ADMIN");
+        }
       }
 
       return row;

--- a/lib/actions/venue-staff.ts
+++ b/lib/actions/venue-staff.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
+import { randomBytes } from "crypto";
 import { Prisma, type VenueStaffRole } from "@prisma/client";
 import { z } from "zod";
 import { prisma } from "@/lib/db/prisma";
@@ -11,7 +12,10 @@ import {
   VENUE_STAFF_ADMIN_ROLES,
 } from "@/lib/auth/session";
 import type { ActionResult } from "@/lib/actions/venue-organizations";
-import { sendVenueStaffInviteEmail } from "@/lib/email/templates";
+import {
+  sendVenueStaffInviteEmail,
+  sendVenueStaffSignupInviteEmail,
+} from "@/lib/email/templates";
 import { rethrowIfNextRedirectError } from "@/lib/utils/next-errors";
 
 // Schemas are local to this module: lib/utils/validation.ts is owned by a
@@ -62,14 +66,17 @@ function revalidateStaffPaths(organizationId: string) {
 }
 
 /**
- * Invite an existing OpenLeague user to an organization's staff (org-wide row,
- * venueId null). OWNER/MANAGER may invite; only an OWNER can grant OWNER.
- * Account-less invites are deferred to the unified Invitation model (Tier 3)
- * because VenueStaff.userId is required.
+ * Invite someone to an organization's staff (org-wide row, venueId null).
+ * OWNER/MANAGER may invite; only an OWNER can grant OWNER.
+ *
+ * Existing OpenLeague users get an INVITED VenueStaff row they accept in-app.
+ * Emails without an account get a unified Invitation (organization target,
+ * venueRole payload); the ACTIVE VenueStaff row is created when they sign up
+ * through the invitation link. `staffId` is null on that account-less path.
  */
 export async function inviteVenueStaff(
   input: InviteVenueStaffInput
-): Promise<ActionResult<{ staffId: string }>> {
+): Promise<ActionResult<{ staffId: string | null }>> {
   try {
     const validated = inviteVenueStaffSchema.parse(input);
     const inviterId = await requireVenueStaffRole(validated.organizationId, VENUE_STAFF_ADMIN_ROLES);
@@ -99,12 +106,54 @@ export async function inviteVenueStaff(
     if (!organization) {
       return { success: false, error: "Venue organization not found" };
     }
+
     if (!invitee) {
-      return {
-        success: false,
-        error:
-          "No OpenLeague account matches that email yet. Ask them to sign up first, then send the invitation.",
-      };
+      // Account-less invite: create a unified Invitation row carrying the
+      // venueRole payload; the VenueStaff row is created at signup acceptance.
+      const pendingInvitation = await prisma.invitation.findFirst({
+        where: {
+          email: validated.email,
+          organizationId: validated.organizationId,
+          status: "PENDING",
+          expiresAt: { gt: new Date() },
+        },
+        select: { id: true },
+      });
+
+      if (pendingInvitation) {
+        return { success: false, error: "That person already has a pending invitation." };
+      }
+
+      const token = randomBytes(32).toString("hex");
+      const expiresAt = new Date();
+      expiresAt.setDate(expiresAt.getDate() + 7);
+
+      await prisma.invitation.create({
+        data: {
+          email: validated.email,
+          token,
+          status: "PENDING",
+          expiresAt,
+          organizationId: validated.organizationId,
+          venueRole: validated.role,
+          invitedById: inviterId,
+        },
+      });
+
+      try {
+        await sendVenueStaffSignupInviteEmail({
+          email: validated.email,
+          organizationName: organization.name,
+          inviterName: inviter?.name || inviter?.email || "A venue administrator",
+          role: validated.role,
+          token,
+        });
+      } catch (emailError) {
+        console.error("Failed to send venue staff signup invite email:", emailError);
+      }
+
+      revalidateStaffPaths(validated.organizationId);
+      return { success: true, data: { staffId: null } };
     }
 
     // Org-wide staff rows use a null venueId; Postgres treats NULLs as

--- a/lib/auth/session.ts
+++ b/lib/auth/session.ts
@@ -277,13 +277,13 @@ export async function isUserApproved(userId: string): Promise<boolean> {
 }
 
 /**
- * Check if a user has admin privileges (system-wide)
- * For now, this checks if user is a LEAGUE_ADMIN in any league
- * In future, could add a separate system admin role
+ * Check if a user is a LEAGUE_ADMIN of ANY league.
+ * This is not a system-wide admin role — it grants the broadest privilege the
+ * app currently has (formerly misnamed `isSystemAdmin`).
  *
  * Uses findFirst for better performance than count
  */
-export async function isSystemAdmin(userId: string): Promise<boolean> {
+export async function isAnyLeagueAdmin(userId: string): Promise<boolean> {
   const admin = await prisma.leagueUser.findFirst({
     where: {
       userId,
@@ -298,15 +298,16 @@ export async function isSystemAdmin(userId: string): Promise<boolean> {
 }
 
 /**
- * Require system admin privileges
- * Returns the session if user is a system admin
+ * Require "system admin" privileges (currently: LEAGUE_ADMIN of any league —
+ * see isAnyLeagueAdmin).
+ * Returns the session if the check passes.
  * Throws an error if not authenticated or not an admin
  */
 export async function requireSystemAdmin() {
   const session = await requireAuth();
   const userId = await requireUserIdFromSession(session);
 
-  const isAdmin = await isSystemAdmin(userId);
+  const isAdmin = await isAnyLeagueAdmin(userId);
   if (!isAdmin) {
     throw new Error("Unauthorized: Admin access required");
   }

--- a/lib/data/dashboard.ts
+++ b/lib/data/dashboard.ts
@@ -6,6 +6,7 @@ import { cache } from "react";
 import { addDays } from "date-fns";
 import { prisma } from "@/lib/db/prisma";
 import type { EventType, LeagueRole, Role, RSVPStatus } from "@prisma/client";
+import type { RsvpTarget } from "@/types/events";
 
 const SCHEDULE_WINDOW_DAYS = 14;
 const SCHEDULE_LIMIT = 10;
@@ -212,37 +213,39 @@ export type NeedsRsvpItem = {
   location: string;
   opponent: string | null;
   teamName: string;
+  /** Which identity the pending response is for: self or a guarded player. */
+  target: RsvpTarget;
 };
 
-/**
- * The viewer's own NO_RESPONSE RSVPs on future events (soonest first, max 5).
- */
-export async function getNeedsRsvp(userId: string): Promise<NeedsRsvpItem[]> {
-  const rsvps = await prisma.rSVP.findMany({
-    where: {
-      userId,
-      status: "NO_RESPONSE",
-      event: { startAt: { gte: new Date() } },
-    },
-    orderBy: { event: { startAt: "asc" } },
-    take: NEEDS_RSVP_LIMIT,
-    select: {
-      event: {
-        select: {
-          id: true,
-          type: true,
-          title: true,
-          startAt: true,
-          timezone: true,
-          location: true,
-          opponent: true,
-          team: { select: { name: true } },
-        },
-      },
-    },
-  });
+// Shared select for the event fields a NeedsRsvpItem carries.
+const needsRsvpEventSelect = {
+  id: true,
+  type: true,
+  title: true,
+  startAt: true,
+  timezone: true,
+  location: true,
+  opponent: true,
+  team: { select: { name: true } },
+} as const;
 
-  return rsvps.map(({ event }) => ({
+type NeedsRsvpEventRow = {
+  id: string;
+  type: EventType;
+  title: string;
+  startAt: Date;
+  timezone: string;
+  location: string;
+  opponent: string | null;
+  team: { name: string };
+};
+
+// Upper bound on upcoming guarded-team events scanned for missing per-child
+// rows (each event can yield several player rows; final list is capped below).
+const NEEDS_RSVP_EVENT_SCAN_LIMIT = 25;
+
+function toNeedsRsvpItem(event: NeedsRsvpEventRow, target: RsvpTarget): NeedsRsvpItem {
+  return {
     eventId: event.id,
     eventType: event.type,
     title: event.title,
@@ -251,7 +254,89 @@ export async function getNeedsRsvp(userId: string): Promise<NeedsRsvpItem[]> {
     location: event.location,
     opponent: event.opponent,
     teamName: event.team.name,
-  }));
+    target,
+  };
+}
+
+/**
+ * The viewer's pending RSVPs on future events, per identity (soonest first,
+ * max 5):
+ * - self rows: the viewer's own NO_RESPONSE rows (playerId null — per-child
+ *   rows are answered separately and never count against "you");
+ * - player rows: players the viewer guards (canRsvp) that have no per-child
+ *   RSVP row yet for an upcoming event of their team (event fan-out only
+ *   creates per-user rows; per-child rows appear on first response).
+ */
+export async function getNeedsRsvp(userId: string): Promise<NeedsRsvpItem[]> {
+  const now = new Date();
+
+  const [selfRsvps, guardians] = await Promise.all([
+    prisma.rSVP.findMany({
+      where: {
+        userId,
+        playerId: null,
+        status: "NO_RESPONSE",
+        event: { startAt: { gte: now } },
+      },
+      orderBy: { event: { startAt: "asc" } },
+      take: NEEDS_RSVP_LIMIT,
+      select: { event: { select: needsRsvpEventSelect } },
+    }),
+    prisma.playerGuardian.findMany({
+      where: { userId, canRsvp: true, player: { team: { isActive: true } } },
+      select: {
+        playerId: true,
+        player: { select: { name: true, teamId: true } },
+      },
+    }),
+  ]);
+
+  const items: NeedsRsvpItem[] = selfRsvps.map(({ event }) =>
+    toNeedsRsvpItem(event, { kind: "self" })
+  );
+
+  if (guardians.length > 0) {
+    const guardedPlayerIds = guardians.map((guardian) => guardian.playerId);
+    const teamIds = [...new Set(guardians.map((guardian) => guardian.player.teamId))];
+
+    const events = await prisma.event.findMany({
+      where: { teamId: { in: teamIds }, startAt: { gte: now } },
+      orderBy: { startAt: "asc" },
+      take: NEEDS_RSVP_EVENT_SCAN_LIMIT,
+      select: {
+        ...needsRsvpEventSelect,
+        teamId: true,
+        rsvps: {
+          where: { playerId: { in: guardedPlayerIds } },
+          select: { playerId: true },
+        },
+      },
+    });
+
+    for (const event of events) {
+      const answeredPlayerIds = new Set(event.rsvps.map((rsvp) => rsvp.playerId));
+      for (const guardian of guardians) {
+        if (
+          guardian.player.teamId !== event.teamId ||
+          answeredPlayerIds.has(guardian.playerId)
+        ) {
+          continue;
+        }
+        items.push(
+          toNeedsRsvpItem(event, {
+            kind: "player",
+            playerId: guardian.playerId,
+            playerName: guardian.player.name,
+          })
+        );
+      }
+    }
+  }
+
+  // ISO-8601 UTC strings sort correctly lexicographically.
+  return items
+    .sort((a, b) => a.startAt.localeCompare(b.startAt))
+    .slice(0, NEEDS_RSVP_LIMIT);
 }
 
 export type RecentMessageItem = {
@@ -381,10 +466,19 @@ export async function getAdminAttention(userId: string): Promise<AdminAttentionD
       teamName: teamNames.get(event.teamId) ?? "",
       noResponseCount: event._count.rsvps,
     })),
-    pendingInvitations: invitationGroups.map((group) => ({
-      teamId: group.teamId,
-      teamName: teamNames.get(group.teamId) ?? "",
-      count: group._count._all,
-    })),
+    // Invitation.teamId is nullable since the unified-target migration; the
+    // where clause restricts to the viewer's admin teams, so null groups
+    // cannot occur — the flatMap only narrows the type.
+    pendingInvitations: invitationGroups.flatMap((group) =>
+      group.teamId === null
+        ? []
+        : [
+            {
+              teamId: group.teamId,
+              teamName: teamNames.get(group.teamId) ?? "",
+              count: group._count._all,
+            },
+          ]
+    ),
   };
 }

--- a/lib/email/templates.ts
+++ b/lib/email/templates.ts
@@ -52,7 +52,8 @@ interface VenueStaffInviteEmailData {
   organizationId: string;
 }
 
-function formatVenueStaffRoleLabel(role: string): string {
+/** "CONTENT_EDITOR" -> "content editor", "HEAD_COACH" -> "head coach". */
+function formatRoleLabel(role: string): string {
   return role.toLowerCase().split("_").join(" ");
 }
 
@@ -63,7 +64,7 @@ function formatVenueStaffRoleLabel(role: string): string {
 export async function sendVenueStaffInviteEmail(data: VenueStaffInviteEmailData): Promise<void> {
   const mailchimp = getMailchimpClient();
   const staffLink = `${BASE_URL}/venue-admin/${data.organizationId}/staff`;
-  const roleLabel = formatVenueStaffRoleLabel(data.role);
+  const roleLabel = formatRoleLabel(data.role);
 
   await mailchimp.messages.send({
     message: {
@@ -71,6 +72,70 @@ export async function sendVenueStaffInviteEmail(data: VenueStaffInviteEmailData)
       subject: `${data.inviterName} invited you to help manage ${data.organizationName}`,
       html: `<p>${data.inviterName} invited you to join the staff of <strong>${data.organizationName}</strong> on OpenLeague with the ${roleLabel} role.</p><p><a href="${staffLink}">Review invitation</a></p><p>If you didn't expect this invitation, you can safely ignore this email.</p>`,
       text: `${data.inviterName} invited you to join the staff of ${data.organizationName} on OpenLeague with the ${roleLabel} role. Review: ${staffLink}\n\nIf you didn't expect this invitation, you can safely ignore this email.`,
+      to: [{ email: data.email, type: "to" as const }],
+    },
+  });
+}
+
+interface VenueStaffSignupInviteEmailData {
+  email: string;
+  organizationName: string;
+  inviterName: string;
+  /** VenueStaffRole enum value, e.g. "CONTENT_EDITOR". */
+  role: string;
+  /** Unified Invitation token — links through /api/invitations/[token]. */
+  token: string;
+}
+
+/**
+ * Invite someone WITHOUT an OpenLeague account to a venue organization's
+ * staff. The link routes through the unified invitation endpoint, which sends
+ * them to signup; the staff membership is created when they accept.
+ */
+export async function sendVenueStaffSignupInviteEmail(
+  data: VenueStaffSignupInviteEmailData
+): Promise<void> {
+  const mailchimp = getMailchimpClient();
+  const invitationLink = `${BASE_URL}/api/invitations/${data.token}`;
+  const roleLabel = formatRoleLabel(data.role);
+
+  await mailchimp.messages.send({
+    message: {
+      from_email: EMAIL_FROM,
+      subject: `${data.inviterName} invited you to help manage ${data.organizationName}`,
+      html: `<p>${data.inviterName} invited you to join the staff of <strong>${data.organizationName}</strong> on OpenLeague with the ${roleLabel} role.</p><p>Create a free account to accept the invitation:</p><p><a href="${invitationLink}">Accept invitation</a></p><p style="color: #666; font-size: 14px;">This invitation will expire in 7 days. If you didn't expect it, you can safely ignore this email.</p>`,
+      text: `${data.inviterName} invited you to join the staff of ${data.organizationName} on OpenLeague with the ${roleLabel} role. Create a free account to accept the invitation: ${invitationLink}\n\nThis invitation will expire in 7 days. If you didn't expect it, you can safely ignore this email.`,
+      to: [{ email: data.email, type: "to" as const }],
+    },
+  });
+}
+
+interface TeamOfficialInviteEmailData {
+  email: string;
+  teamName: string;
+  inviterName: string;
+  /** TeamOfficialRole enum value, e.g. "HEAD_COACH". */
+  role: string;
+  /** Unified Invitation token — links through /api/invitations/[token]. */
+  token: string;
+}
+
+/**
+ * Invite someone WITHOUT an OpenLeague account to join a team as an official
+ * (coach, manager, treasurer, ...). Their TeamOfficial entry is linked to the
+ * account they create when accepting.
+ */
+export async function sendTeamOfficialInviteEmail(data: TeamOfficialInviteEmailData): Promise<void> {
+  const mailchimp = getMailchimpClient();
+  const invitationLink = `${BASE_URL}/api/invitations/${data.token}`;
+  const roleLabel = formatRoleLabel(data.role);
+
+  await mailchimp.messages.send({
+    message: {
+      from_email: EMAIL_FROM,
+      subject: `${data.inviterName} invited you to join ${data.teamName} as ${roleLabel}`,
+      html: `<p>${data.inviterName} invited you to join <strong>${data.teamName}</strong> on OpenLeague as ${roleLabel}.</p><p>Create a free account to accept the invitation:</p><p><a href="${invitationLink}">Accept invitation</a></p><p style="color: #666; font-size: 14px;">This invitation will expire in 7 days. If you didn't expect it, you can safely ignore this email.</p>`,
+      text: `${data.inviterName} invited you to join ${data.teamName} on OpenLeague as ${roleLabel}. Create a free account to accept the invitation: ${invitationLink}\n\nThis invitation will expire in 7 days. If you didn't expect it, you can safely ignore this email.`,
       to: [{ email: data.email, type: "to" as const }],
     },
   });
@@ -345,6 +410,106 @@ Log in at: ${loginLink}`,
     console.error("Error sending existing user notification:", error);
     throw new Error("Failed to send notification email");
   }
+}
+
+interface LeagueInvitationEmailData {
+  email: string;
+  leagueName: string;
+  inviterName: string;
+  /** Unified Invitation token — links through /api/invitations/[token]. */
+  token: string;
+}
+
+/**
+ * Invite someone WITHOUT an OpenLeague account to join a league. Their
+ * LeagueUser membership is created when they accept at signup.
+ */
+export async function sendLeagueInvitationEmail(data: LeagueInvitationEmailData): Promise<void> {
+  const mailchimp = getMailchimpClient();
+  const invitationLink = `${BASE_URL}/api/invitations/${data.token}`;
+
+  const message = {
+    from_email: EMAIL_FROM,
+    subject: `You've been invited to join the ${data.leagueName} league`,
+    html: `
+      <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
+        <h2 style="color: #1976D2;">You've been invited to join ${data.leagueName}</h2>
+
+        <p>Hi there,</p>
+
+        <p>${data.inviterName} has invited you to join the <strong>${data.leagueName}</strong> league on openleague.</p>
+
+        <p style="margin: 30px 0;">
+          <a href="${invitationLink}"
+             style="background-color: #1976D2; color: white; padding: 12px 24px; text-decoration: none; border-radius: 4px; display: inline-block;">
+            Accept Invitation
+          </a>
+        </p>
+
+        <p style="color: #666; font-size: 14px;">
+          Or copy and paste this link into your browser:<br>
+          <a href="${invitationLink}">${invitationLink}</a>
+        </p>
+
+        <p style="color: #666; font-size: 14px; margin-top: 30px;">
+          This invitation will expire in 7 days.
+        </p>
+
+        <hr style="border: none; border-top: 1px solid #eee; margin: 30px 0;">
+
+        <p style="color: #999; font-size: 12px;">
+          If you didn't expect this invitation, you can safely ignore this email.
+        </p>
+      </div>
+    `,
+    text: `You've been invited to join the ${data.leagueName} league
+
+${data.inviterName} has invited you to join the ${data.leagueName} league on openleague.
+
+Accept your invitation by visiting:
+${invitationLink}
+
+This invitation will expire in 7 days.
+
+If you didn't expect this invitation, you can safely ignore this email.`,
+    to: [{ email: data.email, type: "to" as const }],
+  };
+
+  try {
+    await mailchimp.messages.send({ message });
+  } catch (error) {
+    console.error("Error sending league invitation email:", error);
+    throw new Error("Failed to send league invitation email");
+  }
+}
+
+interface LeagueMemberAddedEmailData {
+  email: string;
+  leagueName: string;
+  inviterName: string;
+  /** LeagueRole enum value, e.g. "TEAM_ADMIN". */
+  role: string;
+}
+
+/**
+ * Notify an existing user that they were added to a league.
+ */
+export async function sendLeagueMemberAddedNotification(
+  data: LeagueMemberAddedEmailData
+): Promise<void> {
+  const mailchimp = getMailchimpClient();
+  const loginLink = `${BASE_URL}/login`;
+  const roleLabel = formatRoleLabel(data.role);
+
+  await mailchimp.messages.send({
+    message: {
+      from_email: EMAIL_FROM,
+      subject: `You've been added to the ${data.leagueName} league`,
+      html: `<p>${data.inviterName} added you to the <strong>${data.leagueName}</strong> league on openleague as ${roleLabel}.</p><p><a href="${loginLink}">Log in</a> to see your league.</p><p style="color: #666; font-size: 14px;">If you didn't expect this, contact the league administrator.</p>`,
+      text: `${data.inviterName} added you to the ${data.leagueName} league on openleague as ${roleLabel}. Log in to see your league: ${loginLink}\n\nIf you didn't expect this, contact the league administrator.`,
+      to: [{ email: data.email, type: "to" as const }],
+    },
+  });
 }
 
 interface EventCreatedEmailData {

--- a/lib/utils/validation.ts
+++ b/lib/utils/validation.ts
@@ -453,6 +453,25 @@ export const updateRSVPSchema = z.object({
   status: z.enum(["GOING", "NOT_GOING", "MAYBE"], {
     message: "RSVP status must be GOING, NOT_GOING, or MAYBE",
   }),
+  // Per-child response (identity graph, Tier 3): omitted = self/household row
+  // (RSVP.playerId null); set = guardian/admin answering for a roster player.
+  playerId: z.string().cuid("Invalid player ID format").optional(),
+});
+
+// Guardian validation schemas (identity graph, Tier 3)
+export const addGuardianSchema = z.object({
+  playerId: z.string().cuid("Invalid player ID format"),
+  email: z
+    .string()
+    .trim()
+    .toLowerCase()
+    .email("Invalid email address")
+    .max(254, "Email must be less than 254 characters"),
+  relationship: optionalSanitizedString(50),
+});
+
+export const removeGuardianSchema = z.object({
+  guardianId: z.string().cuid("Invalid guardian ID format"),
 });
 
 // Invitation validation schemas
@@ -651,6 +670,10 @@ export type CreateEventInput = z.infer<typeof createEventSchema>;
 export type UpdateEventInput = z.infer<typeof updateEventSchema>;
 export type CreateInterTeamGameInput = z.infer<typeof createInterTeamGameSchema>;
 export type UpdateRSVPInput = z.infer<typeof updateRSVPSchema>;
+// Contract alias (spec: submitRSVP consumes { eventId, status, playerId? }).
+export type SubmitRSVPInput = z.infer<typeof updateRSVPSchema>;
+export type AddGuardianInput = z.infer<typeof addGuardianSchema>;
+export type RemoveGuardianInput = z.infer<typeof removeGuardianSchema>;
 export type SendInvitationInput = z.infer<typeof sendInvitationSchema>;
 export type SendLeagueInvitationInput = z.infer<typeof sendLeagueInvitationSchema>;
 export type CreateLeagueInput = z.infer<typeof createLeagueSchema>;

--- a/prisma/migrations/20260711120000_identity_graph/migration.sql
+++ b/prisma/migrations/20260711120000_identity_graph/migration.sql
@@ -1,0 +1,108 @@
+-- Identity graph (Tier 3): guardian edges, per-child RSVPs, unified invitation
+-- targets, and the LeagueUser backfill. User remains the identity hub — these
+-- are edges and columns, not a Person refactor.
+
+-- AlterTable: Invitation gains league/organization targets and role payloads;
+-- teamId becomes optional (exactly-one-target CHECK below).
+ALTER TABLE "Invitation" ALTER COLUMN "teamId" DROP NOT NULL;
+ALTER TABLE "Invitation" ADD COLUMN "leagueId" TEXT;
+ALTER TABLE "Invitation" ADD COLUMN "organizationId" TEXT;
+ALTER TABLE "Invitation" ADD COLUMN "officialRole" "TeamOfficialRole";
+ALTER TABLE "Invitation" ADD COLUMN "venueRole" "VenueStaffRole";
+
+-- AlterTable: RSVP gains an optional per-child target. Existing rows keep
+-- playerId NULL (self/household responses) and remain valid.
+ALTER TABLE "RSVP" ADD COLUMN "playerId" TEXT;
+
+-- CreateTable
+CREATE TABLE "player_guardians" (
+    "id" TEXT NOT NULL,
+    "relationship" TEXT,
+    "canRsvp" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "playerId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+
+    CONSTRAINT "player_guardians_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "player_guardians_userId_idx" ON "player_guardians"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "player_guardians_playerId_userId_key" ON "player_guardians"("playerId", "userId");
+
+-- DropIndex: replaced by the (userId, eventId, playerId) unique plus the
+-- partial unique below.
+DROP INDEX "RSVP_userId_eventId_key";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RSVP_userId_eventId_playerId_key" ON "RSVP"("userId", "eventId", "playerId");
+
+-- CreateIndex
+CREATE INDEX "RSVP_playerId_idx" ON "RSVP"("playerId");
+
+-- CreateIndex
+CREATE INDEX "Invitation_leagueId_idx" ON "Invitation"("leagueId");
+
+-- CreateIndex
+CREATE INDEX "Invitation_organizationId_idx" ON "Invitation"("organizationId");
+
+-- AddForeignKey
+ALTER TABLE "player_guardians" ADD CONSTRAINT "player_guardians_playerId_fkey" FOREIGN KEY ("playerId") REFERENCES "Player"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "player_guardians" ADD CONSTRAINT "player_guardians_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RSVP" ADD CONSTRAINT "RSVP_playerId_fkey" FOREIGN KEY ("playerId") REFERENCES "Player"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Invitation" ADD CONSTRAINT "Invitation_leagueId_fkey" FOREIGN KEY ("leagueId") REFERENCES "leagues"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Invitation" ADD CONSTRAINT "Invitation_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "venue_organizations"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- ============================================================================
+-- Integrity constraints not expressible in the Prisma schema DSL.
+-- Existing rows satisfy all of these unchanged.
+-- ============================================================================
+
+-- Postgres treats NULLs as distinct inside composite uniques, so without this
+-- a user could hold duplicate self/household rows (playerId IS NULL) for the
+-- same event. Partial unique index backs up @@unique([userId, eventId, playerId]).
+CREATE UNIQUE INDEX "RSVP_userId_eventId_self_key" ON "RSVP"("userId", "eventId") WHERE "playerId" IS NULL;
+
+-- An invitation has exactly one target entity (team XOR league XOR venue org).
+ALTER TABLE "Invitation" ADD CONSTRAINT "Invitation_exactly_one_target"
+  CHECK (
+    (("teamId" IS NOT NULL)::int
+      + ("leagueId" IS NOT NULL)::int
+      + ("organizationId" IS NOT NULL)::int) = 1
+  );
+
+-- ============================================================================
+-- Data migration: LeagueUser backfill (canonical league-identity rule).
+-- Every TeamMember of a league-linked team gets an explicit LeagueUser row —
+-- TEAM_ADMIN when they are a team ADMIN on any team in that league, else
+-- MEMBER. Deterministic cuid-shaped ids follow the ice-surface backfill
+-- pattern. Existing rows win (ON CONFLICT DO NOTHING).
+-- ============================================================================
+INSERT INTO "league_users" ("id", "role", "joinedAt", "userId", "leagueId")
+SELECT
+    'cl' || left(md5(src."userId" || ':' || src."leagueId" || ':league_user_backfill'), 23),
+    CASE WHEN src."isAdmin" THEN 'TEAM_ADMIN' ELSE 'MEMBER' END::"LeagueRole",
+    CURRENT_TIMESTAMP,
+    src."userId",
+    src."leagueId"
+FROM (
+    SELECT
+        tm."userId",
+        t."leagueId",
+        bool_or(tm."role" = 'ADMIN') AS "isAdmin"
+    FROM "TeamMember" tm
+    JOIN "Team" t ON t."id" = tm."teamId"
+    WHERE t."leagueId" IS NOT NULL
+    GROUP BY tm."userId", t."leagueId"
+) src
+ON CONFLICT ("userId", "leagueId") DO NOTHING;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -24,6 +24,7 @@ model User {
   rsvps                        RSVP[]
   invitations                  Invitation[]
   players                      Player[]
+  playerGuardians              PlayerGuardian[]
   teamOfficials                TeamOfficial[]
   leagueUsers                  LeagueUser[]
   playerTransfers              PlayerTransfer[]
@@ -254,9 +255,31 @@ model Player {
   transfers PlayerTransfer[]
 
   eventRegistrations EventRegistration[]
+  guardians          PlayerGuardian[]
+  rsvps              RSVP[]
 
   @@index([leagueId]) // Optimize league-wide roster queries
   @@index([userId]) // Optimize "my roster entries" lookups
+}
+
+// Guardian edge: a User who manages a roster Player (parent/guardian household
+// link). Identity graph (Tier 3) — User remains the hub; this is an edge, not
+// a Person refactor. Guardians with canRsvp answer per child via RSVP.playerId.
+model PlayerGuardian {
+  id           String   @id @default(cuid())
+  relationship String? // Display-only free text (e.g. "Mother", "Guardian")
+  canRsvp      Boolean  @default(true)
+  createdAt    DateTime @default(now())
+
+  playerId String
+  player   Player @relation(fields: [playerId], references: [id], onDelete: Cascade)
+
+  userId String
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([playerId, userId])
+  @@index([userId])
+  @@map("player_guardians")
 }
 
 // Event model
@@ -328,7 +351,17 @@ model RSVP {
   eventId String
   event   Event  @relation(fields: [eventId], references: [id], onDelete: Cascade)
 
-  @@unique([userId, eventId])
+  // Per-child response (identity graph, decision D5): null keeps the row a
+  // "self/household" response; guardians and admins answer per child via rows
+  // carrying playerId. Event fan-out stays user-level (playerId null).
+  playerId String?
+  player   Player? @relation(fields: [playerId], references: [id], onDelete: Cascade)
+
+  // Postgres treats NULLs as distinct in composite uniques, so a raw-SQL
+  // partial unique index "RSVP_userId_eventId_self_key" ON (userId, eventId)
+  // WHERE playerId IS NULL backs this up (see identity_graph migration).
+  @@unique([userId, eventId, playerId])
+  @@index([playerId])
 }
 
 enum RSVPStatus {
@@ -338,7 +371,11 @@ enum RSVPStatus {
   NO_RESPONSE
 }
 
-// Invitation model
+// Invitation model — unified target (identity graph): exactly one of
+// teamId / leagueId / organizationId is set, enforced by the raw-SQL CHECK
+// constraint "Invitation_exactly_one_target" (not expressible in Prisma DSL).
+// Optional role payloads are applied at acceptance (TeamOfficial / VenueStaff
+// row created or userId-linked inside the acceptance transaction).
 model Invitation {
   id        String           @id @default(cuid())
   email     String
@@ -348,11 +385,25 @@ model Invitation {
   createdAt DateTime         @default(now())
   updatedAt DateTime         @updatedAt
 
-  teamId String
-  team   Team   @relation(fields: [teamId], references: [id], onDelete: Cascade)
+  teamId String?
+  team   Team?   @relation(fields: [teamId], references: [id], onDelete: Cascade)
+
+  leagueId String?
+  league   League? @relation(fields: [leagueId], references: [id], onDelete: Cascade)
+
+  organizationId String?
+  organization   VenueOrganization? @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+
+  // Role payloads applied at acceptance (team target → TeamOfficial link,
+  // organization target → VenueStaff membership).
+  officialRole TeamOfficialRole?
+  venueRole    VenueStaffRole?
 
   invitedById String
   invitedBy   User   @relation(fields: [invitedById], references: [id])
+
+  @@index([leagueId])
+  @@index([organizationId])
 }
 
 enum InvitationStatus {
@@ -391,6 +442,7 @@ model League {
   events                  Event[]
   players                 Player[]
   users                   LeagueUser[]
+  invitations             Invitation[]
   playerTransfers         PlayerTransfer[]
   messages                LeagueMessage[]
   notificationPreferences NotificationPreference[]
@@ -933,6 +985,7 @@ model VenueOrganization {
   staff              VenueStaff[]
   payments           Payment[]
   hostedSignupEvents SignupEvent[]
+  invitations        Invitation[]
 
   @@index([createdById])
   @@index([status])

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -30,6 +30,26 @@ function hoursAfter(date: Date, hours: number): Date {
   return new Date(date.getTime() + hours * HOUR_MS)
 }
 
+type SeedRsvpStatus = 'GOING' | 'NOT_GOING' | 'MAYBE' | 'NO_RESPONSE'
+
+/**
+ * Idempotently ensure a self/household RSVP row (playerId null). The composite
+ * unique (userId, eventId, playerId) rejects null members, so upsert can't
+ * target these rows — integrity comes from the partial unique index
+ * "RSVP_userId_eventId_self_key"; existing rows are left untouched (matches
+ * the old `update: {}` upsert semantics).
+ */
+async function ensureSelfRsvp(userId: string, eventId: string, status: SeedRsvpStatus) {
+  const existing = await prisma.rSVP.findFirst({
+    where: { userId, eventId, playerId: null },
+    select: { id: true },
+  })
+  if (existing) return
+  await prisma.rSVP.create({
+    data: { userId, eventId, status },
+  })
+}
+
 /**
  * Refuse to seed anything that doesn't look like a local/dev database.
  * Neon hostnames are identical between production and dev branches, so
@@ -664,34 +684,76 @@ async function main() {
     },
   })
 
-  // Create test RSVPs for hockey game
-  await prisma.rSVP.upsert({
-    where: {
-      userId_eventId: {
-        userId: adminUser.id,
-        eventId: hockeyGame.id,
-      },
-    },
-    update: {},
+  // Create test RSVPs for hockey game (self/household rows, playerId null)
+  await ensureSelfRsvp(adminUser.id, hockeyGame.id, 'GOING')
+  await ensureSelfRsvp(memberUser.id, hockeyGame.id, 'MAYBE')
+
+  // Guardian fixtures (identity graph, Tier 3): parent@test.com guards the two
+  // hockey players without linked accounts. One per-child RSVP is answered
+  // (Dylan GOING on the hockey game); the other (Sam) has no per-child row —
+  // per-child rows are only created on response, so Sam shows as pending.
+  const parentUser = await prisma.user.upsert({
+    where: { email: 'parent@test.com' },
+    update: { approved: true },
     create: {
-      userId: adminUser.id,
-      eventId: hockeyGame.id,
-      status: 'GOING',
+      email: 'parent@test.com',
+      passwordHash: memberPassword,
+      name: 'Test Parent',
+      approved: true,
     },
   })
 
-  await prisma.rSVP.upsert({
+  await prisma.teamMember.upsert({
     where: {
-      userId_eventId: {
-        userId: memberUser.id,
-        eventId: hockeyGame.id,
+      userId_teamId: {
+        userId: parentUser.id,
+        teamId: hockeyTeam.id,
       },
     },
     update: {},
     create: {
-      userId: memberUser.id,
+      userId: parentUser.id,
+      teamId: hockeyTeam.id,
+      role: 'MEMBER',
+    },
+  })
+
+  const dylanPlayerId = 'cseedplayer00000000000003' // Dylan Bouchard (no linked user)
+  const samPlayerId = 'cseedplayer00000000000004' // Sam Kowalski (no linked user)
+
+  for (const playerId of [dylanPlayerId, samPlayerId]) {
+    await prisma.playerGuardian.upsert({
+      where: {
+        playerId_userId: {
+          playerId,
+          userId: parentUser.id,
+        },
+      },
+      update: {},
+      create: {
+        playerId,
+        userId: parentUser.id,
+        relationship: 'Parent',
+      },
+    })
+  }
+
+  // Per-child response: upsert on the composite unique works here because
+  // playerId is non-null.
+  await prisma.rSVP.upsert({
+    where: {
+      userId_eventId_playerId: {
+        userId: parentUser.id,
+        eventId: hockeyGame.id,
+        playerId: dylanPlayerId,
+      },
+    },
+    update: {},
+    create: {
+      userId: parentUser.id,
       eventId: hockeyGame.id,
-      status: 'MAYBE',
+      playerId: dylanPlayerId,
+      status: 'GOING',
     },
   })
 
@@ -716,9 +778,11 @@ async function main() {
   console.log('📧 Standalone-team accounts:')
   console.log('   Admin: admin@test.com / admin123 — ADMIN of both standalone teams')
   console.log('   Member: member@test.com / member123 — MEMBER of Northside Ice Hawks')
+  console.log('   Parent: parent@test.com / member123 — MEMBER of Northside Ice Hawks + guardian of Dylan Bouchard & Sam Kowalski')
   console.log('🏒 Hockey: Northside Ice Hawks (Winter 2026-27) — 4 players')
   console.log('🥍 Lacrosse: Eastside Thunder (Spring 2026) — 2 players')
   console.log('📅 Events: 2 games + 2 practices scheduled')
+  console.log('👨‍👧 Guardians: parent@test.com answered per child for the hockey game (Dylan GOING); Sam has no per-child row yet (pending)')
   console.log('')
   console.log('🏆 Metro Hockey League (HOCKEY)')
   console.log('   Divisions: U12 Recreational, Adult Competitive')

--- a/types/events.ts
+++ b/types/events.ts
@@ -41,12 +41,49 @@ export interface EventWithRSVPs extends LeagueEvent {
       name: string | null;
       email: string;
     };
+    // Per-child response (identity graph, Tier 3). Absent/null on
+    // self/household rows — existing consumers are unaffected.
+    playerId?: string | null;
+    player?: {
+      id: string;
+      name: string;
+    } | null;
   }>;
 }
 
 export type EventType = "GAME" | "PRACTICE";
 
 export type RSVPStatus = "GOING" | "NOT_GOING" | "MAYBE" | "NO_RESPONSE";
+
+// ---------------------------------------------------------------------------
+// Identity graph (Tier 3) — per-identity RSVP shapes.
+// Shared contracts between lib/actions/rsvp.ts (X2), lib/data/dashboard.ts and
+// the RSVP UI (X3). See docs/superpowers/specs/2026-07-11-tier3-identity-design.md.
+// ---------------------------------------------------------------------------
+
+/**
+ * Who a pending/submitted RSVP is for: the viewer themself (self/household row,
+ * RSVP.playerId null) or a linked player answered per child (RSVP.playerId set).
+ */
+export type RsvpTarget =
+  | { kind: "self" }
+  | { kind: "player"; playerId: string; playerName: string };
+
+/**
+ * One row in an event's attendance view. Player-level responses are listed
+ * where they exist and user-level otherwise; a user row and their child rows
+ * are distinct entries.
+ */
+export interface AttendanceEntry {
+  kind: "user" | "player";
+  name: string;
+  status: RSVPStatus;
+  /** Set on player entries: display name of the guardian/admin who answered. */
+  respondedByName?: string;
+}
+
+/** Attendance counts keyed by status, deduplicated per entry (not per user). */
+export type AttendanceCounts = Record<RSVPStatus, number>;
 
 // Team type for calendar filtering
 export interface TeamWithDivision {

--- a/types/roster.ts
+++ b/types/roster.ts
@@ -63,6 +63,25 @@ export type {
   TeamOfficialStatus,
 } from '@prisma/client';
 
+// Guardian edge (identity graph, Tier 3): a User who manages a roster Player.
+// Guardians with canRsvp answer per child via RSVP rows carrying playerId.
+// Re-exported from the Prisma model so action results and UI props stay in sync.
+export type { PlayerGuardian } from '@prisma/client';
+
+// Guardian row with the linked user's display fields (guardian chips,
+// manage dialogs, attendance attribution).
+export type GuardianWithUser = Prisma.PlayerGuardianGetPayload<{
+  include: {
+    user: {
+      select: {
+        id: true;
+        name: true;
+        email: true;
+      };
+    };
+  };
+}>;
+
 // Team member with user info (for admin views — includes usahMemberId)
 export type TeamMemberWithUser = {
   id: string;


### PR DESCRIPTION
## Summary

Tier 3 (final tier) of the observation-audit roadmap (spec: `docs/superpowers/specs/2026-07-11-tier3-identity-design.md`). **Stacked on #266** — merge that first. Activates the identity-graph seams the audit found designed-but-unwired. Explicitly *not* a unified-Person refactor — `User` stays the hub; everything here is additive edges and columns.

### Schema — `identity_graph` migration
- **`PlayerGuardian`**: multi-guardian join table (`relationship`, per-guardian `canRsvp`), unique per (player, guardian)
- **`RSVP.playerId`** (nullable): per-child responses. Uniqueness handled correctly for the nullable member: composite unique `(userId, eventId, playerId)` **plus a partial unique index** on `(userId, eventId) WHERE playerId IS NULL` — existing self/household rows stay valid untouched
- **Unified `Invitation`**: `teamId` optional; `leagueId`/`organizationId` targets with a DB CHECK enforcing exactly-one; `officialRole`/`venueRole` payloads
- **`LeagueUser` backfill**: every member of a league-linked team gets an explicit row (TEAM_ADMIN for team admins) — the canonical league-identity rule going forward

### Behavior
- **Per-child RSVP (D5)**: guardians (or team admins) answer per child via `submitRSVP({ eventId, status, playerId? })`; RSVPButtons render one response row per identity ("You" + each guarded player); attendance shows player-level entries with "answered by" attribution; the NeedsYourRSVP widget emits per-identity pending rows ("for Emma"). Event fan-out and reminders stay user-level in this tier
- **Guardian management**: PlayerCard guardian chips + admin-gated ManageGuardiansDialog; `getMyPlayers` for parent surfaces
- **Unified invitations**: league and venue-org invitation targets with role payloads; acceptance creates the right membership row (LeagueUser / VenueStaff / TeamOfficial link) in the existing transactions. **Account-less venue staff and team-official invites now work end-to-end** — closing the Tier 2 gap where invitees needed pre-existing accounts
- **League-identity sync**: `ensureLeagueUser` applied at league-team invitation acceptance and `migrateTeamToLeague`; `isSystemAdmin` renamed `isAnyLeagueAdmin` (it never checked anything system-wide — any league's admin passed)

## Verification
- `bun run type-check` ✅ · `bun run lint` ✅ · `bun run test` ✅ **1486/1486** (+37: guardian authz, per-child upsert semantics)
- `bun run build` ✅
- Migration applied to the dev DB (out-of-band `prisma db execute` — the dev DB has long-standing pre-existing migration-history drift that makes `migrate dev` demand a reset; migration files are checked in and `db:migrate:deploy` applies them normally in production). Dev DB schema verified via information_schema probe

## Notes
- Seed now includes a parent guarding two players with per-child RSVP fixtures
- Pre-existing dev-DB drift (13 migrations applied out-of-band historically) is documented in the migration notes — worth a separate cleanup pass someday, unrelated to this PR