### PR TITLE
fix: enforce the ADR-0003 raw-SQL prohibition in CI and ESLint

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -20,6 +20,7 @@ bun run test:coverage       # Vitest coverage
 bun run test:ui             # Vitest UI
 bun run validate-env        # Validate required environment variables
 bun run adr:lint            # Validate the ADR corpus in docs/adr
+bun run check:raw-sql       # Enforce the ADR-0003 raw-SQL prohibition
 bun run adr:explain <path>  # Which architecture decisions govern this file?
 ```
 

--- a/.github/workflows/adr.yml
+++ b/.github/workflows/adr.yml
@@ -44,6 +44,29 @@ jobs:
       - name: Check ADR corpus and version-pin integrity
         run: bun run adr:check-integrity
 
+  # Enforcement of a decision, not validation of the corpus, so it is a job of
+  # its own rather than a step in `lint`. It lives in this workflow because
+  # this workflow runs on pull requests: `bun run lint` -- which carries the
+  # equivalent ESLint rules -- runs only in release.yml and tag-release.yml,
+  # both push-triggered, so an ESLint rule alone would let a violation merge
+  # green and break the release pipeline afterwards. See #310.
+  raw-sql:
+    name: Enforce the ADR-0003 raw-SQL prohibition
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2.0.2
+        with:
+          bun-version: latest
+
+      # No `bun install`: the check imports only node: builtins, precisely so
+      # it cannot be defeated by a dependency or install failure.
+      - name: Check for prohibited raw SQL
+        run: bun run check:raw-sql
+
   governing-decisions:
     name: Comment governing decisions
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -274,7 +274,7 @@ export async function myAction(input: InputType): Promise<ActionResult<OutputTyp
 1. NEVER trust client input - always validate with Zod
 2. ALWAYS check authentication first (`requireUserId()`)
 3. ALWAYS verify authorization (admin role, team membership)
-4. ALWAYS use Prisma (parameterized queries) - NEVER raw SQL
+4. ALWAYS use Prisma (parameterized queries) - NEVER raw SQL (enforced by `bun run check:raw-sql` and ESLint, not just convention - see ADR-0003)
 5. ALWAYS sanitize user input displayed in UI
 6. NEVER expose sensitive data (emergency contacts to non-admins)
 
@@ -519,6 +519,8 @@ bun run adr:explain lib/actions/x.ts  # which decisions govern this file?
 bun run adr:check <changed files...>  # decisions governing a change set
 bun run adr:new "Use X for Y"         # scaffold a new record
 bun run adr:graph -- --format dot     # supersession/relationship graph
+bun run check:raw-sql                 # enforce the ADR-0003 raw-SQL prohibition
+                                      # (also a job in .github/workflows/adr.yml)
 ```
 
 **Before making an architectural change**, check what governs the paths you are

--- a/__tests__/scripts/check-raw-sql.test.ts
+++ b/__tests__/scripts/check-raw-sql.test.ts
@@ -1,0 +1,196 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, it, expect } from "vitest";
+
+import {
+  blankComments,
+  findViolations,
+  scanRepository,
+} from "@/scripts/check-raw-sql";
+
+/**
+ * Tests for the ADR-0003 raw-SQL gate (scripts/check-raw-sql.ts).
+ *
+ * Fixtures are assembled at runtime rather than written as literals, because
+ * this file is inside the scanner's own scan scope and the scanner blanks
+ * comments but deliberately NOT string literals -- a literal call site here
+ * would be a genuine violation of the rule under test.
+ */
+
+const REPO_ROOT = join(__dirname, "..", "..");
+const DOT = String.fromCharCode(46);
+
+/** `prisma.<helper>` in tagged-template position, e.g. a plain raw query. */
+const tagged = (helper: string) =>
+  `const rows = await prisma${DOT}${helper}\`SELECT 1\`;`;
+
+/** `prisma.<helper>(...)` in call position, e.g. an unsafe query. */
+const called = (helper: string) =>
+  `const rows = await prisma${DOT}${helper}(statement);`;
+
+/** `prisma["<helper>"](...)`, the computed form that hides the name in a string. */
+const computed = (helper: string) =>
+  `const rows = await prisma["${helper}"](statement);`;
+
+const QUERY_RAW = `${"$"}queryRaw`;
+const EXECUTE_RAW = `${"$"}executeRaw`;
+const QUERY_RAW_UNSAFE = `${QUERY_RAW}Unsafe`;
+const EXECUTE_RAW_UNSAFE = `${EXECUTE_RAW}Unsafe`;
+
+const HEALTH_ROUTE = "app/api/health/route.ts";
+
+describe("raw-SQL gate: plain $queryRaw / $executeRaw", () => {
+  it("flags a raw query added under lib/", () => {
+    const violations = findViolations("lib/actions/team.ts", tagged(QUERY_RAW));
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0].rule).toBe("raw");
+    expect(violations[0].line).toBe(1);
+  });
+
+  it("flags a raw statement under components/ and under app/", () => {
+    expect(
+      findViolations("components/features/roster/RosterList.tsx", tagged(EXECUTE_RAW)),
+    ).toHaveLength(1);
+    expect(
+      findViolations("app/api/roster/export/route.ts", tagged(QUERY_RAW)),
+    ).toHaveLength(1);
+  });
+
+  it("flags the computed form, which hides the helper name in a string", () => {
+    expect(findViolations("lib/actions/team.ts", computed(QUERY_RAW))).toHaveLength(1);
+  });
+
+  it("allows the health check, the one documented exception", () => {
+    expect(findViolations(HEALTH_ROUTE, tagged(QUERY_RAW))).toEqual([]);
+  });
+
+  it("scopes that exception to the path, not to the statement", () => {
+    // The same source anywhere else is still a violation, so the exemption
+    // cannot be borrowed by copying the health check's query elsewhere.
+    const source = tagged(QUERY_RAW);
+
+    expect(findViolations(HEALTH_ROUTE, source)).toEqual([]);
+    expect(findViolations("app/api/health/other.ts", source)).toHaveLength(1);
+  });
+
+  it("leaves scripts/ alone: it is outside the deployed application", () => {
+    expect(findViolations("scripts/check-cols.ts", tagged(QUERY_RAW))).toEqual([]);
+    expect(findViolations("prisma/seed.ts", tagged(QUERY_RAW))).toEqual([]);
+  });
+});
+
+describe("raw-SQL gate: $queryRawUnsafe / $executeRawUnsafe", () => {
+  it("flags the unsafe helpers under lib/, where plain raw is also banned", () => {
+    const violations = findViolations("lib/actions/team.ts", called(QUERY_RAW_UNSAFE));
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0].rule).toBe("unsafe");
+  });
+
+  it("flags them in scripts/, which is exempt from the plain-raw rule only", () => {
+    const violations = findViolations(
+      "scripts/check-cols.ts",
+      called(EXECUTE_RAW_UNSAFE),
+    );
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0].rule).toBe("unsafe");
+  });
+
+  it("flags them in the health check: rule 2 has no exception anywhere", () => {
+    const violations = findViolations(HEALTH_ROUTE, called(QUERY_RAW_UNSAFE));
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0].rule).toBe("unsafe");
+  });
+
+  it("flags the computed form outside the restricted roots", () => {
+    expect(
+      findViolations("scripts/anything.ts", computed(QUERY_RAW_UNSAFE)),
+    ).toHaveLength(1);
+  });
+
+  it("reports unsafe separately from plain raw rather than as one rule", () => {
+    // `Raw` followed by `U` is not a word boundary, so the plain pattern must
+    // not also claim an unsafe call site and mislabel the message.
+    const violations = findViolations("lib/actions/team.ts", called(QUERY_RAW_UNSAFE));
+
+    expect(violations.map((violation) => violation.rule)).toEqual(["unsafe"]);
+  });
+});
+
+describe("raw-SQL gate: what must not be flagged", () => {
+  it("ignores a mock property, which is not a call site", () => {
+    const mock = `vi.mock("@/lib/db/prisma", () => ({ prisma: { ${QUERY_RAW}: vi.fn() } }));`;
+
+    expect(findViolations("lib/actions/team.test.ts", mock)).toEqual([]);
+  });
+
+  it("ignores prose in comments that names a call site", () => {
+    // Regression: the first run of this gate failed on a JSDoc line in
+    // eslint.config.mjs describing the very pattern it matches.
+    const lineComment = `// never write prisma${DOT}${QUERY_RAW_UNSAFE}(input) here`;
+    const blockComment = `/** Matches prisma${DOT}${QUERY_RAW}\`...\` and prisma["${QUERY_RAW}"]. */`;
+
+    expect(findViolations("lib/actions/team.ts", lineComment)).toEqual([]);
+    expect(findViolations("lib/actions/team.ts", blockComment)).toEqual([]);
+  });
+
+  it("ignores an import path that merely contains the helper name", () => {
+    const source = `import { prisma } from "@/lib/db/prisma";`;
+
+    expect(findViolations("lib/actions/team.ts", source)).toEqual([]);
+  });
+});
+
+describe("raw-SQL gate: comment blanking cannot be used to hide code", () => {
+  it("does not treat // inside a string literal as a comment opener", () => {
+    // Naive comment stripping would delete the rest of this line and miss the
+    // call, which is the obvious way to smuggle one past a text-based gate.
+    const source = `const url = "https://example.com"; ${called(QUERY_RAW_UNSAFE)}`;
+
+    expect(findViolations("lib/actions/team.ts", source)).toHaveLength(1);
+  });
+
+  it("does not treat /* inside a regex literal as a block-comment opener", () => {
+    // Otherwise everything up to the next */ -- potentially the rest of the
+    // file -- would be blanked, taking real call sites with it.
+    const source = [`const pattern = /a\\/*b/;`, called(QUERY_RAW_UNSAFE)].join("\n");
+
+    expect(findViolations("lib/actions/team.ts", source)).toHaveLength(1);
+  });
+
+  it("preserves offsets and line breaks so reported lines stay accurate", () => {
+    const source = ["/* one", "   two */", called(QUERY_RAW_UNSAFE)].join("\n");
+    const blanked = blankComments(source);
+
+    expect(blanked).toHaveLength(source.length);
+    expect(blanked.split("\n")).toHaveLength(3);
+    expect(blanked.split("\n")[0].trim()).toBe("");
+    expect(findViolations("lib/actions/team.ts", source)[0].line).toBe(3);
+  });
+});
+
+describe("raw-SQL gate: the repository itself", () => {
+  it("is clean, and stays clean", () => {
+    expect(scanRepository(REPO_ROOT)).toEqual([]);
+  });
+
+  it("still permits the two real call sites the record documents", () => {
+    // Guards the exemptions against drift in the other direction: if either
+    // file were rewritten or the exception list narrowed, this fails loudly
+    // rather than the gate quietly starting to reject committed code.
+    const health = readFileSync(join(REPO_ROOT, HEALTH_ROUTE), "utf8");
+    const checkCols = readFileSync(join(REPO_ROOT, "scripts/check-cols.ts"), "utf8");
+
+    expect(health).toContain(QUERY_RAW);
+    expect(checkCols).toContain(QUERY_RAW);
+    expect(findViolations(HEALTH_ROUTE, health)).toEqual([]);
+    expect(findViolations("scripts/check-cols.ts", checkCols)).toEqual([]);
+
+    // ...and both would be violations if they moved into application code.
+    expect(findViolations("lib/actions/health.ts", health).length).toBeGreaterThan(0);
+    expect(findViolations("lib/actions/columns.ts", checkCols).length).toBeGreaterThan(0);
+  });
+});

--- a/docs/adr/0003-access-postgresql-exclusively-through-prisma-on-neon-serverless.md
+++ b/docs/adr/0003-access-postgresql-exclusively-through-prisma-on-neon-serverless.md
@@ -22,6 +22,12 @@ affects:
   - type: path
     pattern: "app/api/**"
     note: The other surface that queries the database directly.
+  - type: path
+    pattern: "scripts/check-raw-sql.ts"
+    note: The pull-request gate that enforces the raw-SQL prohibition below.
+  - type: path
+    pattern: "eslint.config.mjs"
+    note: Carries the authoring-time half of the same prohibition.
 provenance:
   authoredBy: agent-drafted
   ratifiedBy: "@mbeacom"
@@ -74,6 +80,11 @@ so its interpolations are parameterized rather than concatenated.
 plain string rather than a tagged template, so they do not parameterize
 anything, and no current or foreseen requirement needs them. Introducing one
 requires superseding this record, not a reviewer's judgment call.
+
+Both rules are enforced by tooling rather than by review: `no-restricted-syntax`
+rules in `eslint.config.mjs` while the code is being written, and
+`scripts/check-raw-sql.ts` as a job in the pull-request-triggered ADR workflow.
+Trade-offs records what that pair does and does not catch.
 
 The client is a single instance created in `lib/db/prisma.ts` and cached on
 `globalThis` outside production so hot reload does not accumulate clients. The
@@ -129,12 +140,22 @@ for a schema this relational.
 - **Complex analytical SQL is awkward.** Anything beyond Prisma's query API
   means raw SQL, which this decision otherwise forbids. If reporting features
   arrive, that tension becomes real.
-- **The prohibition is a convention, not a guarantee.** Prisma still exposes
-  `$queryRawUnsafe` and `$executeRawUnsafe`, which interpolate strings directly.
-  Nothing in CI blocks them today — action item 3 is exactly that gap. Until it
-  is closed, "we do not use raw SQL" is enforced by review, not by the tooling,
-  and a reviewer should not read this record as a guarantee that no unsafe query
-  can reach `main`.
+- **The prohibition is enforced now, but it is still not a guarantee.** Prisma
+  still exposes `$queryRawUnsafe` and `$executeRawUnsafe`, which interpolate
+  strings directly. Two gates block them. `no-restricted-syntax` rules in
+  `eslint.config.mjs` are AST-accurate and fire in the editor;
+  `scripts/check-raw-sql.ts` runs as its own job in the ADR workflow. The
+  second exists because the first is not a merge gate here — `bun run lint`
+  runs only in `release.yml` and `tag-release.yml`, both push-triggered, so an
+  ESLint rule alone would let a violation merge and break the release pipeline
+  afterwards (#310) — and because an inline `eslint-disable` can silence a
+  rule where no comment can silence the script. What neither gate catches:
+  both match member access, so a destructured or aliased binding such as
+  `const { $queryRawUnsafe } = prisma` passes both, and the script matches text
+  rather than parsing (it blanks comments first, but it is a filter, not a
+  proof). Closing that gap needs type-aware linting, which this repo does not
+  run. Read the pair as a gate against the lapse this record is actually
+  worried about, not as a proof that no unsafe query can reach `main`.
 - **Cold-start cost.** The generated client is large; `prisma generate` runs on
   every install, and it fails without a `DATABASE_URL` present — a real papercut
   in fresh environments and CI.
@@ -159,7 +180,10 @@ for a schema this relational.
 
 1. [x] `lib/db/prisma.ts` is the only client construction site
 2. [x] Adapter selection covers Neon and plain PostgreSQL
-3. [ ] Add a lint rule or CI grep failing on `$queryRaw`/`$executeRaw` under
-   `app/`, `lib/`, or `components/`, excepting `app/api/health/`, and on
-   `$queryRawUnsafe`/`$executeRawUnsafe` anywhere. Until this lands, the
-   prohibition above is enforced by review only.
+3. [x] `no-restricted-syntax` rules in `eslint.config.mjs` and
+   `scripts/check-raw-sql.ts` — the latter a job in
+   `.github/workflows/adr.yml`, so it gates pull requests — fail on
+   `$queryRaw`/`$executeRaw` under `app/`, `lib/`, or `components/`, excepting
+   `app/api/health/route.ts`, and on `$queryRawUnsafe`/`$executeRawUnsafe`
+   anywhere. Both were watched failing on a seeded violation before landing.
+   The gap they do not close is recorded under Trade-offs.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,5 +1,58 @@
 import nextConfig from "eslint-config-next";
 
+/**
+ * ADR-0003 prohibits raw SQL.
+ * See docs/adr/0003-access-postgresql-exclusively-through-prisma-on-neon-serverless.md
+ *
+ * These rules are the authoring-time half of that enforcement: AST-accurate,
+ * and they fire in the editor. They are deliberately not the merge gate --
+ * `bun run lint` runs only in release.yml and tag-release.yml, both of which
+ * fire *after* a merge to main, and an inline `eslint-disable` can silence
+ * them. `scripts/check-raw-sql.ts`, wired into the pull-request-triggered ADR
+ * workflow, is the gate that actually blocks a merge.
+ *
+ * Matching on `MemberExpression` targets call sites (`prisma.$queryRaw`,
+ * `prisma["$queryRaw"]`) rather than every mention of the name, so test mocks
+ * shaped like `{ $queryRaw: vi.fn() }` are not false positives.
+ */
+const RAW_SQL_MESSAGE =
+  "ADR-0003 prohibits $queryRaw/$executeRaw under app/, lib/, and components/ " +
+  "(app/api/health/route.ts is the only exception, and its statement takes no " +
+  "input). Use the generated Prisma client, which parameterizes by default.";
+
+const UNSAFE_RAW_SQL_MESSAGE =
+  "ADR-0003 prohibits $queryRawUnsafe/$executeRawUnsafe anywhere in this " +
+  "repository, with no exception: they take a plain string rather than a " +
+  "tagged template, so nothing is parameterized. Introducing one requires " +
+  "superseding docs/adr/0003-*.md, not a reviewer's judgment call.";
+
+/** Matches `prisma.$queryRawUnsafe(...)` and `prisma["$queryRawUnsafe"](...)`. */
+const unsafeRawSqlSelectors = [
+  {
+    selector: "MemberExpression[property.name=/^[$](query|execute)RawUnsafe$/]",
+    message: UNSAFE_RAW_SQL_MESSAGE,
+  },
+  {
+    selector: "MemberExpression[property.value=/^[$](query|execute)RawUnsafe$/]",
+    message: UNSAFE_RAW_SQL_MESSAGE,
+  },
+];
+
+/** Matches the tagged-template and computed forms of the plain raw helpers. */
+const rawSqlSelectors = [
+  {
+    selector: "MemberExpression[property.name=/^[$](query|execute)Raw$/]",
+    message: RAW_SQL_MESSAGE,
+  },
+  {
+    selector: "MemberExpression[property.value=/^[$](query|execute)Raw$/]",
+    message: RAW_SQL_MESSAGE,
+  },
+];
+
+/** The source extensions ESLint parses, used to scope the path-restricted block. */
+const SOURCE_GLOB = "*.{js,jsx,mjs,cjs,ts,tsx}";
+
 const eslintConfig = [
   ...nextConfig,
   {
@@ -13,6 +66,34 @@ const eslintConfig = [
       "*.min.js",
       "next-env.d.ts",
     ],
+  },
+  {
+    name: "adr-0003/no-unsafe-raw-sql",
+    rules: {
+      "no-restricted-syntax": ["error", ...unsafeRawSqlSelectors],
+    },
+  },
+  {
+    // Repeating the unsafe selectors here is load-bearing, not redundant. Flat
+    // config replaces a rule's options wholesale rather than merging them, so
+    // for a file matched by both blocks this entry wins outright -- omitting
+    // the unsafe selectors would silently drop the repo-wide unsafe ban for
+    // exactly the paths where user input reaches the database.
+    name: "adr-0003/no-raw-sql-in-application-code",
+    files: [
+      `app/**/${SOURCE_GLOB}`,
+      `lib/**/${SOURCE_GLOB}`,
+      `components/**/${SOURCE_GLOB}`,
+    ],
+    // The single documented exception: a parameterless `SELECT 1` liveness probe.
+    ignores: ["app/api/health/route.ts"],
+    rules: {
+      "no-restricted-syntax": [
+        "error",
+        ...unsafeRawSqlSelectors,
+        ...rawSqlSelectors,
+      ],
+    },
   },
 ];
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "vercel:build": "bun scripts/vercel-build.mjs",
     "start": "bun --bun next start",
     "lint": "eslint .",
+    "check:raw-sql": "bun scripts/check-raw-sql.ts",
     "type": "tsc --noEmit",
     "type-check": "tsc --noEmit",
     "test": "vitest run",

--- a/scripts/check-raw-sql.ts
+++ b/scripts/check-raw-sql.ts
@@ -1,0 +1,378 @@
+/**
+ * Enforces the ADR-0003 raw-SQL prohibition.
+ * See docs/adr/0003-access-postgresql-exclusively-through-prisma-on-neon-serverless.md
+ *
+ * Two rules:
+ *
+ *   1. The plain raw helpers are prohibited under `app/`, `lib/`, and
+ *      `components/`, with one exception: `app/api/health/route.ts`, whose
+ *      single statement is a parameterless liveness probe. `scripts/` is
+ *      outside the deployed application and is not covered by this rule, so
+ *      `scripts/check-cols.ts` keeps reading `information_schema` through the
+ *      tagged-template form, which parameterizes.
+ *   2. The *Unsafe variants are prohibited everywhere in the repository with no
+ *      exception -- including `scripts/`. They take a plain string rather than
+ *      a tagged template, so they parameterize nothing.
+ *
+ * Why this exists alongside the ESLint rules in eslint.config.mjs: `bun run
+ * lint` runs only in release.yml and tag-release.yml, both of which fire after
+ * a merge to main, and an inline `eslint-disable` can silence a rule. This
+ * script runs in the pull-request-triggered ADR workflow and cannot be
+ * silenced by a comment, so it is the gate that actually blocks a merge. It
+ * depends on nothing outside node: builtins, so its CI job needs no install.
+ *
+ * The patterns match member-access shape -- a dot or a computed index followed
+ * by the helper name -- rather than every occurrence of the name. That targets
+ * real call sites and leaves test mocks shaped like `{ $queryRaw: vi.fn() }`
+ * alone. Comments are blanked before matching (see `blankComments`) so prose
+ * naming a call site is not a violation; string literals deliberately are NOT
+ * blanked, because the computed form hides the helper name inside one.
+ */
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+
+const resolveRepoRoot = (): string => path.resolve(import.meta.dirname, '..');
+
+/** Extensions that can contain a call site. */
+const SOURCE_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs']);
+
+/** Build output, dependencies, and VCS metadata: never source we authored. */
+const SKIP_DIRECTORIES = new Set([
+  '.git',
+  '.next',
+  '.turbo',
+  '.vercel',
+  'build',
+  'coverage',
+  'dist',
+  'node_modules',
+  'out',
+]);
+
+/** Repo-relative prefixes where the plain raw helpers are prohibited. */
+const RESTRICTED_ROOTS = ['app/', 'lib/', 'components/'];
+
+/**
+ * The single documented exception to rule 1: a parameterless liveness probe,
+ * so there is no input to interpolate. It is NOT an exception to rule 2.
+ */
+const RAW_EXEMPT_FILES = new Set(['app/api/health/route.ts']);
+
+const RAW_MESSAGE =
+  'raw SQL is prohibited under app/, lib/, and components/ by ADR-0003 ' +
+  '(app/api/health/route.ts is the only exception). Use the generated Prisma ' +
+  'client, which parameterizes by default.';
+
+const UNSAFE_MESSAGE =
+  'the *Unsafe raw helpers are prohibited everywhere by ADR-0003, with no ' +
+  'exception: they take a plain string rather than a tagged template, so ' +
+  'nothing is parameterized. Introducing one requires superseding the record.';
+
+/**
+ * `\b` after `Raw` is what keeps the plain patterns from also matching the
+ * *Unsafe variants: `Raw` followed by `U` is not a word boundary, so the two
+ * rules stay distinct and each reports its own message.
+ */
+const PATTERNS = [
+  { rule: 'unsafe', find: /[.]\s*[$](?:query|execute)RawUnsafe\b/g },
+  { rule: 'unsafe', find: /\[\s*(['"`])[$](?:query|execute)RawUnsafe\1\s*\]/g },
+  { rule: 'raw', find: /[.]\s*[$](?:query|execute)Raw\b/g },
+  { rule: 'raw', find: /\[\s*(['"`])[$](?:query|execute)Raw\1\s*\]/g },
+] as const;
+
+export interface Violation {
+  file: string;
+  line: number;
+  rule: 'raw' | 'unsafe';
+  message: string;
+}
+
+// --- Comment blanking ------------------------------------------------------
+// A regex alone cannot tell a call site from prose describing one, and this
+// repo comments heavily -- the first run of this check failed on a JSDoc line
+// in eslint.config.mjs. Blanking comments first is what stops the gate crying
+// wolf on its own documentation. Quotes, template literals, and regex literals
+// are tracked only so a `//` or `/*` inside one is not mistaken for a comment
+// opener; their contents are left intact for matching.
+
+/** Consumes a quoted string starting at `start`; returns the index after it. */
+function consumeQuoted(source: string, start: number, quote: string): number {
+  let i = start + 1;
+  while (i < source.length) {
+    const c = source[i];
+    if (c === '\\') {
+      i += 2;
+      continue;
+    }
+    if (c === quote) return i + 1;
+    // An unterminated literal is a syntax error; stop at the newline rather
+    // than swallowing the rest of the file.
+    if (c === '\n') return i;
+    i += 1;
+  }
+  return i;
+}
+
+/** Consumes a template literal starting at its opening backtick. */
+function consumeTemplate(source: string, start: number): number {
+  let i = start + 1;
+  while (i < source.length) {
+    const c = source[i];
+    if (c === '\\') {
+      i += 2;
+      continue;
+    }
+    if (c === '`') return i + 1;
+    if (c === '$' && source[i + 1] === '{') {
+      i = consumeSubstitution(source, i + 1);
+      continue;
+    }
+    i += 1;
+  }
+  return i;
+}
+
+/** Consumes a `${ ... }` substitution starting at its opening brace. */
+function consumeSubstitution(source: string, start: number): number {
+  let depth = 0;
+  let i = start;
+  while (i < source.length) {
+    const c = source[i];
+    if (c === '\\') {
+      i += 2;
+      continue;
+    }
+    if (c === '`') {
+      i = consumeTemplate(source, i);
+      continue;
+    }
+    if (c === '"' || c === "'") {
+      i = consumeQuoted(source, i, c);
+      continue;
+    }
+    if (c === '{') depth += 1;
+    if (c === '}') {
+      depth -= 1;
+      if (depth === 0) return i + 1;
+    }
+    i += 1;
+  }
+  return i;
+}
+
+/** Consumes a regex literal starting at its opening slash. */
+function consumeRegexLiteral(source: string, start: number): number {
+  let i = start + 1;
+  let inCharacterClass = false;
+  while (i < source.length) {
+    const c = source[i];
+    if (c === '\\') {
+      i += 2;
+      continue;
+    }
+    if (c === '\n') return i;
+    if (inCharacterClass) {
+      if (c === ']') inCharacterClass = false;
+    } else if (c === '[') {
+      inCharacterClass = true;
+    } else if (c === '/') {
+      return i + 1;
+    }
+    i += 1;
+  }
+  return i;
+}
+
+/**
+ * Whether a bare `/` here opens a regex literal rather than being division.
+ * Ambiguity resolves toward "regex", which is the safe direction: mistaking
+ * division for a regex only skips characters, whereas mistaking a regex for
+ * division could misread a `/*` inside it and blank real code as a comment.
+ */
+function opensRegexLiteral(previousSignificant: string): boolean {
+  return !/[A-Za-z0-9_$)\]]/.test(previousSignificant);
+}
+
+/**
+ * Replaces comment characters with spaces, preserving length and line breaks
+ * so reported line numbers still point at the original source.
+ */
+export function blankComments(source: string): string {
+  const out = source.split('');
+  const blank = (from: number, to: number): void => {
+    for (let k = from; k < to && k < out.length; k += 1) {
+      if (out[k] !== '\n') out[k] = ' ';
+    }
+  };
+
+  let i = 0;
+  let previousSignificant = '';
+  while (i < source.length) {
+    const c = source[i];
+    const next = source[i + 1];
+
+    // Checked before the regex-literal case: a regex literal can start with
+    // neither `/` nor `*`, so these two openers in code position are always
+    // comments.
+    if (c === '/' && next === '/') {
+      let end = i;
+      while (end < source.length && source[end] !== '\n') end += 1;
+      blank(i, end);
+      i = end;
+      continue;
+    }
+    if (c === '/' && next === '*') {
+      let end = i + 2;
+      while (end < source.length && !(source[end] === '*' && source[end + 1] === '/')) {
+        end += 1;
+      }
+      end = Math.min(end + 2, source.length);
+      blank(i, end);
+      i = end;
+      continue;
+    }
+    if (c === '"' || c === "'") {
+      i = consumeQuoted(source, i, c);
+      previousSignificant = c;
+      continue;
+    }
+    if (c === '`') {
+      i = consumeTemplate(source, i);
+      previousSignificant = c;
+      continue;
+    }
+    if (c === '/' && opensRegexLiteral(previousSignificant)) {
+      i = consumeRegexLiteral(source, i);
+      previousSignificant = '/';
+      continue;
+    }
+    if (!/\s/.test(c)) previousSignificant = c;
+    i += 1;
+  }
+
+  return out.join('');
+}
+
+// --- Scanning --------------------------------------------------------------
+
+/** Whether the plain raw helpers are prohibited in this file. */
+function rawIsProhibitedIn(relativePath: string): boolean {
+  if (RAW_EXEMPT_FILES.has(relativePath)) return false;
+  return RESTRICTED_ROOTS.some((root) => relativePath.startsWith(root));
+}
+
+function lineOf(source: string, index: number): number {
+  let line = 1;
+  for (let i = 0; i < index; i += 1) {
+    if (source.charCodeAt(i) === 10) line += 1;
+  }
+  return line;
+}
+
+/**
+ * Finds prohibited raw-SQL call sites in one file's source.
+ *
+ * @param relativePath repo-relative, POSIX-separated (e.g. `lib/actions/team.ts`)
+ */
+export function findViolations(relativePath: string, source: string): Violation[] {
+  const rawProhibited = rawIsProhibitedIn(relativePath);
+  const code = blankComments(source);
+  const seen = new Set<string>();
+  const violations: Violation[] = [];
+
+  for (const { rule, find } of PATTERNS) {
+    if (rule === 'raw' && !rawProhibited) continue;
+
+    // The patterns are module-level and /g, so reset before reuse.
+    find.lastIndex = 0;
+    for (const match of code.matchAll(find)) {
+      const line = lineOf(code, match.index);
+      // The dot and computed forms can both match one call site; report once.
+      const key = `${rule}:${line}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      violations.push({
+        file: relativePath,
+        line,
+        rule,
+        message: rule === 'unsafe' ? UNSAFE_MESSAGE : RAW_MESSAGE,
+      });
+    }
+  }
+
+  return violations.sort((a, b) => a.line - b.line);
+}
+
+/** Repo-relative, POSIX-separated paths of every scannable source file. */
+export function collectSourceFiles(root: string = resolveRepoRoot()): string[] {
+  const found: string[] = [];
+
+  function walk(absolute: string): void {
+    for (const entry of readdirSync(absolute, { withFileTypes: true })) {
+      if (entry.isDirectory()) {
+        if (SKIP_DIRECTORIES.has(entry.name)) continue;
+        walk(path.join(absolute, entry.name));
+      } else if (entry.isFile() && SOURCE_EXTENSIONS.has(path.extname(entry.name))) {
+        const relative = path.relative(root, path.join(absolute, entry.name));
+        found.push(relative.split(path.sep).join('/'));
+      }
+    }
+  }
+
+  walk(root);
+  return found.sort();
+}
+
+/** Scans a checkout and returns every violation found. */
+export function scanRepository(root: string = resolveRepoRoot()): Violation[] {
+  return collectSourceFiles(root).flatMap((relative) =>
+    findViolations(relative, readFileSync(path.join(root, relative), 'utf8')),
+  );
+}
+
+function main(): void {
+  const repoRoot = resolveRepoRoot();
+
+  // A missing scan root means the script was moved or the checkout is partial;
+  // either way, exiting 0 would be a gate that had silently stopped gating.
+  for (const root of RESTRICTED_ROOTS) {
+    const absolute = path.join(repoRoot, root);
+    let present = false;
+    try {
+      present = statSync(absolute).isDirectory();
+    } catch {
+      present = false;
+    }
+    if (!present) {
+      console.error(
+        `Raw-SQL check failed: expected scan root ${root} does not exist under ${repoRoot}.`,
+      );
+      process.exit(1);
+    }
+  }
+
+  const files = collectSourceFiles();
+  const violations = files.flatMap((relative) =>
+    findViolations(relative, readFileSync(path.join(repoRoot, relative), 'utf8')),
+  );
+
+  if (violations.length > 0) {
+    console.error('Raw-SQL check failed -- ADR-0003 prohibits these call sites:\n');
+    for (const violation of violations) {
+      console.error(`  - ${violation.file}:${violation.line} -- ${violation.message}`);
+    }
+    console.error(
+      '\nSee docs/adr/0003-access-postgresql-exclusively-through-prisma-on-neon-serverless.md.',
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    `Raw-SQL check OK: scanned ${files.length} source file(s); no prohibited raw ` +
+      'SQL under app/, lib/, or components/, and no *Unsafe helper anywhere.',
+  );
+}
+
+// Bun sets this when the file is executed directly. Under Vitest it is
+// undefined, so importing the helpers above does not run the CLI.
+if (import.meta.main) main();


### PR DESCRIPTION
## Summary

ADR-0003 prohibits raw SQL and admitted, in its own Trade-offs section, that the prohibition was enforced by review rather than tooling. This closes that gap — action item 3 on the record.

Enforced now:

- `$queryRaw` / `$executeRaw` fail anywhere under `app/`, `lib/`, or `components/`, except `app/api/health/route.ts` (a parameterless `SELECT 1`).
- `$queryRawUnsafe` / `$executeRawUnsafe` fail **anywhere in the repository, with no exception** — including `scripts/`, and including the health route.
- `scripts/` stays exempt from the plain-raw rule only, so `scripts/check-cols.ts` keeps reading `information_schema` through the tagged-template form.

The repo was already clean, so both gates pass on `main` as-is. This is about keeping it that way.

## Why two gates rather than one

The issue offered ESLint *or* a CI check and preferred ESLint. I implemented both, because investigation turned up something that makes ESLint alone insufficient here: **`bun run lint` is not a pull-request gate in this repo.** It runs only in `release.yml` and `tag-release.yml`, both push-triggered. `bun run test` runs in no workflow at all. That is captured independently in #310.

An ESLint-only rule would therefore let a violating PR merge green and break the release pipeline on `main` afterwards. So:

| Surface | Role | Strength | Weakness |
|---|---|---|---|
| `no-restricted-syntax` in `eslint.config.mjs` | authoring-time | AST-accurate; fires in the editor; part of `bun run lint` | not PR-gated here; silenceable with an inline `eslint-disable` |
| `scripts/check-raw-sql.ts`, a job in `adr.yml` | merge gate | runs on every PR; no comment can silence it; imports only `node:` builtins, so its job needs no `bun install` | text-based, matches member-access shape |

Each covers the other's hole. The path exception is expressed exactly as the issue hoped — a scoped flat-config block with `ignores: ["app/api/health/route.ts"]`.

## Observed-failing evidence

A gate nobody has seen fail is not a gate. Each violation was seeded, both gates observed failing, then reverted and observed passing. Nothing seeded is committed.

**1. `$queryRaw` added under `lib/actions/team.ts`**

```
$ bun run check:raw-sql
Raw-SQL check failed -- ADR-0003 prohibits these call sites:

  - lib/actions/team.ts:186 -- raw SQL is prohibited under app/, lib/, and components/ by ADR-0003
    (app/api/health/route.ts is the only exception). Use the generated Prisma client, which
    parameterizes by default.
exit=1

$ bun run lint
lib/actions/team.ts
  186:10  error  ADR-0003 prohibits $queryRaw/$executeRaw under app/, lib/, and components/ ...  no-restricted-syntax
exit=1
```

**2. `$queryRawUnsafe` added in `scripts/check-cols.ts`** — proving `scripts/` is exempt from the plain-raw rule *only*. Note the pre-existing tagged-template calls at `check-cols.ts:5` and `:29` are still not reported.

```
$ bun run check:raw-sql
Raw-SQL check failed -- ADR-0003 prohibits these call sites:

  - scripts/check-cols.ts:38 -- the *Unsafe raw helpers are prohibited everywhere by ADR-0003,
    with no exception: they take a plain string rather than a tagged template, so nothing is
    parameterized. Introducing one requires superseding the record.
exit=1

$ bun run lint
scripts/check-cols.ts
  38:10  error  ADR-0003 prohibits $queryRawUnsafe/$executeRawUnsafe anywhere in this repository ...  no-restricted-syntax
```

**3. `$queryRawUnsafe` substituted into the exempt health route** — proving the exemption is scoped to the plain-raw rule, not a blanket allow on that file.

```
$ bun run check:raw-sql
Raw-SQL check failed -- ADR-0003 prohibits these call sites:

  - app/api/health/route.ts:33 -- the *Unsafe raw helpers are prohibited everywhere by ADR-0003,
    with no exception ...
exit=1

$ bun run lint
app/api/health/route.ts
  33:11  error  ADR-0003 prohibits $queryRawUnsafe/$executeRawUnsafe anywhere in this repository ...  no-restricted-syntax
```

**Reverted, both gates clean:**

```
$ git status --porcelain      # only the intended changes
$ bun run check:raw-sql
Raw-SQL check OK: scanned 624 source file(s); no prohibited raw SQL under app/, lib/, or
components/, and no *Unsafe helper anywhere.

$ bun run lint
.design-sync/previews/ToastProvider.tsx
  10:6  warning  React Hook React.useEffect has a missing dependency: 'toast' ...
✖ 1 problem (0 errors, 1 warning)      # pre-existing, not from this change
```

## A real bug the seeding discipline caught

The scanner's very first run failed — on a JSDoc line in `eslint.config.mjs` that *described* the pattern it matches. A naive regex cannot tell a call site from prose about one, and this repo comments heavily.

Rather than reword the docs around the checker, the checker now blanks comments before matching, tracking quoted strings, template literals, and regex literals so that:

- a `//` inside a string literal (`"https://…"`) is **not** treated as a comment opener — otherwise the obvious way to smuggle a call past a text-based gate would be to put it after a URL on the same line;
- a `/*` inside a regex literal does not blank the rest of the file;
- string literal *contents* are deliberately **not** blanked, because the computed form `prisma["$queryRawUnsafe"](…)` hides the helper name inside one.

Both evasions have tests.

## Tests

`__tests__/scripts/check-raw-sql.test.ts`, 19 tests, following the `__tests__/rsc-boundary-guard.test.ts` precedent. Fixtures are assembled at runtime from fragments, because the test file is itself inside the scanner's scan scope and a literal call site there would be a genuine violation of the rule under test.

Coverage includes both evasion attempts above, the mock-property shape (`{ $queryRaw: vi.fn() }`) not being a false positive, the exception being path-scoped rather than statement-scoped, and a test asserting the real repository scans clean.

## ADR-0003 changes

- Action item 3 ticked, reworded to describe what actually landed.
- The Trade-offs bullet rewritten. Given this record was already corrected once for overclaiming (during review of #304), the new text deliberately does **not** declare victory. It states what each gate does, why both exist, and what neither catches: both match member access, so a destructured or aliased binding such as `const { $queryRawUnsafe } = prisma` passes both, and the script matches text rather than parsing. Closing that needs type-aware linting, which this repo does not run.
- `affects` extended to `scripts/check-raw-sql.ts` and `eslint.config.mjs`, so weakening or deleting the gate surfaces this record in `adr check` and the CI comment.

## Validation

| Check | Result |
|---|---|
| `bun run type-check` | pass |
| `bun run lint` | pass (1 pre-existing warning in `.design-sync/previews/ToastProvider.tsx`) |
| `bun run test` | 1707 passed / 135 files (was 1688 / 134; +19 new) |
| `bun run adr:lint` | `checked 5 records, 0 errors, 0 warnings` |
| `bun run adr:check-integrity` | pass |
| `bun run check:raw-sql` | pass |

`adr check` on the changed files resolves 0001, 0003, and 0005 as governing, with 0003 reached via both new `affects` patterns.

Closes #308
