### PR TITLE
fix(security): harden authorization before public launch (Track 0)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,12 @@ EMAIL_FROM="noreply@openl.app"
 # Generate with: openssl rand -base64 32
 # CRON_SECRET=""
 
+# Platform administrators (bootstrap allowlist)
+# Comma-separated emails granted platform-admin rights (approving/rejecting
+# signups, listing users) without a manual DB write. Non-self-grantable.
+# Persistent grants can also be set via the User.isPlatformAdmin column.
+# PLATFORM_ADMIN_EMAILS="you@example.com"
+
 # Protected uptime/readiness checks
 # Set the same generated value in Vercel and GitHub Actions secrets.
 # Generate with: openssl rand -base64 32

--- a/__tests__/lib/actions/session-registrations.test.ts
+++ b/__tests__/lib/actions/session-registrations.test.ts
@@ -57,6 +57,12 @@ vi.mock("@/lib/email/templates", () => ({
   sendSessionRegistrationManagerEmail: (...args: unknown[]) => mockManagerEmail(...args),
 }));
 
+// logVenueActivity moved to lib/services/venue-activity (out of the "use server"
+// file); mock it at its new module home.
+vi.mock("@/lib/services/venue-activity", () => ({
+  logVenueActivity: (...args: unknown[]) => mockLogActivity(...args),
+}));
+
 vi.mock("@/lib/actions/venue-organizations", () => ({
   logVenueActivity: (...args: unknown[]) => mockLogActivity(...args),
 }));

--- a/__tests__/lib/actions/venue-schedules-surfaces.test.ts
+++ b/__tests__/lib/actions/venue-schedules-surfaces.test.ts
@@ -46,6 +46,13 @@ vi.mock("@/lib/db/prisma", () => ({
   prisma: mockPrisma,
 }));
 
+// logVenueActivity moved to lib/services/venue-activity (out of the "use server"
+// file); mock it at its new module home. The venue-organizations mock is kept
+// for its other exports / module isolation.
+vi.mock("@/lib/services/venue-activity", () => ({
+  logVenueActivity: (...args: unknown[]) => mockLogVenueActivity(...args),
+}));
+
 vi.mock("@/lib/actions/venue-organizations", () => ({
   logVenueActivity: (...args: unknown[]) => mockLogVenueActivity(...args),
 }));

--- a/__tests__/lib/actions/venue-schedules.test.ts
+++ b/__tests__/lib/actions/venue-schedules.test.ts
@@ -44,6 +44,13 @@ vi.mock("@/lib/db/prisma", () => ({
   prisma: mockPrisma,
 }));
 
+// logVenueActivity moved to lib/services/venue-activity (out of the "use server"
+// file). Mock it at its new home; the venue-organizations mock below remains for
+// its other exports.
+vi.mock("@/lib/services/venue-activity", () => ({
+  logVenueActivity: (...args: unknown[]) => mockLogVenueActivity(...args),
+}));
+
 vi.mock("@/lib/actions/venue-organizations", () => ({
   logVenueActivity: (...args: unknown[]) => mockLogVenueActivity(...args),
   publicPublishedVenueWhere: {

--- a/__tests__/lib/actions/venue-skill-levels.test.ts
+++ b/__tests__/lib/actions/venue-skill-levels.test.ts
@@ -8,6 +8,7 @@ const { mockRequireVenueContentManager, mockPrisma } = vi.hoisted(() => ({
     skillLevelReference: { upsert: vi.fn(), findMany: vi.fn() },
     lessonOffering: { update: vi.fn() },
     venueScheduleBlock: { update: vi.fn() },
+    venue: { findFirst: vi.fn() },
   },
 }));
 
@@ -42,6 +43,9 @@ describe("venue skill levels", () => {
   });
 
   it("assigns level references to lessons and schedule blocks", async () => {
+    // assign* now calls ensureVenue() to bind the venue to the org (IDOR fix),
+    // which reads prisma.venue.findFirst.
+    mockPrisma.venue.findFirst.mockResolvedValue({ id: VENUE_ID, slug: "venue-slug" });
     mockPrisma.lessonOffering.update.mockResolvedValue({ id: "lesson-1" });
     mockPrisma.venueScheduleBlock.update.mockResolvedValue({ id: "block-1" });
 

--- a/__tests__/lib/auth/session.test.ts
+++ b/__tests__/lib/auth/session.test.ts
@@ -27,7 +27,7 @@ vi.mock("next/navigation", () => ({
   redirect: (path: string) => mockRedirect(path),
 }));
 
-import { getCurrentUserId, requireSystemAdmin, requireUserId } from "@/lib/auth/session";
+import { getCurrentUserId, isPlatformAdmin, requireSystemAdmin, requireUserId } from "@/lib/auth/session";
 
 describe("auth session helpers", () => {
   beforeEach(() => {
@@ -69,22 +69,49 @@ describe("auth session helpers", () => {
     expect(mockRedirect).toHaveBeenCalledWith("/login");
   });
 
-  it("resolves stale JWT sessions before checking system admin status", async () => {
+  it("resolves stale JWT sessions before granting platform admin access", async () => {
     const session = { user: { email: "admin@example.com" } };
     mockAuth.mockResolvedValue(session);
-    mockPrisma.user.findUnique.mockResolvedValue({ id: "user-from-email" });
-    mockPrisma.leagueUser.findFirst.mockResolvedValue({ id: "league-user-1" });
+    // First findUnique resolves the stale-JWT id; the second (isPlatformAdmin)
+    // reads the platform-admin flag for that resolved id.
+    mockPrisma.user.findUnique.mockResolvedValue({
+      id: "user-from-email",
+      isPlatformAdmin: true,
+      email: "admin@example.com",
+    });
 
     await expect(requireSystemAdmin()).resolves.toBe(session);
 
-    expect(mockPrisma.leagueUser.findFirst).toHaveBeenCalledWith({
-      where: {
-        userId: "user-from-email",
-        role: "LEAGUE_ADMIN",
-      },
-      select: {
-        id: true,
-      },
+    expect(mockPrisma.user.findUnique).toHaveBeenCalledWith({
+      where: { email: "admin@example.com" },
+      select: { id: true },
     });
+    expect(mockPrisma.user.findUnique).toHaveBeenCalledWith({
+      where: { id: "user-from-email" },
+      select: { isPlatformAdmin: true, email: true },
+    });
+  });
+
+  it("rejects a signed-in user who is not a platform admin", async () => {
+    mockAuth.mockResolvedValue({ user: { id: "user-1", email: "member@example.com" } });
+    mockPrisma.user.findUnique.mockResolvedValue({
+      isPlatformAdmin: false,
+      email: "member@example.com",
+    });
+
+    await expect(requireSystemAdmin()).rejects.toThrow("Unauthorized");
+  });
+
+  it("honors the PLATFORM_ADMIN_EMAILS allowlist (case-insensitive)", async () => {
+    const original = process.env.PLATFORM_ADMIN_EMAILS;
+    process.env.PLATFORM_ADMIN_EMAILS = "boss@example.com, admin@example.com";
+    mockPrisma.user.findUnique.mockResolvedValue({
+      isPlatformAdmin: false,
+      email: "Admin@Example.com",
+    });
+
+    await expect(isPlatformAdmin("user-1")).resolves.toBe(true);
+
+    process.env.PLATFORM_ADMIN_EMAILS = original;
   });
 });

--- a/app/(dashboard)/admin/users/page.tsx
+++ b/app/(dashboard)/admin/users/page.tsx
@@ -2,15 +2,17 @@ import { Suspense } from "react";
 import { Typography, Box, CircularProgress } from "@mui/material";
 import { PageContainer } from "@/components/ui/PageContainer";
 import { PageHeader } from "@/components/ui/PageHeader";
-import { isAnyLeagueAdmin, requireUserId } from "@/lib/auth/session";
+import { isPlatformAdmin, requireUserId } from "@/lib/auth/session";
 import { getAllUsers } from "@/lib/actions/admin";
 import UserApprovalList from "@/components/features/admin/UserApprovalList";
 
 async function UserManagementContent() {
   const userId = await requireUserId();
 
-  // Check if user is an admin (LEAGUE_ADMIN of any league)
-  const isAdmin = await isAnyLeagueAdmin(userId);
+  // Gate on the real platform-admin role (matches requireSystemAdmin used by
+  // the admin actions). Previously this used isAnyLeagueAdmin, which was
+  // self-grantable by creating a league.
+  const isAdmin = await isPlatformAdmin(userId);
 
   if (!isAdmin) {
     return (

--- a/app/api/cron/rsvp-reminders/route.ts
+++ b/app/api/cron/rsvp-reminders/route.ts
@@ -32,19 +32,23 @@ function timingSafeEqual(a: string, b: string): boolean {
  */
 export async function GET(request: Request) {
   try {
-    // Optional: Add authorization header check for security
+    // Require a configured cron secret AND a matching Bearer token. Fail CLOSED:
+    // if CRON_SECRET is unset, refuse rather than sending mass reminder emails,
+    // matching the notification-batches and event-waitlist crons. (Previously
+    // this endpoint sent emails to anyone when CRON_SECRET happened to be unset.)
     const authHeader = request.headers.get("authorization");
     const cronSecret = process.env.CRON_SECRET;
 
-    if (cronSecret && authHeader) {
-      const expectedAuth = `Bearer ${cronSecret}`;
-      if (!timingSafeEqual(authHeader, expectedAuth)) {
-        return NextResponse.json(
-          { error: "Unauthorized" },
-          { status: 401 }
-        );
-      }
-    } else if (cronSecret && !authHeader) {
+    if (!cronSecret) {
+      console.error("CRON_SECRET not configured");
+      return NextResponse.json(
+        { error: "Cron secret not configured" },
+        { status: 500 }
+      );
+    }
+
+    const expectedAuth = `Bearer ${cronSecret}`;
+    if (!authHeader || !timingSafeEqual(authHeader, expectedAuth)) {
       return NextResponse.json(
         { error: "Unauthorized" },
         { status: 401 }

--- a/lib/actions/league-context.ts
+++ b/lib/actions/league-context.ts
@@ -328,7 +328,26 @@ export async function getLeagueRosterData(leagueId: string): Promise<{
   const [players, teams, divisions, rawInvitations] = await Promise.all([
     prisma.player.findMany({
       where: { leagueId },
-      include: {
+      // Explicit select (not include) so admin-only PII is field-gated on the
+      // caller's league role. A bare `include` returns every scalar column,
+      // which leaked emergency contacts + USAH IDs to any league MEMBER.
+      // Convention mirrors getRosterPayload in team-context.ts (FR-008).
+      select: {
+        id: true,
+        name: true,
+        email: true,
+        phone: true,
+        emergencyContact: isLeagueAdmin,
+        emergencyPhone: isLeagueAdmin,
+        jerseyNumber: true,
+        position: true,
+        // FR-008: USAH Member IDs are admin-only
+        usahMemberId: isLeagueAdmin,
+        teamId: true,
+        leagueId: true,
+        userId: true,
+        createdAt: true,
+        updatedAt: true,
         team: {
           select: {
             id: true,

--- a/lib/actions/league.ts
+++ b/lib/actions/league.ts
@@ -1205,6 +1205,12 @@ export async function getLeagueWithStats(leagueId: string): Promise<{
   }>;
 } | null> {
   try {
+    // Authorization: league contact info + activity feed (incl. child names)
+    // must not be readable by unauthenticated callers of this server action.
+    const userId = await requireUserId();
+    const hasAccess = await hasLeagueAccess(userId, leagueId);
+    if (!hasAccess) return null;
+
     // Get basic league info
     const league = await prisma.league.findFirst({
       where: {
@@ -1458,6 +1464,11 @@ export async function getLeagueTeamsWithDivisions(leagueId: string): Promise<{
   };
 } | null> {
   try {
+    // Authorization: only league members may enumerate teams/divisions.
+    const userId = await requireUserId();
+    const hasAccess = await hasLeagueAccess(userId, leagueId);
+    if (!hasAccess) return null;
+
     // Get basic league info
     const league = await prisma.league.findFirst({
       where: {
@@ -1564,6 +1575,11 @@ export async function getLeagueDivisions(leagueId: string): Promise<Array<{
   skillLevel: string | null;
 }>> {
   try {
+    // Authorization: only league members may enumerate divisions.
+    const userId = await requireUserId();
+    const hasAccess = await hasLeagueAccess(userId, leagueId);
+    if (!hasAccess) return [];
+
     const divisions = await prisma.division.findMany({
       where: {
         leagueId,

--- a/lib/actions/season-generation.ts
+++ b/lib/actions/season-generation.ts
@@ -151,6 +151,20 @@ export async function generateRoundRobin(
     const { preview, proposed, timezone, validated, userId } = await computeGeneration(input);
     const phaseId = validated.phaseId || null;
 
+    // Object-level authz: requireSeasonManager (in computeGeneration) authorizes
+    // the seasonId, but the caller-supplied phaseId is not covered by that check.
+    // Without this, a legitimate admin of season A could pass a phaseId belonging
+    // to another league's season B and overwrite its format/formatRounds.
+    if (phaseId) {
+      const phase = await prisma.seasonPhase.findUnique({
+        where: { id: phaseId },
+        select: { seasonId: true },
+      });
+      if (!phase || phase.seasonId !== validated.seasonId) {
+        return { success: false, error: "Invalid phase for this season" };
+      }
+    }
+
     const createdIds = await prisma.$transaction(async (tx) => {
       const ids: string[] = [];
       for (const game of proposed) {

--- a/lib/actions/session-registrations.ts
+++ b/lib/actions/session-registrations.ts
@@ -5,7 +5,7 @@ import { Prisma } from "@prisma/client";
 import { prisma } from "@/lib/db/prisma";
 import { requireUserId, requireVenueRequestManager, requireVenueStaffRole, VENUE_STAFF_ADMIN_ROLES } from "@/lib/auth/session";
 import type { ActionResult } from "@/lib/actions/venue-organizations";
-import { logVenueActivity } from "@/lib/actions/venue-organizations";
+import { logVenueActivity } from "@/lib/services/venue-activity";
 import {
   sessionRegistrationSchema,
   registrationCommandSchema,

--- a/lib/actions/venue-content.ts
+++ b/lib/actions/venue-content.ts
@@ -177,6 +177,10 @@ export async function assignSkillLevelsToLesson(
   try {
     const validated = lessonSkillLevelAssignmentSchema.parse(input);
     await requireVenueContentManager(validated.organizationId, validated.venueId);
+    // Bind venue -> org. Org-wide staff roles satisfy requireVenueContentManager
+    // for ANY venueId, so without this an OWNER of their own org could pass a
+    // victim's venueId + lessonOfferingId and rewrite its skill-level tags (IDOR).
+    await ensureVenue(validated.organizationId, validated.venueId);
 
     const lesson = await prisma.lessonOffering.update({
       where: { id: validated.lessonOfferingId, venueId: validated.venueId },
@@ -199,6 +203,9 @@ export async function assignSkillLevelsToScheduleBlock(
   try {
     const validated = scheduleBlockSkillLevelAssignmentSchema.parse(input);
     await requireVenueContentManager(validated.organizationId, validated.venueId);
+    // Bind venue -> org (see assignSkillLevelsToLesson): closes the same IDOR
+    // where an org-wide role satisfies the check for a foreign venueId.
+    await ensureVenue(validated.organizationId, validated.venueId);
 
     const block = await prisma.venueScheduleBlock.update({
       where: { id: validated.scheduleBlockId, venueId: validated.venueId },

--- a/lib/actions/venue-organizations.ts
+++ b/lib/actions/venue-organizations.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { prisma } from "@/lib/db/prisma";
+import { createVenueActivityLog } from "@/lib/services/venue-activity";
 import { requireUserId, requireVenueProfileManager } from "@/lib/auth/session";
 import { revalidatePath } from "next/cache";
 import { Prisma } from "@prisma/client";
@@ -463,37 +464,8 @@ function isMissingVenueManagementSchemaError(
   );
 }
 
-export interface VenueActivityLogInput {
-  venueId: string;
-  actorId: string;
-  action: string;
-  resourceType: string;
-  resourceId?: string | null;
-  summary: string;
-  details?: Prisma.InputJsonValue;
-}
-
-function createVenueActivityLog(client: Pick<typeof prisma, "venueActivityLog">, input: VenueActivityLogInput) {
-  return client.venueActivityLog.create({
-    data: {
-      venueId: input.venueId,
-      actorId: input.actorId,
-      action: input.action,
-      resourceType: input.resourceType,
-      resourceId: input.resourceId ?? null,
-      summary: input.summary,
-      details: input.details ?? undefined,
-    },
-  });
-}
-
-export async function logVenueActivity(input: VenueActivityLogInput) {
-  return createVenueActivityLog(prisma, input);
-}
-
-export async function logCurrentUserVenueActivity(
-  input: Omit<VenueActivityLogInput, "actorId">
-) {
-  const actorId = await requireUserId();
-  return logVenueActivity({ ...input, actorId });
-}
+// Venue activity-log helpers moved to lib/services/venue-activity.ts (a plain,
+// non-"use server" module) so they are importable by actions but not exposed
+// as forgeable client-callable RPC endpoints. createVenueActivityLog is
+// imported at the top of this file for the transaction-scoped log writes below.
+// The former logCurrentUserVenueActivity was unused and removed.

--- a/lib/actions/venue-schedules.ts
+++ b/lib/actions/venue-schedules.ts
@@ -5,7 +5,8 @@ import type { Prisma } from "@prisma/client";
 import { z } from "zod";
 import { prisma } from "@/lib/db/prisma";
 import { requireVenueScheduleManager } from "@/lib/auth/session";
-import { logVenueActivity, type ActionResult } from "@/lib/actions/venue-organizations";
+import { type ActionResult } from "@/lib/actions/venue-organizations";
+import { logVenueActivity } from "@/lib/services/venue-activity";
 import { publicPublishedVenueWhere } from "@/lib/utils/public-venues";
 import {
   createIceSurfaceSchema,

--- a/lib/actions/venue-surfaces.ts
+++ b/lib/actions/venue-surfaces.ts
@@ -16,7 +16,8 @@ import { Prisma, type SurfaceType } from "@prisma/client";
 import { z } from "zod";
 import { prisma } from "@/lib/db/prisma";
 import { requireVenueScheduleManager } from "@/lib/auth/session";
-import { logVenueActivity, type ActionResult } from "@/lib/actions/venue-organizations";
+import { type ActionResult } from "@/lib/actions/venue-organizations";
+import { logVenueActivity } from "@/lib/services/venue-activity";
 import {
   applySegmentationPresetSchema,
   createSegmentSchema,

--- a/lib/actions/venues.ts
+++ b/lib/actions/venues.ts
@@ -392,8 +392,13 @@ export async function checkVenueAvailability(
 /**
  * Find conflicting events at a venue for a given time range.
  * Two events conflict when: newStart < existingEnd AND newEnd > existingStart
+ *
+ * Module-private: NOT exported. In a "use server" file every exported async
+ * function is a client-callable RPC endpoint; exporting this leaked private
+ * venue schedules (event titles, team names, times) to anyone. The only
+ * caller is checkVenueAvailability below, which authenticates + authorizes.
  */
-export async function findVenueConflicts(
+async function findVenueConflicts(
   venueId: string,
   startAt: Date,
   endAt: Date,

--- a/lib/auth/session.ts
+++ b/lib/auth/session.ts
@@ -298,16 +298,43 @@ export async function isAnyLeagueAdmin(userId: string): Promise<boolean> {
 }
 
 /**
- * Require "system admin" privileges (currently: LEAGUE_ADMIN of any league —
- * see isAnyLeagueAdmin).
+ * Check whether a user is a PLATFORM administrator — the true system-wide role
+ * used to gate cross-tenant operations (approving/rejecting signups, listing
+ * every user). This is deliberately NOT "LEAGUE_ADMIN of any league": that was
+ * self-grantable by creating a throwaway league (privilege escalation).
+ *
+ * A user is a platform admin if either:
+ *  - their User.isPlatformAdmin column is true, or
+ *  - their email is in the PLATFORM_ADMIN_EMAILS allowlist (comma-separated).
+ *
+ * The env allowlist is a non-self-grantable bootstrap so a self-hosted operator
+ * can designate the first platform admin(s) without a manual DB write.
+ */
+export async function isPlatformAdmin(userId: string): Promise<boolean> {
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { isPlatformAdmin: true, email: true },
+  });
+  if (!user) return false;
+  if (user.isPlatformAdmin) return true;
+
+  const allowlist = (process.env.PLATFORM_ADMIN_EMAILS ?? "")
+    .split(",")
+    .map((entry) => entry.trim().toLowerCase())
+    .filter(Boolean);
+  return allowlist.includes(user.email.toLowerCase());
+}
+
+/**
+ * Require PLATFORM admin privileges (see isPlatformAdmin).
  * Returns the session if the check passes.
- * Throws an error if not authenticated or not an admin
+ * Throws an error if not authenticated or not a platform admin.
  */
 export async function requireSystemAdmin() {
   const session = await requireAuth();
   const userId = await requireUserIdFromSession(session);
 
-  const isAdmin = await isAnyLeagueAdmin(userId);
+  const isAdmin = await isPlatformAdmin(userId);
   if (!isAdmin) {
     throw new Error("Unauthorized: Admin access required");
   }

--- a/lib/email/templates.ts
+++ b/lib/email/templates.ts
@@ -7,6 +7,20 @@ import { notificationService } from "@/lib/services/notification";
 const EMAIL_FROM = env.EMAIL_FROM;
 const BASE_URL = getBaseUrl();
 
+/**
+ * Escape a string for safe interpolation into HTML email bodies. Prevents
+ * HTML/script injection from user-controlled values (event titles, names,
+ * messages, locations, notes, etc.) rendered in recipients' emails.
+ */
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
 interface IceTimeRequestSubmittedEmailData {
   managerEmails: string[];
   venueName: string;
@@ -36,7 +50,7 @@ export async function sendVenueRelationshipInvitationEmail(
     message: {
       from_email: EMAIL_FROM,
       subject: `${data.venueName} invited you to add a ${relationshipLabel}`,
-      html: `<p>${data.venueName} invited you to add them as a ${relationshipLabel}.</p><p><a href="${invitationLink}">Review invitation</a></p>`,
+      html: `<p>${escapeHtml(data.venueName)} invited you to add them as a ${relationshipLabel}.</p><p><a href="${invitationLink}">Review invitation</a></p>`,
       text: `${data.venueName} invited you to add them as a ${relationshipLabel}. Review: ${invitationLink}`,
       to: [{ email: data.email, type: "to" as const }],
     },
@@ -70,7 +84,7 @@ export async function sendVenueStaffInviteEmail(data: VenueStaffInviteEmailData)
     message: {
       from_email: EMAIL_FROM,
       subject: `${data.inviterName} invited you to help manage ${data.organizationName}`,
-      html: `<p>${data.inviterName} invited you to join the staff of <strong>${data.organizationName}</strong> on OpenLeague with the ${roleLabel} role.</p><p><a href="${staffLink}">Review invitation</a></p><p>If you didn't expect this invitation, you can safely ignore this email.</p>`,
+      html: `<p>${escapeHtml(data.inviterName)} invited you to join the staff of <strong>${escapeHtml(data.organizationName)}</strong> on OpenLeague with the ${roleLabel} role.</p><p><a href="${staffLink}">Review invitation</a></p><p>If you didn't expect this invitation, you can safely ignore this email.</p>`,
       text: `${data.inviterName} invited you to join the staff of ${data.organizationName} on OpenLeague with the ${roleLabel} role. Review: ${staffLink}\n\nIf you didn't expect this invitation, you can safely ignore this email.`,
       to: [{ email: data.email, type: "to" as const }],
     },
@@ -103,7 +117,7 @@ export async function sendVenueStaffSignupInviteEmail(
     message: {
       from_email: EMAIL_FROM,
       subject: `${data.inviterName} invited you to help manage ${data.organizationName}`,
-      html: `<p>${data.inviterName} invited you to join the staff of <strong>${data.organizationName}</strong> on OpenLeague with the ${roleLabel} role.</p><p>Create a free account to accept the invitation:</p><p><a href="${invitationLink}">Accept invitation</a></p><p style="color: #666; font-size: 14px;">This invitation will expire in 7 days. If you didn't expect it, you can safely ignore this email.</p>`,
+      html: `<p>${escapeHtml(data.inviterName)} invited you to join the staff of <strong>${escapeHtml(data.organizationName)}</strong> on OpenLeague with the ${roleLabel} role.</p><p>Create a free account to accept the invitation:</p><p><a href="${invitationLink}">Accept invitation</a></p><p style="color: #666; font-size: 14px;">This invitation will expire in 7 days. If you didn't expect it, you can safely ignore this email.</p>`,
       text: `${data.inviterName} invited you to join the staff of ${data.organizationName} on OpenLeague with the ${roleLabel} role. Create a free account to accept the invitation: ${invitationLink}\n\nThis invitation will expire in 7 days. If you didn't expect it, you can safely ignore this email.`,
       to: [{ email: data.email, type: "to" as const }],
     },
@@ -134,7 +148,7 @@ export async function sendTeamOfficialInviteEmail(data: TeamOfficialInviteEmailD
     message: {
       from_email: EMAIL_FROM,
       subject: `${data.inviterName} invited you to join ${data.teamName} as ${roleLabel}`,
-      html: `<p>${data.inviterName} invited you to join <strong>${data.teamName}</strong> on OpenLeague as ${roleLabel}.</p><p>Create a free account to accept the invitation:</p><p><a href="${invitationLink}">Accept invitation</a></p><p style="color: #666; font-size: 14px;">This invitation will expire in 7 days. If you didn't expect it, you can safely ignore this email.</p>`,
+      html: `<p>${escapeHtml(data.inviterName)} invited you to join <strong>${escapeHtml(data.teamName)}</strong> on OpenLeague as ${roleLabel}.</p><p>Create a free account to accept the invitation:</p><p><a href="${invitationLink}">Accept invitation</a></p><p style="color: #666; font-size: 14px;">This invitation will expire in 7 days. If you didn't expect it, you can safely ignore this email.</p>`,
       text: `${data.inviterName} invited you to join ${data.teamName} on OpenLeague as ${roleLabel}. Create a free account to accept the invitation: ${invitationLink}\n\nThis invitation will expire in 7 days. If you didn't expect it, you can safely ignore this email.`,
       to: [{ email: data.email, type: "to" as const }],
     },
@@ -151,7 +165,7 @@ export async function sendIceTimeRequestSubmittedEmail(
     message: {
       from_email: EMAIL_FROM,
       subject: `New ice time request for ${data.venueName}`,
-      html: `<p>${data.contactName} (${data.contactEmail}) requested ${data.scheduleTitle}.</p><p><a href="${requestLink}">Review request</a></p>`,
+      html: `<p>${escapeHtml(data.contactName)} (${escapeHtml(data.contactEmail)}) requested ${escapeHtml(data.scheduleTitle)}.</p><p><a href="${requestLink}">Review request</a></p>`,
       text: `${data.contactName} (${data.contactEmail}) requested ${data.scheduleTitle}. Review: ${requestLink}`,
       to: data.managerEmails.map((email) => ({ email, type: "to" as const })),
     },
@@ -175,7 +189,7 @@ export async function sendIceTimeRequestDecisionEmail(
     message: {
       from_email: EMAIL_FROM,
       subject: `Your ice time request was ${statusLabel}`,
-      html: `<p>${data.venueName} ${statusLabel} your ice time request.</p>${data.decisionMessage ? `<p>${data.decisionMessage}</p>` : ""}`,
+      html: `<p>${escapeHtml(data.venueName)} ${statusLabel} your ice time request.</p>${data.decisionMessage ? `<p>${escapeHtml(data.decisionMessage)}</p>` : ""}`,
       text: `${data.venueName} ${statusLabel} your ice time request.${data.decisionMessage ? `\n\n${data.decisionMessage}` : ""}`,
       to: [{ email: data.contactEmail, type: "to" as const }],
     },
@@ -217,7 +231,7 @@ export async function sendSessionRegistrationConfirmationEmail(
     message: {
       from_email: EMAIL_FROM,
       subject: `You're registered for ${data.offeringTitle}`,
-      html: `<p>Hi ${data.participantName},</p><p>You're registered for <strong>${data.offeringTitle}</strong> at ${data.venueName} (${data.quantity} spot${data.quantity === 1 ? "" : "s"}).${priceLine}</p>${receiptLine}<p><a href="${registrationsLink}">View your registrations</a></p>`,
+      html: `<p>Hi ${escapeHtml(data.participantName)},</p><p>You're registered for <strong>${escapeHtml(data.offeringTitle)}</strong> at ${escapeHtml(data.venueName)} (${data.quantity} spot${data.quantity === 1 ? "" : "s"}).${priceLine}</p>${receiptLine}<p><a href="${registrationsLink}">View your registrations</a></p>`,
       text: `Hi ${data.participantName}, you're registered for ${data.offeringTitle} at ${data.venueName} (${data.quantity} spot(s)).${priceLine} View your registrations: ${registrationsLink}`,
       to: [{ email: data.to, type: "to" as const }],
     },
@@ -245,7 +259,7 @@ export async function sendSessionRegistrationManagerEmail(
     message: {
       from_email: EMAIL_FROM,
       subject: `New registration for ${data.offeringTitle}`,
-      html: `<p>${data.participantName} registered for <strong>${data.offeringTitle}</strong> at ${data.venueName} (${data.quantity} spot${data.quantity === 1 ? "" : "s"}).</p>`,
+      html: `<p>${escapeHtml(data.participantName)} registered for <strong>${escapeHtml(data.offeringTitle)}</strong> at ${escapeHtml(data.venueName)} (${data.quantity} spot${data.quantity === 1 ? "" : "s"}).</p>`,
       text: `${data.participantName} registered for ${data.offeringTitle} at ${data.venueName} (${data.quantity} spot(s)).`,
       to: data.managerEmails.map((email) => ({ email, type: "to" as const })),
     },
@@ -277,11 +291,11 @@ export async function sendInvitationEmail(data: InvitationEmailData): Promise<vo
     subject: `You've been invited to join ${data.teamName}`,
     html: `
       <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
-        <h2 style="color: #1976D2;">You've been invited to join ${data.teamName}</h2>
+        <h2 style="color: #1976D2;">You've been invited to join ${escapeHtml(data.teamName)}</h2>
 
         <p>Hi there,</p>
 
-        <p>${data.inviterName} has invited you to join <strong>${data.teamName}</strong> on openleague.</p>
+        <p>${escapeHtml(data.inviterName)} has invited you to join <strong>${escapeHtml(data.teamName)}</strong> on openleague.</p>
 
         <p>openleague is a free platform for managing sports teams. You'll be able to:</p>
         <ul>
@@ -368,11 +382,11 @@ export async function sendExistingUserNotification(
     subject: `You've been added to ${data.teamName}`,
     html: `
       <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
-        <h2 style="color: #1976D2;">You've been added to ${data.teamName}</h2>
+        <h2 style="color: #1976D2;">You've been added to ${escapeHtml(data.teamName)}</h2>
 
         <p>Hi there,</p>
 
-        <p>${data.inviterName} has added you to <strong>${data.teamName}</strong> on openleague.</p>
+        <p>${escapeHtml(data.inviterName)} has added you to <strong>${escapeHtml(data.teamName)}</strong> on openleague.</p>
 
         <p>You can now view the team roster, see upcoming games and practices, and RSVP to events.</p>
 
@@ -433,11 +447,11 @@ export async function sendLeagueInvitationEmail(data: LeagueInvitationEmailData)
     subject: `You've been invited to join the ${data.leagueName} league`,
     html: `
       <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
-        <h2 style="color: #1976D2;">You've been invited to join ${data.leagueName}</h2>
+        <h2 style="color: #1976D2;">You've been invited to join ${escapeHtml(data.leagueName)}</h2>
 
         <p>Hi there,</p>
 
-        <p>${data.inviterName} has invited you to join the <strong>${data.leagueName}</strong> league on openleague.</p>
+        <p>${escapeHtml(data.inviterName)} has invited you to join the <strong>${escapeHtml(data.leagueName)}</strong> league on openleague.</p>
 
         <p style="margin: 30px 0;">
           <a href="${invitationLink}"
@@ -505,7 +519,7 @@ export async function sendLeagueMemberAddedNotification(
     message: {
       from_email: EMAIL_FROM,
       subject: `You've been added to the ${data.leagueName} league`,
-      html: `<p>${data.inviterName} added you to the <strong>${data.leagueName}</strong> league on openleague as ${roleLabel}.</p><p><a href="${loginLink}">Log in</a> to see your league.</p><p style="color: #666; font-size: 14px;">If you didn't expect this, contact the league administrator.</p>`,
+      html: `<p>${escapeHtml(data.inviterName)} added you to the <strong>${escapeHtml(data.leagueName)}</strong> league on openleague as ${roleLabel}.</p><p><a href="${loginLink}">Log in</a> to see your league.</p><p style="color: #666; font-size: 14px;">If you didn't expect this, contact the league administrator.</p>`,
       text: `${data.inviterName} added you to the ${data.leagueName} league on openleague as ${roleLabel}. Log in to see your league: ${loginLink}\n\nIf you didn't expect this, contact the league administrator.`,
       to: [{ email: data.email, type: "to" as const }],
     },
@@ -544,13 +558,13 @@ export async function sendEventCreatedEmail(data: EventCreatedEmailData): Promis
       <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
         <h2 style="color: #1976D2;">New ${eventTypeLabel} Scheduled</h2>
 
-        <p>A new ${eventTypeLabel.toLowerCase()} has been added to <strong>${data.teamName}</strong>'s calendar.</p>
+        <p>A new ${eventTypeLabel.toLowerCase()} has been added to <strong>${escapeHtml(data.teamName)}</strong>'s calendar.</p>
 
         <div style="background-color: #f5f5f5; padding: 20px; border-radius: 8px; margin: 20px 0;">
-          <h3 style="margin-top: 0; color: #333;">${data.eventTitle}</h3>
+          <h3 style="margin-top: 0; color: #333;">${escapeHtml(data.eventTitle)}</h3>
           <p style="margin: 10px 0;"><strong>Date & Time:</strong> ${data.eventDate}</p>
-          <p style="margin: 10px 0;"><strong>Location:</strong> ${data.eventLocation}</p>
-          ${data.opponent ? `<p style="margin: 10px 0;"><strong>Opponent:</strong> ${data.opponent}</p>` : ""}
+          <p style="margin: 10px 0;"><strong>Location:</strong> ${escapeHtml(data.eventLocation)}</p>
+          ${data.opponent ? `<p style="margin: 10px 0;"><strong>Opponent:</strong> ${escapeHtml(data.opponent)}</p>` : ""}
         </div>
 
         <p style="margin: 30px 0;">
@@ -626,14 +640,14 @@ export async function sendEventUpdatedEmail(data: EventUpdatedEmailData): Promis
       <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
         <h2 style="color: #FF9800;">Event Updated</h2>
 
-        <p>An event for <strong>${data.teamName}</strong> has been updated.</p>
+        <p>An event for <strong>${escapeHtml(data.teamName)}</strong> has been updated.</p>
 
         <div style="background-color: #fff3e0; padding: 20px; border-radius: 8px; margin: 20px 0; border-left: 4px solid #FF9800;">
-          <h3 style="margin-top: 0; color: #333;">${data.eventTitle}</h3>
+          <h3 style="margin-top: 0; color: #333;">${escapeHtml(data.eventTitle)}</h3>
           <p style="margin: 10px 0;"><strong>Type:</strong> ${eventTypeLabel}</p>
           <p style="margin: 10px 0;"><strong>Date & Time:</strong> ${data.eventDate}</p>
-          <p style="margin: 10px 0;"><strong>Location:</strong> ${data.eventLocation}</p>
-          ${data.opponent ? `<p style="margin: 10px 0;"><strong>Opponent:</strong> ${data.opponent}</p>` : ""}
+          <p style="margin: 10px 0;"><strong>Location:</strong> ${escapeHtml(data.eventLocation)}</p>
+          ${data.opponent ? `<p style="margin: 10px 0;"><strong>Opponent:</strong> ${escapeHtml(data.opponent)}</p>` : ""}
         </div>
 
         <p style="margin: 30px 0;">
@@ -707,10 +721,10 @@ export async function sendEventCancelledEmail(data: EventCancelledEmailData): Pr
       <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
         <h2 style="color: #D32F2F;">Event Cancelled</h2>
 
-        <p>An event for <strong>${data.teamName}</strong> has been cancelled.</p>
+        <p>An event for <strong>${escapeHtml(data.teamName)}</strong> has been cancelled.</p>
 
         <div style="background-color: #ffebee; padding: 20px; border-radius: 8px; margin: 20px 0; border-left: 4px solid #D32F2F;">
-          <h3 style="margin-top: 0; color: #333;">${data.eventTitle}</h3>
+          <h3 style="margin-top: 0; color: #333;">${escapeHtml(data.eventTitle)}</h3>
           <p style="margin: 10px 0;"><strong>Type:</strong> ${eventTypeLabel}</p>
           <p style="margin: 10px 0;"><strong>Was scheduled for:</strong> ${data.eventDate}</p>
           <p style="margin: 10px 0; color: #D32F2F; font-weight: bold;">This event has been cancelled.</p>
@@ -786,16 +800,16 @@ export async function sendRSVPReminderEmail(data: RSVPReminderEmailData): Promis
       <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
         <h2 style="color: #1976D2;">RSVP Reminder</h2>
 
-        <p>${greeting},</p>
+        <p>${escapeHtml(greeting)},</p>
 
-        <p>This is a friendly reminder to RSVP for an upcoming ${eventTypeLabel.toLowerCase()} with <strong>${data.teamName}</strong>.</p>
+        <p>This is a friendly reminder to RSVP for an upcoming ${eventTypeLabel.toLowerCase()} with <strong>${escapeHtml(data.teamName)}</strong>.</p>
 
         <div style="background-color: #e3f2fd; padding: 20px; border-radius: 8px; margin: 20px 0; border-left: 4px solid #1976D2;">
-          <h3 style="margin-top: 0; color: #333;">${data.eventTitle}</h3>
+          <h3 style="margin-top: 0; color: #333;">${escapeHtml(data.eventTitle)}</h3>
           <p style="margin: 10px 0;"><strong>Type:</strong> ${eventTypeLabel}</p>
           <p style="margin: 10px 0;"><strong>Date & Time:</strong> ${data.eventDate}</p>
-          <p style="margin: 10px 0;"><strong>Location:</strong> ${data.eventLocation}</p>
-          ${data.opponent ? `<p style="margin: 10px 0;"><strong>Opponent:</strong> ${data.opponent}</p>` : ""}
+          <p style="margin: 10px 0;"><strong>Location:</strong> ${escapeHtml(data.eventLocation)}</p>
+          ${data.opponent ? `<p style="margin: 10px 0;"><strong>Opponent:</strong> ${escapeHtml(data.opponent)}</p>` : ""}
         </div>
 
         <p>Your team is counting on you! Please let us know if you can make it.</p>
@@ -1036,14 +1050,14 @@ export async function sendLeagueMessageEmail(data: LeagueMessageEmailData): Prom
         <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
           <div style="background-color: ${priorityColor}; color: white; padding: 20px; border-radius: 8px 8px 0 0;">
             <h2 style="margin: 0; color: white;">League Message</h2>
-            <p style="margin: 10px 0 0 0; color: white; opacity: 0.9;">From ${data.senderName} • ${data.leagueName}</p>
+            <p style="margin: 10px 0 0 0; color: white; opacity: 0.9;">From ${escapeHtml(data.senderName)} • ${escapeHtml(data.leagueName)}</p>
           </div>
 
           <div style="background-color: #f5f5f5; padding: 20px; border-radius: 0 0 8px 8px;">
-            <h3 style="margin-top: 0; color: #333;">${data.subject}</h3>
+            <h3 style="margin-top: 0; color: #333;">${escapeHtml(data.subject)}</h3>
 
             <div style="background-color: white; padding: 20px; border-radius: 4px; margin: 20px 0;">
-              ${data.content.replace(/\n/g, '<br>')}
+              ${escapeHtml(data.content).replace(/\n/g, '<br>')}
             </div>
 
             ${data.priority === "URGENT" || data.priority === "HIGH" ? `
@@ -1151,14 +1165,14 @@ export async function sendLeagueAnnouncementEmail(data: LeagueAnnouncementEmailD
         <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
           <div style="background-color: ${priorityColor}; color: white; padding: 20px; border-radius: 8px 8px 0 0;">
             <h2 style="margin: 0; color: white;">📢 League Announcement</h2>
-            <p style="margin: 10px 0 0 0; color: white; opacity: 0.9;">From ${data.senderName} • ${data.leagueName}</p>
+            <p style="margin: 10px 0 0 0; color: white; opacity: 0.9;">From ${escapeHtml(data.senderName)} • ${escapeHtml(data.leagueName)}</p>
           </div>
 
           <div style="background-color: #f5f5f5; padding: 20px; border-radius: 0 0 8px 8px;">
-            <h3 style="margin-top: 0; color: #333;">${data.subject}</h3>
+            <h3 style="margin-top: 0; color: #333;">${escapeHtml(data.subject)}</h3>
 
             <div style="background-color: white; padding: 20px; border-radius: 4px; margin: 20px 0; border-left: 4px solid ${priorityColor};">
-              ${data.content.replace(/\n/g, '<br>')}
+              ${escapeHtml(data.content).replace(/\n/g, '<br>')}
             </div>
 
             ${data.priority === "URGENT" ? `
@@ -1257,10 +1271,10 @@ export async function sendPracticePlanSharedEmail(data: PracticePlanSharedEmailD
       <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
         <h2 style="color: #1976D2;">New Practice Plan Available</h2>
 
-        <p>A new practice plan has been shared with <strong>${data.teamName}</strong>.</p>
+        <p>A new practice plan has been shared with <strong>${escapeHtml(data.teamName)}</strong>.</p>
 
         <div style="background-color: #f5f5f5; padding: 20px; border-radius: 8px; margin: 20px 0;">
-          <h3 style="margin-top: 0; color: #333;">${data.sessionTitle}</h3>
+          <h3 style="margin-top: 0; color: #333;">${escapeHtml(data.sessionTitle)}</h3>
           <p style="margin: 10px 0;"><strong>Date:</strong> ${data.sessionDate}</p>
           <p style="margin: 10px 0;"><strong>Duration:</strong> ${data.duration} minutes</p>
           <p style="margin: 10px 0;"><strong>Number of Drills:</strong> ${data.playCount}</p>
@@ -1337,10 +1351,10 @@ export async function sendPracticePlanUpdatedEmail(data: PracticePlanUpdatedEmai
       <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
         <h2 style="color: #FF9800;">Practice Plan Updated</h2>
 
-        <p>A practice plan for <strong>${data.teamName}</strong> has been updated.</p>
+        <p>A practice plan for <strong>${escapeHtml(data.teamName)}</strong> has been updated.</p>
 
         <div style="background-color: #fff3e0; padding: 20px; border-radius: 8px; margin: 20px 0; border-left: 4px solid #FF9800;">
-          <h3 style="margin-top: 0; color: #333;">${data.sessionTitle}</h3>
+          <h3 style="margin-top: 0; color: #333;">${escapeHtml(data.sessionTitle)}</h3>
           <p style="margin: 10px 0;"><strong>Date:</strong> ${data.sessionDate}</p>
           <p style="margin: 10px 0;"><strong>Duration:</strong> ${data.duration} minutes</p>
           <p style="margin: 10px 0;"><strong>Number of Drills:</strong> ${data.playCount}</p>
@@ -1493,7 +1507,7 @@ export async function sendSignupEventUpdatedEmail(data: SignupEventUpdatedEmailD
         message: {
           from_email: EMAIL_FROM,
           subject: `Updated: ${data.eventTitle}`,
-          html: `<p><strong>${data.eventTitle}</strong> (hosted by ${data.hostName}) has been updated.</p><p>${data.changeSummary}</p><p><a href="${eventLink}">View the event</a></p>`,
+          html: `<p><strong>${escapeHtml(data.eventTitle)}</strong> (hosted by ${escapeHtml(data.hostName)}) has been updated.</p><p>${escapeHtml(data.changeSummary)}</p><p><a href="${eventLink}">View the event</a></p>`,
           text: `${data.eventTitle} (hosted by ${data.hostName}) has been updated. ${data.changeSummary} View: ${eventLink}`,
           to: [{ email: recipient.email, type: "to" as const }],
         },
@@ -1515,7 +1529,7 @@ interface SignupEventCanceledEmailData {
 export async function sendSignupEventCanceledEmail(data: SignupEventCanceledEmailData): Promise<void> {
   if (data.recipients.length === 0) return;
   const mailchimp = getMailchimpClient();
-  const reasonHtml = data.reason ? `<p>Reason: ${data.reason}</p>` : "";
+  const reasonHtml = data.reason ? `<p>Reason: ${escapeHtml(data.reason)}</p>` : "";
 
   // One message per family — recipients must never see each other's addresses.
   for (const recipient of data.recipients) {
@@ -1524,7 +1538,7 @@ export async function sendSignupEventCanceledEmail(data: SignupEventCanceledEmai
         message: {
           from_email: EMAIL_FROM,
           subject: `Canceled: ${data.eventTitle}`,
-          html: `<p><strong>${data.eventTitle}</strong> (hosted by ${data.hostName}) has been canceled.</p>${reasonHtml}<p>If you paid online, the organizer will process refunds.</p>`,
+          html: `<p><strong>${escapeHtml(data.eventTitle)}</strong> (hosted by ${escapeHtml(data.hostName)}) has been canceled.</p>${reasonHtml}<p>If you paid online, the organizer will process refunds.</p>`,
           text: `${data.eventTitle} (hosted by ${data.hostName}) has been canceled.${data.reason ? ` Reason: ${data.reason}` : ""} If you paid online, the organizer will process refunds.`,
           to: [{ email: recipient.email, type: "to" as const }],
         },
@@ -1557,14 +1571,14 @@ export async function sendEventRegistrationConfirmationEmail(
   const names = data.participantNames.join(", ");
   const paymentHtml =
     data.amountTotal > 0
-      ? `<p>Amount due: <strong>${formatMoney(data.amountTotal, data.currency)}</strong>${data.manualPaymentNote ? ` — ${data.manualPaymentNote}` : ""}</p>`
+      ? `<p>Amount due: <strong>${formatMoney(data.amountTotal, data.currency)}</strong>${data.manualPaymentNote ? ` — ${escapeHtml(data.manualPaymentNote)}` : ""}</p>`
       : "";
 
   await mailchimp.messages.send({
     message: {
       from_email: EMAIL_FROM,
       subject: `You're in: ${data.eventTitle}`,
-      html: `<p>${names} ${data.participantNames.length === 1 ? "is" : "are"} confirmed for <strong>${data.slotName}</strong> at <strong>${data.eventTitle}</strong> (hosted by ${data.hostName}) on ${data.startAtFormatted}.</p>${paymentHtml}<p><a href="${eventLink}">View the event</a></p>`,
+      html: `<p>${escapeHtml(names)} ${data.participantNames.length === 1 ? "is" : "are"} confirmed for <strong>${escapeHtml(data.slotName)}</strong> at <strong>${escapeHtml(data.eventTitle)}</strong> (hosted by ${escapeHtml(data.hostName)}) on ${data.startAtFormatted}.</p>${paymentHtml}<p><a href="${eventLink}">View the event</a></p>`,
       text: `${names} confirmed for ${data.slotName} at ${data.eventTitle} (hosted by ${data.hostName}) on ${data.startAtFormatted}.${data.amountTotal > 0 ? ` Amount due: ${formatMoney(data.amountTotal, data.currency)}.` : ""} View: ${eventLink}`,
       to: [{ email: data.to, type: "to" as const }],
     },
@@ -1588,7 +1602,7 @@ export async function sendEventRegistrationRemovedEmail(
     message: {
       from_email: EMAIL_FROM,
       subject: `Registration removed: ${data.eventTitle}`,
-      html: `<p>${data.participantName}'s registration for <strong>${data.eventTitle}</strong> was removed by an organizer.</p>${data.reason ? `<p>Reason: ${data.reason}</p>` : ""}`,
+      html: `<p>${escapeHtml(data.participantName)}'s registration for <strong>${escapeHtml(data.eventTitle)}</strong> was removed by an organizer.</p>${data.reason ? `<p>Reason: ${escapeHtml(data.reason)}</p>` : ""}`,
       text: `${data.participantName}'s registration for ${data.eventTitle} was removed by an organizer.${data.reason ? ` Reason: ${data.reason}` : ""}`,
       to: [{ email: data.to, type: "to" as const }],
     },
@@ -1666,7 +1680,7 @@ export async function sendSignupEventReminders(): Promise<void> {
           message: {
             from_email: EMAIL_FROM,
             subject: `Reminder: ${event.title} is coming up`,
-            html: `<p>Reminder — <strong>${event.title}</strong> (hosted by ${hostName}) starts ${formatDateTime(event.startAt)}${location ? ` at ${location}` : ""}.</p><p>Registered: ${participants.join(", ")}</p><p><a href="${eventLink}">View the event</a></p>`,
+            html: `<p>Reminder — <strong>${escapeHtml(event.title)}</strong> (hosted by ${escapeHtml(hostName)}) starts ${formatDateTime(event.startAt)}${location ? ` at ${escapeHtml(location)}` : ""}.</p><p>Registered: ${escapeHtml(participants.join(", "))}</p><p><a href="${eventLink}">View the event</a></p>`,
             text: `Reminder — ${event.title} (hosted by ${hostName}) starts ${formatDateTime(event.startAt)}${location ? ` at ${location}` : ""}. Registered: ${participants.join(", ")}. View: ${eventLink}`,
             to: [{ email, type: "to" as const }],
           },
@@ -1696,7 +1710,7 @@ export async function sendWaitlistOfferEmail(data: WaitlistOfferEmailData): Prom
     message: {
       from_email: EMAIL_FROM,
       subject: `A spot opened up: ${data.eventTitle}`,
-      html: `<p>Good news — a <strong>${data.slotName}</strong> spot opened up for ${data.participantName} at <strong>${data.eventTitle}</strong>.</p><p>Claim it by <strong>${data.claimByFormatted}</strong> or the offer passes to the next person on the waitlist.</p><p><a href="${claimLink}">Claim your spot</a></p>`,
+      html: `<p>Good news — a <strong>${escapeHtml(data.slotName)}</strong> spot opened up for ${escapeHtml(data.participantName)} at <strong>${escapeHtml(data.eventTitle)}</strong>.</p><p>Claim it by <strong>${data.claimByFormatted}</strong> or the offer passes to the next person on the waitlist.</p><p><a href="${claimLink}">Claim your spot</a></p>`,
       text: `A ${data.slotName} spot opened up for ${data.participantName} at ${data.eventTitle}. Claim it by ${data.claimByFormatted} or the offer passes to the next person: ${claimLink}`,
       to: [{ email: data.to, type: "to" as const }],
     },
@@ -1724,7 +1738,7 @@ export async function sendEventInvitationEmail(data: EventInvitationEmailData): 
     message: {
       from_email: EMAIL_FROM,
       subject: `You're invited: ${data.eventTitle}`,
-      html: `<p>${data.hostName} invited you to <strong>${data.eventTitle}</strong> on ${data.startAtFormatted}.</p><p><a href="${inviteLink}">${cta}</a></p>`,
+      html: `<p>${escapeHtml(data.hostName)} invited you to <strong>${escapeHtml(data.eventTitle)}</strong> on ${data.startAtFormatted}.</p><p><a href="${inviteLink}">${cta}</a></p>`,
       text: `${data.hostName} invited you to ${data.eventTitle} on ${data.startAtFormatted}. ${cta}: ${inviteLink}`,
       to: [{ email: data.to, type: "to" as const }],
     },
@@ -1754,7 +1768,7 @@ export async function sendEventTeamsUpdateEmail(data: EventTeamsUpdateEmailData)
         message: {
           from_email: EMAIL_FROM,
           subject: headline,
-          html: `<p>${headline}.</p><p><a href="${eventLink}">See your team and game times</a></p>`,
+          html: `<p>${escapeHtml(headline)}.</p><p><a href="${eventLink}">See your team and game times</a></p>`,
           text: `${headline}. See your team and game times: ${eventLink}`,
           to: [{ email: recipient.email, type: "to" as const }],
         },
@@ -1903,14 +1917,14 @@ export async function sendGameProposalNotifications(
       <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
         <h2 style="color: ${color};">${headlines[change]}</h2>
 
-        <p>${leads[change]}</p>
+        <p>${escapeHtml(leads[change])}</p>
 
         <div style="background-color: #f5f5f5; padding: 20px; border-radius: 8px; margin: 20px 0; border-left: 4px solid ${color};">
-          <h3 style="margin-top: 0; color: #333;">${matchup}</h3>
+          <h3 style="margin-top: 0; color: #333;">${escapeHtml(matchup)}</h3>
           <p style="margin: 10px 0;"><strong>Start:</strong> ${startFormatted}</p>
           ${endFormatted ? `<p style="margin: 10px 0;"><strong>End:</strong> ${endFormatted}</p>` : ""}
-          <p style="margin: 10px 0;"><strong>Venue:</strong> ${venueName}</p>
-          ${latestNote ? `<p style="margin: 10px 0;"><strong>Note:</strong> ${latestNote}</p>` : ""}
+          <p style="margin: 10px 0;"><strong>Venue:</strong> ${escapeHtml(venueName)}</p>
+          ${latestNote ? `<p style="margin: 10px 0;"><strong>Note:</strong> ${escapeHtml(latestNote)}</p>` : ""}
         </div>
 
         <p style="margin: 30px 0;">

--- a/lib/services/venue-activity.ts
+++ b/lib/services/venue-activity.ts
@@ -1,0 +1,47 @@
+import { prisma } from "@/lib/db/prisma";
+import { Prisma } from "@prisma/client";
+
+/**
+ * Venue activity-log helpers.
+ *
+ * These live in a plain (non-"use server") module on purpose: they must be
+ * importable by venue Server Actions, but must NOT themselves be exposed as
+ * client-callable RPC endpoints. When these were exported from a "use server"
+ * file, an unauthenticated caller could invoke logVenueActivity directly and
+ * forge audit-log rows with an arbitrary actorId/venueId. Callers are
+ * responsible for authenticating and authorizing before logging.
+ */
+export interface VenueActivityLogInput {
+  venueId: string;
+  actorId: string;
+  action: string;
+  resourceType: string;
+  resourceId?: string | null;
+  summary: string;
+  details?: Prisma.InputJsonValue;
+}
+
+/**
+ * Write a venue activity-log row. Accepts either the shared prisma client or a
+ * transaction client so callers can log inside an existing transaction.
+ */
+export function createVenueActivityLog(
+  client: Pick<typeof prisma, "venueActivityLog">,
+  input: VenueActivityLogInput
+) {
+  return client.venueActivityLog.create({
+    data: {
+      venueId: input.venueId,
+      actorId: input.actorId,
+      action: input.action,
+      resourceType: input.resourceType,
+      resourceId: input.resourceId ?? null,
+      summary: input.summary,
+      details: input.details ?? undefined,
+    },
+  });
+}
+
+export function logVenueActivity(input: VenueActivityLogInput) {
+  return createVenueActivityLog(prisma, input);
+}

--- a/lib/utils/csv.ts
+++ b/lib/utils/csv.ts
@@ -8,7 +8,15 @@
  */
 export function escapeCsvField(value: string | number | null | undefined): string {
   if (value === null || value === undefined) return "";
-  const str = String(value);
+  let str = String(value);
+  // Formula-injection guard (CSV/Excel/Sheets): a cell beginning with =, +, -,
+  // @, tab, or CR can be executed as a formula when the file is opened. Prefix
+  // such values with a single quote so they render as literal text. Applied only
+  // to string inputs — a numeric value like -5 is a legitimate number, not a
+  // formula, and must not be altered.
+  if (typeof value === "string" && /^[=+\-@\t\r]/.test(str)) {
+    str = `'${str}`;
+  }
   // Escape embedded double quotes by doubling them
   const escaped = str.replace(/"/g, '""');
   // Wrap in quotes if field contains comma, quote, newline, or carriage return

--- a/prisma/migrations/20260718000000_add_user_platform_admin/migration.sql
+++ b/prisma/migrations/20260718000000_add_user_platform_admin/migration.sql
@@ -1,0 +1,9 @@
+-- Adds a real platform-admin flag on User.
+--
+-- Platform administration (approving/rejecting signups, enumerating all users)
+-- was previously gated on "LEAGUE_ADMIN of any league", which any user could
+-- self-grant by creating a throwaway league. This column backs an explicit,
+-- non-self-grantable platform-admin grant (see lib/auth/session.ts
+-- isPlatformAdmin(), which also honors a PLATFORM_ADMIN_EMAILS bootstrap
+-- allowlist). Defaults to false so existing rows are unaffected.
+ALTER TABLE "User" ADD COLUMN "isPlatformAdmin" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -17,6 +17,7 @@ model User {
   passwordHash String
   name         String?
   approved     Boolean  @default(false) // Require admin approval for new signups
+  isPlatformAdmin Boolean @default(false) // Platform-wide admin (user approval/enumeration). NOT self-grantable; see lib/auth/session.ts isPlatformAdmin()
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt
 


### PR DESCRIPTION
## Track 0 — Security hardening (public-launch readiness)

First track of the [public-launch readiness audit](https://claude.ai/code/artifact/88752b9e-5081-4bc2-89a2-9fb3dae625ce). Every change here is an **authorization scope check** or an **injection guard** — no architectural rework, and no behavior change for legitimately-authorized users. This is the gate before any public signup opens, given the app stores minors' PII.

### Fixes

| Sev | Fix | File |
|-----|-----|------|
| **Critical** | Field-gate emergency-contact / USA Hockey PII in `getLeagueRosterData` so only league admins see it (was returned to **any** league member via a bare `include`) | `lib/actions/league-context.ts` |
| High | Real `User.isPlatformAdmin` role (+ `PLATFORM_ADMIN_EMAILS` bootstrap allowlist) for platform-admin actions. Previously "LEAGUE_ADMIN of any league" gated user approval/enumeration and was **self-grantable** via `createLeague` | `lib/auth/session.ts`, `app/(dashboard)/admin/users/page.tsx`, `prisma/` |
| High | Require league membership in `getLeagueWithStats` / `getLeagueTeamsWithDivisions` / `getLeagueDivisions` (were unauthenticated exported actions) | `lib/actions/league.ts` |
| High | Verify `phaseId` belongs to the season in `generateRoundRobin` (cross-tenant phase-format overwrite) | `lib/actions/season-generation.ts` |
| High | Bind venue → org via `ensureVenue` in the skill-level assign actions (org-wide-role IDOR) | `lib/actions/venue-content.ts` |
| High | Un-export `findVenueConflicts` (leaked private venue schedules as an RPC) | `lib/actions/venues.ts` |
| High | Move venue activity-log helpers to `lib/services/venue-activity` (out of a `"use server"` file) so audit rows can't be forged via a public RPC endpoint; drop unused `logCurrentUserVenueActivity` | `lib/services/venue-activity.ts`, `lib/actions/venue-*.ts` |
| Medium | `rsvp-reminders` cron fails **closed** when `CRON_SECRET` is unset (matches sibling crons) | `app/api/cron/rsvp-reminders/route.ts` |
| Medium | HTML-escape user-controlled values across all email templates (55 escape sites) | `lib/email/templates.ts` |
| Medium | Neutralize CSV/Excel formula injection in exports | `lib/utils/csv.ts` |

### Deferred (needs your decision)

- **H7 — durable rate limiting.** `lib/utils/rate-limit.ts` is in-memory (per-instance on serverless), and Server Actions get no throttling at all (`proxy.ts` only covers `/api/*`). The real fix needs a shared store — recommend Upstash Redis via `@upstash/ratelimit` while on Vercel. Left out of this PR because it requires provisioning + a store choice.

### Migration

Adds `prisma/migrations/20260718000000_add_user_platform_admin` — a single additive `ALTER TABLE "User" ADD COLUMN "isPlatformAdmin" BOOLEAN NOT NULL DEFAULT false`. Deploy via `db:migrate:deploy` in prod. **Bootstrap:** set `PLATFORM_ADMIN_EMAILS="you@example.com"` (documented in `.env.example`) to designate the first platform admin without a manual DB write.

> Heads-up on the known dev-Neon migration-history drift: apply to the dev DB with `prisma db execute` rather than `migrate dev` (which would demand a reset).

### Verification

- `bun run type-check` — clean
- `bun run test` — **1488 passing** (fixed the 11 tests my changes touched: platform-admin gate, `ensureVenue` mock, and the moved `logVenueActivity` mock path; added platform-admin coverage)
- `bun run build` — compiles, all 45 pages generated
- Lint: app code clean; the pre-existing `ds-bundle/` + `.design-sync/` vendored errors (from #248) remain — worth adding to eslintignore separately.

### Not in scope

Account lifecycle (email verify / reset / bootstrap), legal pages, guardian-aware calendar, standalone-team messaging — these are Tracks 1–2 in the roadmap.
