### PR TITLE
feat: guardian-aware event access and calendar visibility (Track 2)

### DIFF
--- a/__tests__/lib/actions/events.test.ts
+++ b/__tests__/lib/actions/events.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const {
+  mockPrismaEvent,
+  mockPrismaTeamMember,
+  mockPrismaLeagueUser,
+  mockRequireUserId,
+  mockGetViewableTeamIds,
+} = vi.hoisted(() => ({
+  mockPrismaEvent: {
+    findUnique: vi.fn(),
+  },
+  mockPrismaTeamMember: {
+    findUnique: vi.fn(),
+  },
+  mockPrismaLeagueUser: {
+    findFirst: vi.fn(),
+  },
+  mockRequireUserId: vi.fn(),
+  mockGetViewableTeamIds: vi.fn(),
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/session", () => ({
+  requireUserId: (...args: unknown[]) => mockRequireUserId(...args),
+  requireTeamAdmin: vi.fn(),
+  requireTeamMember: vi.fn(),
+  getViewableTeamIds: (...args: unknown[]) => mockGetViewableTeamIds(...args),
+}));
+
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: {
+    event: mockPrismaEvent,
+    teamMember: mockPrismaTeamMember,
+    leagueUser: mockPrismaLeagueUser,
+  },
+}));
+
+// Side-effecting / heavy modules pulled in by events.ts at import time.
+vi.mock("@/lib/email/templates", () => ({
+  sendEventNotifications: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("@/lib/actions/venues", () => ({
+  canUserAccessVenue: vi.fn(),
+}));
+vi.mock("@/lib/utils/availability", () => ({
+  findBookingConflicts: vi.fn(),
+}));
+
+import { getEvent } from "@/lib/actions/events";
+
+const GUARDIAN_USER_ID = "user-guardian";
+const MEMBER_USER_ID = "user-member";
+const TEAM_ID = "cteam00000000000000000001";
+const OTHER_TEAM_ID = "cteam00000000000000000002";
+const EVENT_ID = "cevent0000000000000000001";
+
+/** A standalone (non-league) team event with no RSVP rows. */
+function buildEvent(teamId: string) {
+  return {
+    id: EVENT_ID,
+    type: "GAME",
+    title: "vs Wolves",
+    startAt: new Date("2026-08-01T18:00:00Z"),
+    teamId,
+    leagueId: null,
+    team: { id: teamId, name: "Ice Hawks", leagueId: null },
+    rsvps: [],
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("getEvent — guardian-aware view access", () => {
+  it("lets a guardian-only user view their child's team event at MEMBER level", async () => {
+    mockRequireUserId.mockResolvedValue(GUARDIAN_USER_ID);
+    mockPrismaEvent.findUnique.mockResolvedValue(buildEvent(TEAM_ID));
+    // Guardian is not a direct member of the team.
+    mockPrismaTeamMember.findUnique.mockResolvedValue(null);
+    // Guardianship makes the child's team viewable.
+    mockGetViewableTeamIds.mockResolvedValue([TEAM_ID]);
+
+    const result = await getEvent(EVENT_ID);
+
+    expect(result).not.toBeNull();
+    expect(result?.userRole).toBe("MEMBER");
+    // VIEW only — guardians never get self-RSVP or management controls here.
+    expect(result?.canRSVP).toBe(false);
+    expect(result?.canManageEvent).toBe(false);
+    expect(mockGetViewableTeamIds).toHaveBeenCalledWith(GUARDIAN_USER_ID);
+  });
+
+  it("blocks a guardian from viewing an unrelated team's event (404)", async () => {
+    mockRequireUserId.mockResolvedValue(GUARDIAN_USER_ID);
+    mockPrismaEvent.findUnique.mockResolvedValue(buildEvent(OTHER_TEAM_ID));
+    mockPrismaTeamMember.findUnique.mockResolvedValue(null);
+    // The guardian only guards a child on TEAM_ID, never OTHER_TEAM_ID.
+    mockGetViewableTeamIds.mockResolvedValue([TEAM_ID]);
+
+    const result = await getEvent(EVENT_ID);
+
+    expect(result).toBeNull();
+  });
+
+  it("does not consult guardian access for a direct team member", async () => {
+    mockRequireUserId.mockResolvedValue(MEMBER_USER_ID);
+    mockPrismaEvent.findUnique.mockResolvedValue(buildEvent(TEAM_ID));
+    mockPrismaTeamMember.findUnique.mockResolvedValue({ role: "MEMBER" });
+
+    const result = await getEvent(EVENT_ID);
+
+    expect(result).not.toBeNull();
+    expect(result?.userRole).toBe("MEMBER");
+    expect(result?.canRSVP).toBe(true);
+    expect(result?.canManageEvent).toBe(false);
+    // Membership already grants access — the guardian fallback must be skipped.
+    expect(mockGetViewableTeamIds).not.toHaveBeenCalled();
+  });
+
+  it("returns null for a non-member, non-guardian, non-league-admin viewer", async () => {
+    mockRequireUserId.mockResolvedValue("user-stranger");
+    mockPrismaEvent.findUnique.mockResolvedValue(buildEvent(TEAM_ID));
+    mockPrismaTeamMember.findUnique.mockResolvedValue(null);
+    mockGetViewableTeamIds.mockResolvedValue([]);
+
+    const result = await getEvent(EVENT_ID);
+
+    expect(result).toBeNull();
+  });
+});

--- a/__tests__/lib/auth/session.test.ts
+++ b/__tests__/lib/auth/session.test.ts
@@ -9,6 +9,12 @@ const { mockAuth, mockPrisma, mockRedirect } = vi.hoisted(() => ({
     user: {
       findUnique: vi.fn(),
     },
+    teamMember: {
+      findMany: vi.fn(),
+    },
+    playerGuardian: {
+      findMany: vi.fn(),
+    },
   },
   mockRedirect: vi.fn((path: string) => {
     throw new Error(`NEXT_REDIRECT:${path}`);
@@ -27,7 +33,13 @@ vi.mock("next/navigation", () => ({
   redirect: (path: string) => mockRedirect(path),
 }));
 
-import { getCurrentUserId, isPlatformAdmin, requireSystemAdmin, requireUserId } from "@/lib/auth/session";
+import {
+  getCurrentUserId,
+  getViewableTeamIds,
+  isPlatformAdmin,
+  requireSystemAdmin,
+  requireUserId,
+} from "@/lib/auth/session";
 
 describe("auth session helpers", () => {
   beforeEach(() => {
@@ -113,5 +125,54 @@ describe("auth session helpers", () => {
     await expect(isPlatformAdmin("user-1")).resolves.toBe(true);
 
     process.env.PLATFORM_ADMIN_EMAILS = original;
+  });
+});
+
+describe("getViewableTeamIds", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("unions direct memberships with guardian-linked teams and excludes unrelated teams", async () => {
+    mockPrisma.teamMember.findMany.mockResolvedValue([{ teamId: "team-member" }]);
+    mockPrisma.playerGuardian.findMany.mockResolvedValue([
+      { player: { teamId: "team-guardian" } },
+    ]);
+
+    const teamIds = await getViewableTeamIds("user-1");
+
+    expect(teamIds).toContain("team-member");
+    expect(teamIds).toContain("team-guardian");
+    // Nothing the user has no membership or guardian link to leaks in.
+    expect(teamIds).not.toContain("team-unrelated");
+    expect(teamIds).toHaveLength(2);
+
+    // Both links are scoped to active teams.
+    expect(mockPrisma.teamMember.findMany).toHaveBeenCalledWith({
+      where: { userId: "user-1", team: { isActive: true } },
+      select: { teamId: true },
+    });
+    expect(mockPrisma.playerGuardian.findMany).toHaveBeenCalledWith({
+      where: { userId: "user-1", player: { team: { isActive: true } } },
+      select: { player: { select: { teamId: true } } },
+    });
+  });
+
+  it("returns guardian-linked teams even when the user is not a direct member", async () => {
+    mockPrisma.teamMember.findMany.mockResolvedValue([]);
+    mockPrisma.playerGuardian.findMany.mockResolvedValue([
+      { player: { teamId: "team-guardian" } },
+    ]);
+
+    await expect(getViewableTeamIds("guardian-only")).resolves.toEqual(["team-guardian"]);
+  });
+
+  it("dedupes a team reachable via both membership and guardianship", async () => {
+    mockPrisma.teamMember.findMany.mockResolvedValue([{ teamId: "team-shared" }]);
+    mockPrisma.playerGuardian.findMany.mockResolvedValue([
+      { player: { teamId: "team-shared" } },
+    ]);
+
+    await expect(getViewableTeamIds("user-1")).resolves.toEqual(["team-shared"]);
   });
 });

--- a/lib/actions/events.ts
+++ b/lib/actions/events.ts
@@ -2,7 +2,7 @@
 
 import { z } from "zod";
 import { prisma } from "@/lib/db/prisma";
-import { requireTeamAdmin, requireTeamMember, requireUserId } from "@/lib/auth/session";
+import { getViewableTeamIds, requireTeamAdmin, requireTeamMember, requireUserId } from "@/lib/auth/session";
 import { revalidatePath } from "next/cache";
 import { sendEventNotifications } from "@/lib/email/templates";
 import { canUserAccessVenue as checkVenueAccess } from "@/lib/actions/venues";
@@ -502,15 +502,26 @@ export async function getEvent(eventId: string) {
         })
       : null;
 
+    // Guardian-only viewers (a parent linked to a rostered Player via
+    // PlayerGuardian, but NOT a TeamMember) may VIEW their child's team events
+    // at MEMBER-level detail. Since the direct-member lookup above already
+    // failed, inclusion in the viewable set can only come from a guardian link.
+    // They never get self-RSVP or management controls here — per-child RSVP
+    // stays on its own guarded flow.
+    const isGuardianViewer =
+      !teamMember && !leagueAdmin
+        ? (await getViewableTeamIds(userId)).includes(event.teamId)
+        : false;
+
     // Direct team members can RSVP; league admins can inspect league events
     // without receiving broken RSVP/edit/delete controls for teams they do not belong to.
-    if (!teamMember && !leagueAdmin) {
+    if (!teamMember && !leagueAdmin && !isGuardianViewer) {
       return null;
     }
 
     return {
       ...event,
-      userRole: teamMember?.role ?? "LEAGUE_ADMIN",
+      userRole: teamMember?.role ?? (leagueAdmin ? "LEAGUE_ADMIN" : "MEMBER"),
       canRSVP: !!teamMember,
       canManageEvent: teamMember?.role === "ADMIN",
     };

--- a/lib/auth/session.ts
+++ b/lib/auth/session.ts
@@ -162,6 +162,36 @@ export async function requireTeamMember(teamId: string): Promise<string> {
 }
 
 /**
+ * The set of team IDs a user may VIEW, unioned from two links:
+ *  - TeamMember rows (the user belongs to the team directly), and
+ *  - PlayerGuardian rows (the user guards a Player rostered on the team).
+ *
+ * A guardian of a Player on team T may view team T's events and calendar at
+ * MEMBER-level detail even without a TeamMember row. This is strictly additive
+ * to direct membership and never widens beyond the guarded child's own team(s).
+ *
+ * Both links are scoped to active teams, mirroring getViewerMemberships and
+ * getNeedsRsvp: view access is only granted while the team is active.
+ */
+export async function getViewableTeamIds(userId: string): Promise<string[]> {
+  const [memberships, guardianships] = await Promise.all([
+    prisma.teamMember.findMany({
+      where: { userId, team: { isActive: true } },
+      select: { teamId: true },
+    }),
+    prisma.playerGuardian.findMany({
+      where: { userId, player: { team: { isActive: true } } },
+      select: { player: { select: { teamId: true } } },
+    }),
+  ]);
+
+  const teamIds = new Set<string>();
+  for (const membership of memberships) teamIds.add(membership.teamId);
+  for (const guardianship of guardianships) teamIds.add(guardianship.player.teamId);
+  return [...teamIds];
+}
+
+/**
  * Get user's role in a specific team
  * Returns null if user is not a member of the team
  */

--- a/lib/data/calendar.ts
+++ b/lib/data/calendar.ts
@@ -7,7 +7,7 @@
 import { differenceInCalendarDays, addDays } from "date-fns";
 import type { Prisma } from "@prisma/client";
 import { prisma } from "@/lib/db/prisma";
-import { requireUserId } from "@/lib/auth/session";
+import { getViewableTeamIds, requireUserId } from "@/lib/auth/session";
 import { getViewerMemberships } from "@/lib/data/dashboard";
 import { expandRecurrenceWindow } from "@/lib/utils/venue-schedule";
 import type { CalendarItem } from "@/types/events";
@@ -39,16 +39,23 @@ export async function getUserCalendarItems(window: CalendarWindow): Promise<Cale
   const { from, to } = normalizeWindow(window);
 
   const { teams, leagues } = await getViewerMemberships(userId);
-  const teamIds = teams.map((membership) => membership.team.id);
+  const memberTeamIds = teams.map((membership) => membership.team.id);
   const adminTeamIds = new Set(
     teams.filter((membership) => membership.role === "ADMIN").map((membership) => membership.team.id)
   );
   const leagueIds = leagues.map((membership) => membership.league.id);
 
+  // Events also surface teams the viewer can see via guardianship (a parent of
+  // a rostered player who is not a TeamMember), so a guardian-only parent sees
+  // their child's team schedule here just like a member. Practices and signups
+  // stay scoped to direct memberships — guardian view access is for the games
+  // and practices their child's team runs, not team-internal planning tools.
+  const viewableTeamIds = await getViewableTeamIds(userId);
+
   const [events, practices, signups, venueBlocks] = await Promise.all([
-    fetchTeamAndLeagueEvents({ teamIds, leagueIds, from, to }),
-    fetchPracticeSessions({ userId, teamIds, from, to }),
-    fetchSignupEvents({ userId, teamIds, adminTeamIds, from, to }),
+    fetchTeamAndLeagueEvents({ teamIds: viewableTeamIds, leagueIds, from, to }),
+    fetchPracticeSessions({ userId, teamIds: memberTeamIds, from, to }),
+    fetchSignupEvents({ userId, teamIds: memberTeamIds, adminTeamIds, from, to }),
     fetchVenueScheduleBlocks({ userId, from, to }),
   ]);
 


### PR DESCRIPTION
## Summary

A guardian-only parent — a `User` linked to a rostered `Player` via `PlayerGuardian`, but **not** a `TeamMember` of that team — previously **404'd** when opening an event their child is rostered on, and saw **nothing** on `/calendar`. This makes both surfaces guardian-aware.

## Root causes

- **`getEvent` (`lib/actions/events.ts`)** authorized only `TeamMember` or league-admin. A guardian is neither, so `getEvent` returned `null` → the event detail page called `notFound()`. This same 404 was reachable from the dashboard "needs RSVP" widget (which already lists a guardian's per-child pending events and links to `/events/{id}`).
- **Calendar (`getUserCalendarItems`, `lib/data/calendar.ts`)** derived its team scope from `getViewerMemberships`, which enumerates only `TeamMember` / `LeagueUser` and misses `PlayerGuardian`. A guardian-only viewer had no team scope, so their child's events never appeared.

## The shared helper

Added **`getViewableTeamIds(userId): Promise<string[]>`** to **`lib/auth/session.ts`** (alongside `isTeamMember` / `requireTeamMember` and already imported by the calendar/dashboard read layers). It returns the union of team IDs reachable via **`TeamMember`** OR **`PlayerGuardian`** (a guardian of a `Player` on team T can view team T), both scoped to active teams (mirroring `getViewerMemberships` / `getNeedsRsvp`). Reused in `getEvent` and the calendar path.

## Behavior changes

- **`getEvent`**: when the viewer is not a direct member and not a league admin, it checks `getViewableTeamIds` — inclusion there can only come from a guardian link. Guardians view at **MEMBER-level** detail (`userRole: "MEMBER"`, `canRSVP: false`, `canManageEvent: false`). Admin and league-admin behavior is unchanged; no admin-only fields (emergency contacts, DOB) are exposed — the event payload was already MEMBER-level.
- **Calendar**: the **events** fetch now uses the viewable union, so guardian-linked teams' events show up like a member's teams. Practices and signups stay scoped to direct memberships; `adminTeamIds` still derives from real `ADMIN` rows (guardians never gain admin scope).
- The dashboard widget 404 is fixed transitively: once `getEvent` accepts guardians, the widget's `/events/{id}` link resolves.

## Security boundary

Access never widens beyond the guardian's own child's team(s). Auth first (`requireUserId`), authorization scoped to the specific team, Prisma-only (no raw SQL). **RSVP write permissions are unchanged** — this delivers VIEW access only.

## Verification

- `bun run type-check` — passes
- `bun run test` — **123 files, 1574 passed** (includes new `events.test.ts` + `getViewableTeamIds` tests in `session.test.ts`)
- `bun run build` — compiled successfully, all 48 pages generated

### Tests added

- guardian-only user **CAN** `getEvent` for their child's team event (MEMBER-level, no RSVP/manage)
- guardian-only user **CANNOT** `getEvent` for an unrelated team's event (returns `null`)
- direct member path unchanged and does not consult the guardian fallback
- `getViewableTeamIds` unions guardian-linked teams, dedupes overlap, and excludes unrelated teams