### PR TITLE
docs(adr-0003): record when the raw-SQL gate has been outgrown

### DIFF
--- a/docs/adr/0003-access-postgresql-exclusively-through-prisma-on-neon-serverless.md
+++ b/docs/adr/0003-access-postgresql-exclusively-through-prisma-on-neon-serverless.md
@@ -173,6 +173,15 @@ for a schema this relational.
   regularly — so the "no `$queryRaw`" rule accrues exceptions — the abstraction
   is no longer paying for itself. Equally, if Prisma cold starts become a
   measurable share of serverless response time on the hot paths.
+- **How we would know the *enforcement* has been outgrown:** if either
+  documented gap ever appears in a real diff — a computed name assembled by
+  concatenation (`prisma["$query" + "Raw"]`), or a destructured or aliased
+  binding (`const { $queryRawUnsafe } = prisma`) — then a text-and-selector
+  gate is no longer sufficient, and the answer is type-aware linting rather
+  than another pattern. The concatenation case is the likelier of the two to
+  arrive by accident, since an unlucky refactor reaches it without anyone
+  intending to evade anything; the aliased binding takes deliberate effort.
+  Adding a third regex in response would be treating the symptom.
 - **Revisit if:** reporting or analytics becomes a first-class feature, or the
   deployment target stops being serverless.
 


### PR DESCRIPTION
## What

Adds one bullet to ADR-0003's Consequences section: what it would mean if either documented gap in the new raw-SQL enforcement ever showed up in a real diff.

## Why

#311 added two gates and honestly recorded what neither catches — a computed name built by concatenation (`prisma["$query" + "Raw"]`) and a destructured or aliased binding (`const { $queryRawUnsafe } = prisma`). What the record did *not* say is what to do about it.

That matters, because the obvious reaction to a real evasion is to add a third regex. That keeps a text gate limping along past the point where it has stopped being the right mechanism. Naming the escalation up front means the next person hits a decision rather than a reflex: either gap appearing in a real diff is the signal to move to type-aware linting, not to extend the pattern list.

It also records which gap is likelier and why — concatenation can be reached by an unlucky refactor with nobody intending to evade anything, whereas an aliased binding takes deliberate effort. That asymmetry is the useful part and is not obvious from the code.

This is the `How we would know this was wrong` discipline applied to the *enforcement* rather than to the decision. ADR-0003 already had one for the decision; it had none for the mechanism now defending it.

## Provenance

The reasoning came from the agent that implemented #311, in its handoff. Captured in the record rather than left in a PR thread, since a record is where the next reader will actually look — which is the premise of ADR-0001.

## Validation

- `bun run adr:lint` — 5 records, 0 errors
- `bun run adr:check-integrity` — pass
- `bun run check:raw-sql` — pass over 624 files (the new prose contains `$queryRaw` examples; `.md` is not scanned, so the record does not trip the gate it describes)

Docs-only; no runtime code touched.