### PR TITLE
docs(ci): correct two stale claims in the ADR workflow comments

### DIFF
--- a/.github/workflows/adr.yml
+++ b/.github/workflows/adr.yml
@@ -85,11 +85,17 @@ jobs:
       - name: Resolve decisions governing this pull request
         uses: mbeacom/adrkit/packages/ci@e3155eaaf200c9ed7f3ea572d91f0bd4c11c35cc # v0.7.0
         env:
-          # Required for the action to update its existing comment instead of
-          # posting a new one per push. It only recognises its own comment when
-          # the resolved token equals $GITHUB_TOKEN, and Actions does not export
-          # that variable automatically. Without this the marker lookup is
-          # skipped and every run appends another comment.
+          # Inert as pinned, and safe to delete. Through v0.6.0 the action
+          # recognised its own comment only when the resolved token equalled
+          # $GITHUB_TOKEN, which Actions does not export, so without this block
+          # the marker lookup was skipped and every push appended another
+          # comment (adrkit #107). v0.7.0 deleted that comparison: it now reads
+          # a refused `users.getAuthenticated` call as an app-installation
+          # token and claims its prior comment on `user.type == 'Bot'` plus the
+          # marker leading the body (adrkit ADR-0026). The variable survives
+          # only as a fallback *source* -- `getInput('token') ||
+          # process.env.GITHUB_TOKEN` -- and `with: token:` below is always
+          # set, so this is never read.
           GITHUB_TOKEN: ${{ github.token }}
         with:
           dir: docs/adr

--- a/.github/workflows/adr.yml
+++ b/.github/workflows/adr.yml
@@ -4,11 +4,21 @@ on:
   # Must stay `pull_request`. The governing-decisions job below holds
   # `pull-requests: write`; switching to `pull_request_target` would combine
   # that write token with a checkout of untrusted fork code. Fork PRs get a
-  # read-only token here, so the comment step catches the 403, writes the body
-  # to a notice annotation and returns without failing -- see `comment()` and
-  # `isPermissionError` in the pinned action. That is the intended behaviour,
-  # not a bug to "fix" by changing the trigger. Read from the action's source
-  # and never observed here; see #306 and ADR-0001 action item 8.
+  # read-only token here, so the comment step catches the permission error --
+  # `isPermissionError` is 401/403/404, since a fork token is refused with a
+  # 404 as readily as a 403 -- writes the body to a notice annotation and
+  # returns without failing. That is the intended behaviour, not a bug to
+  # "fix" by changing the trigger.
+  #
+  # The read-only branch is now observed rather than only read from the
+  # action's source: `mbeacom/adrkit-t018-dogfood` run 31773014051 (attempt 2,
+  # job `degrade-read-only`) dispatched the Action under `pull-requests: read`,
+  # logged "no permission to comment on this PR (read-only token); posting the
+  # result to the job log instead", stayed green, and wrote no comment. That
+  # run is a PROXY -- a same-repo pull request holding a downgraded token, not
+  # a pull request from a fork -- so it evidences the read-only-token
+  # condition but not fork provenance. A genuine fork PR remains unobserved
+  # here, so ADR-0001 action item 8 stays open; see #306.
   pull_request:
     branches:
       - main

--- a/docs/adr/0001-record-architecture-decisions-as-versioned-markdown-in-git.md
+++ b/docs/adr/0001-record-architecture-decisions-as-versioned-markdown-in-git.md
@@ -199,3 +199,21 @@ We accept real costs:
    fork PR since the workflow landed, so that is read rather than observed — the
    same distinction as item 7. Confirming it needs a pull request from an
    account that can fork this repository. See #306.
+
+   **Partial evidence exists, and it does not discharge this item.**
+   `mbeacom/adrkit-t018-dogfood` run 31773014051 (attempt 2, job
+   `degrade-read-only`) dispatched the action under `pull-requests: read` and
+   observed the degrade: a `notice` carrying the comment body, a green job, and
+   no comment written. That answers #306's first question — the action degrades
+   without blocking the PR, so the `continue-on-error` and `workflow_run`
+   remedies #306 proposed are moot, and the consequence it anticipated is
+   confirmed: an external contributor silently never receives the comment.
+
+   It is nonetheless a **proxy**, and the box stays unticked because the proxy
+   is *provenance-blind*. Its pull request is same-repo — `head.repo.full_name
+   == base.repo.full_name`, so `is_cross_repo` is false. A downgraded token
+   reproduces the *token* condition this item cares about, but not the
+   *provenance* condition the wording asks for: no fork, no cross-repo
+   `head.repo`, no untrusted-code context. The evidence narrows what is
+   unobserved rather than closing it. Only a pull request from an actual fork
+   ticks this box.

--- a/docs/adr/0001-record-architecture-decisions-as-versioned-markdown-in-git.md
+++ b/docs/adr/0001-record-architecture-decisions-as-versioned-markdown-in-git.md
@@ -217,3 +217,8 @@ We accept real costs:
    `head.repo`, no untrusted-code context. The evidence narrows what is
    unobserved rather than closing it. Only a pull request from an actual fork
    ticks this box.
+
+   The evidence is also scoped to one credential: the default `GITHUB_TOKEN`
+   with its permissions downgraded. A custom GitHub App token reaches the same
+   `app-installation` classification in the action but is a different
+   credential, so the observation does not generalise to it.


### PR DESCRIPTION
## What

Four documentation corrections. Two in `.github/workflows/adr.yml`, two in `docs/adr/0001-…md`. All fix statements that were true when written and are not true against the currently pinned action. Each workflow commit is verified comment-only by a before/after YAML parse.

1. **`env: GITHUB_TOKEN` rationale** in `governing-decisions` — described adrkit's pre-v0.7.0 identity model.
2. **Trigger-level comment** — said the fork-degrade path was "never observed here", and narrowed the degrade trigger to `403`.
3. **ADR-0001 action item 8** — records *why* the new evidence leaves the box unticked, and what credential it is scoped to. The box is **not** ticked.

Observation recorded on **#306**, which asked for exactly this evidence and was closed without ever receiving it: [comment](https://github.com/mbeacom/openleague/issues/306#issuecomment-5289922161). That issue stays closed.

---

## 1. The `GITHUB_TOKEN` rationale was false as pinned

It said:

> It only recognises its own comment when the resolved token equals `$GITHUB_TOKEN` […] Without this the marker lookup is skipped and every run appends another comment.

Read literally, that told a future maintainer that removing the block would make every push append a new comment. It would not. The block is **inert as pinned** — though it genuinely *was* load-bearing through v0.6.0, which the new comment records rather than eliding.

Verified against `mbeacom/adrkit@e3155eaa` (v0.7.0), the pinned commit:

| Claim | Evidence |
|---|---|
| `token` already defaults to `${{ github.token }}` | `packages/ci/action.yml`, `inputs.token.default` |
| The env var is never reached from here | `src/index.ts:19` — `getInput('token') \|\| process.env.GITHUB_TOKEN \|\| ''`. `getInput` is always non-empty: the input has a default **and** this workflow passes `token:` explicitly. |
| It is not an identity signal | `src/index.ts:17-18`, verbatim: *"it is NOT used to identify the token (issue #107/ADR-0026)"* |
| The old comparison is gone | adrkit ADR-0026: *"The `isDefaultToken` plumbing is deleted. `GITHUB_TOKEN` remains a fallback **source**"* |
| What replaced it | `src/github.ts:125` — `comment.user?.type === 'Bot' && markerLeadsBody(comment.body, marker)` |
| Upstream agrees | `site/src/content/docs/ci.mdx:44-48` — *"no longer required — and costs nothing if you still have it"* |

**The `env:` block is kept.** Removing it is a separate decision that was made deliberately; it costs nothing, and the comment now says so outright so the next reader need not re-derive it.

### Observed live on this PR

ADR-0001 path-matches this file, so the PR self-triggers the job. The comment posted as `github-actions[bot]`, `user.type == "Bot"`, marker as the body's **first line** — the two conditions `github.ts:125` keys on. Across repeated dispatches (multiple pushes plus same-commit re-runs) the PR still carries **exactly one** adrkit comment, `created_at` fixed at `05:31:57Z`.

That confirms the de-duplication mechanism the new comment describes. It does **not** prove the block is inert — the block was present throughout. **Inertness rests on the source evidence above, and only on that.**

---

## 2. The trigger comment: one claim outdated, one too narrow

### "never observed here" → observed, via a labelled proxy

[`adrkit-t018-dogfood` run 31773014051 attempt 2](https://github.com/mbeacom/adrkit-t018-dogfood/actions/runs/31773014051/attempts/2), job `degrade-read-only` (**conclusion `success`**, permissions `contents: read` + `pull-requests: read`), dispatched the Action and logged:

```
##[notice]adrkit: no permission to comment on this PR (read-only token); posting the result to the job log instead.
```

It stayed green and wrote no comment; the before/after snapshot was unchanged.

**That run exercised this workflow's exact binary.** `packages/ci/dist/index.js` is byte-identical at the dogfood pin and at `e3155eaa`, the pin used here — blob `8f039d0d0521baff403a769c278780538f542f6d`, 1,809,405 bytes. So the observation is not merely "adrkit at some version"; it is the artifact this job runs.

**It is nonetheless a proxy, and the comment labels it one.** The source PR is same-repo — `head.repo.full_name == base.repo.full_name`, so `is_cross_repo` is **false**. It reproduces the read-only-token condition and the same `isPermissionError` branch, but **no fork is involved**.

So: the read-only branch is observed. A pull request from an actual fork is not.

### "catches the 403" → 401/403/404

`src/github.ts:319-321` — `isPermissionError` is `403 || 401 || 404`. The source note explains why: a fork token *"is denied with a 404 as readily as a 403"*, because GitHub hides a forbidden resource rather than admitting it exists.

---

## 3. ADR-0001 item 8 — annotated, deliberately not ticked

Item 8 asks to confirm the fork behaviour *"by observing a real one."* Evidence now exists that answers **part** of it, and a reader finding that evidence beside an unticked box would reasonably re-litigate the box. The record now says why it stays unticked, so that argument doesn't have to be had twice.

- **What the evidence settles:** #306's *first* question. The action degrades without blocking, so the `continue-on-error` / `workflow_run` remedies #306 proposed are moot, and the consequence it anticipated is confirmed — an external contributor silently never receives the comment.
- **What it doesn't, on provenance:** the proxy is *provenance-blind*. A downgraded token reproduces the token condition but carries no fork provenance — no cross-repo `head.repo`, no untrusted-code context. Same distinction item 7 draws between applying a setting and observing it work.
- **What it doesn't, on credential:** the run downgraded the default `GITHUB_TOKEN`. A custom GitHub App token reaches the same `app-installation` classification but is a different credential, so the observation does not generalise to it.

The gap got smaller. It didn't close. Only a pull request from an actual fork ticks the box.

---

## Verification

- `ruby -ryaml` parse before/after each workflow commit: semantically identical — comment-only
- `bun run adr:lint` → `checked 5 records, 0 errors, 0 warnings`; `bun run adr:check-integrity` OK
- Pin, `env:` block, and `with:` inputs unchanged throughout
- #306 confirmed still `CLOSED` / `COMPLETED` after commenting
- Every quoted log line checked against the raw job log, not the run summary
- `version-check.yml` is path-filtered to `package.json` and does not fire