### PR TITLE
feat(adr): upgrade adrkit to 0.7.0 and publish the corpus badges

### DIFF
--- a/.adrkit/lint.json
+++ b/.adrkit/lint.json
@@ -1,0 +1,4 @@
+{
+  "checked": 5,
+  "findings": []
+}

--- a/.adrkit/queue.json
+++ b/.adrkit/queue.json
@@ -1,0 +1,10 @@
+{
+  "version": "1",
+  "asOf": "2026-08-13",
+  "corpusFingerprint": "23ad5fe123fe1497c92de86734fb5087410230ff91e7fcb5ddb294a44bbcd65f",
+  "totalItems": 0,
+  "totalCorpusFindings": 0,
+  "itemsWithFindings": 0,
+  "items": [],
+  "corpusFindings": []
+}

--- a/.github/copilot-cloud-agent-mcp.md
+++ b/.github/copilot-cloud-agent-mcp.md
@@ -33,7 +33,7 @@ unauthenticated, so there is nothing to add under `COPILOT_MCP_*`.
     "adrkit": {
       "type": "local",
       "command": "npx",
-      "args": ["-y", "@adrkit/mcp@0.4.0", "--dir", "docs/adr"],
+      "args": ["-y", "@adrkit/mcp@0.7.0", "--dir", "docs/adr"],
       "tools": [
         "get_decision",
         "get_decision_context",
@@ -86,7 +86,7 @@ This gap closes only if the agent runner gains a dependable pre-install step
 (`copilot-setup-steps.yml` installing Bun and running `bun install`), at which
 point this entry can move to the local binary like the other two.
 
-**Pinned to `@0.4.0`.** Matches the `@adrkit/cli` and `@adrkit/mcp` pins in
+**Pinned to `@0.7.0`.** Matches the `@adrkit/cli` and `@adrkit/mcp` pins in
 `package.json` and the commit-pinned CI action, per
 [ADR-0001](../docs/adr/0001-record-architecture-decisions-as-versioned-markdown-in-git.md).
 An agent given a floating `@latest` would silently change behaviour on an

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -21,6 +21,7 @@ bun run test:ui             # Vitest UI
 bun run validate-env        # Validate required environment variables
 bun run adr:lint            # Validate the ADR corpus in docs/adr
 bun run adr:review-dates    # Which decisions are past, or near, their reviewBy date?
+bun run adr:queue           # Which decisions are awaiting review (the ARB queue)?
 bun run check:raw-sql       # Enforce the ADR-0003 raw-SQL prohibition
 bun run adr:explain <path>  # Which architecture decisions govern this file?
 ```

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -89,6 +89,20 @@ git push origin v1.2.3
 - Verifies required environment variables are documented
 - Builds the GitHub Pages documentation artifact
 
+### 6. ADR Badge Reports Workflow (`adr-badges.yml`)
+
+**Trigger**: Push to `main` that changes `docs/adr/**`, or manual dispatch
+
+**Purpose**: Publishes the two numbers the README's ADR badges render
+
+**Features**:
+- Regenerates `.adrkit/lint.json` and `.adrkit/queue.json` from the pinned local
+  adrkit binary (never a registry fetch — see ADR-0005)
+- Validates both reports with `bun run adr:check-reports` before publishing, so a
+  truncated write fails the run instead of rendering `no result` on the badge
+- Commits with `[skip ci]` so a report refresh does not start a release
+- Rebases and retries the push, since `release.yml` also writes to `main`
+
 ## Release Configuration
 
 ### `release.yml`

--- a/.github/workflows/adr-badges.yml
+++ b/.github/workflows/adr-badges.yml
@@ -1,0 +1,126 @@
+name: ADR badge reports
+
+# Publishes the two numbers the README badges render: corpus size, from
+# `adr lint --json`, and ARB queue depth, from `adr queue --format json`.
+# adrkit ships no badge service and no `adr badge` command -- both badges are a
+# recipe over JSON it already emits, served from this repository and rendered by
+# shields.io. See ADR-0001 and adrkit's own ADR-0025.
+#
+# Deliberately NOT a `pull_request` workflow and deliberately not a job in
+# `adr.yml`: it holds `contents: write` and pushes to the default branch, which
+# has no business running against untrusted fork code. `adr.yml` stays read-only
+# apart from its one comment step.
+on:
+  push:
+    branches:
+      - main
+    # Only the corpus can change these numbers. Deliberately NOT `.adrkit/**`,
+    # or the workflow's own commit would re-trigger it forever.
+    paths:
+      - 'docs/adr/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# `cancel-in-progress: false`, unlike adr.yml: a cancelled run here leaves the
+# reports stale rather than merely skipping a comment, and two runs racing to
+# push the same file is the one conflict the rebase below cannot resolve
+# cleanly. Serializing costs a few seconds and removes the case entirely.
+concurrency:
+  group: adr-badge-reports
+  cancel-in-progress: false
+
+jobs:
+  regenerate:
+    name: Regenerate the corpus reports
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      # Sole elevated scope: the job commits the two report files to main.
+      # `write` implies read, so there is no separate `contents: read` here.
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          # Full history: the push step rebases onto main when another workflow
+          # (release.yml also pushes there) landed a commit mid-run, and a
+          # shallow clone makes that rebase unreliable.
+          fetch-depth: 0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2.0.2
+        with:
+          bun-version: latest
+
+      # --ignore-scripts skips the Prisma postinstall, which needs a
+      # DATABASE_URL that reading markdown records has no use for.
+      - name: Install dependencies
+        run: bun install --frozen-lockfile --ignore-scripts
+
+      # The upstream recipe fetches `npx @adrkit/cli@x.y.z` here. This runs the
+      # devDependency out of node_modules/.bin instead, for the reason recorded
+      # in ADR-0005 and enforced for the MCP servers by `bun run check:mcp-pins`:
+      # a registry fetch inside a write-capable job gets neither bun.lock's
+      # integrity hash nor the `minimumReleaseAge` quarantine. It also means the
+      # version lives in exactly one place -- package.json -- rather than adding
+      # a sixth pin site that nothing would notice going stale.
+      #
+      # Generated into a staging directory so the reports are validated *before*
+      # anything replaces the published files, and never half-written.
+      - name: Generate the reports
+        run: |
+          mkdir -p .adrkit-staging
+          ./node_modules/.bin/adr lint --json > .adrkit-staging/lint.json
+          ./node_modules/.bin/adr queue --format json > .adrkit-staging/queue.json
+
+      # A truncated or malformed report does not break the badge -- it renders
+      # `no result`, which reads as broken tooling and would go unnoticed until
+      # someone looked. Fail here rather than publish it.
+      - name: Validate before publishing
+        run: bun run adr:check-reports .adrkit-staging
+
+      - name: Publish the validated reports
+        run: |
+          mkdir -p .adrkit
+          mv .adrkit-staging/lint.json .adrkit-staging/queue.json .adrkit/
+          rmdir .adrkit-staging
+
+      - name: Commit when the reports changed
+        run: |
+          # `git diff` alone cannot see an untracked file, so on the first run it
+          # would report "no change" and never publish anything. Compare against
+          # the index, and stage the paths explicitly -- `commit -am` does not
+          # stage a new file and would sweep in unrelated tracked edits.
+          git add .adrkit/lint.json .adrkit/queue.json
+          if git diff --cached --quiet -- .adrkit; then
+            echo "Reports unchanged; nothing to commit."
+            exit 0
+          fi
+
+          git config user.name  'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          # `[skip ci]` matches the convention release.yml already uses for its
+          # version-bump commit. Without it this push starts a release run and a
+          # full quality-gates run for a two-file JSON refresh; `.adrkit/**` is
+          # not covered by release.yml's `paths-ignore`, so the marker is what
+          # stops it.
+          git commit -m 'chore(adr): refresh corpus badge reports [skip ci]'
+
+          # release.yml pushes to main too, so a commit can land between the
+          # checkout and this push. The reports touch only .adrkit/*.json, which
+          # no other workflow writes, so the rebase applies cleanly and a plain
+          # retry is enough. No --force: this is a shared branch.
+          for attempt in 1 2 3; do
+            if git push; then
+              echo "Published on attempt $attempt."
+              exit 0
+            fi
+            echo "Push rejected on attempt $attempt; rebasing onto main."
+            git pull --rebase origin main
+          done
+
+          echo "::error::Could not publish the ADR badge reports after 3 attempts."
+          exit 1

--- a/.github/workflows/adr.yml
+++ b/.github/workflows/adr.yml
@@ -80,10 +80,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
-      # Pinned to the immutable v0.4.0 commit rather than the moving @v0 tag,
+      # Pinned to the immutable v0.7.0 commit rather than the moving @v0 tag,
       # matching the ADR-0001 decision to pin adrkit exactly.
       - name: Resolve decisions governing this pull request
-        uses: mbeacom/adrkit/packages/ci@c3dff3a7a9c3df44233809423eb59a3505fcf6f5 # v0.4.0
+        uses: mbeacom/adrkit/packages/ci@e3155eaaf200c9ed7f3ea572d91f0bd4c11c35cc # v0.7.0
         env:
           # Required for the action to update its existing comment instead of
           # posting a new one per push. It only recognises its own comment when

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -503,7 +503,7 @@ describe('Feature Name', () => {
 
 Architectural decisions are recorded as machine-readable ADRs in `docs/adr/`,
 managed by [adrkit](https://github.com/mbeacom/adrkit) (`@adrkit/cli`, pinned to
-0.4.0). See [ADR-0001](./docs/adr/0001-record-architecture-decisions-as-versioned-markdown-in-git.md)
+0.7.0). See [ADR-0001](./docs/adr/0001-record-architecture-decisions-as-versioned-markdown-in-git.md)
 for why.
 
 `CLAUDE.md` describes *how to work here*; ADRs record *why the conventions are
@@ -516,6 +516,8 @@ bun run adr:lint                      # validate the whole corpus
 bun run adr:check-integrity           # non-empty corpus, discoverable filenames,
                                       # and agreeing adrkit version pins
 bun run adr:review-dates              # decisions past, or near, their reviewBy
+bun run adr:queue                     # decisions awaiting review (the ARB queue)
+bun run adr:check-reports             # validate the generated badge reports
 bun run adr:explain lib/actions/x.ts  # which decisions govern this file?
 bun run adr:check <changed files...>  # decisions governing a change set
 bun run adr:new "Use X for Y"         # scaffold a new record
@@ -554,6 +556,15 @@ extension. `/speckit.plan` offers an optional `after_plan` check.
 
 CI (`.github/workflows/adr.yml`) lints the corpus on every pull request and
 comments the decisions governing the changed files.
+
+The two ADR badges in `README.md` — corpus size and ARB queue depth — are a
+recipe over JSON adrkit already emits, not a hosted service. When the corpus
+changes on `main`, `.github/workflows/adr-badges.yml` regenerates
+`.adrkit/lint.json` (`$.checked`) and `.adrkit/queue.json` (`$.totalItems`),
+validates them with `bun run adr:check-reports`, and commits them for
+shields.io to read. A malformed report renders as `no result` rather than
+failing, so it is validated before it is published; regenerate the pair locally
+with the same two commands the workflow runs if you need to inspect them.
 
 ### CI/CD and Releases
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
   # OpenLeague
 
   [![Release](https://github.com/mbeacom/openleague/workflows/Release/badge.svg)](https://github.com/mbeacom/openleague/actions/workflows/release.yml)
+  [![ADRs](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fmbeacom%2Fopenleague%2Fmain%2F.adrkit%2Flint.json&query=%24.checked&label=ADRs&color=cb492d)](./docs/adr)
+  [![ARB queue](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fmbeacom%2Fopenleague%2Fmain%2F.adrkit%2Fqueue.json&query=%24.totalItems&label=ARB%20queue&suffix=%20pending&color=cb492d)](./docs/adr)
   [![Code License](https://img.shields.io/badge/code-Apache--2.0-blue.svg)](./LICENSE)
   [![Docs License](https://img.shields.io/badge/docs-CC%20BY%204.0-blue.svg)](./LICENSE-DOCS)
   [![Version](https://img.shields.io/github/package-json/v/mbeacom/openleague)](./package.json)

--- a/__tests__/scripts/check-adr-reports.test.ts
+++ b/__tests__/scripts/check-adr-reports.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Regression tests for `scripts/check-adr-reports.ts`.
+ *
+ * The published reports are the only input to the two README badges, and the
+ * failure they guard against is silent: shields.io renders a missing or
+ * non-numeric field as the string `no result` rather than erroring, so a
+ * corrupt report publishes successfully and then misreports indefinitely.
+ * Nothing downstream of the badge would notice. These tests are what keep that
+ * check honest.
+ *
+ * The cases that matter most are the ones that are *shaped* like a valid report
+ * -- `{"checked": true}`, `{"checked": null}`, `{"checked": 2.5}` -- because
+ * each one round-trips through JSON.parse without complaint and would sail past
+ * a looser `typeof x === 'number'` or a truthiness check.
+ */
+import { describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { checkReports } from '@/scripts/check-adr-reports';
+
+/** Verbatim shape of `adr lint --json`, trimmed to the field the badge reads. */
+const VALID_LINT = { checked: 5, findings: [] };
+
+/** Verbatim shape of `adr queue --format json`, trimmed likewise. */
+const VALID_QUEUE = { version: '1', totalItems: 0, items: [] };
+
+interface FixtureOptions {
+  /** Raw file contents. `undefined` writes the valid report; `null` omits it. */
+  lint?: string | null;
+  queue?: string | null;
+}
+
+function withFixture(
+  options: FixtureOptions,
+  assert: (result: ReturnType<typeof checkReports>) => void,
+): void {
+  const { lint, queue } = options;
+  const dir = mkdtempSync(path.join(tmpdir(), 'adr-reports-'));
+
+  const write = (name: string, contents: string | null | undefined, fallback: unknown) => {
+    if (contents === null) return;
+    writeFileSync(
+      path.join(dir, name),
+      contents ?? JSON.stringify(fallback, null, 2),
+      'utf8',
+    );
+  };
+
+  write('lint.json', lint, VALID_LINT);
+  write('queue.json', queue, VALID_QUEUE);
+
+  try {
+    assert(checkReports(dir));
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+}
+
+describe('check-adr-reports', () => {
+  it('passes reports that carry the fields the badges query', () => {
+    withFixture({}, (result) => {
+      expect(result.failures).toEqual([]);
+      expect(result.values).toEqual({ 'lint.json': 5, 'queue.json': 0 });
+    });
+  });
+
+  it('accepts a zero count, which is a real corpus state and not an error', () => {
+    withFixture({ lint: JSON.stringify({ checked: 0 }) }, (result) => {
+      expect(result.failures).toEqual([]);
+      expect(result.values['lint.json']).toBe(0);
+    });
+  });
+
+  it('fails when a report has not been generated yet', () => {
+    withFixture({ queue: null }, (result) => {
+      expect(result.failures).toHaveLength(1);
+      expect(result.failures[0]).toContain('queue.json is missing');
+    });
+  });
+
+  // The exact failure the staging/validate step exists to catch: a write that
+  // was cut short still parses as a file, just not as JSON.
+  it('fails on a truncated write rather than publishing it', () => {
+    withFixture({ lint: '{"checked": 5, "findi' }, (result) => {
+      expect(result.failures).toHaveLength(1);
+      expect(result.failures[0]).toContain('not valid JSON');
+    });
+  });
+
+  it('fails when the report is valid JSON but not an object', () => {
+    withFixture({ queue: '[]' }, (result) => {
+      expect(result.failures).toHaveLength(1);
+      expect(result.failures[0]).toContain('not a JSON object');
+    });
+  });
+
+  it('fails when the queried field is absent', () => {
+    withFixture({ queue: JSON.stringify({ items: [] }) }, (result) => {
+      expect(result.failures).toHaveLength(1);
+      expect(result.failures[0]).toContain('no integer `totalItems`');
+    });
+  });
+
+  // `true` is the case Python's `isinstance(x, int)` accepts, because bool
+  // subclasses int. It must be rejected here, and the badge would render it as
+  // `true` rather than a count.
+  it('rejects a boolean where a count is expected', () => {
+    withFixture({ lint: JSON.stringify({ checked: true }) }, (result) => {
+      expect(result.failures).toHaveLength(1);
+      expect(result.failures[0]).toContain('no integer `checked`');
+    });
+  });
+
+  it('rejects null, which a looser typeof check would let through', () => {
+    withFixture({ lint: JSON.stringify({ checked: null }) }, (result) => {
+      expect(result.failures).toHaveLength(1);
+      expect(result.failures[0]).toContain('no integer `checked`');
+    });
+  });
+
+  it('rejects a non-integer number', () => {
+    withFixture({ queue: JSON.stringify({ totalItems: 2.5 }) }, (result) => {
+      expect(result.failures).toHaveLength(1);
+      expect(result.failures[0]).toContain('no integer `totalItems`');
+    });
+  });
+
+  it('rejects a negative count, which cannot describe a corpus', () => {
+    withFixture({ lint: JSON.stringify({ checked: -1 }) }, (result) => {
+      expect(result.failures).toHaveLength(1);
+      expect(result.failures[0]).toContain('negative `checked`');
+    });
+  });
+
+  it('reports every bad file, not just the first', () => {
+    withFixture({ lint: '{', queue: 'nope' }, (result) => {
+      expect(result.failures).toHaveLength(2);
+      expect(result.values).toEqual({});
+    });
+  });
+});

--- a/bun.lock
+++ b/bun.lock
@@ -37,8 +37,8 @@
         "zod": "^4.4.3",
       },
       "devDependencies": {
-        "@adrkit/cli": "0.4.0",
-        "@adrkit/mcp": "0.4.0",
+        "@adrkit/cli": "0.7.0",
+        "@adrkit/mcp": "0.7.0",
         "@eslint/eslintrc": "^3.3.6",
         "@tailwindcss/postcss": "^4.3.3",
         "@testing-library/jest-dom": "^6.10.0",
@@ -70,13 +70,13 @@
   "packages": {
     "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
 
-    "@adrkit/cli": ["@adrkit/cli@0.4.0", "", { "dependencies": { "@adrkit/core": "0.4.0", "@adrkit/evaluator": "0.4.0" }, "bin": { "adr": "dist/index.js" } }, "sha512-kWBezzNtSNE40oBBLkfwmzWPoqW6xE/xw62DaU7X8u70otVOClhI1bwOevmXmYafCR682aRPXQRH7/d+Oa356A=="],
+    "@adrkit/cli": ["@adrkit/cli@0.7.0", "", { "dependencies": { "@adrkit/core": "0.7.0", "@adrkit/evaluator": "0.7.0" }, "bin": { "adr": "dist/index.js" } }, "sha512-gxac7S0KoCnBGwpFYI0HJy0a6nGclLbP5hL5bTMox5WpTk9gC5cD082ZxzdF2ueZNAdeZAIKmCJwFLdAAtQkqg=="],
 
-    "@adrkit/core": ["@adrkit/core@0.4.0", "", { "dependencies": { "picomatch": "^4", "semver": "^7", "yaml": "latest", "zod": "^4" } }, "sha512-gvvyOKyVScl9u/PUpq3EJ34RTvE5zUYr+IXsnwAuhjRcUQXASpxi3LhwQAAfODg8Ar5gkRoqCBaFQscslizx6g=="],
+    "@adrkit/core": ["@adrkit/core@0.7.0", "", { "dependencies": { "picomatch": "^4", "semver": "^7", "yaml": "latest", "zod": "^4" } }, "sha512-fA9z5m5ho4aUtJD7AOlycgyPdL4opzwnvUFVS1Xr2oHzAP+LH/ITgxfVV6FkZNFT8cnYMlMRXgL9ql+Zpt4vlw=="],
 
-    "@adrkit/evaluator": ["@adrkit/evaluator@0.4.0", "", { "dependencies": { "@adrkit/core": "0.4.0", "jsonpath-rfc9535": "1.3.0" } }, "sha512-iadthsNpWTqDZsZg/deNniEaRin7XPHVe1GDYYjwjR9yjJK031oaq6roEpTljrUKRfS1IwIdXMMZ8bTg4UphXg=="],
+    "@adrkit/evaluator": ["@adrkit/evaluator@0.7.0", "", { "dependencies": { "@adrkit/core": "0.7.0", "jsonpath-rfc9535": "1.3.0" } }, "sha512-mKoDv/gqwpCpZQIV3xx0sP4Tmy8Ds2WkLsQB6gXmez34dPsiuSe9NJSpZQ8hp/X0ydN9eOeUflJqgWsxujT1JA=="],
 
-    "@adrkit/mcp": ["@adrkit/mcp@0.4.0", "", { "dependencies": { "@adrkit/core": "0.4.0", "@modelcontextprotocol/server": "2.0.0", "zod": "^4.2.0" }, "bin": { "adrkit-mcp": "dist/bin.js" } }, "sha512-WhoLbC1w4GgAmli3ZO1SesKQYKHWI0P/Eq1QD8apTtaW34JlthXlueql30tJtV9lMuTuIhGs2AAj3qd4LHHwjA=="],
+    "@adrkit/mcp": ["@adrkit/mcp@0.7.0", "", { "dependencies": { "@adrkit/core": "0.7.0", "@modelcontextprotocol/server": "2.0.0", "zod": "^4.2.0" }, "bin": { "adrkit-mcp": "dist/bin.js" } }, "sha512-JbH1X+MXEWf3VNnzwd/suTb7x+L1WQmtXV3DB48UQiXZ+qkoyBOGHzj8YhvXOhTHAwz8T7FEP6Dxx2EKkxmPDQ=="],
 
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
@@ -2100,7 +2100,7 @@
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
-    "@adrkit/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+    "@adrkit/core/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
     "@apm-js-collab/code-transformer/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -46,6 +46,8 @@ bun run adr:check-integrity             # corpus is non-empty, filenames are
                                         # discoverable, version pins agree
 bun run adr:review-dates                # which decisions are past, or near,
                                         # their reviewBy date?
+bun run adr:queue                       # which decisions await review?
+bun run adr:check-reports               # validate the generated badge reports
 bun run adr:explain lib/actions/team.ts # what governs this file?
 bun run adr:check <changed files...>    # what governs a change set?
 bun run adr:new "Use X for Y"           # scaffold the next record
@@ -154,3 +156,38 @@ days of passing, and closes it again once the dates are moved forward. See
 
 The corpus is excluded from the docs-site path filters, because only top-level
 `docs/*.md` files are published — an ADR change cannot alter the built site.
+
+## Badges
+
+The two ADR badges in the root [`README.md`](../../README.md) report *numbers a
+reader can verify by opening this directory* — corpus size and ARB queue depth.
+Neither is a grade, and neither claims the corpus is healthy.
+
+adrkit ships no badge service and no `adr badge` command. Both badges are a
+recipe over JSON it already emits, served from this repository and rendered by
+shields.io. `.github/workflows/adr-badges.yml` runs on a push to `main` that
+touches `docs/adr/**` and regenerates two files:
+
+| File | Command | Badge reads |
+|------|---------|-------------|
+| `.adrkit/lint.json` | `adr lint --json` | `$.checked` — every record on file, whatever its status |
+| `.adrkit/queue.json` | `adr queue --format json` | `$.totalItems` — records with status `proposed` |
+
+Three things about that workflow are deliberate:
+
+- **It runs the pinned local binary**, not `npx @adrkit/cli@x.y.z` as adrkit's
+  own recipe suggests. A registry fetch inside a job holding `contents: write`
+  gets neither `bun.lock`'s integrity hash nor the `minimumReleaseAge`
+  quarantine (ADR-0005), and it would add a sixth version pin site that nothing
+  would notice going stale.
+- **It validates before publishing.** A truncated write does not break a badge —
+  shields.io renders `no result`, which reads as broken tooling and would go
+  unnoticed indefinitely. `bun run adr:check-reports` fails the run instead.
+- **It commits with `[skip ci]`**, matching `release.yml`'s own convention.
+  `.adrkit/**` is not covered by `release.yml`'s `paths-ignore`, so without the
+  marker a two-file JSON refresh would start a release.
+
+A badge cannot detect its own staleness: if this workflow is disabled or starts
+failing its push, the committed JSON keeps its last value and the badges keep
+rendering it. The signal that covers regeneration is the workflow's own run
+history, not the badges.

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
     "adr:review-dates": "bun scripts/check-adr-review-dates.ts",
     "adr:new": "adr new",
     "adr:check": "adr check",
+    "adr:queue": "adr queue",
+    "adr:check-reports": "bun scripts/check-adr-reports.ts",
     "adr:explain": "adr explain",
     "adr:graph": "adr graph",
     "docs:build-pages": "tsx scripts/build-docs-pages.ts",
@@ -76,8 +78,8 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@adrkit/cli": "0.4.0",
-    "@adrkit/mcp": "0.4.0",
+    "@adrkit/cli": "0.7.0",
+    "@adrkit/mcp": "0.7.0",
     "@eslint/eslintrc": "^3.3.6",
     "@tailwindcss/postcss": "^4.3.3",
     "@testing-library/jest-dom": "^6.10.0",

--- a/scripts/check-adr-reports.ts
+++ b/scripts/check-adr-reports.ts
@@ -1,0 +1,125 @@
+/**
+ * Validates the ADR badge reports before they are published.
+ *
+ * `.adrkit/lint.json` and `.adrkit/queue.json` are the verbatim JSON of
+ * `adr lint --json` and `adr queue --format json`. They exist only to be read
+ * by shields.io, which resolves a JSONPath against them -- `$.checked` and
+ * `$.totalItems` respectively -- and renders whatever it finds.
+ *
+ * The failure this guards against is quiet. A truncated or malformed write does
+ * not break the badge; it renders the string `no result`, which a reader parses
+ * as "their tooling is broken" rather than "that file is corrupt". Nothing
+ * downstream would fail, and the badge would keep showing it until someone
+ * happened to look. So the report is validated before it is committed, and a
+ * bad one fails the workflow instead of being published.
+ *
+ * `Number.isInteger` rather than `typeof x === 'number'`: the count fields must
+ * be whole numbers, and `typeof NaN` is also `'number'`, so the looser check
+ * would accept a `null` that had been coerced somewhere upstream. Booleans are
+ * rejected for free here -- unlike Python, where `bool` subclasses `int` and
+ * `isinstance(True, int)` is true -- but the field is still range-checked,
+ * because a negative count is nonsense that JSONPath would happily render.
+ *
+ * Exported as a pure function of a directory so it can be exercised against
+ * fixtures. Depends on nothing outside node: builtins, like the other
+ * check scripts, so its CI step cannot be defeated by an install failure.
+ */
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+/** Where the workflow writes the reports, relative to the repo root. */
+export const REPORTS_DIR = '.adrkit';
+
+/** A report file, and the field the badge's JSONPath query reads out of it. */
+interface ReportSpec {
+  file: string;
+  field: string;
+  /** The command whose verbatim output this file is, for the error message. */
+  command: string;
+}
+
+export const REPORTS: ReportSpec[] = [
+  { file: 'lint.json', field: 'checked', command: 'adr lint --json' },
+  { file: 'queue.json', field: 'totalItems', command: 'adr queue --format json' },
+];
+
+export interface ReportCheckResult {
+  failures: string[];
+  /** The validated field values, keyed by filename. Empty when a check failed. */
+  values: Record<string, number>;
+}
+
+/**
+ * @param reportsDir Absolute path to the directory holding the report files.
+ */
+export function checkReports(reportsDir: string): ReportCheckResult {
+  const failures: string[] = [];
+  const values: Record<string, number> = {};
+
+  for (const { file, field, command } of REPORTS) {
+    const full = path.join(reportsDir, file);
+
+    if (!existsSync(full)) {
+      failures.push(`${file} is missing. It should be the verbatim output of \`${command}\`.`);
+      continue;
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(readFileSync(full, 'utf8'));
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      failures.push(
+        `${file} is not valid JSON (${detail}). A truncated write renders as ` +
+          '`no result` on the badge rather than failing, so it is rejected here.',
+      );
+      continue;
+    }
+
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      failures.push(`${file} is not a JSON object, so \`$.${field}\` cannot resolve.`);
+      continue;
+    }
+
+    const value = (parsed as Record<string, unknown>)[field];
+
+    if (!Number.isInteger(value)) {
+      failures.push(
+        `${file} has no integer \`${field}\` (found ${JSON.stringify(value) ?? 'undefined'}). ` +
+          `The badge reads \`$.${field}\` and renders \`no result\` when it is absent ` +
+          'or not a number.',
+      );
+      continue;
+    }
+
+    if ((value as number) < 0) {
+      failures.push(`${file} reports a negative \`${field}\` (${value}), which cannot be a count.`);
+      continue;
+    }
+
+    values[file] = value as number;
+  }
+
+  return { failures, values };
+}
+
+function main(): void {
+  const repoRoot = path.resolve(import.meta.dirname, '..');
+  const reportsDir = path.resolve(repoRoot, process.argv[2] ?? REPORTS_DIR);
+  const { failures, values } = checkReports(reportsDir);
+
+  if (failures.length === 0) {
+    const summary = REPORTS.map(({ file, field }) => `${field}=${values[file]}`).join(', ');
+    console.log(`ADR badge reports OK: ${summary}.`);
+    return;
+  }
+
+  console.error('ADR badge report check failed:\n');
+  for (const message of failures) console.error(`  - ${message}`);
+  process.exit(1);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}


### PR DESCRIPTION
## What

Upgrades adrkit `0.4.0` → `0.7.0` and adds the two badges that release ships — corpus size and ARB queue depth — to the README, along with the workflow that publishes the numbers they read.

adrkit ships **no badge service and no `adr badge` command**. Both badges are a recipe over JSON the CLI already emits, served from this repository and rendered by shields.io (adrkit's ADR-0025).

| Badge | File | Command | Query |
|---|---|---|---|
| `ADRs` | `.adrkit/lint.json` | `adr lint --json` | `$.checked` |
| `ARB queue` | `.adrkit/queue.json` | `adr queue --format json` | `$.totalItems` |

## Version pins

All four committed pins move together, as `bun run adr:check-integrity` requires:

- `@adrkit/cli` and `@adrkit/mcp` in `package.json` (+ `bun.lock`)
- the documented cloud-agent MCP setting in `.github/copilot-cloud-agent-mcp.md`
- the CI action in `adr.yml`, now pinned to the immutable v0.7.0 commit `e3155ea` (dereferenced from the annotated tag, not the tag object)

The two local MCP configs need no change — they already run `node_modules/.bin/adrkit-mcp`, so their version *is* the `package.json` pin.

## Three departures from adrkit's published recipe

1. **Runs the pinned local binary**, not `npx @adrkit/cli@x.y.z`. A registry fetch inside a job holding `contents: write` gets neither `bun.lock`'s integrity hash nor the `minimumReleaseAge` quarantine (ADR-0005), and it would add a *sixth* pin site that nothing would notice going stale. This way the version lives in exactly one place.
2. **Validates in TypeScript rather than inline Python**, so the check is unit-tested (11 cases). A truncated report does not break a badge — shields.io renders `no result`, which reads as broken tooling and would go unnoticed indefinitely. Reports are generated into a staging directory and only published once they parse, so a bad run never replaces good files.
3. **Commits with `[skip ci]`**, matching `release.yml`'s existing convention. `.adrkit/**` is *not* covered by `release.yml`'s `paths-ignore`, so without the marker a two-file JSON refresh would start a release and a full quality-gates run. The push also rebases and retries, since `release.yml` writes to `main` too.

The workflow is deliberately separate from `adr.yml` rather than a job in it: it holds `contents: write`, which has no business running against untrusted fork code. `adr.yml` stays read-only apart from its one comment step.

The initial reports are committed so the badges resolve on merge, rather than rendering `resource not found` until the corpus next changes.

## Verification

Both badges were rendered against the **real published files on this branch**, not a mock:

```
ADRs: 5
ARB queue: 0 pending
```

The only difference from the committed URLs is the branch segment, which resolves to `main` on merge.

- `adr:lint` — 5 records, 0 errors, 0 warnings
- `adr:check-integrity` — all pins agree
- `check:mcp-pins`, `check:raw-sql` — pass
- `type-check`, `lint` — clean (one pre-existing warning in `.design-sync/`)
- `bun run test` — **1854 passed / 139 files**
- `actionlint` — clean on both workflows
- `validate-deployment-config` — passes
- `adr:check` on the change set — governed by ADR-0001 and ADR-0005, both satisfied, 0 changed-record errors

Failure paths were exercised directly: a truncated write, a non-object, an absent field, a boolean, `null`, a fractional number, and a negative count each fail the check with exit 1.

## No new ADR

This is a version bump plus additive tooling. It alters no decision — using the local binary over a registry fetch is an *application* of ADR-0005, not a new one.

## Note for after merge

`.github/copilot-cloud-agent-mcp.md` is documentation of a **repository setting**, not configuration GitHub reads. The cloud-agent MCP server needs `@adrkit/mcp@0.7.0` pasted into Settings → Copilot → MCP servers to actually move; nothing in CI can check that.