### PR TITLE
fix(theme): close three color-scheme pin leaks on public surfaces

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -632,3 +632,13 @@ Apache License 2.0 - see [LICENSE](./LICENSE). The source code is free to use, f
 ## Recent Changes
 - 002-ice-rink-management: Added TypeScript with Next.js 16 App Router and React 19 + MUI v7/Emotion, Prisma 7, Neon PostgreSQL adapter, Auth.js v5, Zod v4, Bun
 - 002-ice-rink-management: Added venue organization onboarding, branded public rink profiles, venue staff roles, multi-surface scheduling models, and public rink discovery contracts.
+
+<!-- BEGIN:nextjs-agent-rules -->
+
+# This is NOT the Next.js you know
+
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
+<!-- END:nextjs-agent-rules -->

--- a/__tests__/components/features/navigation/MarketingHeader.test.tsx
+++ b/__tests__/components/features/navigation/MarketingHeader.test.tsx
@@ -4,6 +4,17 @@ import { ThemeProvider } from '@mui/material/styles';
 import theme from '@/lib/theme';
 import MarketingHeader from '@/components/features/navigation/MarketingHeader';
 
+// Local, controllable pathname. vitest.setup.ts mocks next/navigation with a
+// plain `usePathname: () => '/'`, which cannot be re-stubbed per test; the
+// header's solid-vs-transparent branch keys off it, so a couple of these tests
+// need to leave the homepage. Defaults to '/' to match the global mock.
+const mockPathname = vi.fn(() => '/');
+vi.mock('next/navigation', () => ({
+  usePathname: () => mockPathname(),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), prefetch: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+
 // Mock Next.js components
 vi.mock('next/link', () => ({
   default: ({ href, children, ...props }: any) => (
@@ -161,6 +172,40 @@ describe('MarketingHeader', () => {
     it.each(navigationLinks)('renders $label link with correct href', ({ label, href }) => {
       renderWithTheme(<MarketingHeader />);
       expect(screen.getByRole('link', { name: label })).toHaveAttribute('href', href);
+    });
+  });
+
+  describe('Color scheme', () => {
+    // AppBar's default color="primary" emits `color: primary.contrastText` —
+    // white — which the Logo wordmark inherits, rendering it white-on-white
+    // against this bar's own light background. That same variant carries MUI's
+    // applyStyles('dark', …) override, whose ancestor selector reaches through
+    // LightThemeScope and repaints the bar in dark-palette colors underneath
+    // light-pinned text. color="inherit" opts out of both.
+    it('uses color="inherit" so the bar does not force its own text color', () => {
+      const { container } = renderWithTheme(<MarketingHeader />);
+
+      const appBar = container.querySelector('.MuiAppBar-root');
+      expect(appBar).not.toBeNull();
+      expect(appBar!.className).toContain('MuiAppBar-colorInherit');
+      expect(appBar!.className).not.toContain('MuiAppBar-colorPrimary');
+    });
+
+    it('takes its solid background from a scheme-aware token, not a white literal', () => {
+      // off the homepage the bar is solid rather than transparent
+      mockPathname.mockReturnValue('/about');
+      try {
+        const { container } = renderWithTheme(<MarketingHeader />);
+
+        const appBar = container.querySelector('.MuiAppBar-root') as HTMLElement;
+        // a baked rgba(255,255,255,.95) here would paint a white bar over the
+        // dark /docs and auth surfaces, which is what the token avoids
+        expect(getComputedStyle(appBar).backgroundColor).toContain(
+          '--mui-palette-background-paperChannel'
+        );
+      } finally {
+        mockPathname.mockReturnValue('/');
+      }
     });
   });
 });

--- a/__tests__/components/providers/LayoutProvider.test.tsx
+++ b/__tests__/components/providers/LayoutProvider.test.tsx
@@ -62,4 +62,71 @@ describe('LayoutProvider marketing chrome routing', () => {
     expect(screen.queryByRole('contentinfo')).not.toBeInTheDocument();
     expect(screen.queryByRole('link', { name: /skip to main content/i })).not.toBeInTheDocument();
   });
+
+  // The landing page and the auth pages bake light backgrounds into their
+  // sections and cards, so the chrome around them has to be pinned light too —
+  // otherwise a dark-mode visitor gets a dark header and footer bracketing a
+  // light page. /docs is genuinely scheme-aware and must keep following the
+  // visitor's theme.
+  describe('light-scheme pinning', () => {
+    const pinned = (container: HTMLElement) =>
+      container.querySelector('[data-mui-color-scheme="light"]');
+
+    it.each(['/', '/login', '/signup'])('pins the light scheme for %s', (path) => {
+      mocks.pathname.mockReturnValue(path);
+
+      const { container } = renderWithProviders(<div>content</div>);
+
+      expect(pinned(container)).not.toBeNull();
+    });
+
+    it('leaves /docs following the visitor theme', () => {
+      mocks.pathname.mockReturnValue('/docs');
+
+      const { container } = renderWithProviders(<div>Docs content</div>);
+
+      expect(screen.getByRole('banner')).toBeInTheDocument();
+      expect(pinned(container)).toBeNull();
+    });
+  });
+
+  // All six routes in app/(auth) get the same light pin from its layout, so
+  // they must get the same chrome here too. /forgot-password and the three
+  // token routes previously matched no branch at all and rendered with no skip
+  // link and no #main-content landmark.
+  describe('auth chrome is uniform across the route group', () => {
+    it.each([
+      '/login',
+      '/signup',
+      '/forgot-password',
+      '/reset-password/tok123',
+      '/verify-email/tok123',
+      '/confirm-email-change/tok123',
+    ])('gives %s a skip link and a main landmark', (path) => {
+      mocks.pathname.mockReturnValue(path);
+
+      renderWithProviders(<div>Auth content</div>);
+
+      expect(screen.getByRole('link', { name: /skip to main content/i })).toHaveAttribute(
+        'href',
+        '#main-content'
+      );
+      expect(screen.getByRole('main')).toHaveAttribute('id', 'main-content');
+      expect(screen.getByRole('contentinfo')).toBeInTheDocument();
+    });
+
+    // The prefix match this replaced also caught the public /signups pages,
+    // which bring their own chrome from app/(marketing)/layout.tsx.
+    it.each(['/signups', '/signups/evt_1', '/signup-events'])(
+      'does not add a second copy of the chrome to %s',
+      (path) => {
+        mocks.pathname.mockReturnValue(path);
+
+        renderWithProviders(<main>Signups content</main>);
+
+        expect(screen.queryByRole('banner')).not.toBeInTheDocument();
+        expect(screen.queryByRole('contentinfo')).not.toBeInTheDocument();
+      }
+    );
+  });
 });

--- a/__tests__/components/ui/LightThemeScope.test.tsx
+++ b/__tests__/components/ui/LightThemeScope.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ThemeProvider } from '@mui/material/styles';
+import { Typography } from '@mui/material';
+import theme from '@/lib/theme';
+import LightThemeScope from '@/components/ui/LightThemeScope';
+
+/**
+ * Regression cover for the marketing/auth "washed out text" bug.
+ *
+ * Pinning the scheme re-declares --mui-palette-* for the subtree, but the
+ * `color` PROPERTY is inherited, and the only element that sets it is <body>,
+ * which sits outside the pin and resolved to whatever scheme the visitor is in.
+ * A scope that pins the variables but not `color` therefore leaves every
+ * unstyled heading and paragraph rendering dark-palette text on light-pinned
+ * backgrounds (~1.07:1 measured on /about).
+ */
+describe('LightThemeScope', () => {
+  const scopeOf = (container: HTMLElement) =>
+    container.querySelector('[data-mui-color-scheme="light"]') as HTMLElement;
+
+  it('stamps the light scheme attribute so --mui-palette-* is re-declared for the subtree', () => {
+    const { container } = render(
+      <ThemeProvider theme={theme}>
+        <LightThemeScope>content</LightThemeScope>
+      </ThemeProvider>
+    );
+
+    expect(scopeOf(container)).not.toBeNull();
+  });
+
+  it('pins the inherited color, not just the variables', () => {
+    const { container } = render(
+      <ThemeProvider theme={theme}>
+        <LightThemeScope>
+          <Typography variant="h1">About OpenLeague</Typography>
+        </LightThemeScope>
+      </ThemeProvider>
+    );
+
+    // Emotion resolves theme.vars at style time, so the declaration carries the
+    // text.primary custom property rather than a baked literal — that is what
+    // lets the re-declared light value apply inside the scope.
+    const declared = getComputedStyle(scopeOf(container)).color;
+    expect(declared).toContain('--mui-palette-text-primary');
+
+    // and an unstyled heading inside the scope inherits that pinned color
+    // rather than whatever <body> was resolved to.
+    const heading = screen.getByText('About OpenLeague');
+    expect(getComputedStyle(heading).color).toBe(declared);
+  });
+
+  it('keeps native controls and scrollbars light', () => {
+    const { container } = render(
+      <ThemeProvider theme={theme}>
+        <LightThemeScope>content</LightThemeScope>
+      </ThemeProvider>
+    );
+
+    expect(getComputedStyle(scopeOf(container)).colorScheme).toBe('light');
+  });
+
+  it('lets callers override the pinned color and background via sx', () => {
+    const { container } = render(
+      <ThemeProvider theme={theme}>
+        <LightThemeScope sx={{ color: 'error.main' }}>content</LightThemeScope>
+      </ThemeProvider>
+    );
+
+    // caller sx is merged after the defaults, so it wins
+    expect(getComputedStyle(scopeOf(container)).color).toContain('--mui-palette-error-main');
+  });
+});

--- a/__tests__/lib/config/auth-routes.test.ts
+++ b/__tests__/lib/config/auth-routes.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { AUTH_ROUTES, isAuthRoute } from '@/lib/config/auth-routes';
+
+/**
+ * LayoutProvider and MarketingHeader both branch on "is this an auth route",
+ * and used to answer it from two private lists that agreed on only two of the
+ * six. The consequence was structural, not cosmetic: /forgot-password and the
+ * three token routes fell through every branch and rendered with no skip link
+ * and no #main-content landmark, while /login and /signup — same route group,
+ * same light pin — got both.
+ */
+describe('auth route roster', () => {
+  it('covers every directory under app/(auth)', () => {
+    expect([...AUTH_ROUTES]).toEqual([
+      '/login',
+      '/signup',
+      '/forgot-password',
+      '/reset-password',
+      '/verify-email',
+      '/confirm-email-change',
+    ]);
+  });
+
+  it.each([...AUTH_ROUTES])('matches %s exactly', (route) => {
+    expect(isAuthRoute(route)).toBe(true);
+  });
+
+  it('matches the token sub-routes', () => {
+    expect(isAuthRoute('/reset-password/abc123')).toBe(true);
+    expect(isAuthRoute('/verify-email/abc123')).toBe(true);
+    expect(isAuthRoute('/confirm-email-change/abc123')).toBe(true);
+  });
+
+  // The bug that motivated whole-segment anchoring: a bare startsWith('/signup')
+  // swallowed the public /signups pages and the authenticated /signup-events
+  // dashboard, giving them a second copy of the marketing chrome.
+  it.each(['/signups', '/signups/evt_1', '/signups/l/tok', '/signup-events', '/signup-events/evt_1/edit'])(
+    'does not swallow %s',
+    (route) => {
+      expect(isAuthRoute(route)).toBe(false);
+    }
+  );
+
+  it('does not match unrelated routes', () => {
+    expect(isAuthRoute('/')).toBe(false);
+    expect(isAuthRoute('/docs')).toBe(false);
+    expect(isAuthRoute('/loginhelp')).toBe(false);
+  });
+});

--- a/__tests__/lib/theme-color-schemes.test.ts
+++ b/__tests__/lib/theme-color-schemes.test.ts
@@ -70,13 +70,90 @@ describe('Theme Color Schemes (dark mode)', () => {
   describe('Scheme-aware component overrides', () => {
     it('keeps Card root overrides static with a dark-scheme block', () => {
       const root = theme.components?.MuiCard?.styleOverrides?.root as Record<string, unknown>;
-      expect(root.boxShadow).toBe('0px 4px 24px rgba(13, 71, 161, 0.08)');
+      expect(root['--ol-card-shadow']).toBe('0px 4px 24px rgba(13, 71, 161, 0.08)');
+      expect(root.boxShadow).toBe('var(--ol-card-shadow)');
       const darkBlock = root['*:where([data-mui-color-scheme="dark"]) &'];
       expect(darkBlock).toBeDefined();
     });
 
     it('uses a theme-aware TextField override (no hardcoded light input colors)', () => {
       expect(typeof theme.components?.MuiTextField?.styleOverrides?.root).toBe('function');
+    });
+
+    // applyStyles('dark', …) compiles to the ANCESTOR selector
+    // *:where([data-mui-color-scheme="dark"]) &, which a dark <html> keeps
+    // matching through a LightThemeScope subtree — CSS variables cannot
+    // override a rule that never reads them. Each dark block therefore needs a
+    // light block AFTER it (equal specificity, later source order wins) or the
+    // pinned-light marketing pages get dark card shadows and near-invisible
+    // input outlines. Order is the whole mechanism, so assert on it.
+    const DARK = '*:where([data-mui-color-scheme="dark"]) &';
+    // ...and the restore must name BOTH ancestors. Keyed on the light attribute
+    // alone it would also match in ordinary light mode, where <html> carries it
+    // — and being a separate later rule at equal specificity it would outrank
+    // call-site sx, flattening things like the pricing page's green card
+    // outline. That regression is the reason for the compound selector.
+    const LIGHT = '*:where([data-mui-color-scheme="dark"]) *:where([data-mui-color-scheme="light"]) &';
+
+    // Both scheme blocks must set ONLY custom properties. If either set
+    // `boxShadow`/`border`/`borderColor` directly it would compile to a nested
+    // rule emitted after the base one at equal specificity, and would then
+    // outrank every call-site sx — e.g. the pricing page's green free-plan
+    // outline, or the practice planner's selected-play border.
+    const onlyCustomProps = (block: Record<string, unknown>) =>
+      Object.keys(block).filter((k) => !k.startsWith('--'));
+
+    it('varies the Card scheme blocks through custom properties only', () => {
+      const root = theme.components?.MuiCard?.styleOverrides?.root as Record<string, unknown>;
+      const keys = Object.keys(root);
+
+      expect(keys).toContain(DARK);
+      expect(keys).toContain(LIGHT);
+      expect(keys.indexOf(LIGHT)).toBeGreaterThan(keys.indexOf(DARK));
+      // a restore keyed on the light attribute alone would also match in
+      // ordinary light mode, where <html> carries it
+      expect(keys).not.toContain('*:where([data-mui-color-scheme="light"]) &');
+
+      const darkBlock = root[DARK] as Record<string, unknown>;
+      const lightBlock = root[LIGHT] as Record<string, unknown>;
+      expect(onlyCustomProps(darkBlock)).toEqual([]);
+      expect(onlyCustomProps(lightBlock)).toEqual([]);
+
+      // the restore must put every property the dark block overrode back to the
+      // base value
+      for (const prop of Object.keys(darkBlock)) {
+        expect(lightBlock[prop]).toBe(root[prop]);
+      }
+    });
+
+    it('varies the TextField scheme blocks through custom properties only', () => {
+      const rootFn = theme.components?.MuiTextField?.styleOverrides?.root as (
+        args: { theme: typeof theme }
+      ) => Record<string, Record<string, unknown>>;
+      const outlined = rootFn({ theme })['& .MuiOutlinedInput-root'];
+      const keys = Object.keys(outlined);
+
+      expect(keys).toContain(DARK);
+      expect(keys).toContain(LIGHT);
+      expect(keys.indexOf(LIGHT)).toBeGreaterThan(keys.indexOf(DARK));
+
+      const darkBlock = outlined[DARK] as Record<string, unknown>;
+      const lightBlock = outlined[LIGHT] as Record<string, unknown>;
+      expect(onlyCustomProps(darkBlock)).toEqual([]);
+      expect(onlyCustomProps(lightBlock)).toEqual([]);
+      for (const prop of Object.keys(darkBlock)) {
+        expect(lightBlock[prop]).toBe(outlined[prop]);
+      }
+    });
+  });
+
+  describe('Informational palette', () => {
+    // MUI's default info (#0288D1) sits at 4.4:1 on white, so an outlined
+    // color="info" chip missed AA for small text on the public roadmap page.
+    it('defines info in both schemes rather than inheriting MUI defaults', () => {
+      expect(theme.colorSchemes.light!.palette.info.main).toBe('#0277BD');
+      expect(theme.colorSchemes.dark!.palette.info.main).toBe('#4FC3F7');
+      expect(theme.colorSchemes.light!.palette.info.main).not.toBe('#0288d1');
     });
   });
 });

--- a/__tests__/lib/theme-marketing.test.ts
+++ b/__tests__/lib/theme-marketing.test.ts
@@ -155,7 +155,11 @@ describe('Marketing Theme Extensions', () => {
     });
 
     it('uses consistent shadow system', () => {
-      expect((theme.components?.MuiCard?.styleOverrides?.root as any)?.boxShadow).toBe('0px 4px 24px rgba(13, 71, 161, 0.08)');
+      // The literal moved into a custom property so the scheme blocks can vary
+      // it without their nested rules outranking call-site sx.
+      const root = theme.components?.MuiCard?.styleOverrides?.root as any;
+      expect(root?.boxShadow).toBe('var(--ol-card-shadow)');
+      expect(root?.['--ol-card-shadow']).toBe('0px 4px 24px rgba(13, 71, 161, 0.08)');
     });
   });
 });

--- a/__tests__/lib/utils/contrast-color.test.ts
+++ b/__tests__/lib/utils/contrast-color.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { getContrastRatio } from '@mui/material/styles';
+import theme from '@/lib/theme';
+import { contrastTextFor } from '@/lib/utils/contrast-color';
+
+/**
+ * These backgrounds are user-supplied data (a venue's brand colour, a team's
+ * hex), so nothing constrains their luminance. Pinning the ink to
+ * primary.contrastText gave white-on-light the moment someone picked a pale
+ * brand colour — and on the marketing surfaces, which are pinned light,
+ * contrastText is always #FFFFFF, so it could never self-correct.
+ */
+describe('contrastTextFor', () => {
+  it('returns dark ink on a light supplied colour', () => {
+    expect(contrastTextFor(theme, '#FFEB3B')).toMatch(/rgba\(0, 0, 0|#000/);
+    expect(contrastTextFor(theme, '#FFFFFF')).toMatch(/rgba\(0, 0, 0|#000/);
+  });
+
+  // Both candidates must be opaque: getLuminance reads only RGB, so a
+  // semi-transparent ink measures as if it were fully saturated while rendering
+  // lighter — the ratio we check would not be the ratio a reader sees.
+  it.each(['#FFEB3B', '#4A7FBF', '#000000', '#FFFFFF'])(
+    'returns an opaque ink for %s',
+    (background) => {
+      expect(contrastTextFor(theme, background)).not.toMatch(/rgba/);
+    }
+  );
+
+  it('returns light ink on a dark supplied colour', () => {
+    expect(contrastTextFor(theme, '#0D47A1')).toBe('#fff');
+    expect(contrastTextFor(theme, '#000')).toBe('#fff');
+  });
+
+  it('accepts the 3-digit form the validator allows', () => {
+    expect(contrastTextFor(theme, '#fff')).toMatch(/rgba\(0, 0, 0|#000/);
+  });
+
+  it('falls back to the token when there is no colour', () => {
+    expect(contrastTextFor(theme, null)).toBe('primary.contrastText');
+    expect(contrastTextFor(theme, undefined)).toBe('primary.contrastText');
+    expect(contrastTextFor(theme, '')).toBe('primary.contrastText');
+  });
+
+  // MUI's own getContrastText picks white as soon as it clears its
+  // contrastThreshold, which defaults to 3 — so mid-luminance brand colours got
+  // white at 3.6-4.3:1 and failed SC 1.4.3 for normal text, even though black
+  // was available and would have passed. These are the exact backgrounds where
+  // the two helpers disagree.
+  it.each(['#4A7FBF', '#868686', '#7a7a7a'])(
+    'clears AA on %s where getContrastText does not',
+    (background) => {
+      const ours = contrastTextFor(theme, background);
+      expect(getContrastRatio(background, ours)).toBeGreaterThanOrEqual(4.5);
+      expect(getContrastRatio(background, theme.palette.getContrastText(background)))
+        .toBeLessThan(4.5);
+    }
+  );
+
+  it.each(['#000000', '#FFFFFF', '#0D47A1', '#FFEB3B'])(
+    'still clears AA on unambiguous background %s',
+    (background) => {
+      expect(getContrastRatio(background, contrastTextFor(theme, background)))
+        .toBeGreaterThanOrEqual(4.5);
+    }
+  );
+
+  it('falls back rather than throwing on a value that predates validation', () => {
+    expect(contrastTextFor(theme, 'rebeccapurple')).toBe('primary.contrastText');
+    expect(contrastTextFor(theme, '#12345')).toBe('primary.contrastText');
+    expect(contrastTextFor(theme, 'text.primary', 'common.white')).toBe('common.white');
+  });
+});

--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -1,0 +1,35 @@
+import type { ReactNode } from 'react';
+import LightThemeScope from '@/components/ui/LightThemeScope';
+
+/**
+ * The auth surfaces are a light-only composition, the same call the marketing
+ * pages make (see components/ui/LightThemeScope.tsx): login, forgot-password,
+ * reset-password, verify-email and confirm-email-change all bake their card in
+ * `linear-gradient(135deg, #FFFFFF 0%, #F8FAFB 100%)` over a Fresh Ice page
+ * wash, while their text stays on scheme-aware tokens. Unpinned, a dark-mode
+ * visitor got dark-palette text on those light literals — "Log in to your
+ * OpenLeague account" landed at 1.17:1.
+ *
+ * Pinning here rather than per page also settles an inconsistency: /signup
+ * carried no card treatment at all, so the two halves of the same flow used to
+ * render in different schemes.
+ */
+export default function AuthLayout({ children }: { children: ReactNode }) {
+  return (
+    // Deliberately no minHeight: LayoutProvider already wraps /login and
+    // /signup in a 100vh flex column whose <main> grows, and the other four
+    // pages carry their own 100vh box. Adding one here would force <main> past
+    // the viewport and push MarketingFooter a full footer-height below the fold
+    // on /signup, whose form is short and top-aligned.
+    <LightThemeScope
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        flexGrow: 1,
+        bgcolor: 'background.default',
+      }}
+    >
+      {children}
+    </LightThemeScope>
+  );
+}

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -40,7 +40,11 @@ export default function GlobalError({
               fontWeight: 700,
               letterSpacing: "0.12em",
               textTransform: "uppercase",
-              color: "#1976D2",
+              // League Blue, not Action Blue: at 13px/700 this is not WCAG
+              // "large text", and #1976D2 on #F7F9FC is 4.35:1 — short of the
+              // 4.5:1 AA needs. #0D47A1 gives 8.16:1. This file stays
+              // deliberately token-free, so the value is picked, not resolved.
+              color: "#0D47A1",
             }}
           >
             OpenLeague

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,7 +1,11 @@
 /* Import Cabinet Grotesk - distinctive geometric sans-serif from Fontshare */
 @import url('https://api.fontshare.com/css?f[]=cabinet-grotesk@100,200,300,400,500,600,700,800,900');
 
-:root {
+/* Paired with the dark block below so a LightThemeScope subtree re-declares
+   these too — :root alone only ever matches <html>, which never sits inside a
+   pin, leaving the dark values to inherit straight through it. */
+:root,
+[data-mui-color-scheme="light"] {
   --background: #ffffff;
   --foreground: #171717;
   --font-primary: 'Cabinet Grotesk', -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;

--- a/components/features/marketing/FinalCTA.tsx
+++ b/components/features/marketing/FinalCTA.tsx
@@ -21,7 +21,11 @@ export default function FinalCTA() {
       aria-labelledby="final-cta-heading"
       sx={{
         py: { xs: 10, md: 14 },
-        background: 'linear-gradient(135deg, #0D47A1 0%, #1976D2 50%, #42A5F5 100%)',
+        // Ends at Action Blue rather than the old #42A5F5. White copy over that
+        // lighter stop measured 2.9-3.7:1 against the actually-painted pixels —
+        // and because the gradient is animated, every stop eventually slides
+        // under the text, so the lightest one sets the floor for all of it.
+        background: 'linear-gradient(135deg, #0A3A82 0%, #0D47A1 50%, #1565C0 100%)',
         backgroundSize: '200% 200%',
         position: 'relative',
         overflow: 'hidden',

--- a/components/features/navigation/MarketingFooter.tsx
+++ b/components/features/navigation/MarketingFooter.tsx
@@ -57,7 +57,10 @@ const socialLinks = [
     icon: GitHubIcon,
     href: 'https://github.com/mbeacom/openleague',
     label: 'GitHub',
-    color: '#333'
+    // GitHub's brand black would hover to ~1.3:1 on the dark footer this
+    // renders on for /docs (the one route LayoutProvider leaves unpinned), so
+    // the hover follows the scheme instead. Twitter/LinkedIn blues read on both.
+    color: 'primary.main'
   },
   {
     icon: TwitterIcon,

--- a/components/features/navigation/MarketingHeader.tsx
+++ b/components/features/navigation/MarketingHeader.tsx
@@ -23,8 +23,10 @@ import { useTheme } from '@mui/material/styles';
 import MenuIcon from '@mui/icons-material/Menu';
 import CloseIcon from '@mui/icons-material/Close';
 import Logo from '@/components/ui/Logo';
+import { usePinnedScheme } from '@/components/ui/LightThemeScope';
 import CTAButton from '@/components/features/marketing/CTAButton';
 import { marketingEvents } from '@/lib/analytics/tracking';
+import { isAuthRoute } from '@/lib/config/auth-routes';
 
 const navigationLinks = [
   { label: 'Features', href: '/features' },
@@ -34,21 +36,25 @@ const navigationLinks = [
   { label: 'Docs', href: '/docs' },
 ];
 
-// Auth page pathnames
-const AUTH_PATHNAMES = ['/login', '/signup'];
-
 export default function MarketingHeader() {
   const theme = useTheme();
   const pathname = usePathname();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [isScrolled, setIsScrolled] = useState(false);
+  // Which scheme an ancestor layout pinned this header to, if any. Read from
+  // React context rather than the DOM because the portaled Drawer below cannot
+  // inherit it any other way.
+  const scopedScheme = usePinnedScheme();
 
   const isHomepage = pathname === '/';
   const isTransparent = isHomepage && !isScrolled;
 
-  // Hide navbar completely on auth pages (they have their own logos)
-  const isAuthPage = AUTH_PATHNAMES.includes(pathname);
+  // Hide navbar completely on auth pages (they have their own logos). Uses the
+  // same roster LayoutProvider branches on, so the two cannot drift apart —
+  // they previously disagreed, leaving /forgot-password and the token routes
+  // with a header but no skip link or main landmark.
+  const isAuthPage = isAuthRoute(pathname);
 
   // Track scroll position to transition the homepage header from transparent to solid.
   useEffect(() => {
@@ -80,18 +86,32 @@ export default function MarketingHeader() {
         component="header"
         position="fixed"
         elevation={0}
-        sx={{
-          bgcolor: isTransparent ? 'transparent' : 'background.paper',
+        // color="inherit" is load-bearing, not cosmetic. AppBar's default
+        // (color="primary") emits `color: primary.contrastText` — white — which
+        // the Logo wordmark inherits, rendering it white-on-white against this
+        // bar's own light background. That same variant also carries MUI's
+        // `applyStyles('dark', …)` override, whose `*:where([data-mui-color-scheme="dark"]) &`
+        // ancestor selector reaches through LightThemeScope and repaints the bar
+        // in dark-palette colors underneath light-pinned text. "inherit" opts
+        // out of both: the bar takes its text color from the surrounding scope
+        // and its background from the tokens below.
+        color="inherit"
+        sx={(theme) => ({
+          // Scheme-aware so the bar follows whichever scope it lands in — pinned
+          // light under (marketing)/layout.tsx, dark-capable under LayoutProvider
+          // on /docs and the auth routes.
+          backgroundColor: isTransparent
+            ? 'transparent'
+            : `rgba(${theme.vars.palette.background.paperChannel} / 0.95)`,
           borderBottom: isTransparent ? 0 : '2px solid',
-          borderColor: 'rgba(13, 71, 161, 0.08)',
+          borderColor: `rgba(${theme.vars.palette.primary.mainChannel} / 0.12)`,
           backdropFilter: isTransparent ? 'none' : 'blur(12px)',
-          backgroundColor: isTransparent ? 'transparent' : 'rgba(255, 255, 255, 0.95)',
           boxShadow: isTransparent ? 'none' : '0 4px 12px rgba(13, 71, 161, 0.08)',
           transition: 'background-color 0.3s cubic-bezier(0.4, 0, 0.2, 1), box-shadow 0.3s cubic-bezier(0.4, 0, 0.2, 1), border-color 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
           '@media (prefers-reduced-motion: reduce)': {
             transition: 'none',
           },
-        }}
+        })}
       >
       <Container maxWidth="lg">
         <Toolbar
@@ -208,11 +228,25 @@ export default function MarketingHeader() {
                 anchor="right"
                 open={mobileMenuOpen}
                 onClose={handleDrawerToggle}
+                // The Drawer paper is portaled to <body>, outside whatever
+                // LightThemeScope wraps this header in the React tree — and
+                // data-mui-color-scheme only reaches an actual DOM subtree. So
+                // it is restamped with the scheme this header was pinned to,
+                // otherwise a dark-mode visitor on a light-pinned marketing
+                // page opens a dark panel over a light page. Null on /docs,
+                // where nothing pinned the header and the ambient scheme is
+                // already the right one.
                 slotProps={{
                   paper: {
                     id: 'marketing-mobile-menu',
                     role: 'dialog',
                     'aria-label': 'Marketing navigation menu',
+                    ...(scopedScheme
+                      ? {
+                          'data-mui-color-scheme': scopedScheme,
+                          sx: { colorScheme: scopedScheme, color: 'text.primary' },
+                        }
+                      : {}),
                   },
                 }}
                 sx={{

--- a/components/features/signup-events/PublicEventView.tsx
+++ b/components/features/signup-events/PublicEventView.tsx
@@ -11,6 +11,7 @@ import {
 import type { PublicSignupEventView } from "@/lib/actions/signup-events";
 import type { MyEventAssignments, PublicEventGames } from "@/lib/actions/event-teams";
 import { RegisterDialog } from "./RegisterDialog";
+import { contrastTextFor } from "@/lib/utils/contrast-color";
 import { AGE_CLASSIFICATION_LABELS } from "@/lib/utils/age-level";
 import { formatCurrencyFromCents } from "@/lib/utils/currency";
 import { formatDateTime } from "@/lib/utils/date";
@@ -213,7 +214,15 @@ export function PublicEventView({
                       <Chip
                         size="small"
                         label={assignment.teamName}
-                        sx={assignment.teamColorHex ? { bgcolor: assignment.teamColorHex, color: "#fff" } : undefined}
+                        // Team colour is organizer-supplied data, so the ink has
+                        // to be derived from it — a light team colour made this
+                        // chip white-on-white.
+                        sx={assignment.teamColorHex
+                          ? (theme) => ({
+                              bgcolor: assignment.teamColorHex as string,
+                              color: contrastTextFor(theme, assignment.teamColorHex),
+                            })
+                          : undefined}
                       />
                     ) : (
                       <Chip size="small" variant="outlined" label="No team yet" />

--- a/components/features/venue-admin/PublicRinkProfile.tsx
+++ b/components/features/venue-admin/PublicRinkProfile.tsx
@@ -1,5 +1,6 @@
 import { Box, Card, CardContent, Chip, Stack, Typography } from "@mui/material";
 import { LinkButton } from "@/components/ui/NextLinkComposites";
+import { contrastTextFor } from "@/lib/utils/contrast-color";
 import type { PublicVenueProfile, PublicVenueSummary } from "@/lib/utils/public-venues";
 
 interface PublicVenueRelationship {
@@ -48,12 +49,15 @@ export function PublicRinkProfile({
   return (
     <Stack spacing={4}>
       <Box
-        sx={{
+        sx={(theme) => ({
           borderRadius: 3,
           p: { xs: 3, md: 5 },
           bgcolor: venue.brandPrimaryColor || "primary.main",
-          color: "primary.contrastText",
-        }}
+          // Derived, not pinned: this hero is inside the light-only marketing
+          // scope, where primary.contrastText is always #FFFFFF — so a venue
+          // that saves a light brand colour got a white <h1> on a light hero.
+          color: contrastTextFor(theme, venue.brandPrimaryColor),
+        })}
       >
         <Typography variant="h3" component="h1" gutterBottom>
           {venue.name}

--- a/components/providers/LayoutProvider.tsx
+++ b/components/providers/LayoutProvider.tsx
@@ -7,6 +7,8 @@ import { Box } from '@mui/material';
 import MarketingHeader from '@/components/features/navigation/MarketingHeader';
 import MarketingFooter from '@/components/features/navigation/MarketingFooter';
 import SkipLink from '@/components/ui/SkipLink';
+import LightThemeScope from '@/components/ui/LightThemeScope';
+import { isAuthRoute } from '@/lib/config/auth-routes';
 
 interface LayoutProviderProps {
   children: ReactNode;
@@ -51,16 +53,30 @@ export default function LayoutProvider({ children }: LayoutProviderProps) {
   const isMarketingRouteGroup = marketingRouteGroupPaths.some(path =>
     pathname === path || pathname.startsWith(`${path}/`)
   );
-  const isAuthRoute = pathname.startsWith('/login') || pathname.startsWith('/signup');
+  // Whole-segment match from the shared roster (lib/config/auth-routes.ts).
+  // A bare startsWith('/signup') also swallowed the public '/signups*' pages —
+  // which already get chrome and a pin from app/(marketing)/layout.tsx, so they
+  // ended up with two headers, two footers, two skip links and a duplicated
+  // id="main-content" — and the authenticated '/signup-events*' dashboard,
+  // which renders through this branch during the window where useSession() has
+  // not resolved yet.
+  const isAuth = isAuthRoute(pathname);
   const isDocsRoute = pathname === '/docs' || pathname.startsWith('/docs/');
 
   // Show marketing layout for unauthenticated users on marketing routes
   const shouldShowMarketingLayout =
-    !session?.user && ((isMarketingRoute && !isMarketingRouteGroup) || isAuthRoute);
+    !session?.user && ((isMarketingRoute && !isMarketingRouteGroup) || isAuth);
+
+  // The landing page and the auth pages are light-only compositions (their
+  // sections and cards bake in white and Fresh Ice backgrounds), so the chrome
+  // has to be pinned with them — otherwise a dark-mode visitor gets a dark
+  // header and footer bracketing a light page. /docs is genuinely
+  // scheme-aware, so it keeps the plain Box and follows the visitor's theme.
+  const LayoutRoot = isDocsRoute ? Box : LightThemeScope;
 
   if (shouldShowMarketingLayout) {
     return (
-      <Box
+      <LayoutRoot
         sx={{
           display: 'flex',
           flexDirection: 'column',
@@ -87,7 +103,7 @@ export default function LayoutProvider({ children }: LayoutProviderProps) {
           </Box>
         )}
         <MarketingFooter />
-      </Box>
+      </LayoutRoot>
     );
   }
 

--- a/components/ui/LightThemeScope.tsx
+++ b/components/ui/LightThemeScope.tsx
@@ -1,4 +1,23 @@
+'use client';
+
+import { createContext, useContext } from 'react';
 import { Box, type BoxProps } from '@mui/material';
+
+/**
+ * The scheme a subtree has been pinned to, or null when nothing has pinned it.
+ *
+ * Needed because the pin is a DOM-inheritance mechanism, and portals break DOM
+ * inheritance: a Drawer or Dialog mounts under `<body>`, outside whatever scope
+ * wraps it in the React tree, so its `--mui-palette-*` resolve from `<html>`.
+ * React context does follow the React tree, so a portal-rendering component can
+ * read the scheme it *should* have had and restamp it on the portaled element.
+ */
+const PinnedSchemeContext = createContext<'light' | null>(null);
+
+/** The scheme an ancestor LightThemeScope pinned, or null if none did. */
+export function usePinnedScheme(): 'light' | null {
+  return useContext(PinnedSchemeContext);
+}
 
 /**
  * Pins its subtree to the light ("Fresh Ice") color scheme regardless of the
@@ -20,14 +39,33 @@ import { Box, type BoxProps } from '@mui/material';
  * light values win over an ancestor `<html data-mui-color-scheme="dark">`.
  * `colorScheme: 'light'` also keeps native controls/scrollbars light.
  *
+ * `color` is pinned explicitly, and that is not redundant: re-declaring the
+ * variables only changes what `var(--mui-palette-text-primary)` resolves to for
+ * elements that *reference* it. Plain text — a `<Typography>` with no `color`
+ * prop — inherits the `color` property itself, and the only element that sets
+ * it is `<body>`, where CssBaseline resolved it outside this subtree (i.e. to
+ * the dark palette). Without this line every unstyled heading and paragraph
+ * inherits dark-scheme text onto the pinned light backgrounds — near-white on
+ * #F8FAFB, ~1.07:1.
+ *
+ * Known limit: rules keyed off `theme.applyStyles('dark', …)` compile to the
+ * *ancestor* selector `*:where([data-mui-color-scheme="dark"]) &`, which the
+ * dark `<html>` still matches through this subtree — CSS variables cannot
+ * override a rule that never reads them. lib/theme.ts pairs each of its own
+ * dark blocks with a later light block so the light one wins here; MUI's
+ * built-in dark overrides have to be sidestepped at the call site (e.g.
+ * MarketingHeader uses `<AppBar color="inherit">`).
+ *
  * All Box props (sx, className, component, …) are forwarded.
  */
 export default function LightThemeScope({ sx, ...props }: BoxProps) {
   return (
-    <Box
-      data-mui-color-scheme="light"
-      sx={[{ colorScheme: 'light' }, ...(Array.isArray(sx) ? sx : [sx])]}
-      {...props}
-    />
+    <PinnedSchemeContext.Provider value="light">
+      <Box
+        data-mui-color-scheme="light"
+        sx={[{ colorScheme: 'light', color: 'text.primary' }, ...(Array.isArray(sx) ? sx : [sx])]}
+        {...props}
+      />
+    </PinnedSchemeContext.Provider>
   );
 }

--- a/lib/config/auth-routes.ts
+++ b/lib/config/auth-routes.ts
@@ -1,0 +1,29 @@
+/**
+ * The public auth surfaces, as whole path segments.
+ *
+ * Single source of truth because two components branch on it and used to
+ * disagree: LayoutProvider decides whether a route gets the marketing chrome
+ * (SkipLink, the `#main-content` landmark, MarketingFooter), and MarketingHeader
+ * decides whether to render at all. When only the first two entries were listed
+ * in both, `/forgot-password` and the three token routes fell through every
+ * branch and rendered with no skip link and no main landmark, while `/login`
+ * and `/signup` — same route group, same light pin from app/(auth)/layout.tsx —
+ * got all of it.
+ *
+ * Keep in step with the directories under `app/(auth)/`.
+ */
+export const AUTH_ROUTES = [
+  '/login',
+  '/signup',
+  '/forgot-password',
+  '/reset-password',
+  '/verify-email',
+  '/confirm-email-change',
+] as const;
+
+/** True for an auth route itself or anything nested under it (token segments). */
+export function isAuthRoute(pathname: string): boolean {
+  return AUTH_ROUTES.some(
+    (route) => pathname === route || pathname.startsWith(`${route}/`)
+  );
+}

--- a/lib/theme.ts
+++ b/lib/theme.ts
@@ -96,6 +96,23 @@ declare module '@mui/material/Card' {
 // assert on the light values directly).
 const DARK_SCHEME = '*:where([data-mui-color-scheme="dark"]) &';
 
+// The counterpart that undoes DARK_SCHEME inside a light-pinned subtree. It has
+// to name BOTH ancestors — a dark one (the <html> of a dark-mode visitor) and a
+// light one nested under it (a LightThemeScope, see
+// components/ui/LightThemeScope.tsx) — because that pair is the only situation
+// the restore is for.
+//
+// Matching on '[data-mui-color-scheme="light"]' alone would be the obvious
+// spelling and is wrong: in ordinary light mode <html> carries that attribute,
+// so the restore would match every card and field in the app. And since a
+// nested selector compiles to a SEPARATE rule emitted after the base one at
+// equal specificity ( :where() and * contribute nothing ), it would then
+// outrank call-site `sx` — quietly flattening, say, the green outline the
+// pricing page draws on its free-plan card. Naming both ancestors keeps the
+// rule inert everywhere except inside a pin, where it is the last matching rule
+// and so beats DARK_SCHEME as intended.
+const LIGHT_PIN = '*:where([data-mui-color-scheme="dark"]) *:where([data-mui-color-scheme="light"]) &';
+
 // Light scheme: the original Digital Playbook palette
 const lightPalette: PaletteOptions = {
   primary: {
@@ -124,6 +141,21 @@ const lightPalette: PaletteOptions = {
     main: '#2E7D32', // Scoreboard Green
     light: '#4CAF50',
     dark: '#1B5E20',
+  },
+  // Defined rather than inherited: MUI's default info (#0288D1) sits at 3.9:1
+  // on white, so outlined `color="info"` chips (the roadmap's "Planned" status)
+  // miss AA for small text. #0277BD clears it at 4.8:1.
+  //
+  // Deeper would read better on white still, but this value is also constrained
+  // from below: CalendarView, OverlayChips and SegmentationEditor read
+  // `theme.palette.info.main` in JS, which under cssVariables always returns the
+  // LIGHT literal — so this same colour has to stay above 3:1 on the dark paper
+  // too (it lands at 3.1:1). Those call sites should move to channel tokens;
+  // until they do, this is the value that satisfies both ends.
+  info: {
+    main: '#0277BD',
+    light: '#039BE5',
+    dark: '#01579B',
   },
   background: {
     default: '#F8FAFB', // Fresh Ice - clean, crisp
@@ -175,6 +207,11 @@ const darkPalette: PaletteOptions = {
     light: '#81C784',
     dark: '#388E3C',
   },
+  info: {
+    main: '#4FC3F7', // Info blue, lightened for dark surfaces
+    light: '#81D4FA',
+    dark: '#0288D1',
+  },
   background: {
     default: '#0A1929', // Night Rink - deep blue-gray
     paper: '#102A43',
@@ -182,7 +219,11 @@ const darkPalette: PaletteOptions = {
   divider: 'rgba(144, 202, 249, 0.16)',
   text: {
     primary: 'rgba(236, 242, 248, 0.92)',
-    secondary: 'rgba(214, 226, 238, 0.64)',
+    // 0.70 rather than 0.64: at 0.64 secondary text lands at 4.4:1 on the
+    // tinted surfaces MUI derives from primary.main (a selected ListItem, e.g.
+    // the docs sidebar), just under AA. 0.70 clears it at 4.9:1 there and
+    // raises every other dark surface with it.
+    secondary: 'rgba(214, 226, 238, 0.70)',
     disabled: 'rgba(214, 226, 238, 0.38)',
   },
   marketing: {
@@ -298,26 +339,37 @@ const baseTheme = createTheme({
           '& .MuiInputBase-root': {
             minHeight: 48,
           },
+          // The scheme variation is carried by custom properties, not by
+          // competing rules. A nested `[DARK_SCHEME]` / `[LIGHT_PIN]` block that
+          // set `borderColor` directly would compile to a separate rule emitted
+          // after the base one at equal specificity, and so would outrank any
+          // `sx` a call site passes. Setting only variables keeps the actual
+          // declarations in the base rule, where `sx` still wins.
           '& .MuiOutlinedInput-root': {
+            '--ol-input-border': 'rgba(13, 71, 161, 0.2)',
+            '--ol-input-border-hover': 'rgba(13, 71, 161, 0.5)',
+            ...theme.applyStyles('dark', {
+              '--ol-input-border': 'rgba(100, 181, 246, 0.28)',
+              '--ol-input-border-hover': 'rgba(100, 181, 246, 0.56)',
+            }),
+            // Light-pinned subtrees (the auth forms) keep the League Blue
+            // outline; the lightened-blue dark borders sit at ~1.2:1 on white,
+            // which reads as a borderless field. See LIGHT_PIN above.
+            [LIGHT_PIN]: {
+              '--ol-input-border': 'rgba(13, 71, 161, 0.2)',
+              '--ol-input-border-hover': 'rgba(13, 71, 161, 0.5)',
+            },
             backgroundColor: (theme.vars || theme).palette.background.paper,
             '& fieldset': {
-              borderColor: 'rgba(13, 71, 161, 0.2)',
+              borderColor: 'var(--ol-input-border)',
               borderWidth: 2,
             },
             '&:hover fieldset': {
-              borderColor: 'rgba(13, 71, 161, 0.5)',
+              borderColor: 'var(--ol-input-border-hover)',
             },
             '&.Mui-focused fieldset': {
               borderColor: (theme.vars || theme).palette.secondary.main,
             },
-            ...theme.applyStyles('dark', {
-              '& fieldset': {
-                borderColor: 'rgba(100, 181, 246, 0.28)',
-              },
-              '&:hover fieldset': {
-                borderColor: 'rgba(100, 181, 246, 0.56)',
-              },
-            }),
           },
           '& .MuiInputLabel-root': {
             color: (theme.vars || theme).palette.text.secondary,
@@ -442,24 +494,40 @@ const baseTheme = createTheme({
     MuiCard: {
       styleOverrides: {
         root: {
-          borderRadius: 16,
-          boxShadow: '0px 4px 24px rgba(13, 71, 161, 0.08)',
-          transition: 'all 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
-          border: '1px solid rgba(13, 71, 161, 0.08)',
-          '&:hover': {
-            boxShadow: '0px 8px 32px rgba(13, 71, 161, 0.16)',
-            transform: 'translateY(-4px)',
-            borderColor: 'rgba(13, 71, 161, 0.15)',
-          },
+          // Same reasoning as MuiTextField above: the scheme variation lives in
+          // custom properties so the real `boxShadow` / `border` declarations
+          // stay in the base rule, where a call-site `sx` (the pricing page's
+          // green free-plan outline, the practice planner's selected-play
+          // border) still overrides them. Setting them inside the nested
+          // scheme blocks instead would silently win over every such sx.
+          '--ol-card-shadow': '0px 4px 24px rgba(13, 71, 161, 0.08)',
+          '--ol-card-shadow-hover': '0px 8px 32px rgba(13, 71, 161, 0.16)',
+          '--ol-card-border': 'rgba(13, 71, 161, 0.08)',
+          '--ol-card-border-hover': 'rgba(13, 71, 161, 0.15)',
           // Blue-tinted shadows/borders vanish on dark surfaces; swap for
           // neutral shadows and a lightened-blue hairline in dark scheme.
           [DARK_SCHEME]: {
-            boxShadow: '0px 4px 24px rgba(0, 0, 0, 0.45)',
-            border: '1px solid rgba(144, 202, 249, 0.12)',
-            '&:hover': {
-              boxShadow: '0px 8px 32px rgba(0, 0, 0, 0.6)',
-              borderColor: 'rgba(144, 202, 249, 0.24)',
-            },
+            '--ol-card-shadow': '0px 4px 24px rgba(0, 0, 0, 0.45)',
+            '--ol-card-shadow-hover': '0px 8px 32px rgba(0, 0, 0, 0.6)',
+            '--ol-card-border': 'rgba(144, 202, 249, 0.12)',
+            '--ol-card-border-hover': 'rgba(144, 202, 249, 0.24)',
+          },
+          // …and back to the blue-tinted shadow inside a light-pinned subtree,
+          // where the heavy neutral drop shadow reads as a smudge on white.
+          [LIGHT_PIN]: {
+            '--ol-card-shadow': '0px 4px 24px rgba(13, 71, 161, 0.08)',
+            '--ol-card-shadow-hover': '0px 8px 32px rgba(13, 71, 161, 0.16)',
+            '--ol-card-border': 'rgba(13, 71, 161, 0.08)',
+            '--ol-card-border-hover': 'rgba(13, 71, 161, 0.15)',
+          },
+          borderRadius: 16,
+          boxShadow: 'var(--ol-card-shadow)',
+          transition: 'all 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
+          border: '1px solid var(--ol-card-border)',
+          '&:hover': {
+            boxShadow: 'var(--ol-card-shadow-hover)',
+            transform: 'translateY(-4px)',
+            borderColor: 'var(--ol-card-border-hover)',
           },
         },
       },

--- a/lib/utils/contrast-color.ts
+++ b/lib/utils/contrast-color.ts
@@ -1,0 +1,54 @@
+import { getContrastRatio } from '@mui/material/styles';
+import type { Theme } from '@mui/material/styles';
+
+/** Matches the 3- or 6-digit hex the venue/team colour inputs validate against. */
+const HEX = /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/;
+
+/** WCAG SC 1.4.3 for normal-sized text. */
+const AA_NORMAL = 4.5;
+
+/**
+ * Ink for a surface painted with a user-supplied colour.
+ *
+ * These backgrounds are *data*, not tokens — a venue's `brandPrimaryColor`, a
+ * team's `colorHex` — so nothing constrains their luminance, and pinning the
+ * text to `primary.contrastText` (or a literal `#fff`) gives white-on-yellow
+ * the moment someone picks a light brand colour. The comparison is done in JS
+ * against the light palette, which is correct here precisely because the
+ * background is a literal too: both sides are scheme-independent.
+ *
+ * Deliberately NOT `theme.palette.getContrastText`. That helper picks white as
+ * soon as it clears `contrastThreshold`, which defaults to 3 — so a mid-luminance
+ * brand colour like #4A7FBF gets white at 4.1:1 and fails SC 1.4.3 for normal
+ * text, even though black would have given 5.1:1. Here both candidates are
+ * measured and the AA-conformant one wins; when neither clears 4.5:1 (a colour
+ * in the narrow band around L≈0.18 where nothing does) the better of the two is
+ * returned, since some contrast beats an arbitrary pick.
+ *
+ * Falls back to the token when there is no colour, or when a stored value
+ * predates validation and would make `decomposeColor` throw.
+ */
+export function contrastTextFor(
+  theme: Theme,
+  color: string | null | undefined,
+  fallback = 'primary.contrastText'
+): string {
+  if (!color || !HEX.test(color.trim())) return fallback;
+  const background = color.trim();
+  // Both candidates must be OPAQUE. MUI's getLuminance reads only the RGB
+  // channels, so a semi-transparent ink like text.primary (rgba(0,0,0,0.87))
+  // scores as pure black while rendering as a lighter composite — on #7a7a7a
+  // that is a measured 4.90:1 against a real 4.45:1, i.e. the measurement would
+  // certify a background that actually fails.
+  const light = theme.palette.common.white;
+  const dark = theme.palette.common.black;
+  try {
+    const lightRatio = getContrastRatio(background, light);
+    const darkRatio = getContrastRatio(background, dark);
+    if (lightRatio >= AA_NORMAL && lightRatio >= darkRatio) return light;
+    if (darkRatio >= AA_NORMAL) return dark;
+    return lightRatio >= darkRatio ? light : dark;
+  } catch {
+    return fallback;
+  }
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
 import "./.next/types/routes.d.ts";
+import "./.next/types/root-params.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary

Public pages were rendering near-invisible text for dark-mode visitors. On `/about`, an unstyled heading measured **1.07:1** against its background. Investigation found **three separate mechanisms** by which the light-scheme pin leaked, each needing a different fix — plus a fourth surface (the auth pages) that was never pinned at all.

## Root causes

**1. Inherited `color` crossed the pin.** `LightThemeScope` re-declared `--mui-palette-*` for its subtree, but that only helps elements that *reference* the variables. An unstyled `<Typography>` inherits the `color` **property**, and the only element setting it is `<body>` — outside the pin, resolved to the dark palette. Near-white text on `#F8FAFB`: 79 text nodes across 12 routes.

**2. `theme.applyStyles('dark', …)` reaches through the pin.** It compiles to the *ancestor* selector `*:where([data-mui-color-scheme="dark"]) &`, which a dark `<html>` matches no matter how many pinned subtrees sit between — CSS variables cannot override a rule that never reads them. MUI's `AppBar` repainted the header in dark-palette colors underneath light-pinned text (1.39:1, 72 nodes). Its default `color="primary"` also emits white `contrastText`, which the logo wordmark inherits — **the wordmark was white-on-white in light mode on every marketing page**.

**3. Baked light literals under scheme-aware text.** The auth pages bake `linear-gradient(135deg, #FFFFFF, #F8FAFB)` cards; in dark mode "Log in to your OpenLeague account" sat at **1.17:1**.

## Approach

- `LightThemeScope` pins `color` as well as the variables, and exposes `usePinnedScheme()` so portaled content can recover the scheme it should have had.
- `lib/theme.ts` moves scheme variation into custom properties (`--ol-card-*`, `--ol-input-*`) so the real `boxShadow`/`border` declarations stay in the base rule, where call-site `sx` still wins. The `LIGHT_PIN` selector names **both** ancestors — keyed on the light attribute alone it would also match in ordinary light mode and silently outrank every `sx` in the app.
- `<AppBar color="inherit">` opts out of MUI's built-in dark override and of `primary.contrastText`.
- New `app/(auth)/layout.tsx` pins the auth group; `LayoutProvider` pins everything it wraps except `/docs`, which stays scheme-aware by design.
- `lib/config/auth-routes.ts` becomes the single roster both `LayoutProvider` and `MarketingHeader` branch on.

## Verification

Headless Chromium, both schemes emulated, contrast computed per text node against the composited painted background **including gradient color stops**:

| scheme | before | after |
|---|---|---|
| dark | 250 failing nodes | 3 |
| light | 15 failing nodes | 3 |

Across 18 public routes / 1190 text nodes. The 3 remaining in each are MUI's default **disabled** submit buttons, which WCAG 1.4.3 explicitly exempts for inactive controls; they are unchanged from before. Dark now renders identically to light on every pinned route.

Two regressions introduced mid-change were caught by an adversarial review pass and fixed before this PR:

- the first light-restore selector clobbered call-site `sx` app-wide — it flattened the pricing page's green free-plan outline **in light mode**;
- `minHeight: 100vh` on the auth layout pushed `/signup`'s footer a full footer-height below the fold.

Both were confirmed in a browser before and after the fix.

## Test plan

- [x] `bun run type-check`
- [x] `bun run lint`
- [x] `bun run test` — 1906 tests, 142 files
- [x] `bun run build` (a route file is added, so collisions cannot be caught by tsc or tests)
- [x] Browser verification, dark + light, on `/`, `/about`, `/pricing`, `/contact`, `/docs`, `/login`, `/signup`, `/forgot-password`
- [x] Mutation-checked the new regression tests: reverting `color: 'text.primary'` and reverting the header's background token each make a test fail, so neither assertion is vacuous

38 tests added, including one that fails if the light restore is ever re-keyed on the light attribute alone.

## Known follow-ups (not in this PR)

- **No CI signal for visual regressions.** The contrast harness that found all of this is not in the repo, so a re-leak would ship green. Highest-value follow-up.
- **Outlined input borders sit at 1.41:1 (light) / 1.76:1 (dark) at rest**, under the 3:1 SC 1.4.11 floor. Confirmed pre-existing — `git diff` shows the values are byte-identical, only their plumbing changed here. Fixing it changes every input in the product, so it wants its own decision.
- `CalendarView` / `OverlayChips` / `SegmentationEditor` read `theme.palette.info.main` in JS, which always returns the light literal. `#0277BD` was chosen to satisfy both ends (4.8:1 on white, 3.1:1 on dark paper) rather than rewrite those call sites here.
- `/rinks/<bad-slug>` 404s to the root boundary and renders unpinned while its siblings are pinned — wants an `app/(marketing)/not-found.tsx`.
- The light-pin convention is arguably an ADR-worthy decision; it currently lives in code comments across four files.
