### PR TITLE
ci: run type-check, lint, and tests on pull requests

### DIFF
--- a/.github/AUTOMATION.md
+++ b/.github/AUTOMATION.md
@@ -8,11 +8,16 @@ OpenLeague uses GitHub Actions to automate the entire release lifecycle, from ve
 
 | Workflow | Trigger | Status | Purpose |
 |----------|---------|--------|---------|
+| **Quality Gates** | PR to `main`, push to `main` | ![Quality Gates](https://github.com/mbeacom/openleague/workflows/Quality%20Gates/badge.svg) | Type-check, lint, and the unit test suite |
+| **Runtime Smoke Tests** | PR to `main`, push to `main` | ![Runtime Smoke Tests](https://github.com/mbeacom/openleague/workflows/Runtime%20Smoke%20Tests/badge.svg) | Boot the production build, sign in, render critical pages |
+| **Architecture Decision Records** | PR to `main` | ![Architecture Decision Records](https://github.com/mbeacom/openleague/workflows/Architecture%20Decision%20Records/badge.svg) | Lint the ADR corpus, enforce the raw-SQL ban, comment governing decisions |
+| **Architecture Decision Review Dates** | Monthly schedule | ![Architecture Decision Review Dates](https://github.com/mbeacom/openleague/workflows/Architecture%20Decision%20Review%20Dates/badge.svg) | Track ADRs past their `reviewBy` date |
 | **Release** | Push to `main` | ![Release](https://github.com/mbeacom/openleague/workflows/Release/badge.svg) | Automated releases with semantic versioning |
 | **Tag Release** | Push tag `v*.*.*` | ![Tag Release](https://github.com/mbeacom/openleague/workflows/Tag%20Release/badge.svg) | Release from manual tags |
 | **Version Check** | PR to `main` | ![Version Check](https://github.com/mbeacom/openleague/workflows/Version%20Check/badge.svg) | Validate version bumps in PRs |
 | **Documentation Pages** | Docs changes on `main` | ![Documentation Pages](https://github.com/mbeacom/openleague/workflows/Documentation%20Pages/badge.svg) | Build and deploy static docs to GitHub Pages |
 | **Deployment Checks** | Deployment/docs PR changes | ![Deployment Checks](https://github.com/mbeacom/openleague/workflows/Deployment%20Checks/badge.svg) | Validate deployment config and docs artifact |
+| **Uptime Monitoring** | Scheduled | ![Uptime Monitoring](https://github.com/mbeacom/openleague/workflows/Uptime%20Monitoring/badge.svg) | Probe production endpoints |
 
 ## Quick Start
 

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -1,0 +1,71 @@
+name: Quality Gates
+
+# Type-check, lint, and the unit test suite. Before this existed, none of the
+# three ran on a pull request: `bun run type-check` and `bun run lint` appeared
+# only in release.yml and tag-release.yml, both push-triggered, and `bun run
+# test` ran in no workflow at all -- so a change that broke a test merged green
+# and surfaced later on main, in the pipeline that cuts releases (#310).
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: quality-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  quality:
+    name: Type-check, lint, and test
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # Version-bump commits change no source; release.yml skips them the same
+    # way. Scoped to `push` on purpose: `github.event.head_commit` does not
+    # exist on a pull_request event, and an expression that skipped there would
+    # silently disable this gate on exactly the PRs it exists to protect --
+    # a skipped job reports as skipped, not failed, so nobody would notice.
+    if: ${{ github.event_name != 'push' || !contains(github.event.head_commit.message, '[skip ci]') }}
+
+    env:
+      # Prisma client generation runs during bun install. A real secret is used
+      # when available; the fallback only satisfies generate-time URL parsing.
+      DATABASE_URL: ${{ secrets.DATABASE_URL || 'postgresql://postgres:postgres@localhost:5432/openleague_ci' }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2.0.2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      # Five test files and the type-checker import `@prisma/client`, so the
+      # generated client has to exist before either runs. `bun install` runs
+      # this via postinstall, but only when DATABASE_URL parses -- hence the env
+      # above. Running it explicitly makes the dependency visible rather than
+      # implicit in a lifecycle script.
+      - name: Generate Prisma Client
+        run: bun run db:generate
+
+      - name: Type check
+        run: bun run type-check
+
+      # Fails on errors, not warnings. See the pull request that added this
+      # workflow for why zero-warning enforcement was left as a separate call.
+      - name: Lint
+        run: bun run lint
+
+      - name: Unit tests
+        run: bun run test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -562,9 +562,16 @@ OpenLeague uses semantic versioning with conventional commits:
 - `fix:` commits trigger patch version bump (0.0.X)
 - `feat!:` or `BREAKING CHANGE:` trigger major version bump (X.0.0)
 
+**What gates a pull request** (`.github/workflows/quality-gates.yml`):
+type-check, lint, and the full Vitest suite. Until #310 these ran nowhere on a
+PR — `type-check` and `lint` only on push to `main`, and `bun run test` in no
+workflow at all — so a change that broke a test merged green and surfaced later
+in the release pipeline. Alongside these run the ADR corpus checks, the runtime
+smoke tests, deployment checks, and CodeQL.
+
 **Release process**:
 1. Merge to `main` branch triggers automated release workflow
-2. GitHub Actions runs type-checking, linting, and tests
+2. GitHub Actions runs type-checking, linting, and the build
 3. Semantic version determined from commit messages
 4. Changelog generated automatically
 5. GitHub release created with assets


### PR DESCRIPTION
## The gap

None of the three quality gates ran on a pull request. `bun run type-check` and `bun run lint` appeared only in `release.yml` and `tag-release.yml`, both push-triggered, and `bun run test` ran in **no workflow at all** — so 1788 tests across 137 files never gated a merge.

A change that broke a test merged green and surfaced afterwards on `main`, in the pipeline that cuts releases. Recovery was a fix-forward commit on `main` rather than a red check on the PR.

This also quietly weakened everything added recently: the ADR gates, the raw-SQL scanner, and the corpus integrity check are only worth what actually blocks a merge.

## What this adds

`.github/workflows/quality-gates.yml` — type-check, lint, and the unit suite, on pull requests and on push to `main`. It follows the install pattern `release.yml` already uses: full install, then `db:generate`, because five test files and the type-checker import `@prisma/client`.

One job rather than three, so the dependency install is paid once instead of three times.

## Observed failing before trusted

A gate nobody has watched fail is not a gate. Each was seeded, observed failing, reverted, and observed passing again. Nothing seeded is committed — `git status` was clean before the commit.

| Gate | Seeded violation | Result |
|---|---|---|
| type-check | bad annotation in `lib/utils/date.ts` | `error TS2322`, exit 2 |
| lint | conditional hook (`react-hooks/rules-of-hooks`) | 1 error, exit 1 |
| test | inverted return in `isValidTimeZone` | 7 failures, exit 1 |

Worth recording: my **first** lint seed used `no-cond-assign` and `no-var` and produced nothing at all, because neither rule is enabled in this config. Had I stopped at "I added a lint gate", I would have shipped it without ever confirming lint can fail the build.

## A subtlety in the `[skip ci]` guard

`release.yml` skips version-bump commits with `!contains(github.event.head_commit.message, '[skip ci]')`. Copying that verbatim would have been a latent bug: `github.event.head_commit` does not exist on a `pull_request` event, and if that expression ever evaluated truthy the job would be **skipped on every PR** — silently disabling the gate on exactly the pull requests it exists to protect. A skipped job reports as skipped, not failed, so nobody would notice, and a skipped check can satisfy a required-status-check rule.

So the guard is scoped explicitly:

```yaml
if: ${{ github.event_name != 'push' || !contains(github.event.head_commit.message, '[skip ci]') }}
```

**The check list on this PR is the proof** — if `Type-check, lint, and test` appears and runs, the guard is correct.

## Deliberately not in scope

**Zero-warning lint.** `bun run lint` fails on errors, not warnings. The one existing warning is in `.design-sync/previews/ToastProvider.tsx`, whose empty dependency array is intentional — the file's own comment says the effect is mount-only so the visual can be captured statically. Adopting `--max-warnings 0` therefore means either a scoped disable comment (which the design-sync tooling may regenerate away) or excluding that tree from linting. Both are real decisions, and neither belongs in a change about running gates that were missing entirely. Flagging it rather than silently deciding it.

**Required status checks.** Making these blocking is a branch-protection setting, not a file. Worth doing — a green-but-unenforced check is only marginally better than none — but it is yours to set.

## Documentation corrections found along the way

- `CLAUDE.md` claimed GitHub Actions "runs type-checking, linting, and tests" on release. It runs type-check, lint, and **build**; tests ran nowhere. Corrected, and the PR-gating story is now stated explicitly.
- `.github/AUTOMATION.md`'s Active Workflows table listed 5 of the 10 workflows that exist. It was already missing Runtime Smoke Tests, the two ADR workflows, and Uptime Monitoring before this change. Now complete — verified programmatically that every workflow on disk appears and every listed name resolves to a real workflow.

## Validation

`bun run type-check` clean · `bun run lint` clean (the one pre-existing warning) · `bun run test` 1788 passed / 137 files · `bun run adr:lint` 5 records, 0 errors · `bun run adr:check-integrity` OK · `bun run check:raw-sql` OK over 628 files.

ADR-0005 already governs `.github/workflows/**`, so the new workflow is covered by the existing corpus — confirmed with `adr check`. No new record: this implements CI hygiene rather than altering an architectural decision.

Closes #310