### PR TITLE
feat: email verification + password reset replacing manual-approval signup (Track 1)

### DIFF
--- a/__tests__/lib/actions/account-lifecycle.test.ts
+++ b/__tests__/lib/actions/account-lifecycle.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  user: {
+    findUnique: vi.fn(),
+    update: vi.fn(),
+    updateMany: vi.fn(),
+  },
+  issueVerificationToken: vi.fn(),
+  consumeVerificationToken: vi.fn(),
+  sendPasswordResetEmail: vi.fn(),
+  sendVerificationEmail: vi.fn(),
+  hash: vi.fn(),
+}));
+
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: { user: mocks.user },
+}));
+
+vi.mock("@/lib/auth/tokens", () => ({
+  issueVerificationToken: mocks.issueVerificationToken,
+  consumeVerificationToken: mocks.consumeVerificationToken,
+}));
+
+vi.mock("@/lib/email/templates", () => ({
+  sendPasswordResetEmail: mocks.sendPasswordResetEmail,
+  sendVerificationEmail: mocks.sendVerificationEmail,
+}));
+
+vi.mock("bcryptjs", () => ({
+  hash: mocks.hash,
+}));
+
+import {
+  requestPasswordReset,
+  resetPassword,
+  resendVerificationEmail,
+} from "@/lib/actions/account-lifecycle";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.user.findUnique.mockResolvedValue(null);
+  mocks.user.update.mockResolvedValue({});
+  mocks.user.updateMany.mockResolvedValue({ count: 0 });
+  mocks.issueVerificationToken.mockResolvedValue({ raw: "raw-token" });
+  mocks.consumeVerificationToken.mockResolvedValue(null);
+  mocks.sendPasswordResetEmail.mockResolvedValue(undefined);
+  mocks.sendVerificationEmail.mockResolvedValue(undefined);
+  mocks.hash.mockResolvedValue("hashed-password");
+});
+
+describe("requestPasswordReset", () => {
+  it("returns the same success response whether or not the account exists", async () => {
+    const unknown = await requestPasswordReset({ email: "nobody@example.com" });
+
+    mocks.user.findUnique.mockResolvedValue({
+      id: "user-1",
+      email: "someone@example.com",
+      name: "Someone",
+    });
+    const known = await requestPasswordReset({ email: "someone@example.com" });
+
+    expect(unknown).toEqual(known);
+    expect(unknown.success).toBe(true);
+  });
+
+  it("sends a reset email only for existing accounts", async () => {
+    await requestPasswordReset({ email: "nobody@example.com" });
+    expect(mocks.sendPasswordResetEmail).not.toHaveBeenCalled();
+
+    mocks.user.findUnique.mockResolvedValue({
+      id: "user-1",
+      email: "someone@example.com",
+      name: "Someone",
+    });
+    await requestPasswordReset({ email: "someone@example.com" });
+    expect(mocks.issueVerificationToken).toHaveBeenCalledWith("user-1", "PASSWORD_RESET");
+    expect(mocks.sendPasswordResetEmail).toHaveBeenCalledWith({
+      email: "someone@example.com",
+      name: "Someone",
+      token: "raw-token",
+    });
+  });
+
+  it("swallows throttling into the generic success response", async () => {
+    mocks.user.findUnique.mockResolvedValue({
+      id: "user-1",
+      email: "someone@example.com",
+      name: null,
+    });
+    mocks.issueVerificationToken.mockResolvedValue({ throttled: true });
+
+    const result = await requestPasswordReset({ email: "someone@example.com" });
+    expect(result.success).toBe(true);
+    expect(mocks.sendPasswordResetEmail).not.toHaveBeenCalled();
+  });
+
+  it("rejects an invalid email shape", async () => {
+    const result = await requestPasswordReset({ email: "not-an-email" });
+    expect(result).toEqual({ success: false, error: "Please enter a valid email address" });
+  });
+});
+
+describe("resetPassword", () => {
+  it("fails cleanly on an invalid or expired token", async () => {
+    const result = await resetPassword({ token: "bad-token", password: "new-password-1" });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("invalid or has expired");
+    }
+    expect(mocks.user.update).not.toHaveBeenCalled();
+  });
+
+  it("updates the password hash and marks the email verified", async () => {
+    mocks.consumeVerificationToken.mockResolvedValue({ userId: "user-1", newEmail: null });
+
+    const result = await resetPassword({ token: "good-token", password: "new-password-1" });
+    expect(result.success).toBe(true);
+
+    expect(mocks.consumeVerificationToken).toHaveBeenCalledWith("good-token", "PASSWORD_RESET");
+    expect(mocks.hash).toHaveBeenCalledWith("new-password-1", 12);
+    expect(mocks.user.update).toHaveBeenCalledWith({
+      where: { id: "user-1" },
+      data: { passwordHash: "hashed-password" },
+    });
+    expect(mocks.user.updateMany).toHaveBeenCalledWith({
+      where: { id: "user-1", emailVerified: null },
+      data: { emailVerified: expect.any(Date) },
+    });
+  });
+
+  it("enforces the password policy", async () => {
+    const result = await resetPassword({ token: "good-token", password: "short" });
+    expect(result.success).toBe(false);
+    expect(mocks.consumeVerificationToken).not.toHaveBeenCalled();
+  });
+});
+
+describe("resendVerificationEmail", () => {
+  it("is enumeration-safe for unknown addresses", async () => {
+    const result = await resendVerificationEmail({ email: "nobody@example.com" });
+    expect(result.success).toBe(true);
+    expect(mocks.sendVerificationEmail).not.toHaveBeenCalled();
+  });
+
+  it("skips already-verified accounts", async () => {
+    mocks.user.findUnique.mockResolvedValue({
+      id: "user-1",
+      email: "someone@example.com",
+      name: null,
+      emailVerified: new Date(),
+    });
+    const result = await resendVerificationEmail({ email: "someone@example.com" });
+    expect(result.success).toBe(true);
+    expect(mocks.sendVerificationEmail).not.toHaveBeenCalled();
+  });
+
+  it("sends a fresh link for unverified accounts", async () => {
+    mocks.user.findUnique.mockResolvedValue({
+      id: "user-1",
+      email: "someone@example.com",
+      name: "Someone",
+      emailVerified: null,
+    });
+    await resendVerificationEmail({ email: "someone@example.com" });
+    expect(mocks.issueVerificationToken).toHaveBeenCalledWith("user-1", "EMAIL_VERIFICATION");
+    expect(mocks.sendVerificationEmail).toHaveBeenCalledWith({
+      email: "someone@example.com",
+      name: "Someone",
+      token: "raw-token",
+    });
+  });
+});

--- a/__tests__/lib/auth/tokens.test.ts
+++ b/__tests__/lib/auth/tokens.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  verificationToken: {
+    count: vi.fn(),
+    create: vi.fn(),
+    deleteMany: vi.fn(),
+    findUnique: vi.fn(),
+    updateMany: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: { verificationToken: mocks.verificationToken },
+}));
+
+import {
+  hashToken,
+  issueVerificationToken,
+  consumeVerificationToken,
+  TOKEN_TTLS_MS,
+} from "@/lib/auth/tokens";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.verificationToken.count.mockResolvedValue(0);
+  mocks.verificationToken.create.mockResolvedValue({});
+  mocks.verificationToken.deleteMany.mockResolvedValue({ count: 0 });
+  mocks.verificationToken.updateMany.mockResolvedValue({ count: 0 });
+  mocks.verificationToken.findUnique.mockResolvedValue(null);
+});
+
+describe("hashToken", () => {
+  it("is deterministic and never equals the raw value", () => {
+    expect(hashToken("abc")).toBe(hashToken("abc"));
+    expect(hashToken("abc")).not.toBe("abc");
+    expect(hashToken("abc")).toMatch(/^[0-9a-f]{64}$/);
+  });
+});
+
+describe("issueVerificationToken", () => {
+  it("stores only the hash of the returned raw token", async () => {
+    const result = await issueVerificationToken("user-1", "EMAIL_VERIFICATION");
+    expect(result).toHaveProperty("raw");
+    const raw = (result as { raw: string }).raw;
+
+    const createArgs = mocks.verificationToken.create.mock.calls[0][0];
+    expect(createArgs.data.tokenHash).toBe(hashToken(raw));
+    expect(createArgs.data.tokenHash).not.toBe(raw);
+    expect(createArgs.data.type).toBe("EMAIL_VERIFICATION");
+    expect(createArgs.data.userId).toBe("user-1");
+  });
+
+  it("applies the per-type TTL", async () => {
+    const before = Date.now();
+    await issueVerificationToken("user-1", "PASSWORD_RESET");
+    const createArgs = mocks.verificationToken.create.mock.calls[0][0];
+    const expiresAt = createArgs.data.expiresAt as Date;
+    const delta = expiresAt.getTime() - before;
+    expect(delta).toBeGreaterThan(TOKEN_TTLS_MS.PASSWORD_RESET - 5000);
+    expect(delta).toBeLessThanOrEqual(TOKEN_TTLS_MS.PASSWORD_RESET + 5000);
+  });
+
+  it("throttles after 3 issues in an hour", async () => {
+    mocks.verificationToken.count.mockResolvedValue(3);
+    const result = await issueVerificationToken("user-1", "EMAIL_VERIFICATION");
+    expect(result).toEqual({ throttled: true });
+    expect(mocks.verificationToken.create).not.toHaveBeenCalled();
+  });
+
+  it("passes newEmail through for EMAIL_CHANGE tokens", async () => {
+    await issueVerificationToken("user-1", "EMAIL_CHANGE", { newEmail: "new@example.com" });
+    const createArgs = mocks.verificationToken.create.mock.calls[0][0];
+    expect(createArgs.data.newEmail).toBe("new@example.com");
+  });
+});
+
+describe("consumeVerificationToken", () => {
+  it("returns null when no valid token matches", async () => {
+    mocks.verificationToken.updateMany.mockResolvedValue({ count: 0 });
+    const result = await consumeVerificationToken("raw-token", "EMAIL_VERIFICATION");
+    expect(result).toBeNull();
+    expect(mocks.verificationToken.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("guards consumption on type, usedAt, and expiry in one update", async () => {
+    mocks.verificationToken.updateMany.mockResolvedValue({ count: 1 });
+    mocks.verificationToken.findUnique.mockResolvedValue({
+      userId: "user-1",
+      newEmail: null,
+    });
+
+    const result = await consumeVerificationToken("raw-token", "PASSWORD_RESET");
+    expect(result).toEqual({ userId: "user-1", newEmail: null });
+
+    const updateArgs = mocks.verificationToken.updateMany.mock.calls[0][0];
+    expect(updateArgs.where.tokenHash).toBe(hashToken("raw-token"));
+    expect(updateArgs.where.type).toBe("PASSWORD_RESET");
+    expect(updateArgs.where.usedAt).toBeNull();
+    expect(updateArgs.where.expiresAt.gt).toBeInstanceOf(Date);
+    expect(updateArgs.data.usedAt).toBeInstanceOf(Date);
+  });
+
+  it("retires unused sibling tokens of the same type after consumption", async () => {
+    mocks.verificationToken.updateMany.mockResolvedValue({ count: 1 });
+    mocks.verificationToken.findUnique.mockResolvedValue({
+      userId: "user-1",
+      newEmail: null,
+    });
+
+    await consumeVerificationToken("raw-token", "EMAIL_VERIFICATION");
+
+    expect(mocks.verificationToken.deleteMany).toHaveBeenCalledWith({
+      where: { userId: "user-1", type: "EMAIL_VERIFICATION", usedAt: null },
+    });
+  });
+});

--- a/app/(auth)/forgot-password/page.tsx
+++ b/app/(auth)/forgot-password/page.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Alert,
+  Box,
+  Button,
+  Container,
+  Link as MuiLink,
+  Paper,
+  TextField,
+  Typography,
+} from "@mui/material";
+import Link from "next/link";
+import Logo from "@/components/ui/Logo";
+import { requestPasswordReset } from "@/lib/actions/account-lifecycle";
+import { forgotPasswordSchema } from "@/lib/utils/validation";
+
+export default function ForgotPasswordPage() {
+  const [email, setEmail] = useState("");
+  const [fieldError, setFieldError] = useState("");
+  const [generalError, setGeneralError] = useState("");
+  const [successMessage, setSuccessMessage] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setFieldError("");
+    setGeneralError("");
+
+    const validation = forgotPasswordSchema.safeParse({ email });
+    if (!validation.success) {
+      setFieldError(validation.error.issues[0]?.message ?? "Invalid email address");
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      const result = await requestPasswordReset(validation.data);
+      if (result.success) {
+        setSuccessMessage(result.data.message);
+      } else {
+        setGeneralError(result.error);
+      }
+    } catch (error) {
+      console.error("Password reset request error:", error);
+      setGeneralError("An unexpected error occurred. Please try again.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <Box
+      sx={{
+        minHeight: "100vh",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        background: `
+          linear-gradient(135deg, rgba(13, 71, 161, 0.02) 0%, rgba(25, 118, 210, 0.04) 50%, rgba(248, 250, 251, 1) 100%),
+          repeating-linear-gradient(45deg, transparent, transparent 35px, rgba(13, 71, 161, 0.01) 35px, rgba(13, 71, 161, 0.01) 70px)
+        `,
+        py: 4,
+      }}
+    >
+      <Container maxWidth="sm">
+        <Paper
+          elevation={0}
+          sx={{
+            p: { xs: 3, sm: 5 },
+            borderRadius: 3,
+            boxShadow: "0 8px 32px rgba(13, 71, 161, 0.12)",
+            border: "2px solid",
+            borderColor: "rgba(13, 71, 161, 0.08)",
+            background: "linear-gradient(135deg, #FFFFFF 0%, #F8FAFB 100%)",
+          }}
+        >
+          <Box sx={{ display: "flex", flexDirection: "column", alignItems: "center" }}>
+            <Box sx={{ mb: 3 }}>
+              <Logo width={100} height={100} priority href={null} />
+            </Box>
+            <Typography
+              component="h1"
+              variant="h3"
+              sx={{ fontWeight: 800, mb: 1, color: "primary.main", letterSpacing: "-0.02em" }}
+            >
+              Forgot Password
+            </Typography>
+            <Typography variant="body1" color="text.secondary" sx={{ mb: 4, fontWeight: 500, textAlign: "center" }}>
+              Enter your email and we&apos;ll send you a link to reset your password
+            </Typography>
+
+            {successMessage && (
+              <Alert
+                severity="success"
+                sx={{ width: "100%", mb: 3, borderRadius: 2, border: "2px solid", borderColor: "success.light" }}
+              >
+                {successMessage}
+              </Alert>
+            )}
+
+            {generalError && (
+              <Alert
+                severity="error"
+                sx={{ width: "100%", mb: 3, borderRadius: 2, border: "2px solid", borderColor: "error.light" }}
+              >
+                {generalError}
+              </Alert>
+            )}
+
+            <Box component="form" onSubmit={handleSubmit} sx={{ width: "100%" }}>
+              <TextField
+                margin="normal"
+                required
+                fullWidth
+                id="email"
+                label="Email Address"
+                name="email"
+                autoComplete="email"
+                autoFocus
+                type="email"
+                value={email}
+                onChange={(e) => {
+                  setEmail(e.target.value);
+                  setFieldError("");
+                }}
+                error={!!fieldError}
+                helperText={fieldError}
+                inputProps={{ inputMode: "email" }}
+                disabled={!!successMessage}
+              />
+              <Button
+                type="submit"
+                fullWidth
+                variant="contained"
+                sx={{
+                  mt: 4,
+                  mb: 3,
+                  py: 1.75,
+                  fontSize: "1rem",
+                  fontWeight: 700,
+                  bgcolor: "primary.main",
+                  boxShadow: "0 4px 16px rgba(13, 71, 161, 0.25)",
+                  "&:hover": {
+                    boxShadow: "0 6px 24px rgba(13, 71, 161, 0.35)",
+                    transform: "translateY(-2px)",
+                  },
+                  "&:disabled": { bgcolor: "action.disabledBackground" },
+                  transition: "all 0.2s cubic-bezier(0.4, 0, 0.2, 1)",
+                }}
+                disabled={isLoading || !email || !!successMessage}
+              >
+                {isLoading ? "Sending..." : "Send Reset Link"}
+              </Button>
+              <Box sx={{ textAlign: "center" }}>
+                <Typography variant="body2" color="text.secondary">
+                  Remembered your password?{" "}
+                  <MuiLink
+                    component={Link}
+                    href="/login"
+                    underline="hover"
+                    sx={{ color: "primary.main", fontWeight: 600, "&:hover": { color: "primary.dark" } }}
+                  >
+                    Log in
+                  </MuiLink>
+                </Typography>
+              </Box>
+            </Box>
+          </Box>
+        </Paper>
+      </Container>
+    </Box>
+  );
+}

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -18,6 +18,7 @@ import Link from "next/link";
 import Logo from "@/components/ui/Logo";
 import { loginSchema, pickField } from "@/lib/utils/validation";
 import { AUTH_MESSAGES, AUTH_ERROR_CODES } from "@/lib/config/constants";
+import { resendVerificationEmail } from "@/lib/actions/account-lifecycle";
 import { trackAuth } from "@/lib/analytics/umami";
 
 function LoginForm() {
@@ -25,6 +26,8 @@ function LoginForm() {
   const searchParams = useSearchParams();
   const callbackUrl = searchParams.get("callbackUrl") || "/";
   const message = searchParams.get("message");
+  const verified = searchParams.get("verified");
+  const urlError = searchParams.get("error");
 
   const [formData, setFormData] = useState({
     email: "",
@@ -34,13 +37,46 @@ function LoginForm() {
   const [isLoading, setIsLoading] = useState(false);
   const [generalError, setGeneralError] = useState("");
   const [infoMessage, setInfoMessage] = useState("");
+  const [showResend, setShowResend] = useState(false);
+  const [isResending, setIsResending] = useState(false);
 
-  // Set info message based on query parameter
+  // Set info message based on query parameters
   useEffect(() => {
-    if (message === AUTH_MESSAGES.SIGNUP_PENDING_APPROVAL) {
-      setInfoMessage(AUTH_MESSAGES.ACCOUNT_PENDING_MESSAGE);
+    if (message === AUTH_MESSAGES.SIGNUP_CHECK_EMAIL) {
+      setInfoMessage(AUTH_MESSAGES.CHECK_EMAIL_MESSAGE);
+    } else if (message === AUTH_MESSAGES.SIGNUP_READY) {
+      setInfoMessage(AUTH_MESSAGES.SIGNUP_READY_MESSAGE);
+    } else if (message === AUTH_MESSAGES.PASSWORD_RESET_SUCCESS) {
+      setInfoMessage(AUTH_MESSAGES.PASSWORD_RESET_SUCCESS_MESSAGE);
+    } else if (verified === "1") {
+      setInfoMessage(AUTH_MESSAGES.EMAIL_VERIFIED_MESSAGE);
     }
-  }, [message]);
+    if (urlError === "verification_invalid") {
+      setGeneralError(AUTH_MESSAGES.VERIFICATION_INVALID_MESSAGE);
+      setShowResend(true);
+    }
+  }, [message, verified, urlError]);
+
+  const handleResendVerification = async () => {
+    if (!formData.email) {
+      setErrors((prev) => ({ ...prev, email: "Enter your email above first" }));
+      return;
+    }
+    setIsResending(true);
+    try {
+      const result = await resendVerificationEmail({ email: formData.email });
+      setGeneralError("");
+      setShowResend(false);
+      setInfoMessage(
+        result.success ? result.data.message : "Unable to resend right now. Please try again later."
+      );
+    } catch (error) {
+      console.error("Resend verification error:", error);
+      setInfoMessage("Unable to resend right now. Please try again later.");
+    } finally {
+      setIsResending(false);
+    }
+  };
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
@@ -114,7 +150,10 @@ function LoginForm() {
         // Auth.js v5 may pass the custom code via result.code or embed it in result.error
         const errorCode = result.code || result.error;
 
-        if (errorCode?.includes(AUTH_ERROR_CODES.ACCOUNT_NOT_APPROVED)) {
+        if (errorCode?.includes(AUTH_ERROR_CODES.EMAIL_NOT_VERIFIED)) {
+          setGeneralError(AUTH_MESSAGES.EMAIL_NOT_VERIFIED);
+          setShowResend(true);
+        } else if (errorCode?.includes(AUTH_ERROR_CODES.ACCOUNT_NOT_APPROVED)) {
           setGeneralError(AUTH_MESSAGES.ACCOUNT_NOT_APPROVED);
         } else if (errorCode?.includes(AUTH_ERROR_CODES.INVALID_CREDENTIALS)) {
           setGeneralError("Invalid email or password");
@@ -221,6 +260,19 @@ function LoginForm() {
                 }}
               >
                 {generalError}
+                {showResend && (
+                  <Box sx={{ mt: 1 }}>
+                    <Button
+                      size="small"
+                      variant="outlined"
+                      color="inherit"
+                      onClick={handleResendVerification}
+                      disabled={isResending}
+                    >
+                      {isResending ? "Sending..." : "Resend verification email"}
+                    </Button>
+                  </Box>
+                )}
               </Alert>
             )}
 
@@ -285,6 +337,22 @@ function LoginForm() {
                 {isLoading ? "Logging in..." : "Log In"}
               </Button>
               <Box sx={{ textAlign: "center" }}>
+                <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                  <MuiLink
+                    component={Link}
+                    href="/forgot-password"
+                    underline="hover"
+                    sx={{
+                      color: 'primary.main',
+                      fontWeight: 600,
+                      '&:hover': {
+                        color: 'primary.dark',
+                      },
+                    }}
+                  >
+                    Forgot your password?
+                  </MuiLink>
+                </Typography>
                 <Typography variant="body2" color="text.secondary">
                   Don&apos;t have an account?{" "}
                   <MuiLink

--- a/app/(auth)/reset-password/[token]/page.tsx
+++ b/app/(auth)/reset-password/[token]/page.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+import { useState, use } from "react";
+import { useRouter } from "next/navigation";
+import {
+  Alert,
+  Box,
+  Button,
+  Container,
+  Link as MuiLink,
+  Paper,
+  TextField,
+  Typography,
+} from "@mui/material";
+import Link from "next/link";
+import Logo from "@/components/ui/Logo";
+import { resetPassword } from "@/lib/actions/account-lifecycle";
+import { resetPasswordSchema } from "@/lib/utils/validation";
+import { AUTH_MESSAGES } from "@/lib/config/constants";
+
+export default function ResetPasswordPage({
+  params,
+}: {
+  params: Promise<{ token: string }>;
+}) {
+  const { token } = use(params);
+  const router = useRouter();
+
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [fieldErrors, setFieldErrors] = useState<{ password?: string; confirm?: string }>({});
+  const [generalError, setGeneralError] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setFieldErrors({});
+    setGeneralError("");
+
+    const validation = resetPasswordSchema.safeParse({ token, password });
+    if (!validation.success) {
+      setFieldErrors({ password: validation.error.issues[0]?.message ?? "Invalid password" });
+      return;
+    }
+    if (password !== confirmPassword) {
+      setFieldErrors({ confirm: "Passwords do not match" });
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      const result = await resetPassword(validation.data);
+      if (result.success) {
+        router.push(`/login?message=${AUTH_MESSAGES.PASSWORD_RESET_SUCCESS}`);
+        return;
+      }
+      setGeneralError(result.error);
+    } catch (error) {
+      console.error("Password reset error:", error);
+      setGeneralError("An unexpected error occurred. Please try again.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <Box
+      sx={{
+        minHeight: "100vh",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        background: `
+          linear-gradient(135deg, rgba(13, 71, 161, 0.02) 0%, rgba(25, 118, 210, 0.04) 50%, rgba(248, 250, 251, 1) 100%),
+          repeating-linear-gradient(45deg, transparent, transparent 35px, rgba(13, 71, 161, 0.01) 35px, rgba(13, 71, 161, 0.01) 70px)
+        `,
+        py: 4,
+      }}
+    >
+      <Container maxWidth="sm">
+        <Paper
+          elevation={0}
+          sx={{
+            p: { xs: 3, sm: 5 },
+            borderRadius: 3,
+            boxShadow: "0 8px 32px rgba(13, 71, 161, 0.12)",
+            border: "2px solid",
+            borderColor: "rgba(13, 71, 161, 0.08)",
+            background: "linear-gradient(135deg, #FFFFFF 0%, #F8FAFB 100%)",
+          }}
+        >
+          <Box sx={{ display: "flex", flexDirection: "column", alignItems: "center" }}>
+            <Box sx={{ mb: 3 }}>
+              <Logo width={100} height={100} priority href={null} />
+            </Box>
+            <Typography
+              component="h1"
+              variant="h3"
+              sx={{ fontWeight: 800, mb: 1, color: "primary.main", letterSpacing: "-0.02em" }}
+            >
+              Reset Password
+            </Typography>
+            <Typography variant="body1" color="text.secondary" sx={{ mb: 4, fontWeight: 500 }}>
+              Choose a new password for your account
+            </Typography>
+
+            {generalError && (
+              <Alert
+                severity="error"
+                sx={{ width: "100%", mb: 3, borderRadius: 2, border: "2px solid", borderColor: "error.light" }}
+              >
+                {generalError}{" "}
+                <MuiLink
+                  component={Link}
+                  href="/forgot-password"
+                  underline="hover"
+                  sx={{ fontWeight: 600 }}
+                >
+                  Request a new link
+                </MuiLink>
+              </Alert>
+            )}
+
+            <Box component="form" onSubmit={handleSubmit} sx={{ width: "100%" }}>
+              <TextField
+                margin="normal"
+                required
+                fullWidth
+                name="password"
+                label="New Password"
+                type="password"
+                id="password"
+                autoComplete="new-password"
+                autoFocus
+                value={password}
+                onChange={(e) => {
+                  setPassword(e.target.value);
+                  setFieldErrors((prev) => ({ ...prev, password: undefined }));
+                }}
+                error={!!fieldErrors.password}
+                helperText={fieldErrors.password ?? "At least 8 characters"}
+              />
+              <TextField
+                margin="normal"
+                required
+                fullWidth
+                name="confirmPassword"
+                label="Confirm New Password"
+                type="password"
+                id="confirmPassword"
+                autoComplete="new-password"
+                value={confirmPassword}
+                onChange={(e) => {
+                  setConfirmPassword(e.target.value);
+                  setFieldErrors((prev) => ({ ...prev, confirm: undefined }));
+                }}
+                error={!!fieldErrors.confirm}
+                helperText={fieldErrors.confirm}
+              />
+              <Button
+                type="submit"
+                fullWidth
+                variant="contained"
+                sx={{
+                  mt: 4,
+                  mb: 3,
+                  py: 1.75,
+                  fontSize: "1rem",
+                  fontWeight: 700,
+                  bgcolor: "primary.main",
+                  boxShadow: "0 4px 16px rgba(13, 71, 161, 0.25)",
+                  "&:hover": {
+                    boxShadow: "0 6px 24px rgba(13, 71, 161, 0.35)",
+                    transform: "translateY(-2px)",
+                  },
+                  "&:disabled": { bgcolor: "action.disabledBackground" },
+                  transition: "all 0.2s cubic-bezier(0.4, 0, 0.2, 1)",
+                }}
+                disabled={isLoading || !password || !confirmPassword}
+              >
+                {isLoading ? "Updating..." : "Update Password"}
+              </Button>
+              <Box sx={{ textAlign: "center" }}>
+                <Typography variant="body2" color="text.secondary">
+                  Back to{" "}
+                  <MuiLink
+                    component={Link}
+                    href="/login"
+                    underline="hover"
+                    sx={{ color: "primary.main", fontWeight: 600, "&:hover": { color: "primary.dark" } }}
+                  >
+                    Log in
+                  </MuiLink>
+                </Typography>
+              </Box>
+            </Box>
+          </Box>
+        </Paper>
+      </Container>
+    </Box>
+  );
+}

--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -129,11 +129,12 @@ function SignupForm() {
         return;
       }
 
-      // Signup successful - account pending approval
+      // Signup successful — invitation matches skip verification, everyone
+      // else gets a "check your email" prompt on the login page.
       if (result.success) {
         setGeneralError(""); // Clear any previous errors
-        // Show success message instead of trying to sign in
         setErrors({});
+        const emailVerified = result.data?.emailVerified === true;
         setFormData({ email: "", password: "", name: "", invitationToken: undefined });
 
         // Track signup event
@@ -142,8 +143,9 @@ function SignupForm() {
           teamName: teamName || undefined,
         });
 
-        // Redirect to login with a success message
-        router.push(`/login?message=${AUTH_MESSAGES.SIGNUP_PENDING_APPROVAL}`);
+        router.push(
+          `/login?message=${emailVerified ? AUTH_MESSAGES.SIGNUP_READY : AUTH_MESSAGES.SIGNUP_CHECK_EMAIL}`
+        );
         return;
       }
     } catch (error) {

--- a/app/api/auth/verify-email/[token]/route.ts
+++ b/app/api/auth/verify-email/[token]/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/db/prisma";
+import { consumeVerificationToken } from "@/lib/auth/tokens";
+
+/**
+ * Email-verification landing endpoint. The emailed link carries a raw
+ * single-use token (hashed at rest); consuming it marks the account's email
+ * verified and sends the user to the login page.
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ token: string }> }
+) {
+  try {
+    const { token } = await params;
+
+    const consumed = await consumeVerificationToken(token, "EMAIL_VERIFICATION");
+    if (!consumed) {
+      return NextResponse.redirect(
+        new URL("/login?error=verification_invalid", request.url)
+      );
+    }
+
+    // Guarded update: never regress an already-verified timestamp.
+    await prisma.user.updateMany({
+      where: { id: consumed.userId, emailVerified: null },
+      data: { emailVerified: new Date() },
+    });
+
+    return NextResponse.redirect(new URL("/login?verified=1", request.url));
+  } catch (error) {
+    console.error("Error verifying email:", error);
+    return NextResponse.redirect(
+      new URL("/login?error=verification_invalid", request.url)
+    );
+  }
+}

--- a/lib/actions/account-lifecycle.ts
+++ b/lib/actions/account-lifecycle.ts
@@ -1,0 +1,127 @@
+"use server";
+
+import { hash } from "bcryptjs";
+import { ZodError } from "zod";
+import { prisma } from "@/lib/db/prisma";
+import { consumeVerificationToken, issueVerificationToken } from "@/lib/auth/tokens";
+import { sendPasswordResetEmail, sendVerificationEmail } from "@/lib/email/templates";
+import {
+  forgotPasswordSchema,
+  resetPasswordSchema,
+  type ForgotPasswordInput,
+  type ResetPasswordInput,
+} from "@/lib/utils/validation";
+
+export type ActionResult<T = undefined> =
+  | { success: true; data: T }
+  | { success: false; error: string };
+
+/**
+ * Request a password-reset email. Deliberately unauthenticated and
+ * enumeration-safe: the response is identical whether or not the address has
+ * an account, and issuance is throttled per account in lib/auth/tokens.ts.
+ */
+export async function requestPasswordReset(
+  input: ForgotPasswordInput
+): Promise<ActionResult<{ message: string }>> {
+  const message =
+    "If an account exists for that address, we've sent a password reset link. Check your email.";
+  try {
+    const validated = forgotPasswordSchema.parse(input);
+
+    const user = await prisma.user.findUnique({
+      where: { email: validated.email },
+      select: { id: true, email: true, name: true },
+    });
+
+    if (user) {
+      const issued = await issueVerificationToken(user.id, "PASSWORD_RESET");
+      if ("raw" in issued) {
+        await sendPasswordResetEmail({ email: user.email, name: user.name, token: issued.raw });
+      }
+      // Throttled requests fall through to the same generic response.
+    }
+
+    return { success: true, data: { message } };
+  } catch (error) {
+    if (error instanceof ZodError) {
+      return { success: false, error: "Please enter a valid email address" };
+    }
+    console.error("Error requesting password reset:", error);
+    // Still enumeration-safe: transport failures return the generic message.
+    return { success: true, data: { message } };
+  }
+}
+
+/**
+ * Complete a password reset with an emailed token. Consuming the token also
+ * proves inbox ownership, so unverified accounts become verified here.
+ */
+export async function resetPassword(
+  input: ResetPasswordInput
+): Promise<ActionResult<{ message: string }>> {
+  try {
+    const validated = resetPasswordSchema.parse(input);
+
+    const consumed = await consumeVerificationToken(validated.token, "PASSWORD_RESET");
+    if (!consumed) {
+      return {
+        success: false,
+        error: "This reset link is invalid or has expired. Please request a new one.",
+      };
+    }
+
+    const passwordHash = await hash(validated.password, 12);
+    await prisma.user.update({
+      where: { id: consumed.userId },
+      data: { passwordHash },
+    });
+    await prisma.user.updateMany({
+      where: { id: consumed.userId, emailVerified: null },
+      data: { emailVerified: new Date() },
+    });
+
+    return { success: true, data: { message: "Password updated" } };
+  } catch (error) {
+    if (error instanceof ZodError) {
+      const first = error.issues[0]?.message ?? "Invalid input";
+      return { success: false, error: first };
+    }
+    console.error("Error resetting password:", error);
+    return { success: false, error: "Something went wrong. Please try again." };
+  }
+}
+
+/**
+ * Re-send the email-verification link. Enumeration-safe like
+ * requestPasswordReset; already-verified accounts are silently skipped.
+ */
+export async function resendVerificationEmail(
+  input: ForgotPasswordInput
+): Promise<ActionResult<{ message: string }>> {
+  const message =
+    "If an unverified account exists for that address, we've sent a new verification link.";
+  try {
+    const validated = forgotPasswordSchema.parse(input);
+
+    const user = await prisma.user.findUnique({
+      where: { email: validated.email },
+      select: { id: true, email: true, name: true, emailVerified: true },
+    });
+
+    if (user && !user.emailVerified) {
+      const issued = await issueVerificationToken(user.id, "EMAIL_VERIFICATION");
+      if ("raw" in issued) {
+        await sendVerificationEmail({ email: user.email, name: user.name, token: issued.raw });
+      }
+    }
+
+    return { success: true, data: { message } };
+  } catch (error) {
+    if (error instanceof ZodError) {
+      return { success: false, error: "Please enter a valid email address" };
+    }
+    console.error("Error resending verification email:", error);
+    return { success: true, data: { message } };
+  }
+}

--- a/lib/actions/auth.ts
+++ b/lib/actions/auth.ts
@@ -4,6 +4,8 @@ import { hash } from "bcryptjs";
 import type { Invitation, Prisma } from "@prisma/client";
 import { prisma } from "@/lib/db/prisma";
 import { ensureLeagueUser } from "@/lib/actions/league";
+import { issueVerificationToken } from "@/lib/auth/tokens";
+import { sendVerificationEmail } from "@/lib/email/templates";
 import { signupSchema, type SignupInput } from "@/lib/utils/validation";
 import { ZodError } from "zod";
 
@@ -28,48 +30,63 @@ export async function signup(data: SignupWithInvitationInput) {
     // Hash password with bcrypt (cost factor 12)
     const passwordHash = await hash(validated.password, 12);
 
-    // Create user with approved: false (pending approval)
+    // A valid invitation sent to this exact address already proves inbox
+    // ownership (the signup link arrived in that inbox), so those accounts
+    // start verified. Everyone else must click an emailed verification link.
+    const invitation = data.invitationToken
+      ? await prisma.invitation.findUnique({ where: { token: data.invitationToken } })
+      : null;
+    const invitationValid =
+      invitation !== null && invitation.status === "PENDING" && invitation.expiresAt > new Date();
+    const verifiedByInvitation =
+      invitationValid && invitation.email.toLowerCase() === validated.email;
+
     const user = await prisma.user.create({
       data: {
         email: validated.email,
         passwordHash,
         name: validated.name,
-        approved: false, // Require admin approval
+        emailVerified: verifiedByInvitation ? new Date() : null,
       },
       select: {
         id: true,
         email: true,
         name: true,
-        approved: true,
+        emailVerified: true,
       },
     });
 
-    // If there's an invitation token, process it
-    if (data.invitationToken) {
+    if (invitationValid && invitation) {
       try {
-        const invitation = await prisma.invitation.findUnique({
-          where: { token: data.invitationToken },
-        });
-
-        if (invitation && invitation.status === "PENDING" && invitation.expiresAt > new Date()) {
-          // Use transaction to ensure atomicity. The unified Invitation model
-          // targets exactly one of team / league / venue organization.
-          await prisma.$transaction(async (tx) => {
-            await acceptInvitationMemberships(tx, invitation, {
-              id: user.id,
-              name: user.name,
-            });
-
-            // Update invitation status to ACCEPTED
-            await tx.invitation.update({
-              where: { id: invitation.id },
-              data: { status: "ACCEPTED" },
-            });
+        // Use transaction to ensure atomicity. The unified Invitation model
+        // targets exactly one of team / league / venue organization.
+        await prisma.$transaction(async (tx) => {
+          await acceptInvitationMemberships(tx, invitation, {
+            id: user.id,
+            name: user.name,
           });
-        }
+
+          // Update invitation status to ACCEPTED
+          await tx.invitation.update({
+            where: { id: invitation.id },
+            data: { status: "ACCEPTED" },
+          });
+        });
       } catch (inviteError) {
         console.error("Error processing invitation during signup:", inviteError);
         // Don't fail signup if invitation processing fails
+      }
+    }
+
+    if (!user.emailVerified) {
+      try {
+        const issued = await issueVerificationToken(user.id, "EMAIL_VERIFICATION");
+        if ("raw" in issued) {
+          await sendVerificationEmail({ email: user.email, name: user.name, token: issued.raw });
+        }
+      } catch (emailError) {
+        // Signup still succeeds — the login page offers a resend.
+        console.error("Error sending verification email during signup:", emailError);
       }
     }
 
@@ -80,7 +97,7 @@ export async function signup(data: SignupWithInvitationInput) {
         id: user.id,
         email: user.email,
         name: user.name,
-        approved: user.approved,
+        emailVerified: user.emailVerified !== null,
       }
     };
   } catch (error) {

--- a/lib/auth/config.ts
+++ b/lib/auth/config.ts
@@ -44,9 +44,14 @@ export const authOptions: NextAuthConfig = {
           throwCredentialsError(AUTH_ERROR_CODES.INVALID_CREDENTIALS);
         }
 
-        // Check if user is approved
+        // approved is a moderation kill-switch (false = suspended)
         if (!user.approved) {
           throwCredentialsError(AUTH_ERROR_CODES.ACCOUNT_NOT_APPROVED);
+        }
+
+        // New accounts must prove inbox ownership before logging in
+        if (!user.emailVerified) {
+          throwCredentialsError(AUTH_ERROR_CODES.EMAIL_NOT_VERIFIED);
         }
 
         // Return user object (will be stored in JWT)

--- a/lib/auth/tokens.ts
+++ b/lib/auth/tokens.ts
@@ -1,0 +1,104 @@
+import { createHash, randomBytes } from "crypto";
+import type { VerificationTokenType } from "@prisma/client";
+import { prisma } from "@/lib/db/prisma";
+
+/**
+ * Single-use account-lifecycle tokens (email verification, password reset,
+ * email change). Raw tokens are 256-bit base64url strings that exist only in
+ * the emailed link; the database stores their SHA-256 hash, so a leaked table
+ * cannot be replayed into an account takeover.
+ */
+
+export const TOKEN_TTLS_MS: Record<VerificationTokenType, number> = {
+  EMAIL_VERIFICATION: 24 * 60 * 60 * 1000,
+  PASSWORD_RESET: 60 * 60 * 1000,
+  EMAIL_CHANGE: 24 * 60 * 60 * 1000,
+};
+
+/** Max token issues per (user, type) per hour — DB-backed, serverless-safe. */
+const MAX_ISSUES_PER_HOUR = 3;
+
+export function hashToken(raw: string): string {
+  return createHash("sha256").update(raw).digest("hex");
+}
+
+export type IssueTokenResult = { raw: string } | { throttled: true };
+
+/**
+ * Issue a new token of the given type for a user. Previously issued tokens
+ * stay valid until consumed or expired; issuance is throttled per user+type
+ * by counting recent rows, which also serves as the rate-limit audit trail.
+ */
+export async function issueVerificationToken(
+  userId: string,
+  type: VerificationTokenType,
+  options?: { newEmail?: string }
+): Promise<IssueTokenResult> {
+  const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000);
+  const recentCount = await prisma.verificationToken.count({
+    where: { userId, type, createdAt: { gt: oneHourAgo } },
+  });
+  if (recentCount >= MAX_ISSUES_PER_HOUR) {
+    return { throttled: true };
+  }
+
+  const raw = randomBytes(32).toString("base64url");
+  await prisma.verificationToken.create({
+    data: {
+      tokenHash: hashToken(raw),
+      type,
+      userId,
+      newEmail: options?.newEmail,
+      expiresAt: new Date(Date.now() + TOKEN_TTLS_MS[type]),
+    },
+  });
+
+  // Opportunistic cleanup of this user's long-expired tokens (keep the last
+  // hour intact — it backs the throttle above).
+  await prisma.verificationToken.deleteMany({
+    where: { userId, expiresAt: { lt: oneHourAgo }, createdAt: { lt: oneHourAgo } },
+  });
+
+  return { raw };
+}
+
+export interface ConsumedToken {
+  userId: string;
+  newEmail: string | null;
+}
+
+/**
+ * Atomically consume a raw token: valid only if it exists, matches the
+ * expected type, is unused, and is unexpired. Marking usedAt via a guarded
+ * updateMany makes concurrent consumption of the same token single-winner.
+ */
+export async function consumeVerificationToken(
+  raw: string,
+  type: VerificationTokenType
+): Promise<ConsumedToken | null> {
+  const tokenHash = hashToken(raw);
+  const now = new Date();
+
+  const updated = await prisma.verificationToken.updateMany({
+    where: { tokenHash, type, usedAt: null, expiresAt: { gt: now } },
+    data: { usedAt: now },
+  });
+  if (updated.count === 0) {
+    return null;
+  }
+
+  const token = await prisma.verificationToken.findUnique({
+    where: { tokenHash },
+    select: { userId: true, newEmail: true },
+  });
+  if (!token) {
+    return null;
+  }
+
+  // A consumed token retires its unused siblings of the same type.
+  await prisma.verificationToken.deleteMany({
+    where: { userId: token.userId, type, usedAt: null },
+  });
+
+  return { userId: token.userId, newEmail: token.newEmail };
+}

--- a/lib/config/constants.ts
+++ b/lib/config/constants.ts
@@ -35,13 +35,21 @@ export const DOCS_URL = "https://openleague.dev";
 export const AUTH_ERROR_CODES = {
   INVALID_CREDENTIALS: "invalid_credentials",
   ACCOUNT_NOT_APPROVED: "account_not_approved",
+  EMAIL_NOT_VERIFIED: "email_not_verified",
 } as const;
 
 /**
  * Authentication and authorization messages
  */
 export const AUTH_MESSAGES = {
-  SIGNUP_PENDING_APPROVAL: "signup_pending_approval",
-  ACCOUNT_PENDING_MESSAGE: "Account created successfully! Your account is pending approval. You'll be able to log in once an administrator approves your account.",
-  ACCOUNT_NOT_APPROVED: "Your account is pending approval. Please contact an administrator.",
+  SIGNUP_CHECK_EMAIL: "signup_check_email",
+  SIGNUP_READY: "signup_ready",
+  PASSWORD_RESET_SUCCESS: "password_reset_success",
+  CHECK_EMAIL_MESSAGE: "Account created! We've sent you a verification link — check your email, then log in.",
+  SIGNUP_READY_MESSAGE: "Account created! You can log in now.",
+  EMAIL_VERIFIED_MESSAGE: "Email verified — you can now log in.",
+  VERIFICATION_INVALID_MESSAGE: "That verification link is invalid or has expired. Log in to request a new one.",
+  PASSWORD_RESET_SUCCESS_MESSAGE: "Password updated! Log in with your new password.",
+  EMAIL_NOT_VERIFIED: "Please verify your email address first. Check your inbox for the verification link, or resend it below.",
+  ACCOUNT_NOT_APPROVED: "This account has been suspended. Please contact support.",
 } as const;

--- a/lib/email/templates.ts
+++ b/lib/email/templates.ts
@@ -20,6 +20,125 @@ function escapeHtml(value: string): string {
     .replace(/'/g, "&#39;");
 }
 
+interface VerificationEmailData {
+  email: string;
+  name?: string | null;
+  /** Raw verification token — linked through /api/auth/verify-email/[token]. */
+  token: string;
+}
+
+/**
+ * Send the email-address verification link a new (or email-changing) account
+ * must click before logging in. Token expires in 24 hours.
+ */
+export async function sendVerificationEmail(data: VerificationEmailData): Promise<void> {
+  const verifyLink = `${BASE_URL}/api/auth/verify-email/${data.token}`;
+  const greeting = data.name ? `Hi ${escapeHtml(data.name)},` : "Hi there,";
+
+  await sendEmail({
+    subject: "Verify your email address",
+    html: `
+      <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
+        <h2 style="color: #1976D2;">Verify your email address</h2>
+
+        <p>${greeting}</p>
+
+        <p>Thanks for signing up for openleague. Please confirm this email address to activate your account.</p>
+
+        <p style="margin: 30px 0;">
+          <a href="${verifyLink}"
+             style="background-color: #1976D2; color: white; padding: 12px 24px; text-decoration: none; border-radius: 4px; display: inline-block;">
+            Verify Email
+          </a>
+        </p>
+
+        <p style="color: #666; font-size: 14px;">
+          Or copy and paste this link into your browser:<br>
+          <a href="${verifyLink}">${verifyLink}</a>
+        </p>
+
+        <p style="color: #666; font-size: 14px; margin-top: 30px;">
+          This link expires in 24 hours. You can request a new one from the login page.
+        </p>
+
+        <hr style="border: none; border-top: 1px solid #eee; margin: 30px 0;">
+
+        <p style="color: #999; font-size: 12px;">
+          If you didn't create an openleague account, you can safely ignore this email.
+        </p>
+      </div>
+    `,
+    text: `Verify your email address
+
+Thanks for signing up for openleague. Please confirm this email address to activate your account:
+${verifyLink}
+
+This link expires in 24 hours. You can request a new one from the login page.
+
+If you didn't create an openleague account, you can safely ignore this email.`,
+    to: [{ email: data.email }],
+  });
+}
+
+interface PasswordResetEmailData {
+  email: string;
+  name?: string | null;
+  /** Raw reset token — linked through /reset-password/[token]. */
+  token: string;
+}
+
+/**
+ * Send a password-reset link. Token expires in 1 hour and is single-use.
+ */
+export async function sendPasswordResetEmail(data: PasswordResetEmailData): Promise<void> {
+  const resetLink = `${BASE_URL}/reset-password/${data.token}`;
+  const greeting = data.name ? `Hi ${escapeHtml(data.name)},` : "Hi there,";
+
+  await sendEmail({
+    subject: "Reset your openleague password",
+    html: `
+      <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
+        <h2 style="color: #1976D2;">Reset your password</h2>
+
+        <p>${greeting}</p>
+
+        <p>We received a request to reset the password for your openleague account. Click the button below to choose a new password.</p>
+
+        <p style="margin: 30px 0;">
+          <a href="${resetLink}"
+             style="background-color: #1976D2; color: white; padding: 12px 24px; text-decoration: none; border-radius: 4px; display: inline-block;">
+            Reset Password
+          </a>
+        </p>
+
+        <p style="color: #666; font-size: 14px;">
+          Or copy and paste this link into your browser:<br>
+          <a href="${resetLink}">${resetLink}</a>
+        </p>
+
+        <p style="color: #666; font-size: 14px; margin-top: 30px;">
+          This link expires in 1 hour and can be used once.
+        </p>
+
+        <hr style="border: none; border-top: 1px solid #eee; margin: 30px 0;">
+
+        <p style="color: #999; font-size: 12px;">
+          If you didn't request a password reset, you can safely ignore this email — your password will not change.
+        </p>
+      </div>
+    `,
+    text: `Reset your password
+
+We received a request to reset the password for your openleague account. Choose a new password here:
+${resetLink}
+
+This link expires in 1 hour and can be used once.
+
+If you didn't request a password reset, you can safely ignore this email - your password will not change.`,
+    to: [{ email: data.email }],
+  });
+}
+
 interface IceTimeRequestSubmittedEmailData {
   managerEmails: string[];
   venueName: string;

--- a/lib/utils/validation.ts
+++ b/lib/utils/validation.ts
@@ -235,6 +235,25 @@ export const loginSchema = z.object({
   password: z.string().min(1, "Password is required").max(128),
 });
 
+export const forgotPasswordSchema = z.object({
+  email: z
+    .string()
+    .trim()
+    .toLowerCase()
+    .email("Invalid email address")
+    .max(254, "Email must be less than 254 characters"),
+});
+export type ForgotPasswordInput = z.infer<typeof forgotPasswordSchema>;
+
+export const resetPasswordSchema = z.object({
+  token: z.string().min(1, "Reset token is required").max(256),
+  password: z
+    .string()
+    .min(8, "Password must be at least 8 characters")
+    .max(128, "Password must be less than 128 characters"),
+});
+export type ResetPasswordInput = z.infer<typeof resetPasswordSchema>;
+
 /**
  * Format a sport enum value into a user-friendly label.
  *

--- a/prisma/migrations/20260718120000_add_email_verification/migration.sql
+++ b/prisma/migrations/20260718120000_add_email_verification/migration.sql
@@ -1,0 +1,44 @@
+-- Email verification replaces manual admin approval as the signup gate.
+--
+-- "approved" becomes a pure moderation kill-switch (false = suspended) and
+-- now defaults to true; the thing that gates login for new accounts is
+-- "emailVerified", proven via single-use hashed tokens in
+-- verification_tokens (see lib/auth/tokens.ts). Existing users are
+-- grandfathered: everyone present before this migration is marked verified
+-- (previously-approved users demonstrably receive mail at their address;
+-- previously-pending users were stuck in the manual-approval dead end and
+-- are unblocked the same way).
+
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN "emailVerified" TIMESTAMP(3);
+ALTER TABLE "User" ALTER COLUMN "approved" SET DEFAULT true;
+
+-- Grandfather existing accounts: verified as of migration time, and clear
+-- the manual-approval backlog so "approved" only means "not suspended".
+UPDATE "User" SET "emailVerified" = CURRENT_TIMESTAMP;
+UPDATE "User" SET "approved" = true WHERE "approved" = false;
+
+-- CreateEnum
+CREATE TYPE "VerificationTokenType" AS ENUM ('EMAIL_VERIFICATION', 'PASSWORD_RESET', 'EMAIL_CHANGE');
+
+-- CreateTable
+CREATE TABLE "verification_tokens" (
+    "id" TEXT NOT NULL,
+    "tokenHash" TEXT NOT NULL,
+    "type" "VerificationTokenType" NOT NULL,
+    "newEmail" TEXT,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "usedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "userId" TEXT NOT NULL,
+
+    CONSTRAINT "verification_tokens_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "verification_tokens_tokenHash_key" ON "verification_tokens"("tokenHash");
+CREATE INDEX "verification_tokens_userId_type_idx" ON "verification_tokens"("userId", "type");
+CREATE INDEX "verification_tokens_expiresAt_idx" ON "verification_tokens"("expiresAt");
+
+-- AddForeignKey
+ALTER TABLE "verification_tokens" ADD CONSTRAINT "verification_tokens_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -12,15 +12,17 @@ datasource db {
 
 // User model
 model User {
-  id           String   @id @default(cuid())
-  email        String   @unique
-  passwordHash String
-  name         String?
-  approved     Boolean  @default(false) // Require admin approval for new signups
+  id            String    @id @default(cuid())
+  email         String    @unique
+  passwordHash  String
+  name          String?
+  approved      Boolean   @default(true) // Moderation kill-switch: false = suspended (signup gate is email verification)
+  emailVerified DateTime? // Set when the user proves inbox ownership (verification link, invite match, or password reset)
   isPlatformAdmin Boolean @default(false) // Platform-wide admin (user approval/enumeration). NOT self-grantable; see lib/auth/session.ts isPlatformAdmin()
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt
 
+  verificationTokens           VerificationToken[]
   teamMembers                  TeamMember[]
   rsvps                        RSVP[]
   invitations                  Invitation[]
@@ -73,6 +75,32 @@ model User {
   eventTeamAssignmentsMade     EventTeamAssignment[]    @relation("EventTeamAssigner")
   uploadedEventMedia           EventMediaItem[]         @relation("EventMediaUploader")
   removedEventMedia            EventMediaItem[]         @relation("EventMediaRemover")
+}
+
+// Single-use, hashed account-lifecycle tokens (email verification, password
+// reset, email change). Only the SHA-256 hash is stored; the raw value exists
+// solely in the emailed link. See lib/auth/tokens.ts.
+model VerificationToken {
+  id        String                @id @default(cuid())
+  tokenHash String                @unique
+  type      VerificationTokenType
+  newEmail  String? // EMAIL_CHANGE target address, applied on confirmation
+  expiresAt DateTime
+  usedAt    DateTime?
+  createdAt DateTime              @default(now())
+
+  userId String
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId, type])
+  @@index([expiresAt])
+  @@map("verification_tokens")
+}
+
+enum VerificationTokenType {
+  EMAIL_VERIFICATION
+  PASSWORD_RESET
+  EMAIL_CHANGE
 }
 
 // Audit log model for tracking administrative actions and security events

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -155,8 +155,8 @@ async function seedLeagueRoleMatrix(leagueId: string, bladesTeamId: string, hawk
   const upsertUser = (email: string, name: string, passwordHash: string) =>
     prisma.user.upsert({
       where: { email },
-      update: { approved: true }, // Ensure existing users are approved
-      create: { email, passwordHash, name, approved: true },
+      update: { approved: true, emailVerified: new Date() }, // Test accounts can always log in
+      create: { email, passwordHash, name, approved: true, emailVerified: new Date() },
     })
 
   const leagueAdmin = await upsertUser('league-admin@test.com', 'Test League Admin', adminPassword)
@@ -417,23 +417,25 @@ async function main() {
 
   const adminUser = await prisma.user.upsert({
     where: { email: 'admin@test.com' },
-    update: { approved: true }, // Ensure existing users are approved
+    update: { approved: true, emailVerified: new Date() }, // Test accounts can always log in
     create: {
       email: 'admin@test.com',
       passwordHash: adminPassword,
       name: 'Test Admin',
-      approved: true, // Pre-approve test accounts
+      approved: true,
+      emailVerified: new Date(), // Pre-verify test accounts
     },
   })
 
   const memberUser = await prisma.user.upsert({
     where: { email: 'member@test.com' },
-    update: { approved: true }, // Ensure existing users are approved
+    update: { approved: true, emailVerified: new Date() }, // Test accounts can always log in
     create: {
       email: 'member@test.com',
       passwordHash: memberPassword,
       name: 'Test Member',
-      approved: true, // Pre-approve test accounts
+      approved: true,
+      emailVerified: new Date(), // Pre-verify test accounts
     },
   })
 

--- a/scripts/smoke-test.ts
+++ b/scripts/smoke-test.ts
@@ -152,6 +152,7 @@ async function createSmokeUser(): Promise<{ email: string; password: string }> {
       name: "Smoke Test",
       passwordHash: await bcrypt.hash(password, 10),
       approved: true,
+      emailVerified: new Date(), // Login requires a verified email
     },
     select: { id: true },
   });


### PR DESCRIPTION
## Summary

Track 1 launch-readiness: kills the public-signup dead end (accounts created `approved: false` with no bootstrap approver) and replaces it with standard, self-serve email verification — plus a full password-reset flow. **Stacked on #278** (uses its `sendEmail()` seam for the new templates); merge #278 first.

## Flow changes

- **Signup**: account is created immediately (`approved` now defaults `true` and means only *not suspended*); a 24h single-use verification link is emailed. Signing up via an invitation sent to the same address counts as inbox proof and skips verification (`emailVerified` set at creation).
- **Login**: requires `emailVerified`; unverified users get a clear error with a one-click **resend** (enumeration-safe). Suspended (`approved: false`) accounts keep their gate with updated copy.
- **Password reset**: `/forgot-password` → enumeration-safe action (identical response whether the account exists) → 1h single-use emailed link → `/reset-password/[token]`. A successful reset also proves inbox ownership and verifies the email.

## Token design

New `verification_tokens` table stores **SHA-256 hashes** only — the raw 256-bit token exists solely in the emailed link, so a leaked table can't be replayed. Consumption is a guarded `updateMany` (type + unused + unexpired) making concurrent clicks single-winner; consuming retires unused siblings. Issuance is **DB-throttled** (3/hour per user+type) — serverless-safe without new infra, partially mitigating deferred Track 0 H7 for these endpoints. `EMAIL_CHANGE` token type is reserved for the account-settings PR.

## Migration (`20260718120000_add_email_verification`)

- `User.emailVerified` added; `approved` default flips to `true`
- Backfills `emailVerified = now()` for **all** existing users and clears the manual-approval backlog (previously-pending users were stuck with no approver — they're grandfathered like everyone else)

## Also

- New templates (`sendVerificationEmail`, `sendPasswordResetEmail`) written against the #278 seam
- Login page: forgot-password link, verified/check-email/reset-success banners
- Seed + smoke-test users pre-verified so CI smoke keeps passing
- `lib/actions/admin.ts` approve/reject actions are untouched and now function as suspend/restore moderation tools (their pending-approvals list will simply be empty); worth a copy pass in Track 2

## Verification

- `bun run type-check` — clean
- `bun run test` — 117 files, **1519 tests passing** (18 new: token utils + lifecycle actions)
- `bun run build` — green; new routes `/api/auth/verify-email/[token]`, `/forgot-password`, `/reset-password/[token]` all present