### PR TITLE
docs(adr-0001): separate applying the cloud MCP setting from verifying it

### DIFF
--- a/.github/copilot-cloud-agent-mcp.md
+++ b/.github/copilot-cloud-agent-mcp.md
@@ -79,6 +79,11 @@ session log, set `ADRKIT_MCP_CWD` to a literal path under `env`.
 
 ## Verifying it works
 
+**Saving is not the same as working, and the difference is invisible by
+default.** A server that never loaded and a server that loaded and matched
+nothing both show up as an agent that simply did not mention any decisions. So
+this step is required, not optional.
+
 After saving, start a cloud agent task on any change under `lib/actions/`,
 `prisma/`, `lib/theme.ts`, or `bunfig.toml`, and check the session log for an
 `adrkit` tool call. A working server returns the governing decision; a
@@ -86,7 +91,15 @@ misconfigured one says it could not see the corpus. adrkit deliberately renders
 those two cases as different messages, so "no decisions govern this" and "I was
 looking in the wrong place" cannot be confused.
 
-Locally, the same corpus is reachable with `bun run adr:explain <path>`.
+Expected on a working setup: 5 records in the corpus, `lib/theme.ts` governed by
+ADR-0004, and `lib/actions/**` governed by ADR-0002 and ADR-0003.
+
+This cannot be checked from a local session — the setting only affects the cloud
+agent and Copilot code review, and neither exposes an API for reading it back.
+ADR-0001 carries an open action item until someone has observed the tool call.
+
+Locally, the same corpus is reachable with `bun run adr:explain <path>`. That
+exercises the CLI, not this setting, so it is not a substitute.
 
 ## Related
 

--- a/docs/adr/0001-record-architecture-decisions-as-versioned-markdown-in-git.md
+++ b/docs/adr/0001-record-architecture-decisions-as-versioned-markdown-in-git.md
@@ -178,6 +178,11 @@ We accept real costs:
 3. [x] `adr lint` in CI on pull requests
 4. [x] adrkit MCP server registered in `.mcp.json` and `.vscode/mcp.json`
 5. [x] `CLAUDE.md` and `.github/copilot-instructions.md` point at the corpus
-6. [ ] Apply the cloud agent / code review MCP setting in repository settings —
+6. [x] Apply the cloud agent / code review MCP setting in repository settings —
    it is a GitHub web-UI value with no file format and no API, so it cannot be
    committed; the exact JSON is in `.github/copilot-cloud-agent-mcp.md`
+7. [ ] Confirm that setting actually took effect, by observing an `adrkit` tool
+   call in a cloud agent or code review session. Applying it and it working are
+   different claims: a server that never loaded and one that loaded and found
+   nothing both produce silence. Until this is checked, treat cloud-side ADR
+   retrieval as unconfirmed rather than working.


### PR DESCRIPTION
## What

Ticks ADR-0001 action item 6 (the cloud agent MCP setting has been applied), and splits out a new item 7 for confirming it actually works.

## Why not just tick one box

Because "applied" and "working" are different claims, and the record was treating them as one.

The setting has been applied — that part is done. What has *not* happened is anyone observing it function. I made two attempts to confirm it from a cloud agent session; both produced no output at all, so cloud-side ADR retrieval remains unconfirmed.

That distinction matters more than it sounds. A server that never loaded and a server that loaded and matched nothing both present identically: an agent that simply does not mention any decisions. There is no error surfaced to the user, and no API to read the setting back. So a single ticked box would have recorded a capability that nobody has seen work, in the one place future readers and agents will trust as authoritative — which is exactly the silent-failure mode the deep review on #304 flagged for this setting.

## Changes

- `docs/adr/0001-*.md` — item 6 ticked; new item 7 covering observation, stating why the two are not the same check.
- `.github/copilot-cloud-agent-mcp.md` — the "Verifying it works" section now leads with the fact that saving is not the same as working, gives the concrete expected result (5 records; `lib/theme.ts` → ADR-0004; `lib/actions/**` → ADR-0002 and ADR-0003), and notes that `bun run adr:explain` exercises the CLI rather than this setting, so it is not a substitute.

## How to close item 7

Open any cloud agent session and look for an `adrkit` tool call in its log. Roughly a minute of work, and it cannot be done from a local session.

## Validation

- `bun run adr:lint` — 5 records, 0 errors
- `bun run adr:check-integrity` — pass
- `bun run check:raw-sql` — pass over 624 files

Docs-only; no runtime code touched.