### PR TITLE
fix: Adjust theming to pin to light for marketing

### DIFF
--- a/__tests__/app/marketing/home-page.test.tsx
+++ b/__tests__/app/marketing/home-page.test.tsx
@@ -124,6 +124,24 @@ describe('HomePage landing integration', () => {
     expect(mocks.push).not.toHaveBeenCalled();
   });
 
+  it('pins the landing funnel to the light color scheme so it stays legible in dark mode', () => {
+    // The marketing sections bake in light backgrounds while their text uses
+    // scheme-aware tokens; without this pin, dark mode renders light text on
+    // white blocks (illegible). Guard the wrapper that re-scopes MUI's palette
+    // vars to light for the whole funnel.
+    const { container } = renderWithTheme(<HomePage />);
+
+    const scope = container.querySelector<HTMLElement>('[data-mui-color-scheme="light"]');
+    expect(scope).not.toBeNull();
+    // The funnel's named regions must live inside the light-pinned scope.
+    expect(scope).toContainElement(
+      screen.getByRole('region', { name: /see the season run from one playbook/i })
+    );
+    expect(scope).toContainElement(
+      screen.getByRole('region', { name: /get started in 3 simple steps/i })
+    );
+  });
+
   it('shows an accessible loading state while auth status is resolving', () => {
     mocks.useSession.mockReturnValue({ data: null, status: 'loading' });
 

--- a/app/(marketing)/layout.tsx
+++ b/app/(marketing)/layout.tsx
@@ -5,6 +5,7 @@ import { Box } from '@mui/material';
 import MarketingHeader from '@/components/features/navigation/MarketingHeader';
 import MarketingFooter from '@/components/features/navigation/MarketingFooter';
 import SkipLink from '@/components/ui/SkipLink';
+import LightThemeScope from '@/components/ui/LightThemeScope';
 import './marketing.css';
 
 interface MarketingLayoutProps {
@@ -13,7 +14,9 @@ interface MarketingLayoutProps {
 
 export default function MarketingLayout({ children }: MarketingLayoutProps) {
   return (
-    <Box
+    // Marketing pages are designed light-only (baked-light backgrounds); pin the
+    // light scheme so scheme-aware text stays legible even in dark mode.
+    <LightThemeScope
       className="marketing-layout"
       sx={{
         display: 'flex',
@@ -38,6 +41,6 @@ export default function MarketingLayout({ children }: MarketingLayoutProps) {
         {children}
       </Box>
       <MarketingFooter />
-    </Box>
+    </LightThemeScope>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,6 +4,7 @@ import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
 import { useEffect } from "react";
 import { Box, Container, CircularProgress } from "@mui/material";
+import LightThemeScope from "@/components/ui/LightThemeScope";
 import HeroSection from "@/components/features/marketing/HeroSection";
 import FeaturesPreview from "@/components/features/marketing/FeaturesPreview";
 import ProblemSolutionSection from "@/components/features/marketing/ProblemSolutionSection";
@@ -65,14 +66,17 @@ export default function HomePage() {
   return (
     <>
       <StructuredData data={breadcrumbSchema} />
-      <Box>
+      {/* Public landing page is designed light-only; pin the light scheme so its
+          scheme-aware text stays legible on the baked-light backgrounds even
+          when the visitor's system/app theme is dark. */}
+      <LightThemeScope>
         <HeroSection />
         <ProblemSolutionSection />
         <FeaturesPreview />
         <HowItWorks />
         <SocialProofSection />
         <FinalCTA />
-      </Box>
+      </LightThemeScope>
     </>
   );
 }

--- a/components/ui/LightThemeScope.tsx
+++ b/components/ui/LightThemeScope.tsx
@@ -1,0 +1,33 @@
+import { Box, type BoxProps } from '@mui/material';
+
+/**
+ * Pins its subtree to the light ("Fresh Ice") color scheme regardless of the
+ * visitor's active theme (system or app toggle).
+ *
+ * Why: the public marketing surfaces are designed light-only — white section
+ * and card backgrounds are baked in, either as literals or via
+ * `alpha(theme.palette.background.paper, …)`, which resolves to the default
+ * (light) palette in JS. Their text, however, uses scheme-aware tokens
+ * (`color: 'text.primary' | 'text.secondary'` → `var(--mui-palette-text-*)`).
+ * In dark mode the backgrounds stay light while the text flips light, leaving
+ * light text on white blocks (illegible). Pinning the scheme keeps the text
+ * tokens on the light palette so the whole composition stays legible.
+ *
+ * Mechanism: MUI's cssVariables mode (see lib/theme.ts `colorSchemeSelector`)
+ * emits the light palette under both `:root` and `[data-mui-color-scheme="light"]`.
+ * Setting that attribute here re-declares `--mui-palette-*` for this subtree —
+ * custom properties inherit from the nearest ancestor that sets them, so the
+ * light values win over an ancestor `<html data-mui-color-scheme="dark">`.
+ * `colorScheme: 'light'` also keeps native controls/scrollbars light.
+ *
+ * All Box props (sx, className, component, …) are forwarded.
+ */
+export default function LightThemeScope({ sx, ...props }: BoxProps) {
+  return (
+    <Box
+      data-mui-color-scheme="light"
+      sx={[{ colorScheme: 'light' }, ...(Array.isArray(sx) ? sx : [sx])]}
+      {...props}
+    />
+  );
+}


### PR DESCRIPTION
This pull request ensures that all public marketing and landing page surfaces remain legible in dark mode by pinning them to the light color scheme. This prevents issues where light text appears on light backgrounds when users have dark mode enabled. The implementation introduces a new `LightThemeScope` component and updates the marketing layout and homepage to use it, along with corresponding tests.

**Theme enforcement for marketing and landing pages:**

* Added a new `LightThemeScope` component that wraps its subtree and forces the MUI color scheme to light, ensuring text remains legible on baked-in light backgrounds regardless of the user's active theme (`components/ui/LightThemeScope.tsx`).
* Updated the main marketing layout to wrap all content with `LightThemeScope`, enforcing the light scheme across all marketing pages (`app/(marketing)/layout.tsx`). [[1]](diffhunk://#diff-dc3a2a05cdd2589d31f3a809f69ff612d44ebda05ee0cfc6aa28dc80e33dd5feR8) [[2]](diffhunk://#diff-dc3a2a05cdd2589d31f3a809f69ff612d44ebda05ee0cfc6aa28dc80e33dd5feL16-R19) [[3]](diffhunk://#diff-dc3a2a05cdd2589d31f3a809f69ff612d44ebda05ee0cfc6aa28dc80e33dd5feL41-R44)
* Updated the public landing page (`HomePage`) to wrap all funnel content in `LightThemeScope`, ensuring consistent legibility for all sections (`app/page.tsx`). [[1]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0R7) [[2]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0L68-R79)

**Testing and validation:**

* Added a test to verify that the landing funnel is pinned to the light color scheme and that all key regions are contained within the light-pinned scope (`__tests__/app/marketing/home-page.test.tsx`).