### PR TITLE
fix: close the MCP supply-chain gap left by bunx/npx launches

### DIFF
--- a/.github/copilot-cloud-agent-mcp.md
+++ b/.github/copilot-cloud-agent-mcp.md
@@ -10,7 +10,11 @@ Applies to **Copilot cloud agent** (the coding agent that opens pull requests)
 and **Copilot code review**, which share one repository-level MCP configuration.
 It does **not** affect local editors — those read `.mcp.json` (Copilot CLI /
 Claude Code) and `.vscode/mcp.json` (VS Code), both of which are committed and
-do work automatically.
+work once `bun install` has run. Since #307 they launch the adrkit server from
+`node_modules/.bin`, so in a fresh clone or a new worktree the server does not
+start until dependencies are installed. That is deliberate: failing closed is
+the point of a supply-chain control, and the alternative — falling back to a
+registry fetch — is the behaviour being removed.
 
 ## Applying it
 
@@ -55,11 +59,39 @@ but Bun is not preinstalled on the agent's runner and this repository has no
 also keeps the server independent of whether `bun install` has run — it needs no
 `node_modules`, so it cannot be broken by install ordering.
 
-**Pinned to `@0.4.0`.** Matches the `@adrkit/cli` pin in `package.json` and the
-commit-pinned CI action, per
+**A registry fetch, unlike the local configs — and this one cannot be fixed.**
+`.mcp.json` and `.vscode/mcp.json` no longer fetch this package at all. They run
+`node_modules/.bin/adrkit-mcp` from a pinned devDependency, so locally the server
+is covered by `bun.lock`'s integrity hash and by the three-day
+`minimumReleaseAge` quarantine in `bunfig.toml` (#307).
+
+**This config cannot do that, and the gap is real rather than theoretical.** The
+setting may be evaluated before or independently of `bun install`, so
+`./node_modules/.bin/...` would resolve to nothing and the server would simply
+fail to start — including for Copilot code review, which does not run the
+repository's install step at all. So this entry still resolves `@adrkit/mcp` from
+the npm registry at process start, outside the lockfile and outside the
+quarantine. If that exact version were ever replaced on npm, the next cloud agent
+run would execute the replacement, autonomously, with repository access.
+
+The exact-version pin below is the only control available here, and it is a real
+one: npm forbids republishing a version that already exists and restricts
+unpublishing, so an attacker needs a registry-level replacement rather than just
+a new publish. That is the difference between this and a `@latest` entry — but it
+is *not* equivalent to what the local configs now have. Do not read the two as
+being in sync; they deliberately differ, and `bun run adr:check-integrity`
+enforces both shapes separately so neither can silently drift into the other.
+
+This gap closes only if the agent runner gains a dependable pre-install step
+(`copilot-setup-steps.yml` installing Bun and running `bun install`), at which
+point this entry can move to the local binary like the other two.
+
+**Pinned to `@0.4.0`.** Matches the `@adrkit/cli` and `@adrkit/mcp` pins in
+`package.json` and the commit-pinned CI action, per
 [ADR-0001](../docs/adr/0001-record-architecture-decisions-as-versioned-markdown-in-git.md).
 An agent given a floating `@latest` would silently change behaviour on an
-upstream release. Bump this at the same time as the other two.
+upstream release. Bump this at the same time as the others —
+`bun run adr:check-integrity` fails if they disagree.
 
 **An explicit `tools` allowlist rather than `*`.** The agent uses these tools
 autonomously without asking, so GitHub recommends allowlisting read-only tools.
@@ -104,5 +136,6 @@ exercises the CLI, not this setting, so it is not a substitute.
 ## Related
 
 - [`docs/adr/README.md`](../docs/adr/README.md) — the corpus and its workflow
-- [`.mcp.json`](../.mcp.json) / [`.vscode/mcp.json`](../.vscode/mcp.json) — local editor equivalents
+- [`.mcp.json`](../.mcp.json) / [`.vscode/mcp.json`](../.vscode/mcp.json) — local editor equivalents, which run the pinned local binary rather than fetching
+- [ADR-0005](../docs/adr/0005-standardize-on-bun-as-the-development-and-ci-toolchain.md) — the MCP-launch supply-chain policy and the gap recorded above
 - [Configure MCP servers for your repository](https://docs.github.com/en/copilot/how-tos/copilot-on-github/customize-copilot/configure-mcp-servers)

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -69,3 +69,28 @@ jobs:
 
       - name: Unit tests
         run: bun run test
+
+  # A separate job rather than a step in `quality`, and deliberately without
+  # `bun install`: the check imports only node: builtins and makes no network
+  # calls, precisely so it cannot be defeated by a dependency or install
+  # failure -- the same reasoning as the raw-sql job in adr.yml.
+  #
+  # It enforces the ADR-0005 MCP-launch policy: every server in .mcp.json and
+  # .vscode/mcp.json must run a pinned local binary or fetch an exact version.
+  # Nothing else notices a regression to `@latest` -- the config is not
+  # compiled, linted, or type-checked, and a floating tag starts a working
+  # server right up until the day a bad version is published. See #307.
+  mcp-pins:
+    name: Enforce the ADR-0005 MCP pin policy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2.0.2
+        with:
+          bun-version: latest
+
+      - name: Check MCP server pins
+        run: bun run check:mcp-pins

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,28 +1,20 @@
 {
   "mcpServers": {
     "adrkit": {
-      "command": "bunx",
-      "args": [
-        "--bun",
-        "-y",
-        "@adrkit/mcp@0.4.0",
-        "--cwd",
-        ".",
-        "--dir",
-        "docs/adr"
-      ]
+      "command": "./node_modules/.bin/adrkit-mcp",
+      "args": ["--cwd", ".", "--dir", "docs/adr"]
     },
     "context7": {
       "command": "bunx",
-      "args": ["--bun", "-y", "@upstash/context7-mcp@^2"]
+      "args": ["--bun", "-y", "@upstash/context7-mcp@2.3.0"]
     },
     "playwright": {
       "command": "bunx",
-      "args": ["--bun", "-y", "@playwright/mcp@latest"]
+      "args": ["--bun", "-y", "@playwright/mcp@0.0.79"]
     },
     "next-devtools": {
       "command": "bunx",
-      "args": ["--bun", "-y", "next-devtools-mcp@latest"]
+      "args": ["--bun", "-y", "next-devtools-mcp@0.4.0"]
     }
   }
 }

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -2,16 +2,8 @@
   "servers": {
     "adrkit": {
       "type": "stdio",
-      "command": "bunx",
-      "args": [
-        "--bun",
-        "-y",
-        "@adrkit/mcp@0.4.0",
-        "--cwd",
-        "${workspaceFolder}",
-        "--dir",
-        "docs/adr"
-      ]
+      "command": "${workspaceFolder}/node_modules/.bin/adrkit-mcp",
+      "args": ["--cwd", "${workspaceFolder}", "--dir", "docs/adr"]
     }
   }
 }

--- a/__tests__/scripts/check-adr-integrity.test.ts
+++ b/__tests__/scripts/check-adr-integrity.test.ts
@@ -20,23 +20,40 @@ import { runIntegrityChecks } from '@/scripts/check-adr-integrity';
 const ADRKIT_VERSION = '0.4.0';
 const CI_ACTION_SHA = 'c3dff3a7a9c3df44233809423eb59a3505fcf6f5';
 
+/** Matches the real bunfig.toml: every first-party adrkit package exempted. */
+const EXCLUDES = ['@adrkit/cli', '@adrkit/core', '@adrkit/evaluator', '@adrkit/mcp'];
+
 interface FixtureOptions {
   /** Filenames to place in `docs/adr/`. */
   corpus?: string[];
   /** Set false to skip creating `docs/adr/` entirely. */
   withCorpusDir?: boolean;
   cliVersion?: string;
-  mcpVersion?: string;
+  /** devDependencies pin for `@adrkit/mcp`; null omits it entirely. */
+  mcpVersion?: string | null;
   ciActionVersion?: string;
+  cloudDocVersion?: string;
+  /** Raw contents for the two local MCP configs. */
+  localMcpJson?: string;
+  /** Package names to list in `minimumReleaseAgeExcludes`. */
+  excludes?: string[];
   omitFiles?: string[];
 }
+
+/** The compliant launch shape: the local binary, no registry fetch. */
+const LOCAL_MCP_JSON = JSON.stringify({
+  mcpServers: { adrkit: { command: './node_modules/.bin/adrkit-mcp' } },
+});
 
 /** Build a throwaway repo root that the checks can run against. */
 function makeFixture(options: FixtureOptions = {}): string {
   const {
     ciActionVersion = ADRKIT_VERSION,
     cliVersion = ADRKIT_VERSION,
+    cloudDocVersion = ADRKIT_VERSION,
     corpus = ['README.md', '0000-template.md', '0001-a-real-decision.md'],
+    excludes = EXCLUDES,
+    localMcpJson = LOCAL_MCP_JSON,
     mcpVersion = ADRKIT_VERSION,
     omitFiles = [],
     withCorpusDir = true,
@@ -58,15 +75,21 @@ function makeFixture(options: FixtureOptions = {}): string {
     }
   }
 
+  const devDependencies: Record<string, string> = { '@adrkit/cli': cliVersion };
+  if (mcpVersion !== null) devDependencies['@adrkit/mcp'] = mcpVersion;
+
+  write('package.json', JSON.stringify({ devDependencies }, null, 2));
+  write('.mcp.json', localMcpJson);
+  write('.vscode/mcp.json', localMcpJson);
   write(
-    'package.json',
-    JSON.stringify({ devDependencies: { '@adrkit/cli': cliVersion } }, null, 2),
+    'bunfig.toml',
+    '[install]\nminimumReleaseAge = 259200\nminimumReleaseAgeExcludes = [' +
+      excludes.map((name) => `"${name}"`).join(', ') +
+      ']\n',
   );
-  write('.mcp.json', `{"adrkit":{"args":["@adrkit/mcp@${mcpVersion}"]}}`);
-  write('.vscode/mcp.json', `{"adrkit":{"args":["@adrkit/mcp@${mcpVersion}"]}}`);
   write(
     '.github/copilot-cloud-agent-mcp.md',
-    `Paste \`npx @adrkit/mcp@${mcpVersion}\` into repository settings.\n`,
+    `Paste \`npx @adrkit/mcp@${cloudDocVersion}\` into repository settings.\n`,
   );
   write(
     '.github/workflows/adr.yml',
@@ -171,11 +194,27 @@ describe('check-adr-integrity', () => {
   });
 
   describe('version-pin guard', () => {
-    it('fails when the MCP pin drifts from the CLI pin', () => {
+    it('fails when the devDependency MCP pin drifts from the CLI pin', () => {
       withFixture({ mcpVersion: '0.3.0' }, (result) => {
-        const joined = result.failures.join('\n');
-        expect(joined).toContain('.mcp.json pins @adrkit/mcp at 0.3.0');
-        expect(joined).toContain('.vscode/mcp.json');
+        expect(result.failures.join('\n')).toContain(
+          'package.json pins @adrkit/mcp at 0.3.0 but @adrkit/cli at 0.4.0',
+        );
+      });
+    });
+
+    it('fails when @adrkit/mcp is not a devDependency at all', () => {
+      // The local configs run node_modules/.bin/adrkit-mcp, so without the
+      // dependency the server cannot start -- and nothing else would say so.
+      withFixture({ mcpVersion: null }, (result) => {
+        expect(result.failures.join('\n')).toContain(
+          'package.json does not pin @adrkit/mcp in devDependencies',
+        );
+      });
+    });
+
+    it('fails when @adrkit/mcp is a range rather than an exact version', () => {
+      withFixture({ mcpVersion: '^0.4.0' }, (result) => {
+        expect(result.failures.join('\n')).toContain('@adrkit/mcp is "^0.4.0"');
       });
     });
 
@@ -188,19 +227,11 @@ describe('check-adr-integrity', () => {
     });
 
     it('fails when the documented cloud agent config drifts', () => {
-      const root = makeFixture();
-      try {
-        writeFileSync(
-          path.join(root, '.github', 'copilot-cloud-agent-mcp.md'),
-          'Paste `npx @adrkit/mcp@0.1.0` into repository settings.\n',
-          'utf8',
-        );
-        expect(runIntegrityChecks(root).failures.join('\n')).toContain(
+      withFixture({ cloudDocVersion: '0.1.0' }, (result) => {
+        expect(result.failures.join('\n')).toContain(
           'copilot-cloud-agent-mcp.md pins',
         );
-      } finally {
-        rmSync(root, { force: true, recursive: true });
-      }
+      });
     });
 
     it('fails when @adrkit/cli is a range rather than an exact version', () => {
@@ -228,6 +259,89 @@ describe('check-adr-integrity', () => {
     it('fails when a pin site file is missing', () => {
       withFixture({ omitFiles: ['.mcp.json'] }, (result) => {
         expect(result.failures.join('\n')).toContain('.mcp.json is missing');
+      });
+    });
+  });
+
+  describe('local-binary guard (#307)', () => {
+    // A config that went back to `bunx -y @adrkit/mcp@0.4.0` still starts a
+    // working server at the right version, so every other signal stays green.
+    // The only thing that changed is that it is fetching from the registry
+    // again -- outside bun.lock and outside the release quarantine.
+    it('fails when a local config fetches @adrkit/mcp from the registry', () => {
+      withFixture(
+        {
+          localMcpJson: JSON.stringify({
+            mcpServers: { adrkit: { command: 'bunx', args: ['-y', '@adrkit/mcp@0.4.0'] } },
+          }),
+        },
+        (result) => {
+          const joined = result.failures.join('\n');
+          expect(joined).toContain('.mcp.json fetches @adrkit/mcp from the registry');
+          expect(joined).toContain('.vscode/mcp.json fetches');
+        },
+      );
+    });
+
+    it('fails when a local config no longer runs the adrkit binary', () => {
+      withFixture(
+        { localMcpJson: JSON.stringify({ mcpServers: { other: { command: 'true' } } }) },
+        (result) => {
+          expect(result.failures.join('\n')).toContain(
+            'does not run node_modules/.bin/adrkit-mcp',
+          );
+        },
+      );
+    });
+
+    it('accepts the workspace-variable form VS Code uses', () => {
+      withFixture(
+        {
+          localMcpJson: JSON.stringify({
+            mcpServers: {
+              adrkit: { command: '${workspaceFolder}/node_modules/.bin/adrkit-mcp' },
+            },
+          }),
+        },
+        (result) => {
+          expect(result.failures).toEqual([]);
+        },
+      );
+    });
+  });
+
+  describe('quarantine-exclusion guard (#307)', () => {
+    // minimumReleaseAgeExcludes is per-package: it does not cover a package's
+    // dependencies, and it does not accept globs. Miss one and the next adrkit
+    // release cannot be installed for three days -- and it cannot be worked
+    // around by bumping one package first, because the pins must move together.
+    it.each(['@adrkit/core', '@adrkit/evaluator', '@adrkit/mcp', '@adrkit/cli'])(
+      'fails when %s is missing from minimumReleaseAgeExcludes',
+      (missing) => {
+        withFixture(
+          { excludes: EXCLUDES.filter((name) => name !== missing) },
+          (result) => {
+            expect(result.failures.join('\n')).toContain(
+              `does not list "${missing}" in minimumReleaseAgeExcludes`,
+            );
+          },
+        );
+      },
+    );
+
+    it('does not require exclusions when no quarantine is configured', () => {
+      const root = makeFixture();
+      try {
+        writeFileSync(path.join(root, 'bunfig.toml'), '[install]\n', 'utf8');
+        expect(runIntegrityChecks(root).failures).toEqual([]);
+      } finally {
+        rmSync(root, { force: true, recursive: true });
+      }
+    });
+
+    it('fails when bunfig.toml is missing entirely', () => {
+      withFixture({ omitFiles: ['bunfig.toml'] }, (result) => {
+        expect(result.failures.join('\n')).toContain('bunfig.toml is missing');
       });
     });
   });

--- a/__tests__/scripts/check-mcp-pins.test.ts
+++ b/__tests__/scripts/check-mcp-pins.test.ts
@@ -1,0 +1,332 @@
+/**
+ * Regression tests for `scripts/check-mcp-pins.ts`.
+ *
+ * This gate is the only thing stopping an MCP server from going back to
+ * `@latest`. Nothing else notices: the configs are not compiled, not linted,
+ * and not type-checked, and a floating tag looks exactly like a pinned one
+ * until the day a bad version is published. The failure it guards against is
+ * silent by construction, so these tests are the only protection it has.
+ */
+import { describe, expect, it } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { checkMcpPins, splitPackageSpec } from '@/scripts/check-mcp-pins';
+
+type ServerEntry = Record<string, unknown>;
+
+interface FixtureOptions {
+  /** Entries for `.mcp.json`. Omit for a single valid pinned server. */
+  mcpServers?: Record<string, ServerEntry>;
+  /** Entries for `.vscode/mcp.json`. */
+  vscodeServers?: Record<string, ServerEntry>;
+  /** Write these raw strings instead of serialising the objects above. */
+  rawMcpJson?: string;
+  /** Skip creating these files entirely. */
+  omitFiles?: string[];
+}
+
+const pinned = (spec: string): ServerEntry => ({
+  command: 'bunx',
+  args: ['--bun', '-y', spec],
+});
+
+const localBinary: ServerEntry = {
+  command: './node_modules/.bin/adrkit-mcp',
+  args: ['--cwd', '.', '--dir', 'docs/adr'],
+};
+
+function makeFixture(options: FixtureOptions = {}): string {
+  const {
+    mcpServers = { pinned: pinned('some-pkg@1.2.3') },
+    omitFiles = [],
+    rawMcpJson,
+    vscodeServers = { adrkit: localBinary },
+  } = options;
+
+  const root = mkdtempSync(path.join(tmpdir(), 'mcp-pins-'));
+
+  const write = (relative: string, contents: string) => {
+    if (omitFiles.includes(relative)) return;
+    const target = path.join(root, relative);
+    mkdirSync(path.dirname(target), { recursive: true });
+    writeFileSync(target, contents, 'utf8');
+  };
+
+  write('.mcp.json', rawMcpJson ?? JSON.stringify({ mcpServers }, null, 2));
+  write(
+    path.join('.vscode', 'mcp.json'),
+    JSON.stringify({ servers: vscodeServers }, null, 2),
+  );
+
+  return root;
+}
+
+function withFixture(
+  options: FixtureOptions,
+  assert: (result: ReturnType<typeof checkMcpPins>) => void,
+): void {
+  const root = makeFixture(options);
+  try {
+    assert(checkMcpPins(root));
+  } finally {
+    rmSync(root, { force: true, recursive: true });
+  }
+}
+
+describe('check-mcp-pins', () => {
+  it('passes a config where every server is pinned or local', () => {
+    withFixture({}, (result) => {
+      expect(result.failures).toEqual([]);
+      expect(result.serverCount).toBe(2);
+    });
+  });
+
+  describe('floating specifiers', () => {
+    it.each(['@latest', '@next', '@beta'])('rejects the dist-tag %s', (tag) => {
+      withFixture(
+        { mcpServers: { drifty: pinned(`some-pkg${tag}`) } },
+        (result) => {
+          expect(result.failures).toHaveLength(1);
+          expect(result.failures[0].message).toContain('a floating tag');
+          expect(result.failures[0].server).toBe('drifty');
+        },
+      );
+    });
+
+    it.each(['^2', '~1.2.0', '>=1.0.0', '2.x', '*', '2'])(
+      'rejects the range %s',
+      (range) => {
+        withFixture(
+          { mcpServers: { ranged: pinned(`some-pkg@${range}`) } },
+          (result) => {
+            expect(result.failures).toHaveLength(1);
+            expect(result.failures[0].message).toContain('a version range');
+          },
+        );
+      },
+    );
+
+    it('rejects a package with no version at all', () => {
+      withFixture({ mcpServers: { bare: pinned('some-pkg') } }, (result) => {
+        expect(result.failures[0].message).toContain('with no version');
+      });
+    });
+
+    it('rejects a launcher invoked with no package specifier', () => {
+      withFixture(
+        { mcpServers: { empty: { command: 'bunx', args: ['--bun', '-y'] } } },
+        (result) => {
+          expect(result.failures[0].message).toContain('no package specifier');
+        },
+      );
+    });
+
+    it.each(['npx', 'pnpx'])('checks %s as well as bunx', (launcher) => {
+      withFixture(
+        { mcpServers: { other: { command: launcher, args: ['-y', 'some-pkg@latest'] } } },
+        (result) => {
+          expect(result.failures).toHaveLength(1);
+        },
+      );
+    });
+
+    it.each([
+      ['bun', 'x'],
+      ['npm', 'exec'],
+      ['pnpm', 'dlx'],
+      ['yarn', 'dlx'],
+    ])('checks the %s %s subcommand form', (command, subcommand) => {
+      withFixture(
+        {
+          mcpServers: {
+            sub: { command, args: [subcommand, 'some-pkg@latest'] },
+          },
+        },
+        (result) => {
+          expect(result.failures).toHaveLength(1);
+          expect(result.failures[0].message).toContain('a floating tag');
+        },
+      );
+    });
+
+    it.each([
+      ['bun', ['--bun', 'x', 'some-pkg@latest']],
+      ['bun', ['--silent', 'x', 'some-pkg@latest']],
+      ['npm', ['--yes', 'exec', 'some-pkg@latest']],
+      ['pnpm', ['--silent', 'dlx', 'some-pkg@latest']],
+    ] as const)(
+      'still checks %s when a global flag precedes the subcommand',
+      (command, args) => {
+        // Both bun and npm accept global flags before the subcommand, so
+        // neither it nor the package spec sits at a fixed index. Reading either
+        // positionally made `bun --bun x pkg@latest` skip the check entirely --
+        // and `--bun` is the flag already used by every bunx entry in
+        // .mcp.json, so that is the most plausible way to write it.
+        withFixture({ mcpServers: { flagged: { command, args: [...args] } } }, (result) => {
+          expect(result.failures).toHaveLength(1);
+          expect(result.failures[0].message).toContain('a floating tag');
+        });
+      },
+    );
+
+    it.each(['bunx.cmd', 'npx.CMD', 'bunx.exe'])(
+      'checks the Windows shim %s',
+      (command) => {
+        withFixture(
+          { mcpServers: { win: { command, args: ['-y', 'some-pkg@latest'] } } },
+          (result) => {
+            expect(result.failures).toHaveLength(1);
+          },
+        );
+      },
+    );
+
+    it('does not mistake `bun run <script>` for a registry fetch', () => {
+      // `bun` only launches from the registry as `bun x`. Treating a bare
+      // `bun run` as one would report the script name as an unpinned package.
+      withFixture(
+        { mcpServers: { script: { command: 'bun', args: ['run', 'serve-mcp'] } } },
+        (result) => {
+          expect(result.failures).toEqual([]);
+        },
+      );
+    });
+  });
+
+  describe('accepted shapes', () => {
+    it('accepts an exact version', () => {
+      withFixture({ mcpServers: { ok: pinned('some-pkg@1.2.3') } }, (result) => {
+        expect(result.failures).toEqual([]);
+      });
+    });
+
+    it('accepts an exact prerelease version', () => {
+      // @playwright/mcp depends on alpha builds, so a pin can legitimately
+      // carry a prerelease suffix. It is still exact.
+      withFixture(
+        { mcpServers: { alpha: pinned('some-pkg@1.63.0-alpha-2026-08-05') } },
+        (result) => {
+          expect(result.failures).toEqual([]);
+        },
+      );
+    });
+
+    it('accepts a scoped package, splitting on the last @', () => {
+      withFixture({ mcpServers: { scoped: pinned('@scope/pkg@1.2.3') } }, (result) => {
+        expect(result.failures).toEqual([]);
+      });
+    });
+
+    it('accepts a local binary regardless of its args', () => {
+      withFixture({ mcpServers: { local: localBinary } }, (result) => {
+        expect(result.failures).toEqual([]);
+      });
+    });
+
+    it('accepts a local binary whose name is also a launcher name', () => {
+      // Distinguishes the local-binary branch from the "not a launcher" branch:
+      // both return without a failure, so a test using a name like
+      // `adrkit-mcp` passes even if isLocalBinary always returned false. Here
+      // the basename *is* a launcher, so only the local-binary check can
+      // explain the pass -- and the bare form below must still fail.
+      withFixture(
+        { mcpServers: { shadow: { command: './node_modules/.bin/npx', args: ['some-pkg@latest'] } } },
+        (result) => {
+          expect(result.failures).toEqual([]);
+        },
+      );
+
+      withFixture(
+        { mcpServers: { shadow: { command: 'npx', args: ['some-pkg@latest'] } } },
+        (result) => {
+          expect(result.failures).toHaveLength(1);
+        },
+      );
+    });
+
+    it('accepts a workspace-variable path to a local binary', () => {
+      withFixture(
+        {
+          mcpServers: {
+            local: { command: '${workspaceFolder}/node_modules/.bin/adrkit-mcp' },
+          },
+        },
+        (result) => {
+          expect(result.failures).toEqual([]);
+        },
+      );
+    });
+
+    it('ignores a server with no command, such as a remote entry', () => {
+      withFixture(
+        { mcpServers: { remote: { url: 'https://example.invalid/mcp' } } },
+        (result) => {
+          expect(result.failures).toEqual([]);
+          expect(result.serverCount).toBe(2);
+        },
+      );
+    });
+
+    it('ignores an executable that is not a registry launcher', () => {
+      withFixture(
+        { mcpServers: { sys: { command: '/usr/bin/some-daemon', args: ['--serve'] } } },
+        (result) => {
+          expect(result.failures).toEqual([]);
+        },
+      );
+    });
+  });
+
+  describe('malformed input', () => {
+    it('reports invalid JSON rather than throwing', () => {
+      withFixture({ rawMcpJson: '{ not json' }, (result) => {
+        expect(result.failures[0].message).toContain('is not valid JSON');
+      });
+    });
+
+    it('fails when the server map key is missing', () => {
+      // If the config format ever changes, silently finding no servers would
+      // turn this into a gate that passes because it checked nothing.
+      withFixture({ rawMcpJson: '{"somethingElse":{}}' }, (result) => {
+        expect(result.failures[0].message).toContain('has no `mcpServers` object');
+      });
+    });
+
+    it('reports a server entry that is not an object', () => {
+      withFixture({ rawMcpJson: '{"mcpServers":{"weird":"bunx"}}' }, (result) => {
+        expect(result.failures[0].message).toContain('is not an object');
+      });
+    });
+
+    it('fails when a known config file is missing', () => {
+      // Skipping it would let servers be moved into a config this gate does
+      // not know about, going back to unchecked while CI stayed green.
+      withFixture({ omitFiles: ['.mcp.json'] }, (result) => {
+        expect(result.failures).toHaveLength(1);
+        expect(result.failures[0].message).toContain('is missing');
+        expect(result.serverCount).toBe(1);
+      });
+    });
+  });
+
+  describe('splitPackageSpec', () => {
+    it.each([
+      ['some-pkg@1.2.3', 'some-pkg', '1.2.3'],
+      ['@scope/pkg@1.2.3', '@scope/pkg', '1.2.3'],
+      ['@scope/pkg@latest', '@scope/pkg', 'latest'],
+    ])('splits %s', (spec, name, version) => {
+      expect(splitPackageSpec(spec)).toEqual({ name, version });
+    });
+
+    it.each(['some-pkg', '@scope/pkg'])('reports %s as unversioned', (spec) => {
+      expect(splitPackageSpec(spec).version).toBeNull();
+    });
+  });
+
+  it('reports the real repository configs as compliant', () => {
+    const result = checkMcpPins(process.cwd());
+    expect(result.failures).toEqual([]);
+    expect(result.serverCount).toBeGreaterThanOrEqual(5);
+  });
+});

--- a/bun.lock
+++ b/bun.lock
@@ -38,6 +38,7 @@
       },
       "devDependencies": {
         "@adrkit/cli": "0.4.0",
+        "@adrkit/mcp": "0.4.0",
         "@eslint/eslintrc": "^3.3.6",
         "@tailwindcss/postcss": "^4.3.3",
         "@testing-library/jest-dom": "^6.10.0",
@@ -74,6 +75,8 @@
     "@adrkit/core": ["@adrkit/core@0.4.0", "", { "dependencies": { "picomatch": "^4", "semver": "^7", "yaml": "latest", "zod": "^4" } }, "sha512-gvvyOKyVScl9u/PUpq3EJ34RTvE5zUYr+IXsnwAuhjRcUQXASpxi3LhwQAAfODg8Ar5gkRoqCBaFQscslizx6g=="],
 
     "@adrkit/evaluator": ["@adrkit/evaluator@0.4.0", "", { "dependencies": { "@adrkit/core": "0.4.0", "jsonpath-rfc9535": "1.3.0" } }, "sha512-iadthsNpWTqDZsZg/deNniEaRin7XPHVe1GDYYjwjR9yjJK031oaq6roEpTljrUKRfS1IwIdXMMZ8bTg4UphXg=="],
+
+    "@adrkit/mcp": ["@adrkit/mcp@0.4.0", "", { "dependencies": { "@adrkit/core": "0.4.0", "@modelcontextprotocol/server": "2.0.0", "zod": "^4.2.0" }, "bin": { "adrkit-mcp": "dist/bin.js" } }, "sha512-WhoLbC1w4GgAmli3ZO1SesKQYKHWI0P/Eq1QD8apTtaW34JlthXlueql30tJtV9lMuTuIhGs2AAj3qd4LHHwjA=="],
 
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
@@ -380,6 +383,10 @@
     "@mdx-js/mdx": ["@mdx-js/mdx@3.1.1", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdx": "^2.0.0", "acorn": "^8.0.0", "collapse-white-space": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "estree-util-scope": "^1.0.0", "estree-walker": "^3.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "markdown-extensions": "^2.0.0", "recma-build-jsx": "^1.0.0", "recma-jsx": "^1.0.0", "recma-stringify": "^1.0.0", "rehype-recma": "^1.0.0", "remark-mdx": "^3.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "source-map": "^0.7.0", "unified": "^11.0.0", "unist-util-position-from-estree": "^2.0.0", "unist-util-stringify-position": "^4.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ=="],
 
     "@mdx-js/react": ["@mdx-js/react@3.1.1", "", { "dependencies": { "@types/mdx": "^2.0.0" }, "peerDependencies": { "@types/react": ">=16", "react": ">=16" } }, "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw=="],
+
+    "@modelcontextprotocol/core": ["@modelcontextprotocol/core@2.0.0", "", { "dependencies": { "zod": "^4.2.0" } }, "sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA=="],
+
+    "@modelcontextprotocol/server": ["@modelcontextprotocol/server@2.0.0", "", { "dependencies": { "@modelcontextprotocol/core": "2.0.0", "zod": "^4.2.0" } }, "sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw=="],
 
     "@mui/core-downloads-tracker": ["@mui/core-downloads-tracker@7.3.11", "", {}, "sha512-a7I/b/nBTdXYz2cOSlEmkQ9WWE1x8FHpqMhFPp+Y1VPFxcOw91G5ELOHARQAGSPy5V+UCgJua6K/1x70bAtQPw=="],
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,3 +1,21 @@
 [install]
 minimumReleaseAge = 259200 # 3 days (in seconds)
-minimumReleaseAgeExcludes = ["@adrkit/cli"]
+
+# Exclusions are per-package: they do NOT propagate to a package's dependencies,
+# and globs ("@adrkit/*") are not supported -- both verified against Bun 1.3.14.
+# So every first-party adrkit package that install can re-resolve needs its own
+# entry, not just the two this repository depends on directly. Listing only
+# @adrkit/cli appeared to work solely because bun.lock already pinned the rest;
+# the next coordinated adrkit release would have failed every install for three
+# days, since @adrkit/cli and @adrkit/mcp are held to one version by
+# `bun run adr:check-integrity` and so cannot be bumped separately to wait it out.
+#
+# These are first-party packages published by this repository's maintainer, so
+# the "a compromised release is installed before anyone reads about it" threat
+# the quarantine exists to blunt does not apply in the same way. See ADR-0005.
+minimumReleaseAgeExcludes = [
+  "@adrkit/cli",
+  "@adrkit/core",
+  "@adrkit/evaluator",
+  "@adrkit/mcp",
+]

--- a/docs/adr/0005-standardize-on-bun-as-the-development-and-ci-toolchain.md
+++ b/docs/adr/0005-standardize-on-bun-as-the-development-and-ci-toolchain.md
@@ -18,6 +18,10 @@ affects:
   - type: path
     pattern: "package.json"
   - type: path
+    pattern: ".mcp.json"
+  - type: path
+    pattern: ".vscode/mcp.json"
+  - type: path
     pattern: ".github/workflows/**"
   - type: path
     pattern: "vercel.json"
@@ -63,7 +67,9 @@ Two settings follow from the decision rather than merely accompanying it:
 
 - `bunfig.toml` sets `minimumReleaseAge = 259200` — a three-day quarantine
   before a newly published version is installable, which blunts the window in
-  which a compromised release is picked up automatically.
+  which a compromised release is picked up automatically. It applies to
+  `bun install`, and therefore to what is in `bun.lock` — **not** to anything
+  fetched at runtime by some other mechanism.
 - `vercel.json` pins `bunVersion: "1.x"` and installs with
   `--frozen-lockfile`, so deployment resolves exactly what was committed.
 
@@ -74,6 +80,42 @@ Bun is the *toolchain*, not the *runtime contract*. The application is a Next.js
 app deployed to Vercel's Node-compatible serverless runtime. `bun --bun next
 dev` is used locally for speed, but nothing in the application code may depend
 on Bun-only APIs.
+
+### MCP servers are launched outside the quarantine, so they are pinned instead
+
+The scope limit above turned out to matter. MCP servers are configured in
+`.mcp.json` and `.vscode/mcp.json` and launched with `bunx -y` / `npx -y`, which
+resolves and executes from the registry at *process start*. Nothing about that
+path touches `bun install`, so those packages were in neither the lockfile nor
+the quarantine — and two of the four floated on `@latest`, re-resolving on every
+launch. Agents invoke these tools autonomously with repository access, so there
+is no human in the loop at the moment a fetched version runs (#307).
+
+The response is tiered by measured cost rather than applied uniformly:
+
+- **`@adrkit/mcp` is a pinned devDependency**, launched as
+  `node_modules/.bin/adrkit-mcp`. It adds three packages, because `@adrkit/core`
+  is already present via `@adrkit/cli`. This is the full fix: lockfile integrity
+  *and* the quarantine.
+- **The other three keep `bunx`, at an exact version.** Vendoring them was
+  measured and rejected: `@upstash/context7-mcp` adds 56 packages and
+  `next-devtools-mcp` 63, each an Express subtree paid on every CI run, every
+  Vercel build, and every contributor's install, for a tool only agents use in
+  local sessions; `@playwright/mcp` adds only three, but one is a `playwright`
+  **pre-release**, which does not belong in a production application's lockfile.
+- An exact pin is weaker than vendoring but is the larger share of the benefit.
+  It converts the attack from "publish a malicious version" — executed on the
+  next launch — into "replace an already-published version", which npm forbids.
+- `bun run check:mcp-pins` enforces this on pull requests. Like `check:raw-sql`
+  for ADR-0003, the policy is a gate rather than a convention, because a
+  floating tag starts a perfectly working server right up until the day it
+  does not.
+
+`minimumReleaseAgeExcludes` exempts the first-party `@adrkit/*` packages, whose
+releases come from this repository's own maintainer. Every one of them is listed
+individually: exclusions do not propagate to a package's dependencies and globs
+are not supported, so an incomplete list makes the next adrkit release
+uninstallable for three days.
 
 ## Options considered
 
@@ -132,6 +174,17 @@ the divergence class this decision exists to eliminate.
 - **The three-day quarantine cuts both ways.** It also delays security patches
   by up to three days. That is an accepted trade: unattended compromise is
   judged the likelier risk than a three-day-old known CVE.
+- **Pinning the MCP servers trades drift risk for staleness risk.** Versions in
+  `.mcp.json` are not `package.json` dependencies, so Dependabot cannot see
+  them and nothing will bump them automatically — `@latest` at least stayed
+  current. This is the same shape of trade as the quarantine itself, and it is
+  the reason the pins have to be reviewed by hand rather than assumed fresh.
+- **The cloud agent's MCP configuration cannot be covered at all.** It is a
+  GitHub repository *setting*, evaluated before or independently of
+  `bun install`, so it cannot run a local binary and must keep `npx`. It gets
+  the exact-version pin and nothing else. That gap is recorded in
+  `.github/copilot-cloud-agent-mcp.md` rather than papered over, and it closes
+  only if the agent runner gains a dependable pre-install step.
 
 ## Consequences
 
@@ -151,6 +204,13 @@ the divergence class this decision exists to eliminate.
   as Bun itself misbehaving. When something in the supply chain stops working,
   check whether a Bun-specific artifact is the thing the other tool cannot read
   before assuming the other tool is at fault.
+- **A supply-chain control is only as wide as the mechanism it hooks.**
+  `minimumReleaseAge` reads as "this project quarantines new npm releases", but
+  it hooks `bun install` and so covers only the lockfile. Everything that
+  reaches npm by another route — `bunx`, `npx`, an editor's own tooling, a
+  GitHub repository setting — is outside it by default and looks no different
+  from the inside (#307). Before treating any of these settings as covering a
+  new kind of dependency, check which command actually enforces it.
 - **Revisit if:** Vercel drops or degrades Bun support, or the project gains
   enough contributors that npm familiarity outweighs the speed benefit.
 
@@ -161,3 +221,8 @@ the divergence class this decision exists to eliminate.
 2. [x] `bunfig.toml` sets a three-day `minimumReleaseAge`
 3. [x] `vercel.json` pins `bunVersion` and installs `--frozen-lockfile`
 4. [x] Note the Bun prerequisite in the contributing guide
+5. [x] MCP servers are pinned or vendored, and `bun run check:mcp-pins` enforces
+   it on pull requests (#307)
+6. [ ] Move the cloud agent MCP entry to the local binary if the agent runner
+   ever gains a dependable pre-install step; until then the gap stands as
+   documented in `.github/copilot-cloud-agent-mcp.md`

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "start": "bun --bun next start",
     "lint": "eslint .",
     "check:raw-sql": "bun scripts/check-raw-sql.ts",
+    "check:mcp-pins": "bun scripts/check-mcp-pins.ts",
     "type": "tsc --noEmit",
     "type-check": "tsc --noEmit",
     "test": "vitest run",
@@ -76,6 +77,7 @@
   },
   "devDependencies": {
     "@adrkit/cli": "0.4.0",
+    "@adrkit/mcp": "0.4.0",
     "@eslint/eslintrc": "^3.3.6",
     "@tailwindcss/postcss": "^4.3.3",
     "@testing-library/jest-dom": "^6.10.0",

--- a/scripts/check-adr-integrity.ts
+++ b/scripts/check-adr-integrity.ts
@@ -7,6 +7,12 @@
  * view of the version pins scattered across the repo. This covers those three
  * gaps and is deliberately independent of the adrkit version.
  *
+ * Since #307 it also covers the two supply-chain properties that keep the
+ * adrkit MCP server inside the controls ADR-0005 describes: that the local
+ * configs run the pinned local binary rather than fetching from the registry,
+ * and that every first-party adrkit package is exempt from the release
+ * quarantine (without which the next version bump cannot be installed at all).
+ *
  * The checks are exported as a pure function of a repo root so they can be
  * exercised against fixture directories in tests. Nothing here is protected by
  * anything else, so the tests are the only thing standing between a subtle
@@ -28,6 +34,20 @@ export interface IntegrityResult {
   /** Discoverable records found, excluding the template and README. */
   recordCount: number;
 }
+
+/**
+ * The first-party adrkit packages that `bun install` can re-resolve, and so
+ * must each be exempt from the `minimumReleaseAge` quarantine in `bunfig.toml`.
+ * `@adrkit/core` and `@adrkit/evaluator` are transitive, but exclusions do not
+ * propagate to a package's dependencies, so naming only the two direct ones is
+ * not enough.
+ */
+export const ADRKIT_PACKAGES = [
+  '@adrkit/cli',
+  '@adrkit/core',
+  '@adrkit/evaluator',
+  '@adrkit/mcp',
+] as const;
 
 export function runIntegrityChecks(repoRoot: string): IntegrityResult {
   const corpusDir = path.join(repoRoot, CORPUS_DIR);
@@ -72,6 +92,14 @@ export function runIntegrityChecks(repoRoot: string): IntegrityResult {
   // --- 3. The adrkit version pins agree ------------------------------------
   // The version is pinned in four committed places plus one manual GitHub
   // setting. Nothing else notices when a bump updates only some of them.
+  //
+  // Since #307 the two local MCP configs no longer name a version: they run
+  // `adrkit-mcp` out of `node_modules/.bin`, so their version *is* the
+  // package.json pin and lands in bun.lock with an integrity hash. That moves
+  // two of the sites from "a version string in a JSON file" to "a devDependency
+  // plus a launch shape", and both halves are checked below -- a config that
+  // regressed to a registry fetch would otherwise pass while quietly leaving
+  // the quarantine again.
   function checkVersionPins(): void {
     const pkg = JSON.parse(read('package.json')) as {
       devDependencies?: Record<string, string>;
@@ -90,9 +118,28 @@ export function runIntegrityChecks(repoRoot: string): IntegrityResult {
       return;
     }
 
+    // The MCP server is a devDependency rather than a registry fetch, so its
+    // pin lives here and has to match the CLI's.
+    const mcpPin = pkg.devDependencies?.['@adrkit/mcp'];
+    if (!mcpPin) {
+      fail(
+        'package.json does not pin @adrkit/mcp in devDependencies. The local MCP ' +
+          'configs run node_modules/.bin/adrkit-mcp, so without the dependency they ' +
+          'cannot start at all. See #307.',
+      );
+    } else if (!/^\d+\.\d+\.\d+$/.test(mcpPin)) {
+      fail(`@adrkit/mcp is "${mcpPin}"; it must be an exact version, like @adrkit/cli.`);
+    } else if (mcpPin !== expected) {
+      fail(
+        `package.json pins @adrkit/mcp at ${mcpPin} but @adrkit/cli at ${expected}. ` +
+          'The CLI and the MCP server read the same corpus and must be one version.',
+      );
+    }
+
+    checkLocalMcpConfigs();
+    checkQuarantineExclusions();
+
     const sites: { file: string; find: RegExp; label: string }[] = [
-      { file: '.mcp.json', find: /@adrkit\/mcp@(\d+\.\d+\.\d+)/, label: '@adrkit/mcp' },
-      { file: '.vscode/mcp.json', find: /@adrkit\/mcp@(\d+\.\d+\.\d+)/, label: '@adrkit/mcp' },
       {
         file: '.github/copilot-cloud-agent-mcp.md',
         find: /@adrkit\/mcp@(\d+\.\d+\.\d+)/,
@@ -117,6 +164,60 @@ export function runIntegrityChecks(repoRoot: string): IntegrityResult {
         fail(
           `${file} pins ${label} at ${found}, but package.json pins @adrkit/cli at ` +
             `${expected}. Bump every site together.`,
+        );
+      }
+    }
+  }
+
+  // --- 3a. The local MCP configs run the local binary ----------------------
+  // A regression to `bunx -y @adrkit/mcp@x.y.z` would still start a working
+  // server, so nothing else would notice -- it would just be fetching from the
+  // registry again, outside the lockfile and outside the quarantine (#307).
+  function checkLocalMcpConfigs(): void {
+    for (const file of ['.mcp.json', '.vscode/mcp.json']) {
+      if (!existsSync(path.join(repoRoot, file))) {
+        fail(`${file} is missing; it should run node_modules/.bin/adrkit-mcp.`);
+        continue;
+      }
+      const contents = read(file);
+      if (/@adrkit\/mcp@/.test(contents)) {
+        fail(
+          `${file} fetches @adrkit/mcp from the registry. It should run ` +
+            'node_modules/.bin/adrkit-mcp, which is pinned in package.json and ' +
+            'carried in bun.lock. See #307 and ADR-0005.',
+        );
+      } else if (!/node_modules\/\.bin\/adrkit-mcp/.test(contents)) {
+        fail(
+          `${file} does not run node_modules/.bin/adrkit-mcp. If the adrkit server ` +
+            'was removed from this config, remove it from this check too.',
+        );
+      }
+    }
+  }
+
+  // --- 3b. The adrkit packages are exempt from the release quarantine -------
+  // `minimumReleaseAgeExcludes` is not transitive and does not accept globs, so
+  // each first-party package needs its own entry. Miss one and the next
+  // coordinated adrkit release fails every install for three days -- and it
+  // cannot be worked around by bumping one package first, because the check
+  // above requires @adrkit/cli and @adrkit/mcp to move together.
+  function checkQuarantineExclusions(): void {
+    const file = 'bunfig.toml';
+    if (!existsSync(path.join(repoRoot, file))) {
+      fail(`${file} is missing; it should exempt the adrkit packages from the quarantine.`);
+      return;
+    }
+
+    const contents = read(file);
+    if (!/minimumReleaseAge\s*=/.test(contents)) return; // No quarantine, nothing to exempt.
+
+    const block = /minimumReleaseAgeExcludes\s*=\s*\[([\s\S]*?)\]/.exec(contents)?.[1] ?? '';
+    for (const name of ADRKIT_PACKAGES) {
+      if (!block.includes(`"${name}"`)) {
+        fail(
+          `${file} does not list "${name}" in minimumReleaseAgeExcludes. Exclusions ` +
+            'are per-package -- they do not cover a package\'s dependencies -- so the ' +
+            'next adrkit release would fail every install until the quarantine expires.',
         );
       }
     }

--- a/scripts/check-mcp-pins.ts
+++ b/scripts/check-mcp-pins.ts
@@ -1,0 +1,293 @@
+/**
+ * Enforces the MCP-launch supply-chain policy recorded in ADR-0005.
+ *
+ * `bunfig.toml` quarantines newly published npm versions for three days, but
+ * that control operates on `bun install` -- it covers what is in `bun.lock` and
+ * nothing else. An MCP server launched as `bunx -y pkg@latest` resolves from the
+ * registry at process start, so it gets neither the quarantine nor the
+ * lockfile's integrity hash. Agents invoke these tools autonomously with
+ * repository access, so there is no human in the loop at the moment a fetched
+ * version executes (#307).
+ *
+ * Two acceptable shapes, checked here:
+ *
+ *   1. A local binary out of `node_modules/.bin`. The package is a pinned
+ *      devDependency, so it is in `bun.lock` with an integrity hash and it
+ *      passed the quarantine. This is the full fix, and it fails *closed* --
+ *      before `bun install` the server does not start, rather than silently
+ *      falling back to a registry fetch the way a bare `bunx <bin>` would.
+ *   2. A registry fetch at an exact `x.y.z`. This is weaker -- still no
+ *      quarantine, still no lockfile integrity -- but it removes re-resolution.
+ *      A floating `@latest` executes a malicious *publish* on the next launch;
+ *      an exact pin requires replacing an already-published version, which npm
+ *      forbids. ADR-0005 records which servers are deliberately left here and
+ *      why vendoring them was judged the worse trade.
+ *
+ * A floating tag (`@latest`, `@next`), a range (`^2`, `~1.2`, `*`), or a bare
+ * unpinned name is rejected.
+ *
+ * Like `check-raw-sql.ts` this depends on nothing outside node: builtins, so
+ * its CI step cannot be defeated by a dependency or install failure, and it
+ * makes no network calls -- a gate that needed the registry to be reachable
+ * would fail open on exactly the day the registry was having a bad time.
+ */
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+/** A committed MCP config, and the key its server map hangs off. */
+interface ConfigSpec {
+  file: string;
+  /** `.mcp.json` uses `mcpServers`; `.vscode/mcp.json` uses `servers`. */
+  key: string;
+}
+
+export const MCP_CONFIGS: ConfigSpec[] = [
+  { file: '.mcp.json', key: 'mcpServers' },
+  { file: path.join('.vscode', 'mcp.json'), key: 'servers' },
+];
+
+/** Launchers that fetch and run a package directly, with no subcommand. */
+const DIRECT_LAUNCHERS = new Set(['bunx', 'npx', 'pnpx']);
+
+/**
+ * Launchers that only fetch from the registry in their subcommand form. Bare
+ * `bun run <script>` or `pnpm run <script>` is not a registry fetch, and
+ * treating it as one would report the script name as an unpinned package.
+ */
+const SUBCOMMAND_LAUNCHERS: Record<string, string> = {
+  bun: 'x',
+  npm: 'exec',
+  pnpm: 'dlx',
+  yarn: 'dlx',
+};
+
+/** An exact release: `1.2.3`, optionally with a prerelease or build suffix. */
+const EXACT_VERSION = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
+
+/**
+ * Semver range syntax: comparators, wildcards, hyphen ranges, unions, and
+ * partial versions like `2` or `1.2`. Anything left over (`latest`, `next`,
+ * `beta`) is a dist-tag. Only used to word the error message.
+ */
+const RANGE_SYNTAX = /^[\d^~><=*\s|.x X-]+$/;
+
+function describeSpec(version: string): string {
+  return RANGE_SYNTAX.test(version) ? 'a version range' : 'a floating tag';
+}
+
+export interface PinFailure {
+  file: string;
+  server: string;
+  message: string;
+}
+
+export interface PinResult {
+  failures: PinFailure[];
+  /** Server entries examined across every config that exists. */
+  serverCount: number;
+}
+
+/**
+ * Split a package spec into name and version at the *last* `@`, so that a
+ * scoped name keeps its leading one: `@scope/pkg@1.2.3` -> `@scope/pkg`, `1.2.3`.
+ */
+export function splitPackageSpec(spec: string): { name: string; version: string | null } {
+  const at = spec.lastIndexOf('@');
+  if (at <= 0) return { name: spec, version: null };
+  return { name: spec.slice(0, at), version: spec.slice(at + 1) };
+}
+
+/** Does this command run a binary out of the local `node_modules`? */
+function isLocalBinary(command: string): boolean {
+  return command.replace(/\\/g, '/').includes('node_modules/.bin/');
+}
+
+/**
+ * The launcher's bare name. Windows shims are `bunx.cmd` / `npx.cmd`, which
+ * would otherwise not match and skip the check entirely.
+ */
+function launcherName(command: string): string {
+  return path
+    .basename(command.replace(/\\/g, '/'))
+    .replace(/\.(cmd|exe|bat|ps1)$/i, '');
+}
+
+/**
+ * Index of the first argument that is not a `-`-prefixed flag, at or after
+ * `from`. Both `bun` and `npm` accept global flags *before* their subcommand
+ * (`bun --bun x pkg`), so neither the subcommand nor the package spec can be
+ * read from a fixed position.
+ *
+ * A flag that takes a separate value (`npx --package foo bar`) would have its
+ * value read as the spec. No launcher used here does that before the package
+ * name, and `--package foo` names a package anyway, so the spec still lands on
+ * something worth checking.
+ */
+function firstNonFlag(args: string[], from = 0): number {
+  for (let index = from; index < args.length; index += 1) {
+    if (!args[index].startsWith('-')) return index;
+  }
+  return -1;
+}
+
+function checkServer(
+  file: string,
+  server: string,
+  entry: unknown,
+  fail: (message: string) => void,
+): void {
+  if (typeof entry !== 'object' || entry === null) {
+    fail('is not an object.');
+    return;
+  }
+
+  const { command, args } = entry as { command?: unknown; args?: unknown };
+
+  if (typeof command !== 'string' || command.length === 0) {
+    // A server with no command is either a remote (url/http) entry or
+    // malformed. Neither launches a package from the registry, so there is
+    // nothing for this gate to say about it.
+    return;
+  }
+
+  if (isLocalBinary(command)) return;
+
+  const base = launcherName(command);
+  const list = Array.isArray(args) ? args.filter((a): a is string => typeof a === 'string') : [];
+
+  let specIndex: number;
+  const requiredSubcommand = SUBCOMMAND_LAUNCHERS[base];
+
+  if (requiredSubcommand !== undefined) {
+    const subcommand = firstNonFlag(list);
+    // `bun run <script>`, `pnpm install`, etc. -- not a registry fetch.
+    if (subcommand === -1 || list[subcommand] !== requiredSubcommand) return;
+    specIndex = firstNonFlag(list, subcommand + 1);
+  } else if (DIRECT_LAUNCHERS.has(base)) {
+    specIndex = firstNonFlag(list);
+  } else {
+    // Some other executable -- a system binary, or a script in the repo. Out
+    // of scope: this gate is about packages fetched from npm at launch.
+    return;
+  }
+
+  const spec = specIndex === -1 ? undefined : list[specIndex];
+
+  if (!spec) {
+    fail(
+      `launches with \`${base}\` but no package specifier was found in args. ` +
+        'Pin it to an exact version, or run a local binary from node_modules/.bin.',
+    );
+    return;
+  }
+
+  const { name, version } = splitPackageSpec(spec);
+
+  if (version === null) {
+    fail(
+      `fetches \`${name}\` with no version, so it re-resolves on every launch. ` +
+        `Pin it (\`${name}@x.y.z\`), or add it as a devDependency and run ` +
+        'node_modules/.bin/<binary>.',
+    );
+    return;
+  }
+
+  if (!EXACT_VERSION.test(version)) {
+    const kind = describeSpec(version);
+    fail(
+      `fetches \`${name}@${version}\` -- ${kind}, so a new publish is executed on ` +
+        'the next launch with no quarantine and no lockfile integrity. Pin an exact ' +
+        `version (\`${name}@x.y.z\`), or add it as a devDependency and run ` +
+        'node_modules/.bin/<binary>.',
+    );
+  }
+}
+
+/** Run the policy over a checkout and return every violation found. */
+export function checkMcpPins(repoRoot: string): PinResult {
+  const failures: PinFailure[] = [];
+  let serverCount = 0;
+
+  for (const { file, key } of MCP_CONFIGS) {
+    const absolute = path.join(repoRoot, file);
+
+    // Not skipped: moving servers into a config this gate does not know about
+    // (`.cursor/mcp.json`, a split per-tool file) would otherwise leave it green
+    // while the moved servers went back to being unchecked. Deleting a config
+    // for real is fine -- remove it from MCP_CONFIGS in the same change, which
+    // makes the decision visible in review.
+    if (!existsSync(absolute)) {
+      failures.push({
+        file,
+        server: '(file)',
+        message:
+          'is missing. If its servers moved elsewhere, add that config to ' +
+          'MCP_CONFIGS in scripts/check-mcp-pins.ts; if it was removed, drop it ' +
+          'from MCP_CONFIGS. Skipping it silently would stop this gate gating.',
+      });
+      continue;
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(readFileSync(absolute, 'utf8'));
+    } catch (error) {
+      failures.push({
+        file,
+        server: '(file)',
+        message: `is not valid JSON: ${(error as Error).message}`,
+      });
+      continue;
+    }
+
+    const servers = (parsed as Record<string, unknown> | null)?.[key];
+    if (typeof servers !== 'object' || servers === null) {
+      failures.push({
+        file,
+        server: '(file)',
+        message: `has no \`${key}\` object. If the config format changed, update MCP_CONFIGS in scripts/check-mcp-pins.ts -- otherwise this gate silently stops gating.`,
+      });
+      continue;
+    }
+
+    for (const [server, entry] of Object.entries(servers as Record<string, unknown>)) {
+      serverCount += 1;
+      checkServer(file, server, entry, (message) =>
+        failures.push({ file, server, message }),
+      );
+    }
+  }
+
+  return { failures, serverCount };
+}
+
+function main(): void {
+  const repoRoot = path.resolve(import.meta.dirname, '..');
+  const { failures, serverCount } = checkMcpPins(repoRoot);
+
+  if (failures.length > 0) {
+    console.error('MCP pin check failed -- ADR-0005 requires each MCP server to be\n');
+    console.error('  * run from node_modules/.bin (pinned devDependency, in bun.lock), or');
+    console.error('  * fetched at an exact x.y.z version.\n');
+    for (const { file, server, message } of failures) {
+      console.error(`  - ${file} -> ${server} ${message}`);
+    }
+    console.error(
+      '\nSee docs/adr/0005-standardize-on-bun-as-the-development-and-ci-toolchain.md.',
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    `MCP pin check OK: ${serverCount} server entr(ies) across ` +
+      `${MCP_CONFIGS.length} config(s); each runs a local binary or an exact version.`,
+  );
+  console.log(
+    'Reminder: the cloud agent MCP setting is a GitHub repository Settings value ' +
+      'and cannot be checked here. See .github/copilot-cloud-agent-mcp.md.',
+  );
+}
+
+// Bun sets this when the file is executed directly. Under Vitest it is
+// undefined, so importing the helpers above does not run the CLI.
+if (import.meta.main) main();


### PR DESCRIPTION
## The gap

`bunfig.toml` quarantines newly published npm versions for three days, recorded in ADR-0005 as a deliberate supply-chain control for a solo maintainer. That control hooks `bun install`, so it covers **only what is in `bun.lock`**.

The four MCP servers in `.mcp.json` were launched with `bunx -y`, which resolves from the registry at *process start*. None were in the lockfile, so none got the quarantine or integrity checking — and two floated on `@latest`, re-resolving on every launch. Agents invoke these tools autonomously with repository access, so there is no human in the loop at the moment a fetched version executes.

## The policy, and why it is not uniform

I measured the incremental cost of vendoring each server into the existing tree before deciding, because the four are not equally cheap to fix:

| Server | New packages | Verdict |
|---|---:|---|
| `@adrkit/mcp` | **3** | **vendored** — `@adrkit/core` already present via `@adrkit/cli` |
| `@playwright/mcp` | 3 | pinned — one is `playwright@1.63.0-alpha-2026-08-05`, a **pre-release** |
| `@upstash/context7-mcp` | **56** | pinned — full Express 5 subtree |
| `next-devtools-mcp` | **63** | pinned — Express + Hono + `zod-to-json-schema` |

**`@adrkit/mcp` is now a pinned devDependency** launched as `./node_modules/.bin/adrkit-mcp`. It is the one server whose function is specific to *this* repository — the ADR corpus lives here — and at three packages it is essentially free. This is the full fix the issue proposes: lockfile integrity **and** the quarantine.

**The other three keep `bunx`, at an exact version.** I deliberately did not vendor them:

- `@playwright/mcp` adds only three packages, but vendoring writes an **alpha** Playwright build into a production application's lockfile, and it publishes at a 0.0.x cadence so each bump drags a new one.
- `@upstash/context7-mcp` (56) and `next-devtools-mcp` (63) each add an Express server subtree, paid on every install across 7 CI workflows, every Vercel build, every contributor, and every worktree — for a tool only agents use in local sessions.

An exact pin is weaker than vendoring, but it is the larger share of the benefit for none of that cost: it converts the attack from "publish a malicious version" (executed on the next launch) into "replace an already-published version", which npm forbids. That is the same reasoning the issue gives for why adrkit's exposure was already lower.

`@upstash/context7-mcp` is pinned to **2.3.0** — exactly what `^2` resolves to today — so this stays a pure supply-chain change. 4.0.0 exists and exposes an identical tool surface; bumping it is a separate concern.

## Enforced, not just documented

New `scripts/check-mcp-pins.ts` (`bun run check:mcp-pins`): every MCP server must either run a local binary from `node_modules` or be fetched at an exact `x.y.z`. It imports only `node:` builtins and makes no network calls, so it cannot be defeated by an install failure, and it runs as an install-free job in `quality-gates.yml`. Without a gate, `@latest` creeps back — this mirrors how `check:raw-sql` enforces ADR-0003 rather than trusting convention.

## A latent bug this surfaced

`minimumReleaseAgeExcludes` is **not transitive** and **does not support globs** — both verified against Bun 1.3.14. `["@adrkit/cli"]` alone was insufficient:

```
error: Version "@adrkit/core@0.4.0" was published within minimum release age of 259200 seconds
```

It worked only because `bun.lock` already pinned `@adrkit/core`. The next adrkit release would have failed every install for three days **regardless of this change** — and could not be worked around by bumping one package first, since `adr:check-integrity` requires `@adrkit/cli` and `@adrkit/mcp` to move together. All four first-party packages are now listed individually, and the integrity check asserts it.

## The gap that stays open

`.github/copilot-cloud-agent-mcp.md` documents a GitHub *Settings* value that may be evaluated before or independently of `bun install` — including Copilot code review, which does not run the install step at all. It cannot use a local binary and must keep `npx`. It keeps the exact pin, which is the only control available there, and the doc now says plainly that this is **not** equivalent to what the local configs have, rather than implying the gap is closed. It closes only if the agent runner gains a dependable pre-install step.

Locally, the adrkit server now fails to start until `bun install` has run. That is deliberate: failing *closed* is the point of a supply-chain control, and the alternative — `bunx` falling back to a registry fetch — is the behaviour being removed. Documented so it does not read as a bug.

## Verification

- **All four servers launched exactly as configured** and answered `initialize` + `tools/list` over stdio. adrkit `get_decision_context(["lib/theme.ts"])` → **ADR-0004 governing, `recordCount: 5`**.
- Confirmed the gate actually catches regressions, not just that it passes: `@latest`, `^2`, and a bare unpinned spec all fail it.
- `bun install --frozen-lockfile` clean; `@adrkit/mcp` in `bun.lock` with a sha512 hash.
- `type-check` ✅ · `lint` ✅ (only the known pre-existing `ToastProvider.tsx` warning) · `test` **1843 passed / 138 files** (1788/137 baseline held, +55 new) · `adr:lint` ✅ · `adr:check-integrity` ✅ · `check:raw-sql` ✅ · `check:mcp-pins` ✅ · `deployment:check` ✅

A `code-review` pass found three real defects in the first cut of the gate, all fixed and covered by tests:

1. **A floating spec slipped through when a global flag preceded the subcommand** — `bun --bun x pkg@latest` was skipped entirely. Since `--bun` is the flag already used by every `bunx` entry here, that was the most plausible way someone would write it. Subcommand and package spec are now located as the first non-flag argument rather than by index. Verified end-to-end that all five bypassing forms are now caught while `bun run <script>` still passes.
2. **Two local-binary tests passed even if `isLocalBinary` were broken**, since both branches returned no failure. Now distinguished with `./node_modules/.bin/npx`, whose basename *is* a launcher name.
3. **A config file disappearing was skipped silently**, so moving servers to `.cursor/mcp.json` would have left the gate green. A missing known config is now a failure.

ADR-0005 is updated rather than left to drift: the scope limit of the quarantine, the tiered policy and why the three heavy/alpha servers were left alone, the staleness trade-off (pins in `.mcp.json` are invisible to Dependabot, so nothing bumps them automatically), and the uncoverable cloud-agent gap.

Closes #307
