### PR TITLE
feat: team messaging for standalone teams (Track 2)

### DIFF
--- a/__tests__/lib/actions/communication-team.test.ts
+++ b/__tests__/lib/actions/communication-team.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  leagueMessage: { create: vi.fn(), count: vi.fn(), findMany: vi.fn() },
+  messageTargeting: { create: vi.fn() },
+  messageRecipient: { createMany: vi.fn(), updateMany: vi.fn() },
+  user: { findMany: vi.fn() },
+  teamMember: { findFirst: vi.fn() },
+  requireUserId: vi.fn(),
+  isTeamAdmin: vi.fn(),
+  sendOrBatchNotification: vi.fn(),
+}));
+
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+
+vi.mock("@/lib/auth/session", () => ({
+  requireUserId: (...a: unknown[]) => mocks.requireUserId(...a),
+  isTeamAdmin: (...a: unknown[]) => mocks.isTeamAdmin(...a),
+}));
+
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: {
+    leagueMessage: mocks.leagueMessage,
+    messageTargeting: mocks.messageTargeting,
+    messageRecipient: mocks.messageRecipient,
+    user: mocks.user,
+    teamMember: mocks.teamMember,
+  },
+}));
+
+vi.mock("@/lib/services/notification", () => ({
+  notificationService: {
+    sendOrBatchNotification: (...a: unknown[]) => mocks.sendOrBatchNotification(...a),
+  },
+}));
+
+import { sendTeamMessage, getTeamMessages } from "@/lib/actions/communication";
+
+const TEAM_ID = "cjld2cjxh0000qzrmn831i7rn";
+const OTHER_TEAM_ID = "cjld2cjxh0002qzrmn831i7rn";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.requireUserId.mockResolvedValue("user-admin-1");
+  mocks.isTeamAdmin.mockResolvedValue(true);
+  mocks.user.findMany.mockResolvedValue([
+    { id: "u1", email: "a@example.com", name: "A" },
+    { id: "u2", email: "b@example.com", name: "B" },
+  ]);
+  mocks.leagueMessage.create.mockResolvedValue({ id: "msg-1" });
+  mocks.messageTargeting.create.mockResolvedValue({});
+  mocks.messageRecipient.createMany.mockResolvedValue({ count: 2 });
+  mocks.messageRecipient.updateMany.mockResolvedValue({ count: 2 });
+  mocks.sendOrBatchNotification.mockResolvedValue(undefined);
+  mocks.teamMember.findFirst.mockResolvedValue({ id: "member-1" });
+});
+
+const validInput = {
+  teamId: TEAM_ID,
+  subject: "Practice moved",
+  content: "Practice is now at 6pm.",
+  messageType: "MESSAGE" as const,
+  priority: "NORMAL" as const,
+};
+
+describe("sendTeamMessage", () => {
+  it("lets a team admin message their own team", async () => {
+    const result = await sendTeamMessage(validInput);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.recipientCount).toBe(2);
+    }
+    // Scoped to the team, never to a league.
+    const createArg = mocks.leagueMessage.create.mock.calls[0][0];
+    expect(createArg.data.teamId).toBe(TEAM_ID);
+    expect(createArg.data.leagueId).toBeUndefined();
+    // Notification service called per recipient with no leagueId.
+    expect(mocks.sendOrBatchNotification).toHaveBeenCalledTimes(2);
+    expect(mocks.sendOrBatchNotification.mock.calls[0][5]).toBeUndefined();
+  });
+
+  it("rejects a non-admin member", async () => {
+    mocks.isTeamAdmin.mockResolvedValue(false);
+    const result = await sendTeamMessage(validInput);
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toMatch(/Only team admins/i);
+    expect(mocks.leagueMessage.create).not.toHaveBeenCalled();
+  });
+
+  it("rejects sending to a team the caller does not admin", async () => {
+    // isTeamAdmin is checked against the SUPPLIED teamId; a caller who only
+    // admins TEAM_ID cannot target OTHER_TEAM_ID.
+    mocks.isTeamAdmin.mockImplementation(async (_userId: string, teamId: string) => teamId === TEAM_ID);
+    const result = await sendTeamMessage({ ...validInput, teamId: OTHER_TEAM_ID });
+    expect(result.success).toBe(false);
+    expect(mocks.isTeamAdmin).toHaveBeenCalledWith("user-admin-1", OTHER_TEAM_ID);
+    expect(mocks.leagueMessage.create).not.toHaveBeenCalled();
+  });
+
+  it("does not send when the team has no members", async () => {
+    mocks.user.findMany.mockResolvedValue([]);
+    const result = await sendTeamMessage(validInput);
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toMatch(/no team members/i);
+    expect(mocks.leagueMessage.create).not.toHaveBeenCalled();
+  });
+});
+
+describe("getTeamMessages", () => {
+  it("rejects a non-member", async () => {
+    mocks.teamMember.findFirst.mockResolvedValue(null);
+    const result = await getTeamMessages({ teamId: TEAM_ID, page: 1, limit: 20 });
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toMatch(/don't have access/i);
+  });
+
+  it("returns a member's team messages", async () => {
+    mocks.leagueMessage.count.mockResolvedValue(1);
+    mocks.leagueMessage.findMany.mockResolvedValue([
+      {
+        id: "msg-1",
+        subject: "Hi",
+        content: "Body",
+        messageType: "MESSAGE",
+        priority: "NORMAL",
+        createdAt: new Date("2026-07-18T00:00:00Z"),
+        sender: { name: "Coach", email: "c@example.com" },
+        _count: { recipients: 3 },
+      },
+    ]);
+    const result = await getTeamMessages({ teamId: TEAM_ID, page: 1, limit: 20 });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.messages).toHaveLength(1);
+      expect(result.data.messages[0].recipientCount).toBe(3);
+    }
+  });
+});

--- a/app/(dashboard)/team/[teamId]/messages/page.tsx
+++ b/app/(dashboard)/team/[teamId]/messages/page.tsx
@@ -1,0 +1,110 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import {
+  Box,
+  Card,
+  CardContent,
+  Chip,
+  Stack,
+  Typography,
+} from "@mui/material";
+import { ArrowBack as ArrowBackIcon, Forum as ForumIcon } from "@mui/icons-material";
+import { getTeamOverviewData } from "@/lib/actions/team-context";
+import { getTeamMessages } from "@/lib/actions/communication";
+import { LinkButton } from "@/components/ui/NextLinkComposites";
+import { PageContainer } from "@/components/ui/PageContainer";
+import { EmptyState } from "@/components/ui/EmptyState";
+import TeamMessageComposer from "@/components/features/communication/TeamMessageComposer";
+
+export const metadata: Metadata = {
+  title: "Team Messages",
+};
+
+interface TeamMessagesPageProps {
+  params: Promise<{ teamId: string }>;
+}
+
+function formatSentAt(value: Date) {
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(value);
+}
+
+export default async function TeamMessagesPage({ params }: TeamMessagesPageProps) {
+  const { teamId } = await params;
+  const team = await getTeamOverviewData(teamId);
+
+  if (!team) {
+    notFound();
+  }
+
+  const messagesResult = await getTeamMessages({ teamId, page: 1, limit: 20 });
+  const messages = messagesResult.success ? messagesResult.data.messages : [];
+
+  return (
+    <PageContainer>
+      <LinkButton href={`/team/${team.id}`} startIcon={<ArrowBackIcon />} sx={{ mb: 3 }}>
+        Back to team
+      </LinkButton>
+
+      <Stack direction="row" spacing={1.5} alignItems="center" sx={{ mb: 3 }}>
+        <ForumIcon color="primary" />
+        <Typography variant="h4" component="h1" fontWeight={800}>
+          {team.name} messages
+        </Typography>
+      </Stack>
+
+      {team.isAdmin ? (
+        <Box sx={{ mb: 4 }}>
+          <TeamMessageComposer teamId={team.id} memberCount={team.stats.members} />
+        </Box>
+      ) : null}
+
+      <Typography variant="h5" component="h2" fontWeight={700} sx={{ mb: 2 }}>
+        Message history
+      </Typography>
+
+      {messages.length === 0 ? (
+        <EmptyState
+          icon={<ForumIcon />}
+          title="No messages yet"
+          description={
+            team.isAdmin
+              ? "Send your team their first announcement using the box above."
+              : "This team hasn't sent any messages yet."
+          }
+        />
+      ) : (
+        <Stack spacing={1.5}>
+          {messages.map((message) => (
+            <Card key={message.id} variant="outlined">
+              <CardContent>
+                <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap" useFlexGap sx={{ mb: 0.5 }}>
+                  <Typography variant="subtitle1" fontWeight={700}>
+                    {message.subject}
+                  </Typography>
+                  {message.priority === "URGENT" ? (
+                    <Chip size="small" color="error" label="Urgent" />
+                  ) : message.priority === "HIGH" ? (
+                    <Chip size="small" color="warning" label="High" />
+                  ) : null}
+                </Stack>
+                <Typography variant="caption" color="text.secondary">
+                  {message.sender.name ?? message.sender.email} · {formatSentAt(message.createdAt)} ·{" "}
+                  {message.recipientCount} recipient{message.recipientCount === 1 ? "" : "s"}
+                </Typography>
+                <Typography variant="body2" sx={{ mt: 1, whiteSpace: "pre-wrap" }}>
+                  {message.content}
+                </Typography>
+              </CardContent>
+            </Card>
+          ))}
+        </Stack>
+      )}
+    </PageContainer>
+  );
+}

--- a/app/(dashboard)/team/[teamId]/page.tsx
+++ b/app/(dashboard)/team/[teamId]/page.tsx
@@ -12,6 +12,7 @@ import {
   ArrowBack as ArrowBackIcon,
   CalendarToday as CalendarIcon,
   Event as EventIcon,
+  Forum as ForumIcon,
   Groups as GroupsIcon,
   People as PeopleIcon,
   SportsSoccer as SportsIcon,
@@ -128,6 +129,14 @@ export default async function TeamPage({ params }: TeamPageProps) {
                 fullWidth
               >
                 {team.isAdmin ? "Manage roster" : "View roster"}
+              </LinkButton>
+              <LinkButton
+                href={`/team/${team.id}/messages`}
+                variant="outlined"
+                startIcon={<ForumIcon />}
+                fullWidth
+              >
+                {team.isAdmin ? "Message team" : "Team messages"}
               </LinkButton>
               {team.league ? (
                 <LinkButton

--- a/components/features/communication/TeamMessageComposer.tsx
+++ b/components/features/communication/TeamMessageComposer.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { Send as SendIcon } from "@mui/icons-material";
+import { sendTeamMessage } from "@/lib/actions/communication";
+
+interface TeamMessageComposerProps {
+  teamId: string;
+  memberCount: number;
+}
+
+export default function TeamMessageComposer({ teamId, memberCount }: TeamMessageComposerProps) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [subject, setSubject] = useState("");
+  const [content, setContent] = useState("");
+  const [priority, setPriority] = useState<"LOW" | "NORMAL" | "HIGH" | "URGENT">("NORMAL");
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    setError(null);
+    setSuccess(null);
+    if (!subject.trim() || !content.trim()) {
+      setError("Subject and message are required");
+      return;
+    }
+    startTransition(async () => {
+      const result = await sendTeamMessage({
+        teamId,
+        subject: subject.trim(),
+        content: content.trim(),
+        messageType: "MESSAGE",
+        priority,
+      });
+      if (result.success) {
+        setSuccess(`Message sent to ${result.data.recipientCount} team member${result.data.recipientCount === 1 ? "" : "s"}.`);
+        setSubject("");
+        setContent("");
+        setPriority("NORMAL");
+        router.refresh();
+      } else {
+        setError(result.error);
+      }
+    });
+  };
+
+  return (
+    <Card variant="outlined">
+      <CardContent>
+        <Typography variant="h6" fontWeight={700} gutterBottom>
+          Message your team
+        </Typography>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+          Send an announcement to all {memberCount} member{memberCount === 1 ? "" : "s"} of this team.
+          Members who have turned off message emails won&apos;t be emailed.
+        </Typography>
+
+        {error && <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>{error}</Alert>}
+        {success && <Alert severity="success" sx={{ mb: 2 }} onClose={() => setSuccess(null)}>{success}</Alert>}
+
+        <Box component="form" onSubmit={handleSubmit}>
+          <Stack spacing={2}>
+            <FormControl fullWidth>
+              <InputLabel id="team-msg-priority">Priority</InputLabel>
+              <Select
+                labelId="team-msg-priority"
+                label="Priority"
+                value={priority}
+                onChange={(e) => setPriority(e.target.value as typeof priority)}
+              >
+                <MenuItem value="LOW">Low</MenuItem>
+                <MenuItem value="NORMAL">Normal</MenuItem>
+                <MenuItem value="HIGH">High</MenuItem>
+                <MenuItem value="URGENT">Urgent</MenuItem>
+              </Select>
+            </FormControl>
+            <TextField
+              label="Subject"
+              value={subject}
+              onChange={(e) => setSubject(e.target.value)}
+              fullWidth
+              required
+              slotProps={{ htmlInput: { maxLength: 200 } }}
+              helperText={`${subject.length}/200`}
+            />
+            <TextField
+              label="Message"
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+              fullWidth
+              required
+              multiline
+              rows={6}
+              slotProps={{ htmlInput: { maxLength: 5000 } }}
+              helperText={`${content.length}/5000`}
+            />
+            <Box>
+              <Button
+                type="submit"
+                variant="contained"
+                startIcon={<SendIcon />}
+                disabled={isPending || memberCount === 0 || !subject.trim() || !content.trim()}
+              >
+                {isPending ? "Sending..." : "Send to team"}
+              </Button>
+            </Box>
+          </Stack>
+        </Box>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/features/dashboard/widgets/RecentMessagesWidget.tsx
+++ b/components/features/dashboard/widgets/RecentMessagesWidget.tsx
@@ -38,7 +38,11 @@ export default async function RecentMessagesWidget({ userId }: { userId: string 
                     useFlexGap
                   >
                     <LinkMuiLink
-                      href={`/league/${message.leagueId}/messages`}
+                      href={
+                        message.scope.kind === "league"
+                          ? `/league/${message.scope.id}/messages`
+                          : `/team/${message.scope.id}/messages`
+                      }
                       variant="subtitle2"
                       color="inherit"
                       underline="hover"
@@ -46,7 +50,7 @@ export default async function RecentMessagesWidget({ userId }: { userId: string 
                     >
                       {message.subject}
                     </LinkMuiLink>
-                    <Chip size="small" label={message.leagueName} />
+                    <Chip size="small" label={message.scope.name} />
                   </Stack>
                   <Stack
                     direction="row"

--- a/lib/actions/communication.ts
+++ b/lib/actions/communication.ts
@@ -2,9 +2,18 @@
 
 import { z } from "zod";
 import { prisma } from "@/lib/db/prisma";
-import { requireUserId } from "@/lib/auth/session";
+import { requireUserId, isTeamAdmin } from "@/lib/auth/session";
 import { revalidatePath } from "next/cache";
-import { sendLeagueMessageSchema, getLeagueMessagesSchema, type SendLeagueMessageInput, type GetLeagueMessagesInput } from "@/lib/utils/validation";
+import {
+  sendLeagueMessageSchema,
+  getLeagueMessagesSchema,
+  sendTeamMessageSchema,
+  getTeamMessagesSchema,
+  type SendLeagueMessageInput,
+  type GetLeagueMessagesInput,
+  type SendTeamMessageInput,
+  type GetTeamMessagesInput,
+} from "@/lib/utils/validation";
 import { notificationService } from "@/lib/services/notification";
 
 export type ActionResult<T> =
@@ -193,6 +202,193 @@ export async function sendLeagueMessage(
       success: false,
       error: "Failed to send message. Please try again.",
     };
+  }
+}
+
+/**
+ * Send a message to every member of a standalone (non-league) team. Reuses the
+ * LeagueMessage pipeline with leagueId=null and a team scope, so team messages
+ * get the same history, recent-messages widget, and notification-preference
+ * handling as league messages.
+ */
+export async function sendTeamMessage(
+  input: SendTeamMessageInput
+): Promise<ActionResult<{ messageId: string; recipientCount: number }>> {
+  try {
+    const validated = sendTeamMessageSchema.parse(input);
+    const userId = await requireUserId();
+
+    // Only a team ADMIN may message their own team.
+    if (!(await isTeamAdmin(userId, validated.teamId))) {
+      return {
+        success: false,
+        error: "Unauthorized: Only team admins can send messages to their team",
+      };
+    }
+
+    // Recipients: every member of this team (users with accounts).
+    const recipients = await prisma.user.findMany({
+      where: { teamMembers: { some: { teamId: validated.teamId } } },
+      select: { id: true, email: true, name: true },
+      distinct: ["id"],
+    });
+
+    if (recipients.length === 0) {
+      return {
+        success: false,
+        error: "No team members to message yet",
+      };
+    }
+
+    const message = await prisma.leagueMessage.create({
+      data: {
+        subject: validated.subject,
+        content: validated.content,
+        messageType: validated.messageType,
+        priority: validated.priority,
+        teamId: validated.teamId,
+        senderId: userId,
+      },
+    });
+
+    await prisma.messageTargeting.create({
+      data: {
+        messageId: message.id,
+        entireLeague: false,
+        teamId: validated.teamId,
+      },
+    });
+
+    await prisma.messageRecipient.createMany({
+      data: recipients.map((recipient) => ({
+        messageId: message.id,
+        userId: recipient.id,
+        deliveryStatus: "PENDING",
+      })),
+    });
+
+    // Deliver per-recipient so notification preferences are respected. A
+    // team message has no league, so leagueId is omitted (the notification
+    // service resolves the user's league-less preference row).
+    const notificationType =
+      validated.messageType === "ANNOUNCEMENT" ? "leagueAnnouncements" : "leagueMessages";
+    try {
+      for (const recipient of recipients) {
+        try {
+          await notificationService.sendOrBatchNotification(
+            recipient.id,
+            validated.subject,
+            validated.content,
+            validated.priority,
+            notificationType,
+            undefined,
+            message.id
+          );
+        } catch (error) {
+          console.error(`Failed to send team notification to user ${recipient.id}:`, error);
+          await prisma.messageRecipient.updateMany({
+            where: { messageId: message.id, userId: recipient.id },
+            data: { deliveryStatus: "FAILED" },
+          });
+        }
+      }
+
+      await prisma.messageRecipient.updateMany({
+        where: { messageId: message.id, deliveryStatus: "PENDING" },
+        data: { deliveryStatus: "SENT" },
+      });
+    } catch (error) {
+      console.error("Failed to send team message notifications:", error);
+      await prisma.messageRecipient.updateMany({
+        where: { messageId: message.id },
+        data: { deliveryStatus: "FAILED" },
+      });
+    }
+
+    revalidatePath(`/team/${validated.teamId}/messages`);
+
+    return {
+      success: true,
+      data: { messageId: message.id, recipientCount: recipients.length },
+    };
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return { success: false, error: "Invalid input", details: error.issues };
+    }
+    console.error("Error sending team message:", error);
+    return { success: false, error: "Failed to send message. Please try again." };
+  }
+}
+
+/**
+ * List a standalone team's messages (any team member may read their team's
+ * message history).
+ */
+export async function getTeamMessages(input: GetTeamMessagesInput): Promise<
+  ActionResult<{
+    messages: Array<{
+      id: string;
+      subject: string;
+      content: string;
+      messageType: string;
+      priority: string;
+      createdAt: Date;
+      sender: { name: string | null; email: string };
+      recipientCount: number;
+    }>;
+    pagination: { page: number; limit: number; total: number; totalPages: number };
+  }>
+> {
+  try {
+    const validated = getTeamMessagesSchema.parse(input);
+    const userId = await requireUserId();
+
+    const membership = await prisma.teamMember.findFirst({
+      where: { userId, teamId: validated.teamId },
+      select: { id: true },
+    });
+    if (!membership) {
+      return { success: false, error: "Unauthorized: You don't have access to this team" };
+    }
+
+    const whereClause = { teamId: validated.teamId };
+    const total = await prisma.leagueMessage.count({ where: whereClause });
+    const totalPages = Math.ceil(total / validated.limit);
+    const skip = (validated.page - 1) * validated.limit;
+
+    const messages = await prisma.leagueMessage.findMany({
+      where: whereClause,
+      include: {
+        sender: { select: { name: true, email: true } },
+        _count: { select: { recipients: true } },
+      },
+      orderBy: { createdAt: "desc" },
+      skip,
+      take: validated.limit,
+    });
+
+    return {
+      success: true,
+      data: {
+        messages: messages.map((message) => ({
+          id: message.id,
+          subject: message.subject,
+          content: message.content,
+          messageType: message.messageType,
+          priority: message.priority,
+          createdAt: message.createdAt,
+          sender: { name: message.sender.name, email: message.sender.email },
+          recipientCount: message._count.recipients,
+        })),
+        pagination: { page: validated.page, limit: validated.limit, total, totalPages },
+      },
+    };
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return { success: false, error: "Invalid input", details: error.issues };
+    }
+    console.error("Error getting team messages:", error);
+    return { success: false, error: "Failed to get messages. Please try again." };
   }
 }
 

--- a/lib/data/dashboard.ts
+++ b/lib/data/dashboard.ts
@@ -344,8 +344,8 @@ export type RecentMessageItem = {
   subject: string;
   snippet: string;
   sentAt: string; // ISO string
-  leagueId: string;
-  leagueName: string;
+  // A message is scoped to exactly one of a league or a standalone team.
+  scope: { kind: "league"; id: string; name: string } | { kind: "team"; id: string; name: string };
   senderName: string;
 };
 
@@ -378,21 +378,32 @@ export async function getRecentMessages(
           subject: true,
           content: true,
           league: { select: { id: true, name: true } },
+          team: { select: { id: true, name: true } },
           sender: { select: { name: true, email: true } },
         },
       },
     },
   });
 
-  return recipients.map(({ sentAt, message }) => ({
-    id: message.id,
-    subject: message.subject,
-    snippet: toSnippet(message.content),
-    sentAt: sentAt.toISOString(),
-    leagueId: message.league.id,
-    leagueName: message.league.name,
-    senderName: message.sender.name ?? message.sender.email,
-  }));
+  return recipients.flatMap(({ sentAt, message }) => {
+    // Exactly one of league/team is set (DB CHECK). Skip defensively if neither.
+    const scope: RecentMessageItem["scope"] | null = message.league
+      ? { kind: "league", id: message.league.id, name: message.league.name }
+      : message.team
+        ? { kind: "team", id: message.team.id, name: message.team.name }
+        : null;
+    if (!scope) return [];
+    return [
+      {
+        id: message.id,
+        subject: message.subject,
+        snippet: toSnippet(message.content),
+        sentAt: sentAt.toISOString(),
+        scope,
+        senderName: message.sender.name ?? message.sender.email,
+      },
+    ];
+  });
 }
 
 export type AdminAttentionData = {

--- a/lib/utils/validation.ts
+++ b/lib/utils/validation.ts
@@ -732,6 +732,24 @@ export const getLeagueMessagesSchema = z.object({
   priority: z.enum(["LOW", "NORMAL", "HIGH", "URGENT"]).optional(),
 });
 
+// Standalone-team messaging: a team admin announces to their own members.
+// No targeting picker — the whole team is the audience.
+export const sendTeamMessageSchema = z.object({
+  teamId: z.string().cuid("Invalid team ID format"),
+  subject: sanitizedStringWithMin(1, 200),
+  content: sanitizedStringWithMin(1, 5000),
+  messageType: z.enum(["MESSAGE", "ANNOUNCEMENT"]).default("MESSAGE"),
+  priority: z.enum(["LOW", "NORMAL", "HIGH", "URGENT"]).default("NORMAL"),
+});
+export type SendTeamMessageInput = z.infer<typeof sendTeamMessageSchema>;
+
+export const getTeamMessagesSchema = z.object({
+  teamId: z.string().cuid("Invalid team ID format"),
+  page: z.number().int().min(1).default(1),
+  limit: z.number().int().min(1).max(50).default(20),
+});
+export type GetTeamMessagesInput = z.infer<typeof getTeamMessagesSchema>;
+
 // Type exports
 export type SignupInput = z.infer<typeof signupSchema>;
 export type LoginInput = z.infer<typeof loginSchema>;

--- a/prisma/migrations/20260718140000_team_scoped_messages/migration.sql
+++ b/prisma/migrations/20260718140000_team_scoped_messages/migration.sql
@@ -1,0 +1,19 @@
+-- Team-scoped messages: let a standalone (non-league) team admin message
+-- their own members. A LeagueMessage is now scoped to EITHER a league OR a
+-- team (exactly one), reusing the existing targeting / recipient / notification
+-- pipeline. Existing league messages keep leagueId set and are unaffected.
+
+-- Relax leagueId so a message can instead be team-scoped.
+ALTER TABLE "league_messages" ALTER COLUMN "leagueId" DROP NOT NULL;
+
+-- Team scope.
+ALTER TABLE "league_messages" ADD COLUMN "teamId" TEXT;
+
+-- CreateIndex
+CREATE INDEX "league_messages_teamId_createdAt_idx" ON "league_messages"("teamId", "createdAt");
+
+-- AddForeignKey
+ALTER TABLE "league_messages" ADD CONSTRAINT "league_messages_teamId_fkey" FOREIGN KEY ("teamId") REFERENCES "Team"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- Enforce exactly-one scope (league xor team) at the database level.
+ALTER TABLE "league_messages" ADD CONSTRAINT "league_messages_exactly_one_scope" CHECK (num_nonnulls("leagueId", "teamId") = 1);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -169,6 +169,7 @@ model Team {
   transfersFrom      PlayerTransfer[]         @relation("TransferFromTeam")
   transfersTo        PlayerTransfer[]         @relation("TransferToTeam")
   messageTargeting   MessageTargeting[]
+  messages           LeagueMessage[]
   auditLogs          AuditLog[]
   practiceSessions   PracticeSession[]
   plays              Play[]
@@ -589,8 +590,14 @@ model LeagueMessage {
   priority    MessagePriority   @default(NORMAL)
   createdAt   DateTime          @default(now())
 
-  leagueId String
-  league   League @relation(fields: [leagueId], references: [id], onDelete: Cascade)
+  // A message is scoped to EITHER a league OR a standalone team (exactly one;
+  // enforced by a DB CHECK constraint). Standalone teams have no league, so
+  // team-scoped messages let a team admin announce to their own members.
+  leagueId String?
+  league   League? @relation(fields: [leagueId], references: [id], onDelete: Cascade)
+
+  teamId String?
+  team   Team?   @relation(fields: [teamId], references: [id], onDelete: Cascade)
 
   senderId String
   sender   User   @relation(fields: [senderId], references: [id])
@@ -601,6 +608,7 @@ model LeagueMessage {
   batchedMessages BatchedMessage[]
 
   @@index([leagueId, createdAt])
+  @@index([teamId, createdAt])
   @@map("league_messages")
 }
 


### PR DESCRIPTION
## Summary

Track 2 core-flow gap: `sendLeagueMessage` hard-requires a league, so a **standalone (non-league) team admin — the default OpenLeague user — could not send a single announcement to their own team**. This adds team messaging by minimally generalizing the existing message model.

## Design: Option A (generalize the model), not a bolted-on side channel

The notification service already treats `leagueId` as optional throughout, so the cleanest correct change is to let a message be scoped to **either a league or a team**:
- `LeagueMessage.leagueId` is now nullable; new optional `teamId`; a DB CHECK (`num_nonnulls(leagueId, teamId) = 1`) enforces exactly-one scope.
- Team messages reuse the **entire existing pipeline** — targeting, `MessageRecipient`, the notification service, delivery batching, and notification-preference handling — so they get the same history + recent-messages widget as league messages, with no duplicated delivery logic.
- Authorization is a separate `sendTeamMessage` action gated on `requireTeamAdmin` (cleaner than overloading the league action's `requireLeagueRole`).

Existing league messages keep `leagueId` set and are unaffected.

## Changes
- **Actions** (`lib/actions/communication.ts`): `sendTeamMessage` (team admin → all team members; per-recipient notification with no league so the user's league-less preference row applies) and `getTeamMessages` (any team member reads history).
- **Schemas** (`lib/utils/validation.ts`): `sendTeamMessageSchema`, `getTeamMessagesSchema`.
- **Reachable UI**: `/team/[teamId]/messages` — composer for admins, history for all members — linked from a **"Message team"** button on the team page (addresses the audit's recurring "built but unreachable" pattern).
- **Widget fix**: `getRecentMessages` + `RecentMessagesWidget` now handle team-scoped messages (link to `/team/[id]/messages`) instead of assuming every message has a league — this would otherwise have crashed the dashboard once team messages exist.
- **Migration**: `20260718140000_team_scoped_messages` (nullable leagueId, teamId column + FK + index + CHECK).

## Security
Auth-first, `requireTeamAdmin` to send / membership to read, Prisma only, message content is user-supplied and escaped by the existing email template layer. No cross-team or cross-tenant sends (authz is against the supplied teamId). Rate-limiting is out of scope (deferred H7).

## Verification
- `bun run type-check` — clean
- `bun run test` — 123 files, **1573 tests** (6 new: admin sends, non-admin rejected, cross-team rejected, empty-team no-op, history membership-gated)
- `bun run build` — green; new route `/team/[teamId]/messages` present

Do not merge without the parent's merge-down coordination (Track 2 has sibling PRs).