### PR TITLE
docs(adr): record how the governing-decisions comment behaves on fork PRs

### DIFF
--- a/.github/workflows/adr.yml
+++ b/.github/workflows/adr.yml
@@ -4,8 +4,11 @@ on:
   # Must stay `pull_request`. The governing-decisions job below holds
   # `pull-requests: write`; switching to `pull_request_target` would combine
   # that write token with a checkout of untrusted fork code. Fork PRs get a
-  # read-only token here, so the comment step degrades to a log notice --
-  # that is the intended behaviour, not a bug to "fix" by changing the trigger.
+  # read-only token here, so the comment step catches the 403, writes the body
+  # to a notice annotation and returns without failing -- see `comment()` and
+  # `isPermissionError` in the pinned action. That is the intended behaviour,
+  # not a bug to "fix" by changing the trigger. Read from the action's source
+  # and never observed here; see #306 and ADR-0001 action item 8.
   pull_request:
     branches:
       - main

--- a/docs/adr/0001-record-architecture-decisions-as-versioned-markdown-in-git.md
+++ b/docs/adr/0001-record-architecture-decisions-as-versioned-markdown-in-git.md
@@ -102,7 +102,7 @@ alternatives, and the exit conditions; the instruction files point at them.
 | Adoption cost | Low — one devDependency, no service, no account |
 | Agent legibility | High — markdown in the repo, plus a read-only MCP server |
 | Path→decision mapping | Native, via `affects` matchers and `adr explain` |
-| CI enforcement | `adr lint` and a comment-only GitHub Action |
+| CI enforcement | `adr lint`, plus an Action that comments governing decisions and fails on an invalid changed record |
 | Rejected-option retention | First-class; `rejected` and `superseded` are retained statuses |
 | Schema rigidity | Frontmatter is strict; malformed records fail lint |
 
@@ -192,3 +192,10 @@ We accept real costs:
    different claims: a server that never loaded and one that loaded and found
    nothing both produce silence. Until this is checked, treat cloud-side ADR
    retrieval as unconfirmed rather than working.
+8. [ ] Confirm how the governing-decisions comment behaves on a pull request
+   from a fork, by observing a real one. The pinned action's source and adrkit's
+   own documentation agree that it catches the permission error and degrades to
+   a `notice` annotation without failing the job, but this repository has had no
+   fork PR since the workflow landed, so that is read rather than observed — the
+   same distinction as item 7. Confirming it needs a pull request from an
+   account that can fork this repository. See #306.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -103,10 +103,10 @@ days of passing, and closes it again once the dates are moved forward. See
   because the equivalent ESLint rules run only on push, so a violation would
   otherwise merge green and break the release pipeline afterwards. See #310.
 - **governing-decisions** — comments the decisions governing the PR's changed
-  files. It approves nothing and writes nothing to the repository, but it is
-  **not** unconditionally non-blocking: it fails the job when a record **changed
-  in that pull request** is itself invalid. The decisions it merely reports on
-  never block.
+  files. It approves nothing and changes no repository content — its only write
+  is the comment itself — but it is **not** unconditionally non-blocking: it
+  fails the job when a record **changed in that pull request** is itself
+  invalid. The decisions it merely reports on never block.
 
   **On a pull request from a fork, the comment is not posted.** GitHub restricts
   `GITHUB_TOKEN` to read-only for `pull_request` events raised from a fork,

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -98,8 +98,40 @@ days of passing, and closes it again once the dates are moved forward. See
 
 - **lint** — `adr lint` over the whole corpus; fails the build on schema errors,
   duplicate ids, or dangling references.
+- **raw-sql** — enforces the ADR-0003 raw-SQL prohibition with
+  `bun run check:raw-sql`. It is a job here rather than a lone ESLint rule
+  because the equivalent ESLint rules run only on push, so a violation would
+  otherwise merge green and break the release pipeline afterwards. See #310.
 - **governing-decisions** — comments the decisions governing the PR's changed
-  files. Read-only and comment-only; it never approves or blocks anything.
+  files. It approves nothing and writes nothing to the repository, but it is
+  **not** unconditionally non-blocking: it fails the job when a record **changed
+  in that pull request** is itself invalid. The decisions it merely reports on
+  never block.
+
+  **On a pull request from a fork, the comment is not posted.** GitHub restricts
+  `GITHUB_TOKEN` to read-only for `pull_request` events raised from a fork,
+  whatever the workflow's `permissions:` block asks for. The action catches the
+  resulting `403`, writes the comment body to a `notice` annotation on the run
+  instead, and returns without failing — the job still passes, and the content
+  is relocated rather than lost. That is accepted behaviour, not a defect, and
+  in particular not one to "fix" by switching to `pull_request_target`, which
+  would pair a write token with a checkout of untrusted fork code.
+
+  `lint` and `raw-sql` need only `contents: read`, so a fork PR is still gated
+  on corpus validity and the raw-SQL prohibition exactly as a branch PR is.
+
+  **Contributing from a fork?** You will not receive the comment. Ask for the
+  same answer locally before you push:
+
+  ```bash
+  bun run adr:check <changed files...>   # decisions governing your change
+  bun run adr:explain <path>             # decisions governing one file
+  ```
+
+  This is read from the pinned action's source and from adrkit's own
+  documentation, which states the Action "degrades (never fails the job) on a
+  read-only fork token". It has **not** been observed here — this repository has
+  had no fork PR since the workflow landed. Tracked as ADR-0001 action item 8.
 
 `.github/workflows/adr-review.yml` runs monthly, and on demand via
 `workflow_dispatch`:


### PR DESCRIPTION
Closes #306.

## TL;DR

The `governing-decisions` job **degrades gracefully** on a fork PR: the comment is not posted, the body goes to a `notice` annotation on the run, and the job still passes. So the issue's failure branch does not apply and no workflow change is needed — this PR documents the behaviour and corrects two claims the investigation proved false.

⚠️ **This is a source-read conclusion, not an observed one.** See [Confidence](#confidence).

## Why it could not be observed

The issue proposes confirming with a real fork PR. That is not available: @mbeacom owns this repository, and GitHub does not permit an account to fork its own repo, so a genuine fork PR requires a second account. Throwaway accounts and org-forks were ruled out as ways to manufacture one. The conclusion below is therefore read from the pinned action's source.

Action traced: `mbeacom/adrkit/packages/ci@c3dff3a7a9c3df44233809423eb59a3505fcf6f5` (`# v0.4.0`), file `packages/ci/dist/index.js`.

## 1. Does `"skipped"` lead to a failure up the chain? **No.**

`setFailed` is the only thing that sets a non-zero exit (`process.exitCode = ExitCode.Failure`, L29064). It is reachable in exactly three places:

| Line | Trigger | On the fork path? |
|---|---|---|
| 48443 | no token available | No — `GITHUB_TOKEN` is present, merely read-only |
| 48427 | a **changed** ADR record fails validation | Only if the PR edits a bad record |
| 48461 | top-level `.catch()` | No — the 403 is caught before it propagates |

The chain is `main()` → `runAction()` → `comment()` → `upsertMarkedComment` → `createComment`/`updateComment` → **403** → `isPermissionError` (matches 403/401/404, L48387) → `log.notice(...)` → returns `"skipped"` (L48403).

`runAction` binds that to `result` and returns it as `comment: result` (L48429) but computes `failed` **solely** from `changedRecordErrors` (L48424–48425), never consulting it. Then the decisive step: **`main()` discards `runAction`'s return value entirely** — L48447 is a bare `await runAction({...})`, and the function ends at L48459 without inspecting anything. `notice()` issues an annotation and never touches the exit code.

**The graceful degradation is real, not illusory.**

## 2. Does anything earlier need write and fail first? **No.**

Every API call the action makes, in execution order:

| Call | Access | Fork outcome |
|---|---|---|
| `pulls.listFiles` (L48347) | read | OK |
| `users.getAuthenticated` (L48340) | read | Fails on *every* run, fork or not — `GITHUB_TOKEN` is not a user token. Already wrapped in its own try/catch falling back to `github-actions[bot]` (L48317–48319). |
| `issues.listComments` (L48361) | read | OK |
| `createComment` / `updateComment` (L48373/48382) | **write** | **403 → caught** |

The single write is also the **last** thing attempted, so it cannot be masking an earlier failure. `actions/checkout` works on fork PRs with a read token.

## 3. Are `lint` and `raw-sql` correct on a fork? **Yes.**

Both run under the workflow-level `permissions: contents: read` and are checkout + Bun + local scripts, with no API writes. Fork PRs remain gated on corpus validity and the ADR-0003 raw-SQL prohibition.

## Two defects the same trace exposed

Tracing the `setFailed` call sites disproved a claim in two places:

1. **`docs/adr/README.md`** — "Read-only and comment-only; it never approves or blocks anything." It *does* block: `runAction` calls `setFailed` when a record **changed in that PR** is invalid (L48424–48428).
2. **`docs/adr/0001-…md`** — the options table described it as "a comment-only GitHub Action". Same error, same root cause. Flagged by @mbeacom; fixing one and leaving the other is the drift ADR-0001 exists to prevent.

Rather than delete the claim, both now split the two things "read-only" was doing in one sentence: the action **changes no repository content** (its only write is the comment itself) **and approves nothing**, but it **does** gate on changed-record validity. That distinction is load-bearing — it is why a fork PR is still gated on corpus validity despite having no comment permission.

## Also in this PR

- **The `raw-sql` job** (from #310/#311) is added to the README's CI list, which never picked it up. `.github/AUTOMATION.md` already described it correctly.
- **A self-serve pointer for fork contributors** — `bun run adr:check` / `adr:explain` — since they will not receive the comment. Both verified to work.
- **ADR-0001 action item 8**, tracking the unobserved claim so it does not evaporate when this issue closes. It deliberately mirrors item 7's framing ("applying it and it working are different claims").

## Deliberately not done

No `workflow_run` split. The issue makes that conditional on the job *failing*, and it does not. More to the point: shipping an untested two-workflow artifact-handoff pipeline to fix an unobserved problem would repeat exactly the mistake this repo's recent work exists to stop. The trigger stays `pull_request`; the `pull_request_target` prohibition is untouched and now better explained.

The gap that survives is real and worth naming: **fork contributors silently never receive the comment** — the audience least likely to know which decisions constrain their change. The `adr:check` pointer is a partial mitigation, not a fix.

<h2 id="confidence">Confidence</h2>

| Claim | Status |
|---|---|
| The job fails when a changed ADR record is invalid | **Observed locally.** `bun run adr:check` on this PR's own files reports `1 changed records, 0 changed-record errors` — the same `checkChanges()` core the action uses, exercising the exact path that calls `setFailed`. |
| Fork PRs get a read-only token | **Documented by GitHub.** "GitHub restricts these events to a read-only `GITHUB_TOKEN`" — [Securely using `pull_request_target`](https://docs.github.com/en/actions/reference/security/securely-using-pull_request_target). |
| The 403 is caught and the job still passes | **Read, not observed.** Source trace above, corroborated by adrkit's own README: the Action "degrades (never fails the job) on a read-only fork token". Not independent — same author — but it is the author's stated intent and it matches the code. |

**What would confirm it:** one real fork PR from a second account. Until then the fork behaviour should be treated as documented, not verified. Tracked as ADR-0001 action item 8.

## Note for upstream (not filed — @mbeacom asked to raise it himself)

adrkit's `README.md:60` says the CI Action is "read-only, comment-only, no database, no approval" — this is where the wording here came from, and it carries the same over-generalization: it *can* fail the job on an invalid changed record. Worth tightening upstream. By contrast `README.md:182` is accurate as scoped and was useful corroboration here.

## Validation

| Check | Result |
|---|---|
| `bun run type-check` | ✅ clean |
| `bun run lint` | ✅ 0 errors, 1 warning — the pre-existing `ToastProvider.tsx` one, untouched |
| `bun run test` | ✅ **1788 passed / 137 files** |
| `bun run adr:lint` | ✅ 5 records, 0 errors, 0 warnings |
| `bun run adr:check-integrity` | ✅ 5 discoverable records, all pins agree |
| `bun run check:raw-sql` | ✅ 628 files scanned, no violations |

`adr:lint` passing matters more than usual here: this PR **changes** ADR-0001, making it a changed record — precisely the input that would fail the `governing-decisions` job.

Docs and one YAML comment only; no runtime code touched. Branch was already at `origin/main` tip `70d5b3f` (post-`bun.lock`), so no rebase was required.
