### PR TITLE
fix: preserve COPPA parental-consent audit rows past player deletion (Track 2)

### DIFF
--- a/__tests__/lib/actions/roster-coppa.test.ts
+++ b/__tests__/lib/actions/roster-coppa.test.ts
@@ -117,8 +117,28 @@ describe("addPlayer COPPA enforcement", () => {
         grantedByUserId: USER_ID,
         method: CONSENT_METHOD_ACCOUNT_ATTESTATION,
         consentVersion: COPPA_CONSENT_VERSION,
+        childName: baseInput.name,
+        childDateOfBirth: new Date(`${under13Dob()}T00:00:00.000Z`),
+        teamId: TEAM_ID,
       },
     });
+  });
+
+  it("captures the child snapshot (name/DOB/team) so the audit row survives player deletion", async () => {
+    const dob = under13Dob();
+    await addPlayer({ ...baseInput, dateOfBirth: dob, parentalConsent: true });
+
+    const data = mockTxParentalConsent.create.mock.calls[0][0].data as {
+      childName: string;
+      childDateOfBirth: Date;
+      teamId: string;
+      playerId: string;
+    };
+    expect(data.childName).toBe(baseInput.name);
+    expect(data.childDateOfBirth).toBeInstanceOf(Date);
+    expect(data.childDateOfBirth.toISOString()).toBe(`${dob}T00:00:00.000Z`);
+    expect(data.teamId).toBe(TEAM_ID);
+    expect(data.playerId).toBe(PLAYER_ID);
   });
 
   it("does not require consent for a 13+ DOB", async () => {
@@ -192,6 +212,9 @@ describe("updatePlayer COPPA enforcement", () => {
         grantedByUserId: USER_ID,
         method: CONSENT_METHOD_ACCOUNT_ATTESTATION,
         consentVersion: COPPA_CONSENT_VERSION,
+        childName: baseInput.name,
+        childDateOfBirth: new Date(`${under13Dob()}T00:00:00.000Z`),
+        teamId: TEAM_ID,
       },
     });
   });

--- a/lib/actions/roster.ts
+++ b/lib/actions/roster.ts
@@ -85,6 +85,10 @@ export async function addPlayer(input: AddPlayerInput) {
             grantedByUserId: userId,
             method: CONSENT_METHOD_ACCOUNT_ATTESTATION,
             consentVersion: COPPA_CONSENT_VERSION,
+            // Denormalized child snapshot so the audit row survives player deletion
+            childName: validated.name,
+            childDateOfBirth: dateOfBirth,
+            teamId: validated.teamId,
           },
         });
       }
@@ -209,6 +213,10 @@ export async function updatePlayer(input: UpdatePlayerInput) {
             grantedByUserId: userId,
             method: CONSENT_METHOD_ACCOUNT_ATTESTATION,
             consentVersion: COPPA_CONSENT_VERSION,
+            // Denormalized child snapshot so the audit row survives player deletion
+            childName: validated.name,
+            childDateOfBirth: dateOfBirth,
+            teamId: validated.teamId,
           },
         });
       }

--- a/prisma/migrations/20260719010000_parental_consent_retention/migration.sql
+++ b/prisma/migrations/20260719010000_parental_consent_retention/migration.sql
@@ -1,0 +1,26 @@
+-- COPPA retention hardening. A ParentalConsent row must outlive the child's
+-- roster entry: it is the auditable proof that guardian consent (and any later
+-- revocation) existed. The original table used ON DELETE CASCADE on playerId,
+-- so deleting a Player — a routine one-click ADMIN action — destroyed its
+-- consent + revocation rows, defeating the model's own retention intent.
+--
+-- This mirrors the grantedByUserId design (SET NULL): playerId becomes nullable
+-- and its FK becomes ON DELETE SET NULL, so deleting a Player detaches the
+-- consent row instead of deleting it. A denormalized snapshot of the child
+-- (name, DOB, team) is added so a detached row (playerId → NULL) stays
+-- meaningful for audit. Snapshot columns are populated by application logic
+-- (lib/actions/roster.ts) at consent-write time.
+
+-- Denormalized child snapshot (captured at consent-write time)
+ALTER TABLE "parental_consents" ADD COLUMN "childName" TEXT;
+ALTER TABLE "parental_consents" ADD COLUMN "childDateOfBirth" DATE;
+ALTER TABLE "parental_consents" ADD COLUMN "teamId" TEXT;
+
+-- Make playerId nullable so it can be SET NULL when the Player is deleted
+ALTER TABLE "parental_consents" ALTER COLUMN "playerId" DROP NOT NULL;
+
+-- DropForeignKey (old ON DELETE CASCADE)
+ALTER TABLE "parental_consents" DROP CONSTRAINT "parental_consents_playerId_fkey";
+
+-- AddForeignKey (retention-preserving ON DELETE SET NULL)
+ALTER TABLE "parental_consents" ADD CONSTRAINT "parental_consents_playerId_fkey" FOREIGN KEY ("playerId") REFERENCES "Player"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -316,8 +316,10 @@ model PlayerGuardian {
 
 // COPPA parental-consent audit record for players under 13. One row per grant;
 // revocation sets revokedAt (never delete) so the audit trail survives.
-// grantedByUserId is SetNull on user deletion for the same reason — the
-// consent record must outlive the granting account.
+// The consent record must outlive BOTH the granting account and the child's
+// roster entry, so playerId and grantedByUserId are both nullable + SetNull.
+// A denormalized snapshot of the child (name, DOB, team) is captured at
+// consent-write time so a detached row (playerId → null) stays auditable.
 model ParentalConsent {
   id             String    @id @default(cuid())
   method         String // How consent was captured (e.g. "ACCOUNT_ATTESTATION")
@@ -325,8 +327,17 @@ model ParentalConsent {
   grantedAt      DateTime  @default(now())
   revokedAt      DateTime?
 
-  playerId String
-  player   Player @relation(fields: [playerId], references: [id], onDelete: Cascade)
+  // Denormalized child snapshot at consent-capture time. Retention-preserving:
+  // these outlive Player deletion so the audit record identifies who consent
+  // covered even after playerId is nulled out.
+  childName        String? // Player.name at capture time
+  childDateOfBirth DateTime? @db.Date // Player.dateOfBirth at capture time
+  teamId           String? // Player.teamId at capture time (plain snapshot, not an FK)
+
+  // Nullable + SetNull (mirrors grantedByUserId): deleting the child's roster
+  // entry must NOT destroy the consent/revocation audit trail.
+  playerId String?
+  player   Player? @relation(fields: [playerId], references: [id], onDelete: SetNull)
 
   grantedByUserId String?
   grantedBy       User?   @relation("ParentalConsentGrantor", fields: [grantedByUserId], references: [id], onDelete: SetNull)


### PR DESCRIPTION
## Problem

`ParentalConsent` records under-13 parental consent, and its own comments state the audit row must outlive the child's roster entry (revocation sets `revokedAt`, never deletes; `grantedByUserId` is `SetNull`). But `ParentalConsent.player` used `onDelete: Cascade`, so deleting a `Player` — a routine one-click ADMIN action in `deletePlayer` (`lib/actions/roster.ts`) — destroyed the consent **and** revocation audit rows, defeating the retention/compliance intent.

## Change (retention-preserving redesign)

Mirrors the existing `grantedByUserId` `SetNull` choice:

- **`ParentalConsent.playerId` → nullable + `onDelete: SetNull`**: deleting a `Player` now detaches the consent row instead of deleting it.
- **Denormalized child snapshot columns** so a detached row (`playerId` → NULL) stays meaningful for audit:
  - `childName String?` — `Player.name` at capture time
  - `childDateOfBirth DateTime? @db.Date` — `Player.dateOfBirth` at capture time
  - `teamId String?` — `Player.teamId` at capture time (plain snapshot, **not** an FK, so it survives team deletion too)
- **Consent-write path** (`addPlayer` + `updatePlayer` in `lib/actions/roster.ts`) now populates the snapshot fields from the player being created/updated. Both paths already had the DOB and name in hand, so no extra queries were added.

Under-13 **enforcement** logic is unchanged — attestation is still required; only the retention/schema shape + snapshot capture changed.

## Migration

Hand-written `prisma/migrations/20260719010000_parental_consent_retention/migration.sql` (timestamp after the existing `20260718130000_add_player_dob_parental_consent`):

- Adds `childName`, `childDateOfBirth`, `teamId` snapshot columns
- `ALTER COLUMN "playerId" DROP NOT NULL`
- Drops the old `ON DELETE CASCADE` FK and re-adds it as `ON DELETE SET NULL ON UPDATE CASCADE`

Follows the repo's hand-written-migration convention (same pattern as `20251017212500_update_audit_log_cascade_to_set_null`). Not run against a live DB; `bunx prisma validate` passes and Prisma Client was regenerated.

## Tests

Extended `__tests__/lib/actions/roster-coppa.test.ts`:
- Updated the two `addPlayer`/`updatePlayer` "creates a consent row" assertions to expect the new snapshot fields (`childName`, `childDateOfBirth`, `teamId`).
- Added a dedicated test asserting the child snapshot (name/DOB/team) is captured so the audit row survives player deletion.

## Verification

- `bun run type-check` — pass
- `bun run test` — **1568 passed (122 files)**, full suite green
- `bun run build` — pass (exit 0)