### PR TITLE
feat(gear): add league gear domain foundation

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -63,6 +63,9 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Apply migrations to a clean PostgreSQL database
+        run: bunx prisma migrate deploy --config prisma/prisma.config.ts
+
       - name: Push schema to smoke database
         run: bunx prisma db push --config prisma/prisma.config.ts
 

--- a/__tests__/lib/utils/gear.test.ts
+++ b/__tests__/lib/utils/gear.test.ts
@@ -10,6 +10,7 @@ import {
   canTransitionUnit,
   datesOverlap,
   hasExactlyOneNotificationRecipient,
+  isValidInventoryMovementDirection,
   isRetryablePrismaConflict,
   isActiveTaggedAllocationStatus,
   normalizeGearAssetTag,
@@ -117,11 +118,18 @@ describe("gear utilities", () => {
     ).toBe(false);
   });
 
-  it("requires an immutable outbox row to retain exactly one recipient target", () => {
-    expect(hasExactlyOneNotificationRecipient({ userId: "user" })).toBe(true);
+  it("requires an immutable outbox row to retain a delivery-email snapshot", () => {
     expect(hasExactlyOneNotificationRecipient({ email: "user@example.com" })).toBe(true);
-    expect(hasExactlyOneNotificationRecipient({ userId: "user", email: "user@example.com" })).toBe(false);
-    expect(hasExactlyOneNotificationRecipient({})).toBe(false);
+    expect(hasExactlyOneNotificationRecipient({ userId: "user", email: "user@example.com" })).toBe(true);
+    expect(hasExactlyOneNotificationRecipient({ email: "   " })).toBe(false);
+  });
+
+  it("requires an explicit signed direction for every inventory movement", () => {
+    expect(isValidInventoryMovementDirection("ADJUSTMENT", "INCREASE")).toBe(true);
+    expect(isValidInventoryMovementDirection("ADJUSTMENT", "DECREASE")).toBe(true);
+    expect(isValidInventoryMovementDirection("ADJUSTMENT", "NEUTRAL")).toBe(false);
+    expect(isValidInventoryMovementDirection("TRANSFER", "NEUTRAL")).toBe(true);
+    expect(isValidInventoryMovementDirection("ALLOCATION", "INCREASE")).toBe(false);
   });
 
   it("permits only legal workflow transitions", () => {

--- a/__tests__/lib/utils/gear.test.ts
+++ b/__tests__/lib/utils/gear.test.ts
@@ -2,15 +2,19 @@ import { describe, expect, it } from "vitest";
 import {
   allocationIsConsistent,
   allocationRemainingForReturn,
+  allocationStatusQuantitiesValid,
   availablePoolQuantity,
   canAllocatePoolStock,
   canTransitionAllocation,
   canTransitionReservation,
   canTransitionUnit,
   datesOverlap,
+  hasExactlyOneNotificationRecipient,
   isRetryablePrismaConflict,
+  isActiveTaggedAllocationStatus,
   normalizeGearAssetTag,
   normalizeGearKey,
+  taggedAllocationWindowsConflict,
 } from "@/lib/utils/gear";
 
 describe("gear utilities", () => {
@@ -50,6 +54,74 @@ describe("gear utilities", () => {
     expect(
       allocationIsConsistent({ allocatedQty: 4, pickedUpQty: 3, returnedQty: 4, releasedQty: 0 }),
     ).toBe(false);
+  });
+
+  it("enforces status-aware terminal allocation reconciliation", () => {
+    expect(
+      allocationStatusQuantitiesValid("PARTIALLY_RETURNED", {
+        allocatedQty: 4,
+        pickedUpQty: 4,
+        returnedQty: 1,
+        releasedQty: 0,
+      }),
+    ).toBe(true);
+    expect(
+      allocationStatusQuantitiesValid("RETURNED", {
+        allocatedQty: 4,
+        pickedUpQty: 3,
+        returnedQty: 3,
+        releasedQty: 1,
+      }),
+    ).toBe(true);
+    expect(
+      allocationStatusQuantitiesValid("RETURNED", {
+        allocatedQty: 4,
+        pickedUpQty: 3,
+        returnedQty: 2,
+        releasedQty: 1,
+      }),
+    ).toBe(false);
+    expect(
+      allocationStatusQuantitiesValid("RELEASED", {
+        allocatedQty: 4,
+        pickedUpQty: 1,
+        returnedQty: 1,
+        releasedQty: 3,
+      }),
+    ).toBe(false);
+  });
+
+  it("blocks overlapping active or pending tagged allocations but permits separate windows", () => {
+    const pending = { status: "PENDING" as const, startDate: "2026-09-01", endDate: "2026-09-03" };
+    expect(isActiveTaggedAllocationStatus(pending.status)).toBe(true);
+    expect(
+      taggedAllocationWindowsConflict(pending, {
+        status: "ALLOCATED",
+        startDate: "2026-09-03",
+        endDate: "2026-09-05",
+      }),
+    ).toBe(true);
+    expect(
+      taggedAllocationWindowsConflict(pending, {
+        status: "RETURNED",
+        startDate: "2026-09-01",
+        endDate: "2026-09-03",
+      }),
+    ).toBe(false);
+    expect(
+      taggedAllocationWindowsConflict(pending, {
+        status: "ALLOCATED",
+        startDate: "2026-09-04",
+        endDate: "2026-09-05",
+      }),
+    ).toBe(false);
+  });
+
+  it("requires an immutable outbox row to retain exactly one recipient target", () => {
+    expect(hasExactlyOneNotificationRecipient({ userId: "user" })).toBe(true);
+    expect(hasExactlyOneNotificationRecipient({ email: "user@example.com" })).toBe(true);
+    expect(hasExactlyOneNotificationRecipient({ userId: "user", email: "user@example.com" })).toBe(false);
+    expect(hasExactlyOneNotificationRecipient({})).toBe(false);
   });
 
   it("permits only legal workflow transitions", () => {

--- a/__tests__/lib/utils/gear.test.ts
+++ b/__tests__/lib/utils/gear.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import {
+  allocationIsConsistent,
+  allocationRemainingForReturn,
+  availablePoolQuantity,
+  canAllocatePoolStock,
+  canTransitionAllocation,
+  canTransitionReservation,
+  canTransitionUnit,
+  datesOverlap,
+  isRetryablePrismaConflict,
+  normalizeGearAssetTag,
+  normalizeGearKey,
+} from "@/lib/utils/gear";
+
+describe("gear utilities", () => {
+  it("normalizes tenant-scoped catalog keys and asset tags predictably", () => {
+    expect(normalizeGearKey("  Youth   Helmet ")).toBe("youth helmet");
+    expect(normalizeGearAssetTag(" tag  42 ")).toBe("TAG42");
+  });
+
+  it("treats inclusive date-only reservation windows as overlapping", () => {
+    expect(
+      datesOverlap(
+        { startDate: "2026-09-01", endDate: "2026-09-03" },
+        { startDate: "2026-09-03", endDate: "2026-09-05" },
+      ),
+    ).toBe(true);
+    expect(
+      datesOverlap(
+        { startDate: "2026-09-01", endDate: "2026-09-02" },
+        { startDate: "2026-09-03", endDate: "2026-09-05" },
+      ),
+    ).toBe(false);
+  });
+
+  it("calculates available pool inventory without allowing over-allocation", () => {
+    const stock = { quantityOnHand: 8, allocatedQuantity: 3 };
+    expect(availablePoolQuantity(stock)).toBe(5);
+    expect(canAllocatePoolStock(stock, 5)).toBe(true);
+    expect(canAllocatePoolStock(stock, 6)).toBe(false);
+    expect(canAllocatePoolStock(stock, 0)).toBe(false);
+  });
+
+  it("guards allocation quantity accounting", () => {
+    expect(
+      allocationIsConsistent({ allocatedQty: 4, pickedUpQty: 3, returnedQty: 1, releasedQty: 1 }),
+    ).toBe(true);
+    expect(allocationRemainingForReturn({ allocatedQty: 4, pickedUpQty: 3, returnedQty: 1, releasedQty: 1 })).toBe(2);
+    expect(
+      allocationIsConsistent({ allocatedQty: 4, pickedUpQty: 3, returnedQty: 4, releasedQty: 0 }),
+    ).toBe(false);
+  });
+
+  it("permits only legal workflow transitions", () => {
+    expect(canTransitionReservation("REQUESTED", "APPROVED")).toBe(true);
+    expect(canTransitionReservation("CLOSED", "APPROVED")).toBe(false);
+    expect(canTransitionAllocation("ALLOCATED", "PICKED_UP")).toBe(true);
+    expect(canTransitionAllocation("RELEASED", "PICKED_UP")).toBe(false);
+    expect(canTransitionUnit("AVAILABLE", "RESERVED")).toBe(true);
+    expect(canTransitionUnit("RETIRED", "AVAILABLE")).toBe(false);
+  });
+
+  it("recognizes Prisma serialization conflicts as retryable", () => {
+    expect(isRetryablePrismaConflict({ code: "P2034" })).toBe(true);
+    expect(isRetryablePrismaConflict({ code: "P2002" })).toBe(false);
+  });
+});

--- a/__tests__/lib/utils/permissions-gear.test.ts
+++ b/__tests__/lib/utils/permissions-gear.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { findFirst, getUserLeagueAccessLevel } = vi.hoisted(() => ({
+  findFirst: vi.fn(),
+  getUserLeagueAccessLevel: vi.fn(),
+}));
+
+vi.mock("@/lib/utils/security", () => ({
+  AuditAction: { PERMISSION_DENIED: "PERMISSION_DENIED" },
+  LeagueAccessLevel: {
+    NONE: "NONE",
+    MEMBER: "MEMBER",
+    TEAM_ADMIN: "TEAM_ADMIN",
+    LEAGUE_ADMIN: "LEAGUE_ADMIN",
+  },
+  getUserLeagueAccessLevel,
+  logAuditEvent: vi.fn(),
+}));
+
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: { teamMember: { findFirst } },
+}));
+
+import { hasPermission, Permission } from "@/lib/utils/permissions";
+
+describe("team-scoped gear permissions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getUserLeagueAccessLevel.mockResolvedValue("TEAM_ADMIN");
+  });
+
+  it("fails closed when a team-scoped gear permission omits teamId", async () => {
+    await expect(
+      hasPermission("user-1", "league-1", Permission.CREATE_TEAM_GEAR_NEED),
+    ).resolves.toBe(false);
+    expect(findFirst).not.toHaveBeenCalled();
+  });
+
+  it("rejects team admins for a different team", async () => {
+    findFirst.mockResolvedValue(null);
+
+    await expect(
+      hasPermission("user-1", "league-1", Permission.REQUEST_TEAM_GEAR, "team-2"),
+    ).resolves.toBe(false);
+    expect(findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ teamId: "team-2" }),
+      }),
+    );
+  });
+
+  it("requires league admins to provide the team they act for", async () => {
+    getUserLeagueAccessLevel.mockResolvedValue("LEAGUE_ADMIN");
+
+    await expect(
+      hasPermission("user-1", "league-1", Permission.REQUEST_TEAM_GEAR),
+    ).resolves.toBe(false);
+    await expect(
+      hasPermission("user-1", "league-1", Permission.REQUEST_TEAM_GEAR, "team-2"),
+    ).resolves.toBe(true);
+  });
+});

--- a/__tests__/lib/utils/validation-gear.test.ts
+++ b/__tests__/lib/utils/validation-gear.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, it } from "vitest";
 import {
   createGearPledgeSchema,
   createGearReservationSchema,
+  gearActivityDetailsSchema,
+  gearNotificationPayloadSchema,
+  recordGearInventoryMovementSchema,
   receiveGearPledgeSchema,
 } from "@/lib/utils/validation";
 
@@ -48,6 +51,48 @@ describe("gear validation schemas", () => {
     expect(receiveGearPledgeSchema.safeParse({ ...base, poolStockId: STOCK_ID }).success).toBe(true);
     expect(
       receiveGearPledgeSchema.safeParse({ ...base, poolStockId: STOCK_ID, gearUnitId: UNIT_ID }).success,
+    ).toBe(false);
+    expect(receiveGearPledgeSchema.safeParse({ ...base, gearUnitId: UNIT_ID, quantity: 2 }).success).toBe(false);
+  });
+
+  it("requires tagged movement quantities of one and compatible adjustment direction", () => {
+    const base = {
+      leagueId: LEAGUE_ID,
+      gearUnitId: UNIT_ID,
+      type: "ADJUSTMENT" as const,
+      direction: "INCREASE" as const,
+      quantity: 1,
+    };
+
+    expect(recordGearInventoryMovementSchema.safeParse(base).success).toBe(true);
+    expect(recordGearInventoryMovementSchema.safeParse({ ...base, quantity: 2 }).success).toBe(false);
+    expect(recordGearInventoryMovementSchema.safeParse({ ...base, direction: "NEUTRAL" }).success).toBe(false);
+  });
+
+  it("allows only typed, non-PII activity and notification payload fields", () => {
+    expect(
+      gearActivityDetailsSchema.safeParse({
+        action: "reservation_requested",
+        metadata: { lineCount: 2 },
+      }).success,
+    ).toBe(true);
+    expect(
+      gearActivityDetailsSchema.safeParse({
+        action: "reservation_requested",
+        donorEmail: "donor@example.com",
+      }).success,
+    ).toBe(false);
+    expect(
+      gearNotificationPayloadSchema.safeParse({
+        kind: "GEAR_RESERVATION",
+        data: { reservationId: ITEM_ID },
+      }).success,
+    ).toBe(true);
+    expect(
+      gearNotificationPayloadSchema.safeParse({
+        kind: "GEAR_RESERVATION",
+        data: { recipientEmail: "player@example.com" },
+      }).success,
     ).toBe(false);
   });
 

--- a/__tests__/lib/utils/validation-gear.test.ts
+++ b/__tests__/lib/utils/validation-gear.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import {
+  createGearPledgeSchema,
+  createGearReservationSchema,
+  receiveGearPledgeSchema,
+} from "@/lib/utils/validation";
+
+const LEAGUE_ID = "clleague0000000000000001";
+const TEAM_ID = "clteam00000000000000001";
+const ITEM_ID = "clcatalog000000000000001";
+const STOCK_ID = "clstock00000000000000001";
+const UNIT_ID = "clunit00000000000000001";
+
+describe("gear validation schemas", () => {
+  it("accepts an inclusive reservation date window", () => {
+    expect(
+      createGearReservationSchema.safeParse({
+        leagueId: LEAGUE_ID,
+        teamId: TEAM_ID,
+        requestedStartDate: "2026-09-01",
+        requestedEndDate: "2026-09-01",
+        custodianNameSnapshot: "Team Manager",
+        lines: [{ nameSnapshot: "Youth helmet", requestedQty: 4 }],
+      }).success,
+    ).toBe(true);
+  });
+
+  it("rejects a reservation that ends before it starts", () => {
+    expect(
+      createGearReservationSchema.safeParse({
+        leagueId: LEAGUE_ID,
+        teamId: TEAM_ID,
+        requestedStartDate: "2026-09-02",
+        requestedEndDate: "2026-09-01",
+        custodianNameSnapshot: "Team Manager",
+        lines: [{ nameSnapshot: "Youth helmet", requestedQty: 4 }],
+      }).success,
+    ).toBe(false);
+  });
+
+  it("requires exactly one receipt inventory destination", () => {
+    const base = {
+      leagueId: LEAGUE_ID,
+      pledgeId: ITEM_ID,
+      quantity: 1,
+    };
+
+    expect(receiveGearPledgeSchema.safeParse({ ...base, poolStockId: STOCK_ID }).success).toBe(true);
+    expect(
+      receiveGearPledgeSchema.safeParse({ ...base, poolStockId: STOCK_ID, gearUnitId: UNIT_ID }).success,
+    ).toBe(false);
+  });
+
+  it("requires an idempotency key for public pledges", () => {
+    expect(
+      createGearPledgeSchema.safeParse({
+        wishlistToken: "a".repeat(16),
+        wishlistItemId: ITEM_ID,
+        donorName: "A donor",
+        quantity: 1,
+        idempotencyKey: "b".repeat(16),
+      }).success,
+    ).toBe(true);
+    expect(
+      createGearPledgeSchema.safeParse({
+        wishlistToken: "a".repeat(16),
+        wishlistItemId: ITEM_ID,
+        donorName: "A donor",
+        quantity: 1,
+        idempotencyKey: "short",
+      }).success,
+    ).toBe(false);
+  });
+});

--- a/__tests__/prisma/gear-domain-foundation.test.ts
+++ b/__tests__/prisma/gear-domain-foundation.test.ts
@@ -1,0 +1,49 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const schema = readFileSync(join(process.cwd(), "prisma/schema.prisma"), "utf8");
+const migration = readFileSync(
+  join(process.cwd(), "prisma/migrations/20260816180000_gear_domain_foundation/migration.sql"),
+  "utf8",
+);
+
+describe("gear domain foundation persistence invariants", () => {
+  it("uses League-scoped composite relations for gear resources", () => {
+    expect(schema).toContain(
+      '@relation(fields: [leagueId, catalogItemId], references: [leagueId, id], onDelete: Restrict)',
+    );
+    expect(schema).toContain(
+      '@relation(fields: [leagueId, reservationLineId], references: [leagueId, id], onDelete: Restrict)',
+    );
+    expect(schema).toContain(
+      '@relation(fields: [leagueId, wishlistItemId], references: [leagueId, id], onDelete: Restrict)',
+    );
+    expect(migration).toContain(
+      'FOREIGN KEY ("leagueId", "gearUnitId") REFERENCES "gear_units"("leagueId", "id")',
+    );
+    expect(migration).toContain(
+      'FOREIGN KEY ("leagueId", "beforeLocationId") REFERENCES "gear_storage_locations"("leagueId", "id") ON DELETE RESTRICT',
+    );
+  });
+
+  it("protects tagged allocation windows and terminal quantities in the database", () => {
+    expect(schema).toMatch(/effectiveStartDate\s+DateTime\?\s+@db\.Date/);
+    expect(migration).toContain("CREATE EXTENSION IF NOT EXISTS btree_gist");
+    expect(migration).toContain("gear_allocations_tagged_unit_active_window_excl");
+    expect(migration).toContain("'PENDING', 'ALLOCATED', 'PICKED_UP', 'PARTIALLY_RETURNED'");
+    expect(migration).toContain("gear_allocations_status_quantities_valid");
+  });
+
+  it("retains immutable outbox recipients and movement locations", () => {
+    expect(schema).toContain(
+      '@relation("NotificationOutboxRecipient", fields: [recipientUserId], references: [id], onDelete: Restrict)',
+    );
+    expect(migration).toContain(
+      'FOREIGN KEY ("recipientUserId") REFERENCES "User"("id") ON DELETE RESTRICT',
+    );
+    expect(migration).not.toContain(
+      'gear_inventory_movements_beforeLocationId_fkey" FOREIGN KEY ("leagueId", "beforeLocationId") REFERENCES "gear_storage_locations"("leagueId", "id") ON DELETE SET NULL',
+    );
+  });
+});

--- a/__tests__/prisma/gear-domain-foundation.test.ts
+++ b/__tests__/prisma/gear-domain-foundation.test.ts
@@ -35,15 +35,39 @@ describe("gear domain foundation persistence invariants", () => {
     expect(migration).toContain("gear_allocations_status_quantities_valid");
   });
 
-  it("retains immutable outbox recipients and movement locations", () => {
+  it("preserves movement locations and allows user deletion without deleting delivery intent", () => {
     expect(schema).toContain(
-      '@relation("NotificationOutboxRecipient", fields: [recipientUserId], references: [id], onDelete: Restrict)',
+      '@relation("NotificationOutboxRecipient", fields: [recipientUserId], references: [id], onDelete: SetNull)',
     );
     expect(migration).toContain(
-      'FOREIGN KEY ("recipientUserId") REFERENCES "User"("id") ON DELETE RESTRICT',
+      'FOREIGN KEY ("recipientUserId") REFERENCES "User"("id") ON DELETE SET NULL',
     );
     expect(migration).not.toContain(
       'gear_inventory_movements_beforeLocationId_fkey" FOREIGN KEY ("leagueId", "beforeLocationId") REFERENCES "gear_storage_locations"("leagueId", "id") ON DELETE SET NULL',
     );
+  });
+
+  it("makes ledger rows append-only and validates polymorphic activity tenancy", () => {
+    expect(migration.trimStart()).toMatch(/^--[\s\S]*?BEGIN;/);
+    expect(migration.trimEnd()).toMatch(/COMMIT;$/);
+    expect(migration).toContain('CREATE FUNCTION "gear_reject_ledger_mutation"()');
+    expect(migration).toContain('"gear_handoffs_append_only"');
+    expect(migration).toContain('"gear_activity_append_only"');
+    expect(migration).toContain('"gear_inventory_movements_append_only"');
+    expect(migration).toContain('CREATE FUNCTION "gear_validate_activity_entity_league"()');
+    expect(migration).toContain('"gear_activity_entity_league"');
+  });
+
+  it("guards durable outbox intent while supporting terminal PII redaction", () => {
+    expect(migration).toContain('CREATE FUNCTION "guard_notification_outbox_mutation"()');
+    expect(migration).toContain('"notification_outbox_delivery_state_only"');
+    expect(migration).toContain('CREATE FUNCTION "redact_notification_outbox_recipient"("outbox_id" TEXT)');
+    expect(migration).toContain('REVOKE ALL ON FUNCTION "redact_notification_outbox_recipient"(TEXT) FROM PUBLIC');
+  });
+
+  it("requires a quantity of one for tagged movements and pledge receipts", () => {
+    expect(migration).toContain("gear_inventory_movements_tagged_unit_quantity");
+    expect(migration).toContain("gear_pledge_receipts_tagged_unit_quantity");
+    expect(migration).toContain("gear_inventory_movements_direction_valid");
   });
 });

--- a/docs/adr/0006-model-league-owned-gear-with-ledger-projections-and-an-outbox.md
+++ b/docs/adr/0006-model-league-owned-gear-with-ledger-projections-and-an-outbox.md
@@ -2,8 +2,9 @@
 schemaVersion: 0.1.0
 id: "0006"
 title: Model league-owned gear with ledger projections and an outbox
-status: proposed
+status: accepted
 date: 2026-08-16
+created: 2026-08-16
 deciders: ["@mbeacom"]
 tags: [architecture, gear, inventory, ledger, notifications]
 scope: org
@@ -21,13 +22,21 @@ affects:
     pattern: "lib/utils/gear.ts"
   - type: path
     pattern: "types/gear.ts"
+  - type: path
+    pattern: "lib/utils/validation.ts"
+  - type: path
+    pattern: "lib/utils/permissions.ts"
+  - type: path
+    pattern: ".github/workflows/smoke-tests.yml"
 provenance:
   authoredBy: agent-drafted
+  ratifiedBy: "@mbeacom"
+  sourceArtifact: "PR #331 review adjudication"
 review:
   tier: async
   tierReason: >-
-    The model introduces a durable operational boundary spanning inventory,
-    custody, public pledges, and notification delivery.
+    Ratified after persistence, privacy, and operational review of the
+    implementation boundary spanning inventory, custody, pledges, and delivery.
 reviewBy: 2027-08-16
 ---
 
@@ -59,8 +68,9 @@ is never copied to generic activity details.
 Allocation mutations will execute in serializable Prisma transactions and use
 optimistic versions on mutable inventory and workflow projections. PostgreSQL
 checks and partial unique indexes enforce local invariants such as nonnegative
-quantities, one inventory source per allocation, one active allocation for a
-tagged unit, and exactly one notification recipient target.
+quantities, one inventory source per allocation, and one active allocation for
+a tagged unit. The ledger tables are insert-only at the PostgreSQL boundary;
+corrections use compensating entries.
 
 Tagged-unit allocations retain their effective date window and are protected by
 a PostgreSQL exclusion constraint, so pending and active allocations for the
@@ -69,8 +79,21 @@ Locations referenced by immutable movements are archive-only: history-bearing
 references restrict deletion rather than being nulled.
 
 Every notification intent will be persisted to a durable outbox in the same
-transaction as its aggregate mutation. A later worker owns delivery, retries,
-and status transitions; actions do not deliver notifications inline.
+transaction as its aggregate mutation. A later gear outbox worker owns claiming
+and retry scheduling only; it delegates preferences, batching, and provider
+delivery to the existing `NotificationService` and its `NotificationBatch`
+path. That service remains the sole delivery-state owner, preventing a second
+notification state machine.
+
+Outbox rows retain a nullable user relation plus an immutable delivery-email
+snapshot, so deleting a user cannot block an already durable notification. A
+privileged terminal-retention procedure may replace that email with a redacted
+address after the retention period; it preserves the event fact, intent
+metadata, and delivery outcome. Donor and custodian contact data is held only
+in mutable pledge/reservation snapshot fields, is never copied to activity or
+outbox payloads, and is subject to the same controlled retention/redaction
+policy. Activity and outbox payloads use typed allowlists rather than arbitrary
+PII-bearing JSON.
 
 ## Options considered
 
@@ -110,9 +133,12 @@ commits, leaving no durable retry intent.
 
 - Projection and ledger writes must be kept in the same transaction.
 - Serializable transactions can abort and need bounded retry handling.
-- Restrictive foreign keys retain operational history, including outbox
-  recipients and before/after movement locations, but make destructive cleanup
-  intentionally harder; locations must be archived instead.
+- Restrictive foreign keys retain operational movement-location history; storage
+  locations must be archived rather than deleted.
+- Migration SQL is transaction-wrapped. If a deployment fails, do not edit an
+  applied migration: use `prisma migrate resolve` only after inspecting the
+  failed migration, then recover a Neon branch from its restore point or create
+  a fresh branch before retrying a corrected deployment.
 - The outbox adds a processing component and monitoring requirement.
 
 ## Consequences
@@ -134,3 +160,5 @@ commits, leaving no durable retry intent.
    notification outbox to the Prisma schema and migration.
 2. [ ] Implement serializable inventory actions with retryable conflict handling.
 3. [ ] Implement an outbox worker with bounded retries and observability.
+4. [ ] Define production ledger/outbox capacity thresholds and archival policy.
+5. [ ] Add parity guards before future gear enum changes duplicate across layers.

--- a/docs/adr/0006-model-league-owned-gear-with-ledger-projections-and-an-outbox.md
+++ b/docs/adr/0006-model-league-owned-gear-with-ledger-projections-and-an-outbox.md
@@ -62,6 +62,12 @@ checks and partial unique indexes enforce local invariants such as nonnegative
 quantities, one inventory source per allocation, one active allocation for a
 tagged unit, and exactly one notification recipient target.
 
+Tagged-unit allocations retain their effective date window and are protected by
+a PostgreSQL exclusion constraint, so pending and active allocations for the
+same unit cannot overlap while separate future windows remain possible.
+Locations referenced by immutable movements are archive-only: history-bearing
+references restrict deletion rather than being nulled.
+
 Every notification intent will be persisted to a durable outbox in the same
 transaction as its aggregate mutation. A later worker owns delivery, retries,
 and status transitions; actions do not deliver notifications inline.
@@ -104,8 +110,9 @@ commits, leaving no durable retry intent.
 
 - Projection and ledger writes must be kept in the same transaction.
 - Serializable transactions can abort and need bounded retry handling.
-- Restrictive foreign keys retain operational history but make destructive
-  cleanup intentionally harder.
+- Restrictive foreign keys retain operational history, including outbox
+  recipients and before/after movement locations, but make destructive cleanup
+  intentionally harder; locations must be archived instead.
 - The outbox adds a processing component and monitoring requirement.
 
 ## Consequences

--- a/docs/adr/0006-model-league-owned-gear-with-ledger-projections-and-an-outbox.md
+++ b/docs/adr/0006-model-league-owned-gear-with-ledger-projections-and-an-outbox.md
@@ -1,0 +1,129 @@
+---
+schemaVersion: 0.1.0
+id: "0006"
+title: Model league-owned gear with ledger projections and an outbox
+status: proposed
+date: 2026-08-16
+deciders: ["@mbeacom"]
+tags: [architecture, gear, inventory, ledger, notifications]
+scope: org
+reversibility: one-way-door
+blastRadius: org
+relatesTo: ["0002", "0003"]
+affects:
+  - type: path
+    pattern: "prisma/schema.prisma"
+  - type: path
+    pattern: "prisma/migrations/*_gear_domain_foundation/**"
+  - type: path
+    pattern: "lib/actions/gear/**"
+  - type: path
+    pattern: "lib/utils/gear.ts"
+  - type: path
+    pattern: "types/gear.ts"
+provenance:
+  authoredBy: agent-drafted
+review:
+  tier: async
+  tierReason: >-
+    The model introduces a durable operational boundary spanning inventory,
+    custody, public pledges, and notification delivery.
+reviewBy: 2027-08-16
+---
+
+# ADR-0006: Model league-owned gear with ledger projections and an outbox
+
+## Context
+
+Associations need to track pooled gear, individually tagged assets, storage,
+team needs, temporary custody, and public in-kind pledges. Gear is an
+association resource, so its owner is a `League`, not a venue or venue
+organization. Inventory changes and handoffs can affect safety, availability,
+and accountability; replacing their history with a current row loses the
+reasoning needed to resolve discrepancies.
+
+The application also needs to notify people after gear changes. Sending a
+message directly inside an inventory transaction couples durable state to an
+unreliable external operation and creates a gap when the transaction succeeds
+but delivery does not.
+
+## Decision
+
+We will model all gear as League-owned. Catalog items and named storage
+locations support either pooled counts or individually tracked units. Current
+inventory, reservation, allocation, and wishlist rows are mutable projections;
+append-only gear activity, handoff, and inventory-movement rows retain the
+operational ledger. Public donor contact data remains confined to pledges and
+is never copied to generic activity details.
+
+Allocation mutations will execute in serializable Prisma transactions and use
+optimistic versions on mutable inventory and workflow projections. PostgreSQL
+checks and partial unique indexes enforce local invariants such as nonnegative
+quantities, one inventory source per allocation, one active allocation for a
+tagged unit, and exactly one notification recipient target.
+
+Every notification intent will be persisted to a durable outbox in the same
+transaction as its aggregate mutation. A later worker owns delivery, retries,
+and status transitions; actions do not deliver notifications inline.
+
+## Options considered
+
+### Option A: League-owned projections with an immutable ledger and outbox (chosen)
+
+| Dimension | Assessment |
+|---|---|
+| Ownership | Matches association responsibility and keeps venue inventory out of scope |
+| Operational history | Preserves physical movements and custody independently of current state |
+| Concurrency | Serializable allocation writes protect scarce inventory |
+| Delivery reliability | The outbox closes the database-commit-to-notification gap |
+| Complexity | Requires projection and ledger writes to stay transactionally coordinated |
+
+### Option B: Mutable inventory rows only
+
+**Pros:** fewer tables and simpler CRUD.
+
+**Cons:** cannot explain a missing unit, a returned damaged item, or an
+availability adjustment after the current row is overwritten.
+
+### Option C: Full event sourcing
+
+**Pros:** one immutable source for all state and complete replayability.
+
+**Cons:** read models, replay tooling, and event-versioning infrastructure are
+unjustified for the first gear workflows. The domain needs durable history, not
+the operational cost of a full event-sourced platform.
+
+### Option D: Synchronous notifications from actions
+
+**Pros:** fewer persisted records and immediate apparent delivery.
+
+**Cons:** external delivery failure can occur after the inventory transaction
+commits, leaving no durable retry intent.
+
+## Trade-offs
+
+- Projection and ledger writes must be kept in the same transaction.
+- Serializable transactions can abort and need bounded retry handling.
+- Restrictive foreign keys retain operational history but make destructive
+  cleanup intentionally harder.
+- The outbox adds a processing component and monitoring requirement.
+
+## Consequences
+
+- Easier: reconcile inventory, audit custody, retry delivery, and add later
+  gear workflows without redefining ownership.
+- Harder: implement mutations because each state change must record both a
+  projection update and its ledger/outbox effects.
+- **How we would know this was wrong:** if normal gear workflows require
+  replaying the ledger to answer routine reads, projections are insufficient;
+  if the outbox repeatedly exceeds its delivery SLA, inline delivery may need a
+  separate immediate channel in addition to—not instead of—the durable intent.
+- Revisit if: venue operators must own inventory independently, or cross-league
+  inventory transfers become a supported product requirement.
+
+## Action items
+
+1. [x] Add tenant-safe gear projections, immutable ledger records, and the
+   notification outbox to the Prisma schema and migration.
+2. [ ] Implement serializable inventory actions with retryable conflict handling.
+3. [ ] Implement an outbox worker with bounded retries and observability.

--- a/lib/utils/gear.ts
+++ b/lib/utils/gear.ts
@@ -1,6 +1,7 @@
 import type {
   GearAllocationQuantities,
   GearAllocationStatus,
+  GearInventoryDirection,
   GearPoolAvailability,
   GearReservationStatus,
   GearReservationWindow,
@@ -136,7 +137,32 @@ export function taggedAllocationWindowsConflict(
 }
 
 export function hasExactlyOneNotificationRecipient(recipient: NotificationRecipient): boolean {
-  return Boolean(recipient.userId) !== Boolean(recipient.email);
+  return recipient.email.trim().length > 0;
+}
+
+export function isValidInventoryMovementDirection(
+  type:
+    | "RECEIPT"
+    | "ALLOCATION"
+    | "RELEASE"
+    | "RETURN"
+    | "TRANSFER"
+    | "ADJUSTMENT"
+    | "WRITE_OFF",
+  direction: GearInventoryDirection,
+): boolean {
+  const expectedDirections = {
+    RECEIPT: "INCREASE",
+    ALLOCATION: "DECREASE",
+    RELEASE: "INCREASE",
+    RETURN: "INCREASE",
+    TRANSFER: "NEUTRAL",
+    ADJUSTMENT: undefined,
+    WRITE_OFF: "DECREASE",
+  } as const;
+
+  const expected = expectedDirections[type];
+  return expected ? direction === expected : direction === "INCREASE" || direction === "DECREASE";
 }
 
 export function canTransitionReservation(

--- a/lib/utils/gear.ts
+++ b/lib/utils/gear.ts
@@ -5,6 +5,8 @@ import type {
   GearReservationStatus,
   GearReservationWindow,
   GearTrackingMode,
+  NotificationRecipient,
+  TaggedAllocationWindow,
   GearUnitStatus,
 } from "@/types/gear";
 
@@ -74,6 +76,67 @@ export function allocationIsConsistent(allocation: GearAllocationQuantities): bo
     allocation.returnedQty <= allocation.pickedUpQty &&
     allocation.releasedQty <= allocation.allocatedQty - allocation.pickedUpQty
   );
+}
+
+export function allocationStatusQuantitiesValid(
+  status: GearAllocationStatus,
+  allocation: GearAllocationQuantities,
+): boolean {
+  if (!allocationIsConsistent(allocation)) {
+    return false;
+  }
+
+  switch (status) {
+    case "PENDING":
+      return (
+        allocation.allocatedQty === 0 &&
+        allocation.pickedUpQty === 0 &&
+        allocation.returnedQty === 0 &&
+        allocation.releasedQty === 0
+      );
+    case "ALLOCATED":
+      return allocation.allocatedQty > 0 && allocation.pickedUpQty === 0 && allocation.returnedQty === 0 && allocation.releasedQty === 0;
+    case "PICKED_UP":
+      return allocation.pickedUpQty > 0 && allocation.returnedQty === 0 && allocation.releasedQty === 0;
+    case "PARTIALLY_RETURNED":
+      return (
+        allocation.pickedUpQty > 0 &&
+        allocation.returnedQty > 0 &&
+        allocation.returnedQty < allocation.pickedUpQty &&
+        allocation.releasedQty === 0
+      );
+    case "RETURNED":
+      return (
+        allocation.pickedUpQty === allocation.returnedQty &&
+        allocation.returnedQty + allocation.releasedQty === allocation.allocatedQty
+      );
+    case "RELEASED":
+      return (
+        allocation.allocatedQty > 0 &&
+        allocation.pickedUpQty === 0 &&
+        allocation.returnedQty === 0 &&
+        allocation.releasedQty === allocation.allocatedQty
+      );
+  }
+}
+
+export function isActiveTaggedAllocationStatus(status: GearAllocationStatus): boolean {
+  return ["PENDING", "ALLOCATED", "PICKED_UP", "PARTIALLY_RETURNED"].includes(status);
+}
+
+export function taggedAllocationWindowsConflict(
+  candidate: TaggedAllocationWindow,
+  existing: TaggedAllocationWindow,
+): boolean {
+  return (
+    isActiveTaggedAllocationStatus(candidate.status) &&
+    isActiveTaggedAllocationStatus(existing.status) &&
+    datesOverlap(candidate, existing)
+  );
+}
+
+export function hasExactlyOneNotificationRecipient(recipient: NotificationRecipient): boolean {
+  return Boolean(recipient.userId) !== Boolean(recipient.email);
 }
 
 export function canTransitionReservation(

--- a/lib/utils/gear.ts
+++ b/lib/utils/gear.ts
@@ -1,0 +1,110 @@
+import type {
+  GearAllocationQuantities,
+  GearAllocationStatus,
+  GearPoolAvailability,
+  GearReservationStatus,
+  GearReservationWindow,
+  GearTrackingMode,
+  GearUnitStatus,
+} from "@/types/gear";
+
+const reservationTransitions: Record<GearReservationStatus, readonly GearReservationStatus[]> = {
+  DRAFT: ["REQUESTED", "CANCELED"],
+  REQUESTED: ["APPROVED", "DECLINED", "CANCELED"],
+  APPROVED: ["FULFILLED", "CANCELED"],
+  DECLINED: [],
+  CANCELED: [],
+  FULFILLED: ["CLOSED"],
+  CLOSED: [],
+};
+
+const allocationTransitions: Record<GearAllocationStatus, readonly GearAllocationStatus[]> = {
+  PENDING: ["ALLOCATED", "RELEASED"],
+  ALLOCATED: ["PICKED_UP", "RELEASED"],
+  PICKED_UP: ["PARTIALLY_RETURNED", "RETURNED"],
+  PARTIALLY_RETURNED: ["RETURNED"],
+  RETURNED: [],
+  RELEASED: [],
+};
+
+const unitTransitions: Record<GearUnitStatus, readonly GearUnitStatus[]> = {
+  AVAILABLE: ["RESERVED", "MAINTENANCE", "RETIRED", "LOST"],
+  RESERVED: ["AVAILABLE", "CHECKED_OUT", "MAINTENANCE"],
+  CHECKED_OUT: ["AVAILABLE", "MAINTENANCE", "LOST"],
+  MAINTENANCE: ["AVAILABLE", "RETIRED"],
+  RETIRED: [],
+  LOST: [],
+};
+
+export function normalizeGearKey(value: string): string {
+  return value.trim().replace(/\s+/g, " ").toLowerCase();
+}
+
+export function normalizeGearAssetTag(value: string): string {
+  return value.trim().replace(/\s+/g, "").toUpperCase();
+}
+
+export function datesOverlap(left: GearReservationWindow, right: GearReservationWindow): boolean {
+  return left.startDate <= right.endDate && right.startDate <= left.endDate;
+}
+
+export function availablePoolQuantity(stock: GearPoolAvailability): number {
+  return Math.max(0, stock.quantityOnHand - stock.allocatedQuantity);
+}
+
+export function canAllocatePoolStock(stock: GearPoolAvailability, quantity: number): boolean {
+  return Number.isSafeInteger(quantity) && quantity > 0 && quantity <= availablePoolQuantity(stock);
+}
+
+export function allocationRemainingForReturn(allocation: GearAllocationQuantities): number {
+  return Math.max(0, allocation.pickedUpQty - allocation.returnedQty);
+}
+
+export function allocationIsConsistent(allocation: GearAllocationQuantities): boolean {
+  const values = [
+    allocation.allocatedQty,
+    allocation.pickedUpQty,
+    allocation.returnedQty,
+    allocation.releasedQty,
+  ];
+
+  return (
+    values.every((value) => Number.isSafeInteger(value) && value >= 0) &&
+    allocation.pickedUpQty <= allocation.allocatedQty &&
+    allocation.returnedQty <= allocation.pickedUpQty &&
+    allocation.releasedQty <= allocation.allocatedQty - allocation.pickedUpQty
+  );
+}
+
+export function canTransitionReservation(
+  from: GearReservationStatus,
+  to: GearReservationStatus,
+): boolean {
+  return reservationTransitions[from].includes(to);
+}
+
+export function canTransitionAllocation(from: GearAllocationStatus, to: GearAllocationStatus): boolean {
+  return allocationTransitions[from].includes(to);
+}
+
+export function canTransitionUnit(from: GearUnitStatus, to: GearUnitStatus): boolean {
+  return unitTransitions[from].includes(to);
+}
+
+export function requiresTaggedUnit(mode: GearTrackingMode): boolean {
+  return mode === "INDIVIDUAL";
+}
+
+export function isRetryablePrismaConflict(error: unknown): boolean {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+
+  const candidate = error as { code?: unknown; message?: unknown };
+  return (
+    candidate.code === "P2034" ||
+    candidate.code === "40001" ||
+    (typeof candidate.message === "string" &&
+      /(serialization failure|could not serialize access)/i.test(candidate.message))
+  );
+}

--- a/lib/utils/permissions.ts
+++ b/lib/utils/permissions.ts
@@ -68,6 +68,23 @@ export enum Permission {
     REQUEST_TEAM_GEAR = "request_team_gear",
 }
 
+export const TEAM_SCOPED_PERMISSIONS = [
+    Permission.UPDATE_TEAM,
+    Permission.DELETE_TEAM,
+    Permission.ADD_PLAYER,
+    Permission.UPDATE_PLAYER,
+    Permission.REMOVE_PLAYER,
+    Permission.CREATE_EVENT,
+    Permission.UPDATE_EVENT,
+    Permission.DELETE_EVENT,
+    Permission.SEND_TEAM_MESSAGE,
+    Permission.EXPORT_TEAM_DATA,
+    Permission.CREATE_TEAM_GEAR_NEED,
+    Permission.REQUEST_TEAM_GEAR,
+] as const;
+
+export type TeamScopedPermission = (typeof TEAM_SCOPED_PERMISSIONS)[number];
+
 /**
  * Permission matrix mapping access levels to permissions
  * Using lazy initialization to avoid forward reference issues
@@ -183,9 +200,17 @@ export async function hasPermission(
         const allowedPermissions = getPermissionMatrix()[accessLevel] || [];
         const hasBasePermission = allowedPermissions.includes(permission);
 
-        // For team-specific permissions, verify team access if teamId is provided
-        if (hasBasePermission && teamId && isTeamSpecificPermission(permission)) {
-            return await hasTeamSpecificPermission(userId, leagueId, teamId, permission, accessLevel);
+        if (isTeamSpecificPermission(permission)) {
+            // Team-specific operations are never league-wide by omission. League
+            // admins still receive access to a supplied team through the exact
+            // same scoped path as team admins.
+            if (!teamId) {
+                return false;
+            }
+
+            return hasBasePermission
+                ? await hasTeamSpecificPermission(userId, leagueId, teamId, permission, accessLevel)
+                : false;
         }
 
         return hasBasePermission;
@@ -198,23 +223,17 @@ export async function hasPermission(
 /**
  * Check if a permission is team-specific
  */
-function isTeamSpecificPermission(permission: Permission): boolean {
-    const teamSpecificPermissions = [
-        Permission.UPDATE_TEAM,
-        Permission.DELETE_TEAM,
-        Permission.ADD_PLAYER,
-        Permission.UPDATE_PLAYER,
-        Permission.REMOVE_PLAYER,
-        Permission.CREATE_EVENT,
-        Permission.UPDATE_EVENT,
-        Permission.DELETE_EVENT,
-        Permission.SEND_TEAM_MESSAGE,
-        Permission.EXPORT_TEAM_DATA,
-        Permission.CREATE_TEAM_GEAR_NEED,
-        Permission.REQUEST_TEAM_GEAR,
-    ];
+export function isTeamSpecificPermission(permission: Permission): permission is TeamScopedPermission {
+    return (TEAM_SCOPED_PERMISSIONS as readonly Permission[]).includes(permission);
+}
 
-    return teamSpecificPermissions.includes(permission);
+export async function hasTeamPermission(
+    userId: string,
+    leagueId: string,
+    permission: TeamScopedPermission,
+    teamId: string,
+): Promise<boolean> {
+    return hasPermission(userId, leagueId, permission, teamId);
 }
 
 /**

--- a/lib/utils/permissions.ts
+++ b/lib/utils/permissions.ts
@@ -58,6 +58,14 @@ export enum Permission {
     EXPORT_TEAM_DATA = "export_team_data",
     VIEW_LEAGUE_REPORTS = "view_league_reports",
     VIEW_FINANCIAL_REPORTS = "view_financial_reports",
+
+    // League-owned gear. Team-admin grants must always be evaluated with the
+    // requested team ID, while inventory and public wishlist administration
+    // remain league-admin operations.
+    MANAGE_GEAR_INVENTORY = "manage_gear_inventory",
+    MANAGE_GEAR_WISHLIST = "manage_gear_wishlist",
+    CREATE_TEAM_GEAR_NEED = "create_team_gear_need",
+    REQUEST_TEAM_GEAR = "request_team_gear",
 }
 
 /**
@@ -97,6 +105,8 @@ const getPermissionMatrix = (): Record<LeagueAccessLevel, Permission[]> => ({
 
         // Reporting
         Permission.EXPORT_TEAM_DATA,
+        Permission.CREATE_TEAM_GEAR_NEED,
+        Permission.REQUEST_TEAM_GEAR,
     ],
 
     [LeagueAccessLevel.LEAGUE_ADMIN]: [
@@ -148,6 +158,10 @@ const getPermissionMatrix = (): Record<LeagueAccessLevel, Permission[]> => ({
         Permission.EXPORT_LEAGUE_DATA,
         Permission.VIEW_LEAGUE_REPORTS,
         Permission.VIEW_FINANCIAL_REPORTS,
+        Permission.MANAGE_GEAR_INVENTORY,
+        Permission.MANAGE_GEAR_WISHLIST,
+        Permission.CREATE_TEAM_GEAR_NEED,
+        Permission.REQUEST_TEAM_GEAR,
     ],
 });
 
@@ -196,6 +210,8 @@ function isTeamSpecificPermission(permission: Permission): boolean {
         Permission.DELETE_EVENT,
         Permission.SEND_TEAM_MESSAGE,
         Permission.EXPORT_TEAM_DATA,
+        Permission.CREATE_TEAM_GEAR_NEED,
+        Permission.REQUEST_TEAM_GEAR,
     ];
 
     return teamSpecificPermissions.includes(permission);

--- a/lib/utils/validation.ts
+++ b/lib/utils/validation.ts
@@ -2064,6 +2064,16 @@ export const GEAR_TRACKING_MODES = ["POOLED", "INDIVIDUAL"] as const;
 export const GEAR_CONDITIONS = ["NEW", "EXCELLENT", "GOOD", "FAIR", "POOR", "DAMAGED"] as const;
 export const GEAR_NEED_PRIORITIES = ["LOW", "NORMAL", "HIGH", "URGENT"] as const;
 export const GEAR_RETURN_DISPOSITIONS = ["GOOD", "DAMAGED", "LOST", "CONSUMED"] as const;
+export const GEAR_INVENTORY_DIRECTIONS = ["INCREASE", "DECREASE", "NEUTRAL"] as const;
+export const GEAR_INVENTORY_MOVEMENT_TYPES = [
+  "RECEIPT",
+  "ALLOCATION",
+  "RELEASE",
+  "RETURN",
+  "TRANSFER",
+  "ADJUSTMENT",
+  "WRITE_OFF",
+] as const;
 
 const gearDateSchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Date must be YYYY-MM-DD");
 const gearQuantitySchema = z.coerce.number().int("Quantity must be a whole number").min(1, "Quantity must be at least 1");
@@ -2211,7 +2221,94 @@ export const receiveGearPledgeSchema = z.object({
       path: ["poolStockId"],
     });
   }
+  if (value.gearUnitId && value.quantity !== 1) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "A tagged-unit receipt quantity must be exactly 1",
+      path: ["quantity"],
+    });
+  }
 });
+
+export const recordGearInventoryMovementSchema = z
+  .object({
+    leagueId: gearCuidSchema,
+    type: z.enum(GEAR_INVENTORY_MOVEMENT_TYPES),
+    direction: z.enum(GEAR_INVENTORY_DIRECTIONS),
+    poolStockId: gearCuidSchema.optional().or(z.literal("")),
+    gearUnitId: gearCuidSchema.optional().or(z.literal("")),
+    quantity: gearQuantitySchema,
+    notes: optionalSanitizedString(1_000),
+  })
+  .superRefine((value, context) => {
+    const inventoryLinks = [value.poolStockId, value.gearUnitId].filter(Boolean);
+    if (inventoryLinks.length !== 1) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "A movement must link to exactly one pool stock row or tagged unit",
+        path: ["poolStockId"],
+      });
+    }
+    if (value.gearUnitId && value.quantity !== 1) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "A tagged-unit movement quantity must be exactly 1",
+        path: ["quantity"],
+      });
+    }
+    const validDirection =
+      (value.type === "RECEIPT" && value.direction === "INCREASE") ||
+      (value.type === "ALLOCATION" && value.direction === "DECREASE") ||
+      (value.type === "RELEASE" && value.direction === "INCREASE") ||
+      (value.type === "RETURN" && value.direction === "INCREASE") ||
+      (value.type === "TRANSFER" && value.direction === "NEUTRAL") ||
+      (value.type === "WRITE_OFF" && value.direction === "DECREASE") ||
+      (value.type === "ADJUSTMENT" && value.direction !== "NEUTRAL");
+    if (!validDirection) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Movement type and direction are incompatible",
+        path: ["direction"],
+      });
+    }
+  });
+
+export const gearActivityDetailsSchema = z
+  .object({
+    action: sanitizedStringWithMin(1, 80),
+    summary: optionalSanitizedString(500),
+    metadata: z.record(z.string().max(80), z.union([z.string().max(500), z.number(), z.boolean(), z.null()])).optional(),
+  })
+  .superRefine((value, context) => {
+    for (const key of Object.keys(value.metadata ?? {})) {
+      if (/(email|phone|name|address|contact)/i.test(key)) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "Activity metadata cannot contain contact PII",
+          path: ["metadata", key],
+        });
+      }
+    }
+  })
+  .strict();
+
+export const gearNotificationPayloadSchema = z
+  .object({
+    kind: z.enum(["GEAR_RESERVATION", "GEAR_ALLOCATION", "GEAR_PLEDGE", "GEAR_WISHLIST"]),
+    data: z.record(z.string().max(80), z.union([z.string().max(500), z.number(), z.boolean(), z.null()])),
+  })
+  .superRefine((value, context) => {
+    for (const key of Object.keys(value.data)) {
+      if (/(email|phone|name|address|contact)/i.test(key)) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "Outbox payloads cannot contain contact PII",
+          path: ["data", key],
+        });
+      }
+    }
+  })
+  .strict();
 
 export const recordGearHandoffSchema = z.object({
   leagueId: gearCuidSchema,
@@ -2232,4 +2329,5 @@ export type CreateGearReservationInput = z.input<typeof createGearReservationSch
 export type SaveGearWishlistInput = z.input<typeof saveGearWishlistSchema>;
 export type CreateGearPledgeInput = z.input<typeof createGearPledgeSchema>;
 export type ReceiveGearPledgeInput = z.input<typeof receiveGearPledgeSchema>;
+export type RecordGearInventoryMovementInput = z.input<typeof recordGearInventoryMovementSchema>;
 export type RecordGearHandoffInput = z.input<typeof recordGearHandoffSchema>;

--- a/lib/utils/validation.ts
+++ b/lib/utils/validation.ts
@@ -2057,3 +2057,179 @@ export type SetSegmentActiveInput = z.input<typeof setSegmentActiveSchema>;
 export type SetWholeSurfaceLabelInput = z.input<typeof setWholeSurfaceLabelSchema>;
 export type SuggestCoexistenceInput = z.input<typeof suggestCoexistenceSchema>;
 export type SaveVenueLayoutInput = z.input<typeof saveVenueLayoutSchema>;
+
+// League-owned gear foundation. These schemas describe future action inputs;
+// authorization and tenant-consistency checks remain action responsibilities.
+export const GEAR_TRACKING_MODES = ["POOLED", "INDIVIDUAL"] as const;
+export const GEAR_CONDITIONS = ["NEW", "EXCELLENT", "GOOD", "FAIR", "POOR", "DAMAGED"] as const;
+export const GEAR_NEED_PRIORITIES = ["LOW", "NORMAL", "HIGH", "URGENT"] as const;
+export const GEAR_RETURN_DISPOSITIONS = ["GOOD", "DAMAGED", "LOST", "CONSUMED"] as const;
+
+const gearDateSchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Date must be YYYY-MM-DD");
+const gearQuantitySchema = z.coerce.number().int("Quantity must be a whole number").min(1, "Quantity must be at least 1");
+const gearOptionalQuantitySchema = z.coerce.number().int("Quantity must be a whole number").min(0);
+const gearCuidSchema = z.string().cuid("Invalid gear identifier");
+const gearAttributesSchema = z.record(z.string().max(80), z.unknown()).optional();
+
+export const createGearCatalogItemSchema = z.object({
+  leagueId: gearCuidSchema,
+  name: sanitizedStringWithMin(1, 160),
+  category: sanitizedStringWithMin(1, 80),
+  size: optionalSanitizedString(80),
+  brand: optionalSanitizedString(100),
+  model: optionalSanitizedString(100),
+  description: optionalSanitizedString(2_000),
+  attributes: gearAttributesSchema,
+  trackingMode: z.enum(GEAR_TRACKING_MODES),
+});
+
+export const createGearStorageLocationSchema = z.object({
+  leagueId: gearCuidSchema,
+  name: sanitizedStringWithMin(1, 120),
+  address: optionalSanitizedString(500),
+  privateNotes: optionalSanitizedString(2_000),
+});
+
+export const adjustGearPoolStockSchema = z.object({
+  leagueId: gearCuidSchema,
+  catalogItemId: gearCuidSchema,
+  locationId: gearCuidSchema,
+  condition: z.enum(GEAR_CONDITIONS),
+  quantityDelta: z.coerce.number().int("Quantity adjustment must be a whole number").refine((value) => value !== 0, {
+    message: "Quantity adjustment cannot be zero",
+  }),
+  expectedVersion: z.coerce.number().int().min(0),
+  notes: optionalSanitizedString(1_000),
+});
+
+export const createGearUnitSchema = z.object({
+  leagueId: gearCuidSchema,
+  catalogItemId: gearCuidSchema,
+  currentLocationId: gearCuidSchema.optional().or(z.literal("")),
+  assetTag: optionalSanitizedString(80),
+  serialNumber: optionalSanitizedString(160),
+  currentCondition: z.enum(GEAR_CONDITIONS).default("GOOD"),
+  acquiredAt: gearDateSchema.optional().or(z.literal("")),
+  notes: optionalSanitizedString(2_000),
+});
+
+export const createTeamGearNeedSchema = z.object({
+  leagueId: gearCuidSchema,
+  teamId: gearCuidSchema,
+  title: sanitizedStringWithMin(1, 160),
+  notes: optionalSanitizedString(2_000),
+  lines: z
+    .array(
+      z.object({
+        catalogItemId: gearCuidSchema.optional().or(z.literal("")),
+        nameSnapshot: sanitizedStringWithMin(1, 160),
+        categorySnapshot: optionalSanitizedString(80),
+        sizeSnapshot: optionalSanitizedString(80),
+        trackingMode: z.enum(GEAR_TRACKING_MODES).optional(),
+        requestedQty: gearQuantitySchema,
+        priority: z.enum(GEAR_NEED_PRIORITIES).default("NORMAL"),
+        notes: optionalSanitizedString(1_000),
+      }),
+    )
+    .min(1, "Add at least one gear need line")
+    .max(100),
+});
+
+export const createGearReservationSchema = z
+  .object({
+    leagueId: gearCuidSchema,
+    teamId: gearCuidSchema,
+    requestedStartDate: gearDateSchema,
+    requestedEndDate: gearDateSchema,
+    custodianNameSnapshot: sanitizedStringWithMin(1, 160),
+    custodianEmailSnapshot: optionalEmailSchema,
+    custodianPhoneSnapshot: optionalSanitizedString(40),
+    requestNotes: optionalSanitizedString(2_000),
+    lines: z
+      .array(
+        z.object({
+          catalogItemId: gearCuidSchema.optional().or(z.literal("")),
+          needLineId: gearCuidSchema.optional().or(z.literal("")),
+          nameSnapshot: sanitizedStringWithMin(1, 160),
+          requestedQty: gearQuantitySchema,
+        }),
+      )
+      .min(1, "Add at least one reservation line")
+      .max(100),
+  })
+  .refine((value) => value.requestedEndDate >= value.requestedStartDate, {
+    message: "Reservation end date must be on or after the start date",
+    path: ["requestedEndDate"],
+  });
+
+export const saveGearWishlistSchema = z.object({
+  leagueId: gearCuidSchema,
+  title: sanitizedStringWithMin(1, 160),
+  description: optionalSanitizedString(2_000),
+  publish: z.boolean(),
+  expectedVersion: z.coerce.number().int().min(0).optional(),
+  items: z
+    .array(
+      z.object({
+        catalogItemId: gearCuidSchema.optional().or(z.literal("")),
+        nameSnapshot: sanitizedStringWithMin(1, 160),
+        categorySnapshot: optionalSanitizedString(80),
+        sizeSnapshot: optionalSanitizedString(80),
+        description: optionalSanitizedString(1_000),
+        targetQty: gearQuantitySchema,
+      }),
+    )
+    .max(100),
+});
+
+export const createGearPledgeSchema = z.object({
+  wishlistToken: z.string().trim().min(16).max(255),
+  wishlistItemId: gearCuidSchema,
+  donorName: sanitizedStringWithMin(1, 160),
+  donorEmail: optionalEmailSchema,
+  donorPhone: optionalSanitizedString(40),
+  contactConsent: z.boolean().default(false),
+  quantity: gearQuantitySchema,
+  note: optionalSanitizedString(1_000),
+  idempotencyKey: z.string().trim().min(16).max(255),
+});
+
+export const receiveGearPledgeSchema = z.object({
+  leagueId: gearCuidSchema,
+  pledgeId: gearCuidSchema,
+  catalogItemId: gearCuidSchema.optional().or(z.literal("")),
+  poolStockId: gearCuidSchema.optional().or(z.literal("")),
+  gearUnitId: gearCuidSchema.optional().or(z.literal("")),
+  quantity: gearQuantitySchema,
+  notes: optionalSanitizedString(1_000),
+}).superRefine((value, context) => {
+  const inventoryLinks = [value.poolStockId, value.gearUnitId].filter(Boolean);
+  if (inventoryLinks.length !== 1) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "A receipt must link to exactly one pool stock row or tagged unit",
+      path: ["poolStockId"],
+    });
+  }
+});
+
+export const recordGearHandoffSchema = z.object({
+  leagueId: gearCuidSchema,
+  allocationId: gearCuidSchema,
+  type: z.enum(["PICKUP", "RETURN", "TRANSFER"]),
+  returnDisposition: z.enum(GEAR_RETURN_DISPOSITIONS).optional(),
+  quantity: gearQuantitySchema,
+  notes: optionalSanitizedString(1_000),
+  expectedVersion: z.coerce.number().int().min(0),
+});
+
+export type CreateGearCatalogItemInput = z.input<typeof createGearCatalogItemSchema>;
+export type CreateGearStorageLocationInput = z.input<typeof createGearStorageLocationSchema>;
+export type AdjustGearPoolStockInput = z.input<typeof adjustGearPoolStockSchema>;
+export type CreateGearUnitInput = z.input<typeof createGearUnitSchema>;
+export type CreateTeamGearNeedInput = z.input<typeof createTeamGearNeedSchema>;
+export type CreateGearReservationInput = z.input<typeof createGearReservationSchema>;
+export type SaveGearWishlistInput = z.input<typeof saveGearWishlistSchema>;
+export type CreateGearPledgeInput = z.input<typeof createGearPledgeSchema>;
+export type ReceiveGearPledgeInput = z.input<typeof receiveGearPledgeSchema>;
+export type RecordGearHandoffInput = z.input<typeof recordGearHandoffSchema>;

--- a/prisma/migrations/20260816180000_gear_domain_foundation/migration.sql
+++ b/prisma/migrations/20260816180000_gear_domain_foundation/migration.sql
@@ -2,6 +2,8 @@
 -- outbox. Application mutations use Prisma transactions; the constraints here
 -- protect invariants that PostgreSQL can enforce locally.
 
+BEGIN;
+
 CREATE TYPE "GearTrackingMode" AS ENUM ('POOLED', 'INDIVIDUAL');
 CREATE TYPE "GearCondition" AS ENUM ('NEW', 'EXCELLENT', 'GOOD', 'FAIR', 'POOR', 'DAMAGED');
 CREATE TYPE "GearUnitStatus" AS ENUM ('AVAILABLE', 'RESERVED', 'CHECKED_OUT', 'MAINTENANCE', 'RETIRED', 'LOST');
@@ -13,6 +15,7 @@ CREATE TYPE "GearAllocationStatus" AS ENUM ('PENDING', 'ALLOCATED', 'PICKED_UP',
 CREATE TYPE "GearHandoffType" AS ENUM ('PICKUP', 'RETURN', 'TRANSFER', 'RECEIPT', 'ADJUSTMENT');
 CREATE TYPE "GearReturnDisposition" AS ENUM ('GOOD', 'DAMAGED', 'LOST', 'CONSUMED');
 CREATE TYPE "GearInventoryMovementType" AS ENUM ('RECEIPT', 'ALLOCATION', 'RELEASE', 'RETURN', 'TRANSFER', 'ADJUSTMENT', 'WRITE_OFF');
+CREATE TYPE "GearInventoryDirection" AS ENUM ('INCREASE', 'DECREASE', 'NEUTRAL');
 CREATE TYPE "GearWishlistStatus" AS ENUM ('DRAFT', 'PUBLISHED', 'ARCHIVED');
 CREATE TYPE "GearPledgeStatus" AS ENUM ('PLEDGED', 'RECEIVED', 'DECLINED', 'CANCELED', 'EXPIRED');
 CREATE TYPE "GearActivityEntityType" AS ENUM ('CATALOG_ITEM', 'STORAGE_LOCATION', 'POOL_STOCK', 'UNIT', 'NEED', 'RESERVATION', 'ALLOCATION', 'HANDOFF', 'MOVEMENT', 'WISHLIST', 'PLEDGE');
@@ -317,7 +320,8 @@ CREATE TABLE "gear_pledge_receipts" (
   "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
   CONSTRAINT "gear_pledge_receipts_pkey" PRIMARY KEY ("id"),
   CONSTRAINT "gear_pledge_receipts_exactly_one_inventory_target" CHECK (("poolStockId" IS NOT NULL) <> ("gearUnitId" IS NOT NULL)),
-  CONSTRAINT "gear_pledge_receipts_quantity_positive" CHECK ("quantity" > 0)
+  CONSTRAINT "gear_pledge_receipts_quantity_positive" CHECK ("quantity" > 0),
+  CONSTRAINT "gear_pledge_receipts_tagged_unit_quantity" CHECK ("gearUnitId" IS NULL OR "quantity" = 1)
 );
 
 CREATE TABLE "gear_activity" (
@@ -337,6 +341,7 @@ CREATE TABLE "gear_inventory_movements" (
   "id" TEXT NOT NULL,
   "leagueId" TEXT NOT NULL,
   "type" "GearInventoryMovementType" NOT NULL,
+  "direction" "GearInventoryDirection" NOT NULL,
   "poolStockId" TEXT,
   "gearUnitId" TEXT,
   "allocationId" TEXT,
@@ -353,14 +358,25 @@ CREATE TABLE "gear_inventory_movements" (
   "recordedById" TEXT,
   CONSTRAINT "gear_inventory_movements_pkey" PRIMARY KEY ("id"),
   CONSTRAINT "gear_inventory_movements_exactly_one_inventory_target" CHECK (("poolStockId" IS NOT NULL) <> ("gearUnitId" IS NOT NULL)),
-  CONSTRAINT "gear_inventory_movements_quantity_positive" CHECK ("quantity" > 0)
+  CONSTRAINT "gear_inventory_movements_quantity_positive" CHECK ("quantity" > 0),
+  CONSTRAINT "gear_inventory_movements_tagged_unit_quantity" CHECK ("gearUnitId" IS NULL OR "quantity" = 1),
+  CONSTRAINT "gear_inventory_movements_direction_valid" CHECK (
+    ("type" = 'RECEIPT' AND "direction" = 'INCREASE')
+    OR ("type" = 'ALLOCATION' AND "direction" = 'DECREASE')
+    OR ("type" = 'RELEASE' AND "direction" = 'INCREASE')
+    OR ("type" = 'RETURN' AND "direction" = 'INCREASE')
+    OR ("type" = 'TRANSFER' AND "direction" = 'NEUTRAL')
+    OR ("type" = 'WRITE_OFF' AND "direction" = 'DECREASE')
+    OR ("type" = 'ADJUSTMENT' AND "direction" IN ('INCREASE', 'DECREASE'))
+  )
 );
 
 CREATE TABLE "notification_outbox" (
   "id" TEXT NOT NULL,
   "leagueId" TEXT NOT NULL,
   "recipientUserId" TEXT,
-  "recipientEmail" TEXT,
+  "recipientEmail" TEXT NOT NULL,
+  "recipientRedactedAt" TIMESTAMP(3),
   "eventType" TEXT NOT NULL,
   "aggregateType" TEXT NOT NULL,
   "aggregateId" TEXT NOT NULL,
@@ -377,7 +393,7 @@ CREATE TABLE "notification_outbox" (
   "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
   "updatedAt" TIMESTAMP(3) NOT NULL,
   CONSTRAINT "notification_outbox_pkey" PRIMARY KEY ("id"),
-  CONSTRAINT "notification_outbox_exactly_one_recipient" CHECK (("recipientUserId" IS NOT NULL) <> ("recipientEmail" IS NOT NULL)),
+  CONSTRAINT "notification_outbox_recipient_email_present" CHECK (length(btrim("recipientEmail")) > 0),
   CONSTRAINT "notification_outbox_attempts_nonnegative" CHECK ("attempts" >= 0)
 );
 
@@ -498,4 +514,132 @@ ALTER TABLE "gear_inventory_movements" ADD CONSTRAINT "gear_inventory_movements_
 ALTER TABLE "gear_inventory_movements" ADD CONSTRAINT "gear_inventory_movements_afterLocationId_fkey" FOREIGN KEY ("leagueId", "afterLocationId") REFERENCES "gear_storage_locations"("leagueId", "id") ON DELETE RESTRICT ON UPDATE CASCADE;
 ALTER TABLE "gear_inventory_movements" ADD CONSTRAINT "gear_inventory_movements_recordedById_fkey" FOREIGN KEY ("recordedById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
 ALTER TABLE "notification_outbox" ADD CONSTRAINT "notification_outbox_leagueId_fkey" FOREIGN KEY ("leagueId") REFERENCES "leagues"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-ALTER TABLE "notification_outbox" ADD CONSTRAINT "notification_outbox_recipientUserId_fkey" FOREIGN KEY ("recipientUserId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "notification_outbox" ADD CONSTRAINT "notification_outbox_recipientUserId_fkey" FOREIGN KEY ("recipientUserId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- The operational ledger is append-only. Corrections are represented as
+-- compensating handoffs, movements, or activity entries rather than rewrites.
+CREATE FUNCTION "gear_reject_ledger_mutation"() RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  RAISE EXCEPTION '% records are append-only; create a compensating entry instead', TG_TABLE_NAME
+    USING ERRCODE = '55000';
+END;
+$$;
+
+CREATE TRIGGER "gear_handoffs_append_only"
+  BEFORE UPDATE OR DELETE ON "gear_handoffs"
+  FOR EACH ROW EXECUTE FUNCTION "gear_reject_ledger_mutation"();
+CREATE TRIGGER "gear_activity_append_only"
+  BEFORE UPDATE OR DELETE ON "gear_activity"
+  FOR EACH ROW EXECUTE FUNCTION "gear_reject_ledger_mutation"();
+CREATE TRIGGER "gear_inventory_movements_append_only"
+  BEFORE UPDATE OR DELETE ON "gear_inventory_movements"
+  FOR EACH ROW EXECUTE FUNCTION "gear_reject_ledger_mutation"();
+
+-- An activity row may name any gear aggregate, but it must name that aggregate
+-- within the activity's League. PostgreSQL cannot express this polymorphic
+-- foreign key declaratively, so the trigger is the tenant boundary.
+CREATE FUNCTION "gear_validate_activity_entity_league"() RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  entity_exists BOOLEAN;
+BEGIN
+  CASE NEW."entityType"
+    WHEN 'CATALOG_ITEM' THEN SELECT EXISTS (SELECT 1 FROM "gear_catalog_items" WHERE "id" = NEW."entityId" AND "leagueId" = NEW."leagueId") INTO entity_exists;
+    WHEN 'STORAGE_LOCATION' THEN SELECT EXISTS (SELECT 1 FROM "gear_storage_locations" WHERE "id" = NEW."entityId" AND "leagueId" = NEW."leagueId") INTO entity_exists;
+    WHEN 'POOL_STOCK' THEN SELECT EXISTS (SELECT 1 FROM "gear_pool_stocks" WHERE "id" = NEW."entityId" AND "leagueId" = NEW."leagueId") INTO entity_exists;
+    WHEN 'UNIT' THEN SELECT EXISTS (SELECT 1 FROM "gear_units" WHERE "id" = NEW."entityId" AND "leagueId" = NEW."leagueId") INTO entity_exists;
+    WHEN 'NEED' THEN SELECT EXISTS (SELECT 1 FROM "team_gear_needs" WHERE "id" = NEW."entityId" AND "leagueId" = NEW."leagueId") INTO entity_exists;
+    WHEN 'RESERVATION' THEN SELECT EXISTS (SELECT 1 FROM "gear_reservations" WHERE "id" = NEW."entityId" AND "leagueId" = NEW."leagueId") INTO entity_exists;
+    WHEN 'ALLOCATION' THEN SELECT EXISTS (SELECT 1 FROM "gear_allocations" WHERE "id" = NEW."entityId" AND "leagueId" = NEW."leagueId") INTO entity_exists;
+    WHEN 'HANDOFF' THEN SELECT EXISTS (SELECT 1 FROM "gear_handoffs" WHERE "id" = NEW."entityId" AND "leagueId" = NEW."leagueId") INTO entity_exists;
+    WHEN 'MOVEMENT' THEN SELECT EXISTS (SELECT 1 FROM "gear_inventory_movements" WHERE "id" = NEW."entityId" AND "leagueId" = NEW."leagueId") INTO entity_exists;
+    WHEN 'WISHLIST' THEN SELECT EXISTS (SELECT 1 FROM "gear_wishlists" WHERE "id" = NEW."entityId" AND "leagueId" = NEW."leagueId") INTO entity_exists;
+    WHEN 'PLEDGE' THEN SELECT EXISTS (SELECT 1 FROM "gear_pledges" WHERE "id" = NEW."entityId" AND "leagueId" = NEW."leagueId") INTO entity_exists;
+    ELSE RAISE EXCEPTION 'Unsupported gear activity entity type: %', NEW."entityType" USING ERRCODE = '23514';
+  END CASE;
+
+  IF NOT entity_exists THEN
+    RAISE EXCEPTION 'Gear activity entity % does not belong to League %', NEW."entityId", NEW."leagueId"
+      USING ERRCODE = '23503';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER "gear_activity_entity_league"
+  BEFORE INSERT ON "gear_activity"
+  FOR EACH ROW EXECUTE FUNCTION "gear_validate_activity_entity_league"();
+
+-- Workers may update delivery state only. The email destination is immutable
+-- except for the terminal redaction procedure below; the nullable user link is
+-- also allowed to become NULL when the user is deleted.
+CREATE FUNCTION "guard_notification_outbox_mutation"() RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    RAISE EXCEPTION 'notification_outbox records are durable and cannot be deleted'
+      USING ERRCODE = '55000';
+  END IF;
+
+  IF NEW."leagueId" IS DISTINCT FROM OLD."leagueId"
+    OR NEW."eventType" IS DISTINCT FROM OLD."eventType"
+    OR NEW."aggregateType" IS DISTINCT FROM OLD."aggregateType"
+    OR NEW."aggregateId" IS DISTINCT FROM OLD."aggregateId"
+    OR NEW."payload" IS DISTINCT FROM OLD."payload"
+    OR NEW."dedupeKey" IS DISTINCT FROM OLD."dedupeKey"
+    OR NEW."createdAt" IS DISTINCT FROM OLD."createdAt" THEN
+    RAISE EXCEPTION 'notification_outbox intent fields are immutable'
+      USING ERRCODE = '55000';
+  END IF;
+
+  IF NEW."recipientUserId" IS DISTINCT FROM OLD."recipientUserId"
+    AND NEW."recipientUserId" IS NOT NULL THEN
+    RAISE EXCEPTION 'notification_outbox recipient user can only be cleared'
+      USING ERRCODE = '55000';
+  END IF;
+
+  IF NEW."recipientEmail" IS DISTINCT FROM OLD."recipientEmail"
+    OR NEW."recipientRedactedAt" IS DISTINCT FROM OLD."recipientRedactedAt" THEN
+    IF OLD."status" NOT IN ('SENT', 'FAILED', 'CANCELED')
+      OR current_setting('openleague.notification_outbox_redaction', true) <> 'on'
+      OR NEW."recipientUserId" IS NOT NULL
+      OR NEW."recipientEmail" <> ('redacted:' || OLD."id" || '@invalid.openleague')
+      OR NEW."recipientRedactedAt" IS NULL THEN
+      RAISE EXCEPTION 'notification_outbox recipient destination is immutable'
+        USING ERRCODE = '55000';
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER "notification_outbox_delivery_state_only"
+  BEFORE UPDATE OR DELETE ON "notification_outbox"
+  FOR EACH ROW EXECUTE FUNCTION "guard_notification_outbox_mutation"();
+
+-- This routine is intentionally not granted to PUBLIC. An operations-only
+-- retention role may use it after a terminal record reaches its retention date.
+CREATE FUNCTION "redact_notification_outbox_recipient"("outbox_id" TEXT) RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+BEGIN
+  PERFORM set_config('openleague.notification_outbox_redaction', 'on', true);
+  UPDATE public."notification_outbox"
+  SET "recipientUserId" = NULL,
+      "recipientEmail" = 'redacted:' || "id" || '@invalid.openleague',
+      "recipientRedactedAt" = CURRENT_TIMESTAMP
+  WHERE "id" = "outbox_id"
+    AND "status" IN ('SENT', 'FAILED', 'CANCELED')
+    AND "recipientRedactedAt" IS NULL;
+END;
+$$;
+REVOKE ALL ON FUNCTION "redact_notification_outbox_recipient"(TEXT) FROM PUBLIC;
+
+COMMIT;

--- a/prisma/migrations/20260816180000_gear_domain_foundation/migration.sql
+++ b/prisma/migrations/20260816180000_gear_domain_foundation/migration.sql
@@ -18,6 +18,7 @@ CREATE TYPE "GearPledgeStatus" AS ENUM ('PLEDGED', 'RECEIVED', 'DECLINED', 'CANC
 CREATE TYPE "GearActivityEntityType" AS ENUM ('CATALOG_ITEM', 'STORAGE_LOCATION', 'POOL_STOCK', 'UNIT', 'NEED', 'RESERVATION', 'ALLOCATION', 'HANDOFF', 'MOVEMENT', 'WISHLIST', 'PLEDGE');
 CREATE TYPE "GearActivityActorKind" AS ENUM ('USER', 'SYSTEM', 'PUBLIC_DONOR');
 CREATE TYPE "NotificationOutboxStatus" AS ENUM ('PENDING', 'PROCESSING', 'SENT', 'FAILED', 'CANCELED');
+CREATE EXTENSION IF NOT EXISTS btree_gist;
 
 CREATE TABLE "gear_catalog_items" (
   "id" TEXT NOT NULL,
@@ -107,6 +108,7 @@ CREATE TABLE "team_gear_needs" (
 
 CREATE TABLE "team_gear_need_lines" (
   "id" TEXT NOT NULL,
+  "leagueId" TEXT NOT NULL,
   "needId" TEXT NOT NULL,
   "catalogItemId" TEXT,
   "nameSnapshot" TEXT NOT NULL,
@@ -164,6 +166,7 @@ CREATE TABLE "gear_reservations" (
 
 CREATE TABLE "gear_reservation_lines" (
   "id" TEXT NOT NULL,
+  "leagueId" TEXT NOT NULL,
   "reservationId" TEXT NOT NULL,
   "catalogItemId" TEXT,
   "needLineId" TEXT,
@@ -191,6 +194,8 @@ CREATE TABLE "gear_allocations" (
   "pickedUpQty" INTEGER NOT NULL DEFAULT 0,
   "returnedQty" INTEGER NOT NULL DEFAULT 0,
   "releasedQty" INTEGER NOT NULL DEFAULT 0,
+  "effectiveStartDate" DATE,
+  "effectiveEndDate" DATE,
   "version" INTEGER NOT NULL DEFAULT 0,
   "allocatedAt" TIMESTAMP(3),
   "pickedUpAt" TIMESTAMP(3),
@@ -209,6 +214,19 @@ CREATE TABLE "gear_allocations" (
   ),
   CONSTRAINT "gear_allocations_tagged_unit_quantity" CHECK (
     "gearUnitId" IS NULL OR ("allocatedQty" <= 1 AND "pickedUpQty" <= 1 AND "returnedQty" <= 1 AND "releasedQty" <= 1)
+  ),
+  CONSTRAINT "gear_allocations_status_quantities_valid" CHECK (
+    ("status" = 'PENDING' AND "allocatedQty" = 0 AND "pickedUpQty" = 0 AND "returnedQty" = 0 AND "releasedQty" = 0)
+    OR ("status" = 'ALLOCATED' AND "allocatedQty" > 0 AND "pickedUpQty" = 0 AND "returnedQty" = 0 AND "releasedQty" = 0)
+    OR ("status" = 'PICKED_UP' AND "allocatedQty" > 0 AND "pickedUpQty" > 0 AND "returnedQty" = 0 AND "releasedQty" = 0)
+    OR ("status" = 'PARTIALLY_RETURNED' AND "pickedUpQty" > 0 AND "returnedQty" > 0 AND "returnedQty" < "pickedUpQty" AND "releasedQty" = 0)
+    OR ("status" = 'RETURNED' AND "pickedUpQty" = "returnedQty" AND "returnedQty" + "releasedQty" = "allocatedQty")
+    OR ("status" = 'RELEASED' AND "allocatedQty" > 0 AND "pickedUpQty" = 0 AND "returnedQty" = 0 AND "releasedQty" = "allocatedQty")
+  ),
+  CONSTRAINT "gear_allocations_tagged_unit_dates_valid" CHECK (
+    "gearUnitId" IS NULL
+    OR "status" NOT IN ('PENDING', 'ALLOCATED', 'PICKED_UP', 'PARTIALLY_RETURNED')
+    OR ("effectiveStartDate" IS NOT NULL AND "effectiveEndDate" IS NOT NULL AND "effectiveEndDate" >= "effectiveStartDate")
   ),
   CONSTRAINT "gear_allocations_version_nonnegative" CHECK ("version" >= 0)
 );
@@ -246,6 +264,7 @@ CREATE TABLE "gear_wishlists" (
 
 CREATE TABLE "gear_wishlist_items" (
   "id" TEXT NOT NULL,
+  "leagueId" TEXT NOT NULL,
   "wishlistId" TEXT NOT NULL,
   "catalogItemId" TEXT,
   "normalizedKey" TEXT NOT NULL,
@@ -363,98 +382,120 @@ CREATE TABLE "notification_outbox" (
 );
 
 CREATE UNIQUE INDEX "gear_catalog_items_leagueId_normalizedKey_key" ON "gear_catalog_items"("leagueId", "normalizedKey");
+CREATE UNIQUE INDEX "Team_leagueId_id_key" ON "Team"("leagueId", "id");
+CREATE UNIQUE INDEX "gear_catalog_items_leagueId_id_key" ON "gear_catalog_items"("leagueId", "id");
 CREATE INDEX "gear_catalog_items_leagueId_isActive_idx" ON "gear_catalog_items"("leagueId", "isActive");
 CREATE UNIQUE INDEX "gear_storage_locations_leagueId_normalizedName_key" ON "gear_storage_locations"("leagueId", "normalizedName");
+CREATE UNIQUE INDEX "gear_storage_locations_leagueId_id_key" ON "gear_storage_locations"("leagueId", "id");
 CREATE INDEX "gear_storage_locations_leagueId_isActive_idx" ON "gear_storage_locations"("leagueId", "isActive");
 CREATE UNIQUE INDEX "gear_pool_stocks_leagueId_catalogItemId_locationId_condition_key" ON "gear_pool_stocks"("leagueId", "catalogItemId", "locationId", "condition");
+CREATE UNIQUE INDEX "gear_pool_stocks_leagueId_id_key" ON "gear_pool_stocks"("leagueId", "id");
 CREATE INDEX "gear_pool_stocks_leagueId_catalogItemId_idx" ON "gear_pool_stocks"("leagueId", "catalogItemId");
 CREATE INDEX "gear_pool_stocks_leagueId_locationId_idx" ON "gear_pool_stocks"("leagueId", "locationId");
 CREATE UNIQUE INDEX "gear_units_leagueId_assetTag_key" ON "gear_units"("leagueId", "assetTag");
+CREATE UNIQUE INDEX "gear_units_leagueId_id_key" ON "gear_units"("leagueId", "id");
 CREATE INDEX "gear_units_leagueId_catalogItemId_status_idx" ON "gear_units"("leagueId", "catalogItemId", "status");
 CREATE INDEX "gear_units_currentLocationId_idx" ON "gear_units"("currentLocationId");
 CREATE INDEX "team_gear_needs_leagueId_teamId_status_idx" ON "team_gear_needs"("leagueId", "teamId", "status");
+CREATE UNIQUE INDEX "team_gear_needs_leagueId_id_key" ON "team_gear_needs"("leagueId", "id");
 CREATE INDEX "team_gear_need_lines_needId_status_idx" ON "team_gear_need_lines"("needId", "status");
+CREATE UNIQUE INDEX "team_gear_need_lines_leagueId_id_key" ON "team_gear_need_lines"("leagueId", "id");
 CREATE INDEX "team_gear_need_lines_catalogItemId_idx" ON "team_gear_need_lines"("catalogItemId");
 CREATE INDEX "gear_reservations_leagueId_teamId_status_idx" ON "gear_reservations"("leagueId", "teamId", "status");
+CREATE UNIQUE INDEX "gear_reservations_leagueId_id_key" ON "gear_reservations"("leagueId", "id");
 CREATE INDEX "gear_reservations_leagueId_requestedStartDate_requestedEndDate_idx" ON "gear_reservations"("leagueId", "requestedStartDate", "requestedEndDate");
 CREATE INDEX "gear_reservation_lines_reservationId_idx" ON "gear_reservation_lines"("reservationId");
+CREATE UNIQUE INDEX "gear_reservation_lines_leagueId_id_key" ON "gear_reservation_lines"("leagueId", "id");
 CREATE INDEX "gear_reservation_lines_needLineId_idx" ON "gear_reservation_lines"("needLineId");
 CREATE INDEX "gear_allocations_leagueId_status_idx" ON "gear_allocations"("leagueId", "status");
+CREATE UNIQUE INDEX "gear_allocations_leagueId_id_key" ON "gear_allocations"("leagueId", "id");
 CREATE INDEX "gear_allocations_reservationLineId_idx" ON "gear_allocations"("reservationLineId");
 CREATE INDEX "gear_allocations_poolStockId_idx" ON "gear_allocations"("poolStockId");
 CREATE INDEX "gear_allocations_gearUnitId_idx" ON "gear_allocations"("gearUnitId");
-CREATE UNIQUE INDEX "gear_allocations_active_tagged_unit_key" ON "gear_allocations"("gearUnitId")
-  WHERE "gearUnitId" IS NOT NULL AND "status" IN ('ALLOCATED', 'PICKED_UP', 'PARTIALLY_RETURNED');
+ALTER TABLE "gear_allocations" ADD CONSTRAINT "gear_allocations_tagged_unit_active_window_excl"
+  EXCLUDE USING gist (
+    "gearUnitId" WITH =,
+    daterange("effectiveStartDate", "effectiveEndDate", '[]') WITH &&
+  )
+  WHERE ("gearUnitId" IS NOT NULL AND "status" IN ('PENDING', 'ALLOCATED', 'PICKED_UP', 'PARTIALLY_RETURNED'));
 CREATE INDEX "gear_handoffs_leagueId_occurredAt_idx" ON "gear_handoffs"("leagueId", "occurredAt");
+CREATE UNIQUE INDEX "gear_handoffs_leagueId_id_key" ON "gear_handoffs"("leagueId", "id");
 CREATE INDEX "gear_handoffs_reservationId_idx" ON "gear_handoffs"("reservationId");
 CREATE INDEX "gear_handoffs_allocationId_idx" ON "gear_handoffs"("allocationId");
 CREATE UNIQUE INDEX "gear_wishlists_leagueId_key" ON "gear_wishlists"("leagueId");
+CREATE UNIQUE INDEX "gear_wishlists_leagueId_id_key" ON "gear_wishlists"("leagueId", "id");
 CREATE UNIQUE INDEX "gear_wishlists_shareToken_key" ON "gear_wishlists"("shareToken");
 CREATE INDEX "gear_wishlists_status_idx" ON "gear_wishlists"("status");
 CREATE INDEX "gear_wishlist_items_wishlistId_isActive_idx" ON "gear_wishlist_items"("wishlistId", "isActive");
+CREATE UNIQUE INDEX "gear_wishlist_items_leagueId_id_key" ON "gear_wishlist_items"("leagueId", "id");
 CREATE INDEX "gear_wishlist_items_catalogItemId_idx" ON "gear_wishlist_items"("catalogItemId");
 CREATE UNIQUE INDEX "gear_pledges_leagueId_idempotencyKey_key" ON "gear_pledges"("leagueId", "idempotencyKey");
+CREATE UNIQUE INDEX "gear_pledges_leagueId_id_key" ON "gear_pledges"("leagueId", "id");
 CREATE INDEX "gear_pledges_wishlistItemId_status_idx" ON "gear_pledges"("wishlistItemId", "status");
 CREATE INDEX "gear_pledge_receipts_leagueId_receivedAt_idx" ON "gear_pledge_receipts"("leagueId", "receivedAt");
+CREATE UNIQUE INDEX "gear_pledge_receipts_leagueId_id_key" ON "gear_pledge_receipts"("leagueId", "id");
 CREATE INDEX "gear_pledge_receipts_pledgeId_idx" ON "gear_pledge_receipts"("pledgeId");
 CREATE INDEX "gear_activity_leagueId_entityType_entityId_occurredAt_idx" ON "gear_activity"("leagueId", "entityType", "entityId", "occurredAt");
+CREATE UNIQUE INDEX "gear_activity_leagueId_id_key" ON "gear_activity"("leagueId", "id");
 CREATE INDEX "gear_inventory_movements_leagueId_occurredAt_idx" ON "gear_inventory_movements"("leagueId", "occurredAt");
+CREATE UNIQUE INDEX "gear_inventory_movements_leagueId_id_key" ON "gear_inventory_movements"("leagueId", "id");
 CREATE INDEX "gear_inventory_movements_poolStockId_idx" ON "gear_inventory_movements"("poolStockId");
 CREATE INDEX "gear_inventory_movements_gearUnitId_idx" ON "gear_inventory_movements"("gearUnitId");
 CREATE INDEX "gear_inventory_movements_allocationId_idx" ON "gear_inventory_movements"("allocationId");
 CREATE UNIQUE INDEX "notification_outbox_leagueId_dedupeKey_key" ON "notification_outbox"("leagueId", "dedupeKey");
+CREATE UNIQUE INDEX "notification_outbox_leagueId_id_key" ON "notification_outbox"("leagueId", "id");
 CREATE INDEX "notification_outbox_status_scheduledAt_idx" ON "notification_outbox"("status", "scheduledAt");
 CREATE INDEX "notification_outbox_leagueId_aggregateType_aggregateId_idx" ON "notification_outbox"("leagueId", "aggregateType", "aggregateId");
 
 ALTER TABLE "gear_catalog_items" ADD CONSTRAINT "gear_catalog_items_leagueId_fkey" FOREIGN KEY ("leagueId") REFERENCES "leagues"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
 ALTER TABLE "gear_storage_locations" ADD CONSTRAINT "gear_storage_locations_leagueId_fkey" FOREIGN KEY ("leagueId") REFERENCES "leagues"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
 ALTER TABLE "gear_pool_stocks" ADD CONSTRAINT "gear_pool_stocks_leagueId_fkey" FOREIGN KEY ("leagueId") REFERENCES "leagues"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-ALTER TABLE "gear_pool_stocks" ADD CONSTRAINT "gear_pool_stocks_catalogItemId_fkey" FOREIGN KEY ("catalogItemId") REFERENCES "gear_catalog_items"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-ALTER TABLE "gear_pool_stocks" ADD CONSTRAINT "gear_pool_stocks_locationId_fkey" FOREIGN KEY ("locationId") REFERENCES "gear_storage_locations"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "gear_pool_stocks" ADD CONSTRAINT "gear_pool_stocks_catalogItemId_fkey" FOREIGN KEY ("leagueId", "catalogItemId") REFERENCES "gear_catalog_items"("leagueId", "id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "gear_pool_stocks" ADD CONSTRAINT "gear_pool_stocks_locationId_fkey" FOREIGN KEY ("leagueId", "locationId") REFERENCES "gear_storage_locations"("leagueId", "id") ON DELETE RESTRICT ON UPDATE CASCADE;
 ALTER TABLE "gear_units" ADD CONSTRAINT "gear_units_leagueId_fkey" FOREIGN KEY ("leagueId") REFERENCES "leagues"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-ALTER TABLE "gear_units" ADD CONSTRAINT "gear_units_catalogItemId_fkey" FOREIGN KEY ("catalogItemId") REFERENCES "gear_catalog_items"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-ALTER TABLE "gear_units" ADD CONSTRAINT "gear_units_currentLocationId_fkey" FOREIGN KEY ("currentLocationId") REFERENCES "gear_storage_locations"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "gear_units" ADD CONSTRAINT "gear_units_catalogItemId_fkey" FOREIGN KEY ("leagueId", "catalogItemId") REFERENCES "gear_catalog_items"("leagueId", "id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "gear_units" ADD CONSTRAINT "gear_units_currentLocationId_fkey" FOREIGN KEY ("leagueId", "currentLocationId") REFERENCES "gear_storage_locations"("leagueId", "id") ON DELETE RESTRICT ON UPDATE CASCADE;
 ALTER TABLE "team_gear_needs" ADD CONSTRAINT "team_gear_needs_leagueId_fkey" FOREIGN KEY ("leagueId") REFERENCES "leagues"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-ALTER TABLE "team_gear_needs" ADD CONSTRAINT "team_gear_needs_teamId_fkey" FOREIGN KEY ("teamId") REFERENCES "Team"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "team_gear_needs" ADD CONSTRAINT "team_gear_needs_teamId_fkey" FOREIGN KEY ("leagueId", "teamId") REFERENCES "Team"("leagueId", "id") ON DELETE RESTRICT ON UPDATE CASCADE;
 ALTER TABLE "team_gear_needs" ADD CONSTRAINT "team_gear_needs_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
-ALTER TABLE "team_gear_need_lines" ADD CONSTRAINT "team_gear_need_lines_needId_fkey" FOREIGN KEY ("needId") REFERENCES "team_gear_needs"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-ALTER TABLE "team_gear_need_lines" ADD CONSTRAINT "team_gear_need_lines_catalogItemId_fkey" FOREIGN KEY ("catalogItemId") REFERENCES "gear_catalog_items"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "team_gear_need_lines" ADD CONSTRAINT "team_gear_need_lines_needId_fkey" FOREIGN KEY ("leagueId", "needId") REFERENCES "team_gear_needs"("leagueId", "id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "team_gear_need_lines" ADD CONSTRAINT "team_gear_need_lines_catalogItemId_fkey" FOREIGN KEY ("leagueId", "catalogItemId") REFERENCES "gear_catalog_items"("leagueId", "id") ON DELETE RESTRICT ON UPDATE CASCADE;
 ALTER TABLE "gear_reservations" ADD CONSTRAINT "gear_reservations_leagueId_fkey" FOREIGN KEY ("leagueId") REFERENCES "leagues"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-ALTER TABLE "gear_reservations" ADD CONSTRAINT "gear_reservations_teamId_fkey" FOREIGN KEY ("teamId") REFERENCES "Team"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "gear_reservations" ADD CONSTRAINT "gear_reservations_teamId_fkey" FOREIGN KEY ("leagueId", "teamId") REFERENCES "Team"("leagueId", "id") ON DELETE RESTRICT ON UPDATE CASCADE;
 ALTER TABLE "gear_reservations" ADD CONSTRAINT "gear_reservations_requestedById_fkey" FOREIGN KEY ("requestedById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
 ALTER TABLE "gear_reservations" ADD CONSTRAINT "gear_reservations_decidedById_fkey" FOREIGN KEY ("decidedById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
-ALTER TABLE "gear_reservation_lines" ADD CONSTRAINT "gear_reservation_lines_reservationId_fkey" FOREIGN KEY ("reservationId") REFERENCES "gear_reservations"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-ALTER TABLE "gear_reservation_lines" ADD CONSTRAINT "gear_reservation_lines_catalogItemId_fkey" FOREIGN KEY ("catalogItemId") REFERENCES "gear_catalog_items"("id") ON DELETE SET NULL ON UPDATE CASCADE;
-ALTER TABLE "gear_reservation_lines" ADD CONSTRAINT "gear_reservation_lines_needLineId_fkey" FOREIGN KEY ("needLineId") REFERENCES "team_gear_need_lines"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "gear_reservation_lines" ADD CONSTRAINT "gear_reservation_lines_reservationId_fkey" FOREIGN KEY ("leagueId", "reservationId") REFERENCES "gear_reservations"("leagueId", "id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "gear_reservation_lines" ADD CONSTRAINT "gear_reservation_lines_catalogItemId_fkey" FOREIGN KEY ("leagueId", "catalogItemId") REFERENCES "gear_catalog_items"("leagueId", "id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "gear_reservation_lines" ADD CONSTRAINT "gear_reservation_lines_needLineId_fkey" FOREIGN KEY ("leagueId", "needLineId") REFERENCES "team_gear_need_lines"("leagueId", "id") ON DELETE RESTRICT ON UPDATE CASCADE;
 ALTER TABLE "gear_allocations" ADD CONSTRAINT "gear_allocations_leagueId_fkey" FOREIGN KEY ("leagueId") REFERENCES "leagues"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-ALTER TABLE "gear_allocations" ADD CONSTRAINT "gear_allocations_reservationLineId_fkey" FOREIGN KEY ("reservationLineId") REFERENCES "gear_reservation_lines"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-ALTER TABLE "gear_allocations" ADD CONSTRAINT "gear_allocations_poolStockId_fkey" FOREIGN KEY ("poolStockId") REFERENCES "gear_pool_stocks"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-ALTER TABLE "gear_allocations" ADD CONSTRAINT "gear_allocations_gearUnitId_fkey" FOREIGN KEY ("gearUnitId") REFERENCES "gear_units"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "gear_allocations" ADD CONSTRAINT "gear_allocations_reservationLineId_fkey" FOREIGN KEY ("leagueId", "reservationLineId") REFERENCES "gear_reservation_lines"("leagueId", "id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "gear_allocations" ADD CONSTRAINT "gear_allocations_poolStockId_fkey" FOREIGN KEY ("leagueId", "poolStockId") REFERENCES "gear_pool_stocks"("leagueId", "id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "gear_allocations" ADD CONSTRAINT "gear_allocations_gearUnitId_fkey" FOREIGN KEY ("leagueId", "gearUnitId") REFERENCES "gear_units"("leagueId", "id") ON DELETE RESTRICT ON UPDATE CASCADE;
 ALTER TABLE "gear_allocations" ADD CONSTRAINT "gear_allocations_allocatedById_fkey" FOREIGN KEY ("allocatedById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
 ALTER TABLE "gear_handoffs" ADD CONSTRAINT "gear_handoffs_leagueId_fkey" FOREIGN KEY ("leagueId") REFERENCES "leagues"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-ALTER TABLE "gear_handoffs" ADD CONSTRAINT "gear_handoffs_reservationId_fkey" FOREIGN KEY ("reservationId") REFERENCES "gear_reservations"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-ALTER TABLE "gear_handoffs" ADD CONSTRAINT "gear_handoffs_allocationId_fkey" FOREIGN KEY ("allocationId") REFERENCES "gear_allocations"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "gear_handoffs" ADD CONSTRAINT "gear_handoffs_reservationId_fkey" FOREIGN KEY ("leagueId", "reservationId") REFERENCES "gear_reservations"("leagueId", "id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "gear_handoffs" ADD CONSTRAINT "gear_handoffs_allocationId_fkey" FOREIGN KEY ("leagueId", "allocationId") REFERENCES "gear_allocations"("leagueId", "id") ON DELETE RESTRICT ON UPDATE CASCADE;
 ALTER TABLE "gear_handoffs" ADD CONSTRAINT "gear_handoffs_handledById_fkey" FOREIGN KEY ("handledById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
 ALTER TABLE "gear_wishlists" ADD CONSTRAINT "gear_wishlists_leagueId_fkey" FOREIGN KEY ("leagueId") REFERENCES "leagues"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-ALTER TABLE "gear_wishlist_items" ADD CONSTRAINT "gear_wishlist_items_wishlistId_fkey" FOREIGN KEY ("wishlistId") REFERENCES "gear_wishlists"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-ALTER TABLE "gear_wishlist_items" ADD CONSTRAINT "gear_wishlist_items_catalogItemId_fkey" FOREIGN KEY ("catalogItemId") REFERENCES "gear_catalog_items"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "gear_wishlist_items" ADD CONSTRAINT "gear_wishlist_items_wishlistId_fkey" FOREIGN KEY ("leagueId", "wishlistId") REFERENCES "gear_wishlists"("leagueId", "id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "gear_wishlist_items" ADD CONSTRAINT "gear_wishlist_items_catalogItemId_fkey" FOREIGN KEY ("leagueId", "catalogItemId") REFERENCES "gear_catalog_items"("leagueId", "id") ON DELETE RESTRICT ON UPDATE CASCADE;
 ALTER TABLE "gear_pledges" ADD CONSTRAINT "gear_pledges_leagueId_fkey" FOREIGN KEY ("leagueId") REFERENCES "leagues"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-ALTER TABLE "gear_pledges" ADD CONSTRAINT "gear_pledges_wishlistItemId_fkey" FOREIGN KEY ("wishlistItemId") REFERENCES "gear_wishlist_items"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "gear_pledges" ADD CONSTRAINT "gear_pledges_wishlistItemId_fkey" FOREIGN KEY ("leagueId", "wishlistItemId") REFERENCES "gear_wishlist_items"("leagueId", "id") ON DELETE RESTRICT ON UPDATE CASCADE;
 ALTER TABLE "gear_pledge_receipts" ADD CONSTRAINT "gear_pledge_receipts_leagueId_fkey" FOREIGN KEY ("leagueId") REFERENCES "leagues"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-ALTER TABLE "gear_pledge_receipts" ADD CONSTRAINT "gear_pledge_receipts_pledgeId_fkey" FOREIGN KEY ("pledgeId") REFERENCES "gear_pledges"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-ALTER TABLE "gear_pledge_receipts" ADD CONSTRAINT "gear_pledge_receipts_catalogItemId_fkey" FOREIGN KEY ("catalogItemId") REFERENCES "gear_catalog_items"("id") ON DELETE SET NULL ON UPDATE CASCADE;
-ALTER TABLE "gear_pledge_receipts" ADD CONSTRAINT "gear_pledge_receipts_poolStockId_fkey" FOREIGN KEY ("poolStockId") REFERENCES "gear_pool_stocks"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-ALTER TABLE "gear_pledge_receipts" ADD CONSTRAINT "gear_pledge_receipts_gearUnitId_fkey" FOREIGN KEY ("gearUnitId") REFERENCES "gear_units"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "gear_pledge_receipts" ADD CONSTRAINT "gear_pledge_receipts_pledgeId_fkey" FOREIGN KEY ("leagueId", "pledgeId") REFERENCES "gear_pledges"("leagueId", "id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "gear_pledge_receipts" ADD CONSTRAINT "gear_pledge_receipts_catalogItemId_fkey" FOREIGN KEY ("leagueId", "catalogItemId") REFERENCES "gear_catalog_items"("leagueId", "id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "gear_pledge_receipts" ADD CONSTRAINT "gear_pledge_receipts_poolStockId_fkey" FOREIGN KEY ("leagueId", "poolStockId") REFERENCES "gear_pool_stocks"("leagueId", "id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "gear_pledge_receipts" ADD CONSTRAINT "gear_pledge_receipts_gearUnitId_fkey" FOREIGN KEY ("leagueId", "gearUnitId") REFERENCES "gear_units"("leagueId", "id") ON DELETE RESTRICT ON UPDATE CASCADE;
 ALTER TABLE "gear_activity" ADD CONSTRAINT "gear_activity_leagueId_fkey" FOREIGN KEY ("leagueId") REFERENCES "leagues"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
 ALTER TABLE "gear_activity" ADD CONSTRAINT "gear_activity_actorUserId_fkey" FOREIGN KEY ("actorUserId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
 ALTER TABLE "gear_inventory_movements" ADD CONSTRAINT "gear_inventory_movements_leagueId_fkey" FOREIGN KEY ("leagueId") REFERENCES "leagues"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-ALTER TABLE "gear_inventory_movements" ADD CONSTRAINT "gear_inventory_movements_poolStockId_fkey" FOREIGN KEY ("poolStockId") REFERENCES "gear_pool_stocks"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-ALTER TABLE "gear_inventory_movements" ADD CONSTRAINT "gear_inventory_movements_gearUnitId_fkey" FOREIGN KEY ("gearUnitId") REFERENCES "gear_units"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-ALTER TABLE "gear_inventory_movements" ADD CONSTRAINT "gear_inventory_movements_allocationId_fkey" FOREIGN KEY ("allocationId") REFERENCES "gear_allocations"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-ALTER TABLE "gear_inventory_movements" ADD CONSTRAINT "gear_inventory_movements_handoffId_fkey" FOREIGN KEY ("handoffId") REFERENCES "gear_handoffs"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-ALTER TABLE "gear_inventory_movements" ADD CONSTRAINT "gear_inventory_movements_pledgeReceiptId_fkey" FOREIGN KEY ("pledgeReceiptId") REFERENCES "gear_pledge_receipts"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-ALTER TABLE "gear_inventory_movements" ADD CONSTRAINT "gear_inventory_movements_beforeLocationId_fkey" FOREIGN KEY ("beforeLocationId") REFERENCES "gear_storage_locations"("id") ON DELETE SET NULL ON UPDATE CASCADE;
-ALTER TABLE "gear_inventory_movements" ADD CONSTRAINT "gear_inventory_movements_afterLocationId_fkey" FOREIGN KEY ("afterLocationId") REFERENCES "gear_storage_locations"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "gear_inventory_movements" ADD CONSTRAINT "gear_inventory_movements_poolStockId_fkey" FOREIGN KEY ("leagueId", "poolStockId") REFERENCES "gear_pool_stocks"("leagueId", "id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "gear_inventory_movements" ADD CONSTRAINT "gear_inventory_movements_gearUnitId_fkey" FOREIGN KEY ("leagueId", "gearUnitId") REFERENCES "gear_units"("leagueId", "id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "gear_inventory_movements" ADD CONSTRAINT "gear_inventory_movements_allocationId_fkey" FOREIGN KEY ("leagueId", "allocationId") REFERENCES "gear_allocations"("leagueId", "id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "gear_inventory_movements" ADD CONSTRAINT "gear_inventory_movements_handoffId_fkey" FOREIGN KEY ("leagueId", "handoffId") REFERENCES "gear_handoffs"("leagueId", "id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "gear_inventory_movements" ADD CONSTRAINT "gear_inventory_movements_pledgeReceiptId_fkey" FOREIGN KEY ("leagueId", "pledgeReceiptId") REFERENCES "gear_pledge_receipts"("leagueId", "id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "gear_inventory_movements" ADD CONSTRAINT "gear_inventory_movements_beforeLocationId_fkey" FOREIGN KEY ("leagueId", "beforeLocationId") REFERENCES "gear_storage_locations"("leagueId", "id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "gear_inventory_movements" ADD CONSTRAINT "gear_inventory_movements_afterLocationId_fkey" FOREIGN KEY ("leagueId", "afterLocationId") REFERENCES "gear_storage_locations"("leagueId", "id") ON DELETE RESTRICT ON UPDATE CASCADE;
 ALTER TABLE "gear_inventory_movements" ADD CONSTRAINT "gear_inventory_movements_recordedById_fkey" FOREIGN KEY ("recordedById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
 ALTER TABLE "notification_outbox" ADD CONSTRAINT "notification_outbox_leagueId_fkey" FOREIGN KEY ("leagueId") REFERENCES "leagues"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-ALTER TABLE "notification_outbox" ADD CONSTRAINT "notification_outbox_recipientUserId_fkey" FOREIGN KEY ("recipientUserId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "notification_outbox" ADD CONSTRAINT "notification_outbox_recipientUserId_fkey" FOREIGN KEY ("recipientUserId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/migrations/20260816180000_gear_domain_foundation/migration.sql
+++ b/prisma/migrations/20260816180000_gear_domain_foundation/migration.sql
@@ -1,0 +1,460 @@
+-- League-owned gear projections, immutable operational ledger, and notification
+-- outbox. Application mutations use Prisma transactions; the constraints here
+-- protect invariants that PostgreSQL can enforce locally.
+
+CREATE TYPE "GearTrackingMode" AS ENUM ('POOLED', 'INDIVIDUAL');
+CREATE TYPE "GearCondition" AS ENUM ('NEW', 'EXCELLENT', 'GOOD', 'FAIR', 'POOR', 'DAMAGED');
+CREATE TYPE "GearUnitStatus" AS ENUM ('AVAILABLE', 'RESERVED', 'CHECKED_OUT', 'MAINTENANCE', 'RETIRED', 'LOST');
+CREATE TYPE "GearNeedPriority" AS ENUM ('LOW', 'NORMAL', 'HIGH', 'URGENT');
+CREATE TYPE "GearNeedStatus" AS ENUM ('DRAFT', 'SUBMITTED', 'APPROVED', 'FULFILLED', 'CANCELED');
+CREATE TYPE "GearNeedLineStatus" AS ENUM ('OPEN', 'PARTIALLY_FULFILLED', 'FULFILLED', 'CANCELED');
+CREATE TYPE "GearReservationStatus" AS ENUM ('DRAFT', 'REQUESTED', 'APPROVED', 'DECLINED', 'CANCELED', 'FULFILLED', 'CLOSED');
+CREATE TYPE "GearAllocationStatus" AS ENUM ('PENDING', 'ALLOCATED', 'PICKED_UP', 'PARTIALLY_RETURNED', 'RETURNED', 'RELEASED');
+CREATE TYPE "GearHandoffType" AS ENUM ('PICKUP', 'RETURN', 'TRANSFER', 'RECEIPT', 'ADJUSTMENT');
+CREATE TYPE "GearReturnDisposition" AS ENUM ('GOOD', 'DAMAGED', 'LOST', 'CONSUMED');
+CREATE TYPE "GearInventoryMovementType" AS ENUM ('RECEIPT', 'ALLOCATION', 'RELEASE', 'RETURN', 'TRANSFER', 'ADJUSTMENT', 'WRITE_OFF');
+CREATE TYPE "GearWishlistStatus" AS ENUM ('DRAFT', 'PUBLISHED', 'ARCHIVED');
+CREATE TYPE "GearPledgeStatus" AS ENUM ('PLEDGED', 'RECEIVED', 'DECLINED', 'CANCELED', 'EXPIRED');
+CREATE TYPE "GearActivityEntityType" AS ENUM ('CATALOG_ITEM', 'STORAGE_LOCATION', 'POOL_STOCK', 'UNIT', 'NEED', 'RESERVATION', 'ALLOCATION', 'HANDOFF', 'MOVEMENT', 'WISHLIST', 'PLEDGE');
+CREATE TYPE "GearActivityActorKind" AS ENUM ('USER', 'SYSTEM', 'PUBLIC_DONOR');
+CREATE TYPE "NotificationOutboxStatus" AS ENUM ('PENDING', 'PROCESSING', 'SENT', 'FAILED', 'CANCELED');
+
+CREATE TABLE "gear_catalog_items" (
+  "id" TEXT NOT NULL,
+  "leagueId" TEXT NOT NULL,
+  "normalizedKey" TEXT NOT NULL,
+  "name" TEXT NOT NULL,
+  "category" TEXT NOT NULL,
+  "size" TEXT,
+  "brand" TEXT,
+  "model" TEXT,
+  "description" TEXT,
+  "attributes" JSONB,
+  "trackingMode" "GearTrackingMode" NOT NULL DEFAULT 'POOLED',
+  "isActive" BOOLEAN NOT NULL DEFAULT true,
+  "archivedAt" TIMESTAMP(3),
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "gear_catalog_items_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "gear_storage_locations" (
+  "id" TEXT NOT NULL,
+  "leagueId" TEXT NOT NULL,
+  "normalizedName" TEXT NOT NULL,
+  "name" TEXT NOT NULL,
+  "address" TEXT,
+  "privateNotes" TEXT,
+  "isActive" BOOLEAN NOT NULL DEFAULT true,
+  "archivedAt" TIMESTAMP(3),
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "gear_storage_locations_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "gear_pool_stocks" (
+  "id" TEXT NOT NULL,
+  "leagueId" TEXT NOT NULL,
+  "catalogItemId" TEXT NOT NULL,
+  "locationId" TEXT NOT NULL,
+  "condition" "GearCondition" NOT NULL DEFAULT 'GOOD',
+  "quantityOnHand" INTEGER NOT NULL DEFAULT 0,
+  "version" INTEGER NOT NULL DEFAULT 0,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "gear_pool_stocks_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "gear_pool_stocks_quantity_nonnegative" CHECK ("quantityOnHand" >= 0),
+  CONSTRAINT "gear_pool_stocks_version_nonnegative" CHECK ("version" >= 0)
+);
+
+CREATE TABLE "gear_units" (
+  "id" TEXT NOT NULL,
+  "leagueId" TEXT NOT NULL,
+  "catalogItemId" TEXT NOT NULL,
+  "currentLocationId" TEXT,
+  "assetTag" TEXT,
+  "serialNumber" TEXT,
+  "status" "GearUnitStatus" NOT NULL DEFAULT 'AVAILABLE',
+  "currentCondition" "GearCondition" NOT NULL DEFAULT 'GOOD',
+  "acquiredAt" DATE,
+  "retiredAt" DATE,
+  "notes" TEXT,
+  "version" INTEGER NOT NULL DEFAULT 0,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "gear_units_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "gear_units_version_nonnegative" CHECK ("version" >= 0)
+);
+
+CREATE TABLE "team_gear_needs" (
+  "id" TEXT NOT NULL,
+  "leagueId" TEXT NOT NULL,
+  "teamId" TEXT NOT NULL,
+  "title" TEXT NOT NULL,
+  "status" "GearNeedStatus" NOT NULL DEFAULT 'DRAFT',
+  "notes" TEXT,
+  "version" INTEGER NOT NULL DEFAULT 0,
+  "submittedAt" TIMESTAMP(3),
+  "approvedAt" TIMESTAMP(3),
+  "fulfilledAt" TIMESTAMP(3),
+  "canceledAt" TIMESTAMP(3),
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  "createdById" TEXT,
+  CONSTRAINT "team_gear_needs_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "team_gear_needs_version_nonnegative" CHECK ("version" >= 0)
+);
+
+CREATE TABLE "team_gear_need_lines" (
+  "id" TEXT NOT NULL,
+  "needId" TEXT NOT NULL,
+  "catalogItemId" TEXT,
+  "nameSnapshot" TEXT NOT NULL,
+  "categorySnapshot" TEXT,
+  "sizeSnapshot" TEXT,
+  "trackingMode" "GearTrackingMode",
+  "requestedQty" INTEGER NOT NULL,
+  "fulfilledQty" INTEGER NOT NULL DEFAULT 0,
+  "canceledQty" INTEGER NOT NULL DEFAULT 0,
+  "priority" "GearNeedPriority" NOT NULL DEFAULT 'NORMAL',
+  "status" "GearNeedLineStatus" NOT NULL DEFAULT 'OPEN',
+  "notes" TEXT,
+  "version" INTEGER NOT NULL DEFAULT 0,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "team_gear_need_lines_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "team_gear_need_lines_quantities_valid" CHECK (
+    "requestedQty" > 0 AND "fulfilledQty" >= 0 AND "canceledQty" >= 0
+    AND "fulfilledQty" + "canceledQty" <= "requestedQty"
+  ),
+  CONSTRAINT "team_gear_need_lines_version_nonnegative" CHECK ("version" >= 0)
+);
+
+CREATE TABLE "gear_reservations" (
+  "id" TEXT NOT NULL,
+  "leagueId" TEXT NOT NULL,
+  "teamId" TEXT NOT NULL,
+  "status" "GearReservationStatus" NOT NULL DEFAULT 'DRAFT',
+  "requestedStartDate" DATE NOT NULL,
+  "requestedEndDate" DATE NOT NULL,
+  "approvedStartDate" DATE,
+  "approvedEndDate" DATE,
+  "custodianNameSnapshot" TEXT NOT NULL,
+  "custodianEmailSnapshot" TEXT,
+  "custodianPhoneSnapshot" TEXT,
+  "requestNotes" TEXT,
+  "decisionNotes" TEXT,
+  "version" INTEGER NOT NULL DEFAULT 0,
+  "requestedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "decidedAt" TIMESTAMP(3),
+  "custodyStartedAt" TIMESTAMP(3),
+  "custodyEndedAt" TIMESTAMP(3),
+  "canceledAt" TIMESTAMP(3),
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  "requestedById" TEXT,
+  "decidedById" TEXT,
+  CONSTRAINT "gear_reservations_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "gear_reservations_requested_dates_valid" CHECK ("requestedEndDate" >= "requestedStartDate"),
+  CONSTRAINT "gear_reservations_approved_dates_valid" CHECK (
+    "approvedStartDate" IS NULL OR "approvedEndDate" IS NULL OR "approvedEndDate" >= "approvedStartDate"
+  ),
+  CONSTRAINT "gear_reservations_version_nonnegative" CHECK ("version" >= 0)
+);
+
+CREATE TABLE "gear_reservation_lines" (
+  "id" TEXT NOT NULL,
+  "reservationId" TEXT NOT NULL,
+  "catalogItemId" TEXT,
+  "needLineId" TEXT,
+  "nameSnapshot" TEXT NOT NULL,
+  "requestedQty" INTEGER NOT NULL,
+  "approvedQty" INTEGER NOT NULL DEFAULT 0,
+  "allocatedQty" INTEGER NOT NULL DEFAULT 0,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "gear_reservation_lines_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "gear_reservation_lines_quantities_valid" CHECK (
+    "requestedQty" > 0 AND "approvedQty" >= 0 AND "allocatedQty" >= 0
+    AND "allocatedQty" <= "approvedQty" AND "approvedQty" <= "requestedQty"
+  )
+);
+
+CREATE TABLE "gear_allocations" (
+  "id" TEXT NOT NULL,
+  "leagueId" TEXT NOT NULL,
+  "reservationLineId" TEXT NOT NULL,
+  "poolStockId" TEXT,
+  "gearUnitId" TEXT,
+  "status" "GearAllocationStatus" NOT NULL DEFAULT 'PENDING',
+  "allocatedQty" INTEGER NOT NULL DEFAULT 0,
+  "pickedUpQty" INTEGER NOT NULL DEFAULT 0,
+  "returnedQty" INTEGER NOT NULL DEFAULT 0,
+  "releasedQty" INTEGER NOT NULL DEFAULT 0,
+  "version" INTEGER NOT NULL DEFAULT 0,
+  "allocatedAt" TIMESTAMP(3),
+  "pickedUpAt" TIMESTAMP(3),
+  "returnedAt" TIMESTAMP(3),
+  "releasedAt" TIMESTAMP(3),
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  "allocatedById" TEXT,
+  CONSTRAINT "gear_allocations_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "gear_allocations_exactly_one_source" CHECK (("poolStockId" IS NOT NULL) <> ("gearUnitId" IS NOT NULL)),
+  CONSTRAINT "gear_allocations_quantities_valid" CHECK (
+    "allocatedQty" >= 0 AND "pickedUpQty" >= 0 AND "returnedQty" >= 0 AND "releasedQty" >= 0
+    AND "pickedUpQty" <= "allocatedQty"
+    AND "returnedQty" <= "pickedUpQty"
+    AND "releasedQty" <= "allocatedQty" - "pickedUpQty"
+  ),
+  CONSTRAINT "gear_allocations_tagged_unit_quantity" CHECK (
+    "gearUnitId" IS NULL OR ("allocatedQty" <= 1 AND "pickedUpQty" <= 1 AND "returnedQty" <= 1 AND "releasedQty" <= 1)
+  ),
+  CONSTRAINT "gear_allocations_version_nonnegative" CHECK ("version" >= 0)
+);
+
+CREATE TABLE "gear_handoffs" (
+  "id" TEXT NOT NULL,
+  "leagueId" TEXT NOT NULL,
+  "reservationId" TEXT,
+  "allocationId" TEXT,
+  "type" "GearHandoffType" NOT NULL,
+  "returnDisposition" "GearReturnDisposition",
+  "custodianNameSnapshot" TEXT,
+  "occurredAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "notes" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "handledById" TEXT,
+  CONSTRAINT "gear_handoffs_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "gear_wishlists" (
+  "id" TEXT NOT NULL,
+  "leagueId" TEXT NOT NULL,
+  "shareToken" TEXT NOT NULL,
+  "status" "GearWishlistStatus" NOT NULL DEFAULT 'DRAFT',
+  "title" TEXT NOT NULL,
+  "description" TEXT,
+  "version" INTEGER NOT NULL DEFAULT 0,
+  "publishedAt" TIMESTAMP(3),
+  "archivedAt" TIMESTAMP(3),
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "gear_wishlists_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "gear_wishlists_version_nonnegative" CHECK ("version" >= 0)
+);
+
+CREATE TABLE "gear_wishlist_items" (
+  "id" TEXT NOT NULL,
+  "wishlistId" TEXT NOT NULL,
+  "catalogItemId" TEXT,
+  "normalizedKey" TEXT NOT NULL,
+  "nameSnapshot" TEXT NOT NULL,
+  "categorySnapshot" TEXT,
+  "sizeSnapshot" TEXT,
+  "description" TEXT,
+  "targetQty" INTEGER NOT NULL,
+  "pledgedQty" INTEGER NOT NULL DEFAULT 0,
+  "receivedQty" INTEGER NOT NULL DEFAULT 0,
+  "isActive" BOOLEAN NOT NULL DEFAULT true,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "gear_wishlist_items_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "gear_wishlist_items_quantities_valid" CHECK (
+    "targetQty" > 0 AND "pledgedQty" >= 0 AND "receivedQty" >= 0
+  )
+);
+
+CREATE TABLE "gear_pledges" (
+  "id" TEXT NOT NULL,
+  "leagueId" TEXT NOT NULL,
+  "wishlistItemId" TEXT NOT NULL,
+  "donorName" TEXT NOT NULL,
+  "donorEmail" TEXT,
+  "donorPhone" TEXT,
+  "contactConsentAt" TIMESTAMP(3),
+  "status" "GearPledgeStatus" NOT NULL DEFAULT 'PLEDGED',
+  "quantity" INTEGER NOT NULL,
+  "note" TEXT,
+  "idempotencyKey" TEXT NOT NULL,
+  "expiresAt" TIMESTAMP(3),
+  "receivedAt" TIMESTAMP(3),
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "gear_pledges_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "gear_pledges_quantity_positive" CHECK ("quantity" > 0)
+);
+
+CREATE TABLE "gear_pledge_receipts" (
+  "id" TEXT NOT NULL,
+  "leagueId" TEXT NOT NULL,
+  "pledgeId" TEXT NOT NULL,
+  "catalogItemId" TEXT,
+  "poolStockId" TEXT,
+  "gearUnitId" TEXT,
+  "quantity" INTEGER NOT NULL,
+  "receivedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "notes" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "gear_pledge_receipts_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "gear_pledge_receipts_exactly_one_inventory_target" CHECK (("poolStockId" IS NOT NULL) <> ("gearUnitId" IS NOT NULL)),
+  CONSTRAINT "gear_pledge_receipts_quantity_positive" CHECK ("quantity" > 0)
+);
+
+CREATE TABLE "gear_activity" (
+  "id" TEXT NOT NULL,
+  "leagueId" TEXT NOT NULL,
+  "entityType" "GearActivityEntityType" NOT NULL,
+  "entityId" TEXT NOT NULL,
+  "action" TEXT NOT NULL,
+  "actorKind" "GearActivityActorKind" NOT NULL,
+  "details" JSONB,
+  "occurredAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "actorUserId" TEXT,
+  CONSTRAINT "gear_activity_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "gear_inventory_movements" (
+  "id" TEXT NOT NULL,
+  "leagueId" TEXT NOT NULL,
+  "type" "GearInventoryMovementType" NOT NULL,
+  "poolStockId" TEXT,
+  "gearUnitId" TEXT,
+  "allocationId" TEXT,
+  "handoffId" TEXT,
+  "pledgeReceiptId" TEXT,
+  "quantity" INTEGER NOT NULL,
+  "beforeLocationId" TEXT,
+  "afterLocationId" TEXT,
+  "beforeCondition" "GearCondition",
+  "afterCondition" "GearCondition",
+  "occurredAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "notes" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "recordedById" TEXT,
+  CONSTRAINT "gear_inventory_movements_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "gear_inventory_movements_exactly_one_inventory_target" CHECK (("poolStockId" IS NOT NULL) <> ("gearUnitId" IS NOT NULL)),
+  CONSTRAINT "gear_inventory_movements_quantity_positive" CHECK ("quantity" > 0)
+);
+
+CREATE TABLE "notification_outbox" (
+  "id" TEXT NOT NULL,
+  "leagueId" TEXT NOT NULL,
+  "recipientUserId" TEXT,
+  "recipientEmail" TEXT,
+  "eventType" TEXT NOT NULL,
+  "aggregateType" TEXT NOT NULL,
+  "aggregateId" TEXT NOT NULL,
+  "payload" JSONB NOT NULL,
+  "dedupeKey" TEXT NOT NULL,
+  "status" "NotificationOutboxStatus" NOT NULL DEFAULT 'PENDING',
+  "attempts" INTEGER NOT NULL DEFAULT 0,
+  "scheduledAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "lockedAt" TIMESTAMP(3),
+  "lastAttemptAt" TIMESTAMP(3),
+  "sentAt" TIMESTAMP(3),
+  "failedAt" TIMESTAMP(3),
+  "lastError" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "notification_outbox_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "notification_outbox_exactly_one_recipient" CHECK (("recipientUserId" IS NOT NULL) <> ("recipientEmail" IS NOT NULL)),
+  CONSTRAINT "notification_outbox_attempts_nonnegative" CHECK ("attempts" >= 0)
+);
+
+CREATE UNIQUE INDEX "gear_catalog_items_leagueId_normalizedKey_key" ON "gear_catalog_items"("leagueId", "normalizedKey");
+CREATE INDEX "gear_catalog_items_leagueId_isActive_idx" ON "gear_catalog_items"("leagueId", "isActive");
+CREATE UNIQUE INDEX "gear_storage_locations_leagueId_normalizedName_key" ON "gear_storage_locations"("leagueId", "normalizedName");
+CREATE INDEX "gear_storage_locations_leagueId_isActive_idx" ON "gear_storage_locations"("leagueId", "isActive");
+CREATE UNIQUE INDEX "gear_pool_stocks_leagueId_catalogItemId_locationId_condition_key" ON "gear_pool_stocks"("leagueId", "catalogItemId", "locationId", "condition");
+CREATE INDEX "gear_pool_stocks_leagueId_catalogItemId_idx" ON "gear_pool_stocks"("leagueId", "catalogItemId");
+CREATE INDEX "gear_pool_stocks_leagueId_locationId_idx" ON "gear_pool_stocks"("leagueId", "locationId");
+CREATE UNIQUE INDEX "gear_units_leagueId_assetTag_key" ON "gear_units"("leagueId", "assetTag");
+CREATE INDEX "gear_units_leagueId_catalogItemId_status_idx" ON "gear_units"("leagueId", "catalogItemId", "status");
+CREATE INDEX "gear_units_currentLocationId_idx" ON "gear_units"("currentLocationId");
+CREATE INDEX "team_gear_needs_leagueId_teamId_status_idx" ON "team_gear_needs"("leagueId", "teamId", "status");
+CREATE INDEX "team_gear_need_lines_needId_status_idx" ON "team_gear_need_lines"("needId", "status");
+CREATE INDEX "team_gear_need_lines_catalogItemId_idx" ON "team_gear_need_lines"("catalogItemId");
+CREATE INDEX "gear_reservations_leagueId_teamId_status_idx" ON "gear_reservations"("leagueId", "teamId", "status");
+CREATE INDEX "gear_reservations_leagueId_requestedStartDate_requestedEndDate_idx" ON "gear_reservations"("leagueId", "requestedStartDate", "requestedEndDate");
+CREATE INDEX "gear_reservation_lines_reservationId_idx" ON "gear_reservation_lines"("reservationId");
+CREATE INDEX "gear_reservation_lines_needLineId_idx" ON "gear_reservation_lines"("needLineId");
+CREATE INDEX "gear_allocations_leagueId_status_idx" ON "gear_allocations"("leagueId", "status");
+CREATE INDEX "gear_allocations_reservationLineId_idx" ON "gear_allocations"("reservationLineId");
+CREATE INDEX "gear_allocations_poolStockId_idx" ON "gear_allocations"("poolStockId");
+CREATE INDEX "gear_allocations_gearUnitId_idx" ON "gear_allocations"("gearUnitId");
+CREATE UNIQUE INDEX "gear_allocations_active_tagged_unit_key" ON "gear_allocations"("gearUnitId")
+  WHERE "gearUnitId" IS NOT NULL AND "status" IN ('ALLOCATED', 'PICKED_UP', 'PARTIALLY_RETURNED');
+CREATE INDEX "gear_handoffs_leagueId_occurredAt_idx" ON "gear_handoffs"("leagueId", "occurredAt");
+CREATE INDEX "gear_handoffs_reservationId_idx" ON "gear_handoffs"("reservationId");
+CREATE INDEX "gear_handoffs_allocationId_idx" ON "gear_handoffs"("allocationId");
+CREATE UNIQUE INDEX "gear_wishlists_leagueId_key" ON "gear_wishlists"("leagueId");
+CREATE UNIQUE INDEX "gear_wishlists_shareToken_key" ON "gear_wishlists"("shareToken");
+CREATE INDEX "gear_wishlists_status_idx" ON "gear_wishlists"("status");
+CREATE INDEX "gear_wishlist_items_wishlistId_isActive_idx" ON "gear_wishlist_items"("wishlistId", "isActive");
+CREATE INDEX "gear_wishlist_items_catalogItemId_idx" ON "gear_wishlist_items"("catalogItemId");
+CREATE UNIQUE INDEX "gear_pledges_leagueId_idempotencyKey_key" ON "gear_pledges"("leagueId", "idempotencyKey");
+CREATE INDEX "gear_pledges_wishlistItemId_status_idx" ON "gear_pledges"("wishlistItemId", "status");
+CREATE INDEX "gear_pledge_receipts_leagueId_receivedAt_idx" ON "gear_pledge_receipts"("leagueId", "receivedAt");
+CREATE INDEX "gear_pledge_receipts_pledgeId_idx" ON "gear_pledge_receipts"("pledgeId");
+CREATE INDEX "gear_activity_leagueId_entityType_entityId_occurredAt_idx" ON "gear_activity"("leagueId", "entityType", "entityId", "occurredAt");
+CREATE INDEX "gear_inventory_movements_leagueId_occurredAt_idx" ON "gear_inventory_movements"("leagueId", "occurredAt");
+CREATE INDEX "gear_inventory_movements_poolStockId_idx" ON "gear_inventory_movements"("poolStockId");
+CREATE INDEX "gear_inventory_movements_gearUnitId_idx" ON "gear_inventory_movements"("gearUnitId");
+CREATE INDEX "gear_inventory_movements_allocationId_idx" ON "gear_inventory_movements"("allocationId");
+CREATE UNIQUE INDEX "notification_outbox_leagueId_dedupeKey_key" ON "notification_outbox"("leagueId", "dedupeKey");
+CREATE INDEX "notification_outbox_status_scheduledAt_idx" ON "notification_outbox"("status", "scheduledAt");
+CREATE INDEX "notification_outbox_leagueId_aggregateType_aggregateId_idx" ON "notification_outbox"("leagueId", "aggregateType", "aggregateId");
+
+ALTER TABLE "gear_catalog_items" ADD CONSTRAINT "gear_catalog_items_leagueId_fkey" FOREIGN KEY ("leagueId") REFERENCES "leagues"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "gear_storage_locations" ADD CONSTRAINT "gear_storage_locations_leagueId_fkey" FOREIGN KEY ("leagueId") REFERENCES "leagues"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "gear_pool_stocks" ADD CONSTRAINT "gear_pool_stocks_leagueId_fkey" FOREIGN KEY ("leagueId") REFERENCES "leagues"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "gear_pool_stocks" ADD CONSTRAINT "gear_pool_stocks_catalogItemId_fkey" FOREIGN KEY ("catalogItemId") REFERENCES "gear_catalog_items"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "gear_pool_stocks" ADD CONSTRAINT "gear_pool_stocks_locationId_fkey" FOREIGN KEY ("locationId") REFERENCES "gear_storage_locations"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "gear_units" ADD CONSTRAINT "gear_units_leagueId_fkey" FOREIGN KEY ("leagueId") REFERENCES "leagues"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "gear_units" ADD CONSTRAINT "gear_units_catalogItemId_fkey" FOREIGN KEY ("catalogItemId") REFERENCES "gear_catalog_items"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "gear_units" ADD CONSTRAINT "gear_units_currentLocationId_fkey" FOREIGN KEY ("currentLocationId") REFERENCES "gear_storage_locations"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "team_gear_needs" ADD CONSTRAINT "team_gear_needs_leagueId_fkey" FOREIGN KEY ("leagueId") REFERENCES "leagues"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "team_gear_needs" ADD CONSTRAINT "team_gear_needs_teamId_fkey" FOREIGN KEY ("teamId") REFERENCES "Team"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "team_gear_needs" ADD CONSTRAINT "team_gear_needs_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "team_gear_need_lines" ADD CONSTRAINT "team_gear_need_lines_needId_fkey" FOREIGN KEY ("needId") REFERENCES "team_gear_needs"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "team_gear_need_lines" ADD CONSTRAINT "team_gear_need_lines_catalogItemId_fkey" FOREIGN KEY ("catalogItemId") REFERENCES "gear_catalog_items"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "gear_reservations" ADD CONSTRAINT "gear_reservations_leagueId_fkey" FOREIGN KEY ("leagueId") REFERENCES "leagues"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "gear_reservations" ADD CONSTRAINT "gear_reservations_teamId_fkey" FOREIGN KEY ("teamId") REFERENCES "Team"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "gear_reservations" ADD CONSTRAINT "gear_reservations_requestedById_fkey" FOREIGN KEY ("requestedById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "gear_reservations" ADD CONSTRAINT "gear_reservations_decidedById_fkey" FOREIGN KEY ("decidedById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "gear_reservation_lines" ADD CONSTRAINT "gear_reservation_lines_reservationId_fkey" FOREIGN KEY ("reservationId") REFERENCES "gear_reservations"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "gear_reservation_lines" ADD CONSTRAINT "gear_reservation_lines_catalogItemId_fkey" FOREIGN KEY ("catalogItemId") REFERENCES "gear_catalog_items"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "gear_reservation_lines" ADD CONSTRAINT "gear_reservation_lines_needLineId_fkey" FOREIGN KEY ("needLineId") REFERENCES "team_gear_need_lines"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "gear_allocations" ADD CONSTRAINT "gear_allocations_leagueId_fkey" FOREIGN KEY ("leagueId") REFERENCES "leagues"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "gear_allocations" ADD CONSTRAINT "gear_allocations_reservationLineId_fkey" FOREIGN KEY ("reservationLineId") REFERENCES "gear_reservation_lines"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "gear_allocations" ADD CONSTRAINT "gear_allocations_poolStockId_fkey" FOREIGN KEY ("poolStockId") REFERENCES "gear_pool_stocks"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "gear_allocations" ADD CONSTRAINT "gear_allocations_gearUnitId_fkey" FOREIGN KEY ("gearUnitId") REFERENCES "gear_units"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "gear_allocations" ADD CONSTRAINT "gear_allocations_allocatedById_fkey" FOREIGN KEY ("allocatedById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "gear_handoffs" ADD CONSTRAINT "gear_handoffs_leagueId_fkey" FOREIGN KEY ("leagueId") REFERENCES "leagues"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "gear_handoffs" ADD CONSTRAINT "gear_handoffs_reservationId_fkey" FOREIGN KEY ("reservationId") REFERENCES "gear_reservations"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "gear_handoffs" ADD CONSTRAINT "gear_handoffs_allocationId_fkey" FOREIGN KEY ("allocationId") REFERENCES "gear_allocations"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "gear_handoffs" ADD CONSTRAINT "gear_handoffs_handledById_fkey" FOREIGN KEY ("handledById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "gear_wishlists" ADD CONSTRAINT "gear_wishlists_leagueId_fkey" FOREIGN KEY ("leagueId") REFERENCES "leagues"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "gear_wishlist_items" ADD CONSTRAINT "gear_wishlist_items_wishlistId_fkey" FOREIGN KEY ("wishlistId") REFERENCES "gear_wishlists"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "gear_wishlist_items" ADD CONSTRAINT "gear_wishlist_items_catalogItemId_fkey" FOREIGN KEY ("catalogItemId") REFERENCES "gear_catalog_items"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "gear_pledges" ADD CONSTRAINT "gear_pledges_leagueId_fkey" FOREIGN KEY ("leagueId") REFERENCES "leagues"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "gear_pledges" ADD CONSTRAINT "gear_pledges_wishlistItemId_fkey" FOREIGN KEY ("wishlistItemId") REFERENCES "gear_wishlist_items"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "gear_pledge_receipts" ADD CONSTRAINT "gear_pledge_receipts_leagueId_fkey" FOREIGN KEY ("leagueId") REFERENCES "leagues"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "gear_pledge_receipts" ADD CONSTRAINT "gear_pledge_receipts_pledgeId_fkey" FOREIGN KEY ("pledgeId") REFERENCES "gear_pledges"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "gear_pledge_receipts" ADD CONSTRAINT "gear_pledge_receipts_catalogItemId_fkey" FOREIGN KEY ("catalogItemId") REFERENCES "gear_catalog_items"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "gear_pledge_receipts" ADD CONSTRAINT "gear_pledge_receipts_poolStockId_fkey" FOREIGN KEY ("poolStockId") REFERENCES "gear_pool_stocks"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "gear_pledge_receipts" ADD CONSTRAINT "gear_pledge_receipts_gearUnitId_fkey" FOREIGN KEY ("gearUnitId") REFERENCES "gear_units"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "gear_activity" ADD CONSTRAINT "gear_activity_leagueId_fkey" FOREIGN KEY ("leagueId") REFERENCES "leagues"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "gear_activity" ADD CONSTRAINT "gear_activity_actorUserId_fkey" FOREIGN KEY ("actorUserId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "gear_inventory_movements" ADD CONSTRAINT "gear_inventory_movements_leagueId_fkey" FOREIGN KEY ("leagueId") REFERENCES "leagues"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "gear_inventory_movements" ADD CONSTRAINT "gear_inventory_movements_poolStockId_fkey" FOREIGN KEY ("poolStockId") REFERENCES "gear_pool_stocks"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "gear_inventory_movements" ADD CONSTRAINT "gear_inventory_movements_gearUnitId_fkey" FOREIGN KEY ("gearUnitId") REFERENCES "gear_units"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "gear_inventory_movements" ADD CONSTRAINT "gear_inventory_movements_allocationId_fkey" FOREIGN KEY ("allocationId") REFERENCES "gear_allocations"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "gear_inventory_movements" ADD CONSTRAINT "gear_inventory_movements_handoffId_fkey" FOREIGN KEY ("handoffId") REFERENCES "gear_handoffs"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "gear_inventory_movements" ADD CONSTRAINT "gear_inventory_movements_pledgeReceiptId_fkey" FOREIGN KEY ("pledgeReceiptId") REFERENCES "gear_pledge_receipts"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "gear_inventory_movements" ADD CONSTRAINT "gear_inventory_movements_beforeLocationId_fkey" FOREIGN KEY ("beforeLocationId") REFERENCES "gear_storage_locations"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "gear_inventory_movements" ADD CONSTRAINT "gear_inventory_movements_afterLocationId_fkey" FOREIGN KEY ("afterLocationId") REFERENCES "gear_storage_locations"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "gear_inventory_movements" ADD CONSTRAINT "gear_inventory_movements_recordedById_fkey" FOREIGN KEY ("recordedById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "notification_outbox" ADD CONSTRAINT "notification_outbox_leagueId_fkey" FOREIGN KEY ("leagueId") REFERENCES "leagues"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "notification_outbox" ADD CONSTRAINT "notification_outbox_recipientUserId_fkey" FOREIGN KEY ("recipientUserId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -12,16 +12,16 @@ datasource db {
 
 // User model
 model User {
-  id            String    @id @default(cuid())
-  email         String    @unique
-  passwordHash  String
-  name          String?
-  approved      Boolean   @default(true) // Moderation kill-switch: false = suspended (signup gate is email verification)
-  emailVerified DateTime? // Set when the user proves inbox ownership (verification link, invite match, or password reset)
-  isPlatformAdmin Boolean @default(false) // Platform-wide admin (user approval/enumeration). NOT self-grantable; see lib/auth/session.ts isPlatformAdmin()
-  sessionVersion Int     @default(0) // Bumped on password reset/change + email change to evict existing JWT sessions; checked in the auth jwt callback
-  createdAt    DateTime @default(now())
-  updatedAt    DateTime @updatedAt
+  id              String    @id @default(cuid())
+  email           String    @unique
+  passwordHash    String
+  name            String?
+  approved        Boolean   @default(true) // Moderation kill-switch: false = suspended (signup gate is email verification)
+  emailVerified   DateTime? // Set when the user proves inbox ownership (verification link, invite match, or password reset)
+  isPlatformAdmin Boolean   @default(false) // Platform-wide admin (user approval/enumeration). NOT self-grantable; see lib/auth/session.ts isPlatformAdmin()
+  sessionVersion  Int       @default(0) // Bumped on password reset/change + email change to evict existing JWT sessions; checked in the auth jwt callback
+  createdAt       DateTime  @default(now())
+  updatedAt       DateTime  @updatedAt
 
   verificationTokens           VerificationToken[]
   teamMembers                  TeamMember[]
@@ -77,6 +77,14 @@ model User {
   uploadedEventMedia           EventMediaItem[]         @relation("EventMediaUploader")
   removedEventMedia            EventMediaItem[]         @relation("EventMediaRemover")
   grantedParentalConsents      ParentalConsent[]        @relation("ParentalConsentGrantor")
+  createdGearNeeds             TeamGearNeed[]           @relation("GearNeedCreator")
+  requestedGearReservations    GearReservation[]        @relation("GearReservationRequester")
+  decidedGearReservations      GearReservation[]        @relation("GearReservationDecider")
+  gearAllocations              GearAllocation[]         @relation("GearAllocationAllocator")
+  handledGearHandoffs          GearHandoff[]            @relation("GearHandoffHandler")
+  recordedGearMovements        GearInventoryMovement[]  @relation("GearMovementRecorder")
+  gearActivity                 GearActivity[]           @relation("GearActivityActor")
+  notificationOutbox           NotificationOutbox[]     @relation("NotificationOutboxRecipient")
 }
 
 // Single-use, hashed account-lifecycle tokens (email verification, password
@@ -200,6 +208,8 @@ model Team {
   iceTimeRequests    IceTimeRequest[]
   hostedSignupEvents SignupEvent[]
   signupPhases       EventRegistrationPhase[] @relation("PhaseTeams")
+  gearNeeds          TeamGearNeed[]
+  gearReservations   GearReservation[]
 
   @@index([leagueId]) // Optimize league-team queries
   @@index([divisionId]) // Optimize division-team queries
@@ -277,7 +287,7 @@ enum TeamOfficialStatus {
 // - A single person can exist as both a Player (roster entry) and have a User account (TeamMember)
 // - In MVP: Keep Player for roster display, use TeamMember.userId for RSVP and auth operations
 model Player {
-  id               String   @id @default(cuid())
+  id               String    @id @default(cuid())
   name             String
   email            String?
   phone            String?
@@ -285,11 +295,11 @@ model Player {
   emergencyPhone   String? // Admin-only field, not visible to regular members
   jerseyNumber     Int? // Optional jersey number (1–99). No unique constraint; duplicates trigger warning only.
   position         String? // Free-text position (e.g., Center, Goalie, Midfielder). Varies by sport.
-  usahMemberId     String?  @db.VarChar(20) // USA Hockey Member ID. Admin-only.
+  usahMemberId     String?   @db.VarChar(20) // USA Hockey Member ID. Admin-only.
   dateOfBirth      DateTime? @db.Date // Admin-only, like emergencyContact. COPPA: under-13 requires an active ParentalConsent row.
   userId           String? // Optional link to User account if player has registered
-  createdAt        DateTime @default(now())
-  updatedAt        DateTime @updatedAt
+  createdAt        DateTime  @default(now())
+  updatedAt        DateTime  @updatedAt
 
   teamId String
   team   Team   @relation(fields: [teamId], references: [id], onDelete: Cascade)
@@ -536,6 +546,20 @@ model League {
   iceTimeRequests         IceTimeRequest[]
   hostedSignupEvents      SignupEvent[]
   payments                Payment[]
+  gearCatalogItems        GearCatalogItem[]
+  gearStorageLocations    GearStorageLocation[]
+  gearPoolStocks          GearPoolStock[]
+  gearUnits               GearUnit[]
+  gearNeeds               TeamGearNeed[]
+  gearReservations        GearReservation[]
+  gearAllocations         GearAllocation[]
+  gearHandoffs            GearHandoff[]
+  gearInventoryMovements  GearInventoryMovement[]
+  gearWishlist            GearWishlist?
+  gearPledges             GearPledge[]
+  gearPledgeReceipts      GearPledgeReceipt[]
+  gearActivity            GearActivity[]
+  notificationOutbox      NotificationOutbox[]
 
   @@map("leagues")
 }
@@ -582,6 +606,597 @@ enum LeagueRole {
   LEAGUE_ADMIN // Full league control
   TEAM_ADMIN // Team management within league
   MEMBER // Basic member
+}
+
+enum GearTrackingMode {
+  POOLED
+  INDIVIDUAL
+}
+
+enum GearCondition {
+  NEW
+  EXCELLENT
+  GOOD
+  FAIR
+  POOR
+  DAMAGED
+}
+
+enum GearUnitStatus {
+  AVAILABLE
+  RESERVED
+  CHECKED_OUT
+  MAINTENANCE
+  RETIRED
+  LOST
+}
+
+enum GearNeedPriority {
+  LOW
+  NORMAL
+  HIGH
+  URGENT
+}
+
+enum GearNeedStatus {
+  DRAFT
+  SUBMITTED
+  APPROVED
+  FULFILLED
+  CANCELED
+}
+
+enum GearNeedLineStatus {
+  OPEN
+  PARTIALLY_FULFILLED
+  FULFILLED
+  CANCELED
+}
+
+enum GearReservationStatus {
+  DRAFT
+  REQUESTED
+  APPROVED
+  DECLINED
+  CANCELED
+  FULFILLED
+  CLOSED
+}
+
+enum GearAllocationStatus {
+  PENDING
+  ALLOCATED
+  PICKED_UP
+  PARTIALLY_RETURNED
+  RETURNED
+  RELEASED
+}
+
+enum GearHandoffType {
+  PICKUP
+  RETURN
+  TRANSFER
+  RECEIPT
+  ADJUSTMENT
+}
+
+enum GearReturnDisposition {
+  GOOD
+  DAMAGED
+  LOST
+  CONSUMED
+}
+
+enum GearInventoryMovementType {
+  RECEIPT
+  ALLOCATION
+  RELEASE
+  RETURN
+  TRANSFER
+  ADJUSTMENT
+  WRITE_OFF
+}
+
+enum GearWishlistStatus {
+  DRAFT
+  PUBLISHED
+  ARCHIVED
+}
+
+enum GearPledgeStatus {
+  PLEDGED
+  RECEIVED
+  DECLINED
+  CANCELED
+  EXPIRED
+}
+
+enum GearActivityEntityType {
+  CATALOG_ITEM
+  STORAGE_LOCATION
+  POOL_STOCK
+  UNIT
+  NEED
+  RESERVATION
+  ALLOCATION
+  HANDOFF
+  MOVEMENT
+  WISHLIST
+  PLEDGE
+}
+
+enum GearActivityActorKind {
+  USER
+  SYSTEM
+  PUBLIC_DONOR
+}
+
+enum NotificationOutboxStatus {
+  PENDING
+  PROCESSING
+  SENT
+  FAILED
+  CANCELED
+}
+
+// League-owned gear catalog and location projections. Tenant consistency across
+// related rows is enforced by future action transactions.
+model GearCatalogItem {
+  id            String           @id @default(cuid())
+  leagueId      String
+  normalizedKey String
+  name          String
+  category      String
+  size          String?
+  brand         String?
+  model         String?
+  description   String?
+  attributes    Json?
+  trackingMode  GearTrackingMode @default(POOLED)
+  isActive      Boolean          @default(true)
+  archivedAt    DateTime?
+  createdAt     DateTime         @default(now())
+  updatedAt     DateTime         @updatedAt
+
+  league           League                @relation(fields: [leagueId], references: [id], onDelete: Restrict)
+  poolStocks       GearPoolStock[]
+  units            GearUnit[]
+  needLines        TeamGearNeedLine[]
+  reservationLines GearReservationLine[]
+  wishlistItems    GearWishlistItem[]
+  pledgeReceipts   GearPledgeReceipt[]
+
+  @@unique([leagueId, normalizedKey])
+  @@index([leagueId, isActive])
+  @@map("gear_catalog_items")
+}
+
+model GearStorageLocation {
+  id             String    @id @default(cuid())
+  leagueId       String
+  normalizedName String
+  name           String
+  address        String?
+  privateNotes   String?
+  isActive       Boolean   @default(true)
+  archivedAt     DateTime?
+  createdAt      DateTime  @default(now())
+  updatedAt      DateTime  @updatedAt
+
+  league          League                  @relation(fields: [leagueId], references: [id], onDelete: Restrict)
+  poolStocks      GearPoolStock[]
+  currentUnits    GearUnit[]              @relation("GearUnitCurrentLocation")
+  movementsBefore GearInventoryMovement[] @relation("GearMovementBeforeLocation")
+  movementsAfter  GearInventoryMovement[] @relation("GearMovementAfterLocation")
+
+  @@unique([leagueId, normalizedName])
+  @@index([leagueId, isActive])
+  @@map("gear_storage_locations")
+}
+
+model GearPoolStock {
+  id             String        @id @default(cuid())
+  leagueId       String
+  catalogItemId  String
+  locationId     String
+  condition      GearCondition @default(GOOD)
+  quantityOnHand Int           @default(0)
+  version        Int           @default(0)
+  createdAt      DateTime      @default(now())
+  updatedAt      DateTime      @updatedAt
+
+  league             League                  @relation(fields: [leagueId], references: [id], onDelete: Restrict)
+  catalogItem        GearCatalogItem         @relation(fields: [catalogItemId], references: [id], onDelete: Restrict)
+  location           GearStorageLocation     @relation(fields: [locationId], references: [id], onDelete: Restrict)
+  allocations        GearAllocation[]
+  inventoryMovements GearInventoryMovement[]
+  pledgeReceipts     GearPledgeReceipt[]
+
+  @@unique([leagueId, catalogItemId, locationId, condition])
+  @@index([leagueId, catalogItemId])
+  @@index([leagueId, locationId])
+  @@map("gear_pool_stocks")
+}
+
+model GearUnit {
+  id                String         @id @default(cuid())
+  leagueId          String
+  catalogItemId     String
+  currentLocationId String?
+  assetTag          String?
+  serialNumber      String?
+  status            GearUnitStatus @default(AVAILABLE)
+  currentCondition  GearCondition  @default(GOOD)
+  acquiredAt        DateTime?      @db.Date
+  retiredAt         DateTime?      @db.Date
+  notes             String?
+  version           Int            @default(0)
+  createdAt         DateTime       @default(now())
+  updatedAt         DateTime       @updatedAt
+
+  league             League                  @relation(fields: [leagueId], references: [id], onDelete: Restrict)
+  catalogItem        GearCatalogItem         @relation(fields: [catalogItemId], references: [id], onDelete: Restrict)
+  currentLocation    GearStorageLocation?    @relation("GearUnitCurrentLocation", fields: [currentLocationId], references: [id], onDelete: SetNull)
+  allocations        GearAllocation[]
+  inventoryMovements GearInventoryMovement[]
+  pledgeReceipts     GearPledgeReceipt[]
+
+  @@unique([leagueId, assetTag])
+  @@index([leagueId, catalogItemId, status])
+  @@index([currentLocationId])
+  @@map("gear_units")
+}
+
+model TeamGearNeed {
+  id          String         @id @default(cuid())
+  leagueId    String
+  teamId      String
+  title       String
+  status      GearNeedStatus @default(DRAFT)
+  notes       String?
+  version     Int            @default(0)
+  submittedAt DateTime?
+  approvedAt  DateTime?
+  fulfilledAt DateTime?
+  canceledAt  DateTime?
+  createdAt   DateTime       @default(now())
+  updatedAt   DateTime       @updatedAt
+  createdById String?
+
+  league    League             @relation(fields: [leagueId], references: [id], onDelete: Restrict)
+  team      Team               @relation(fields: [teamId], references: [id], onDelete: Restrict)
+  createdBy User?              @relation("GearNeedCreator", fields: [createdById], references: [id], onDelete: SetNull)
+  lines     TeamGearNeedLine[]
+
+  @@index([leagueId, teamId, status])
+  @@map("team_gear_needs")
+}
+
+model TeamGearNeedLine {
+  id               String             @id @default(cuid())
+  needId           String
+  catalogItemId    String?
+  nameSnapshot     String
+  categorySnapshot String?
+  sizeSnapshot     String?
+  trackingMode     GearTrackingMode?
+  requestedQty     Int
+  fulfilledQty     Int                @default(0)
+  canceledQty      Int                @default(0)
+  priority         GearNeedPriority   @default(NORMAL)
+  status           GearNeedLineStatus @default(OPEN)
+  notes            String?
+  version          Int                @default(0)
+  createdAt        DateTime           @default(now())
+  updatedAt        DateTime           @updatedAt
+
+  need             TeamGearNeed          @relation(fields: [needId], references: [id], onDelete: Restrict)
+  catalogItem      GearCatalogItem?      @relation(fields: [catalogItemId], references: [id], onDelete: SetNull)
+  reservationLines GearReservationLine[]
+
+  @@index([needId, status])
+  @@index([catalogItemId])
+  @@map("team_gear_need_lines")
+}
+
+model GearReservation {
+  id                     String                @id @default(cuid())
+  leagueId               String
+  teamId                 String
+  status                 GearReservationStatus @default(DRAFT)
+  requestedStartDate     DateTime              @db.Date
+  requestedEndDate       DateTime              @db.Date
+  approvedStartDate      DateTime?             @db.Date
+  approvedEndDate        DateTime?             @db.Date
+  custodianNameSnapshot  String
+  custodianEmailSnapshot String?
+  custodianPhoneSnapshot String?
+  requestNotes           String?
+  decisionNotes          String?
+  version                Int                   @default(0)
+  requestedAt            DateTime              @default(now())
+  decidedAt              DateTime?
+  custodyStartedAt       DateTime?
+  custodyEndedAt         DateTime?
+  canceledAt             DateTime?
+  createdAt              DateTime              @default(now())
+  updatedAt              DateTime              @updatedAt
+  requestedById          String?
+  decidedById            String?
+
+  league      League                @relation(fields: [leagueId], references: [id], onDelete: Restrict)
+  team        Team                  @relation(fields: [teamId], references: [id], onDelete: Restrict)
+  requestedBy User?                 @relation("GearReservationRequester", fields: [requestedById], references: [id], onDelete: SetNull)
+  decidedBy   User?                 @relation("GearReservationDecider", fields: [decidedById], references: [id], onDelete: SetNull)
+  lines       GearReservationLine[]
+  handoffs    GearHandoff[]
+
+  @@index([leagueId, teamId, status])
+  @@index([leagueId, requestedStartDate, requestedEndDate])
+  @@map("gear_reservations")
+}
+
+model GearReservationLine {
+  id            String   @id @default(cuid())
+  reservationId String
+  catalogItemId String?
+  needLineId    String?
+  nameSnapshot  String
+  requestedQty  Int
+  approvedQty   Int      @default(0)
+  allocatedQty  Int      @default(0)
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+
+  reservation GearReservation   @relation(fields: [reservationId], references: [id], onDelete: Restrict)
+  catalogItem GearCatalogItem?  @relation(fields: [catalogItemId], references: [id], onDelete: SetNull)
+  needLine    TeamGearNeedLine? @relation(fields: [needLineId], references: [id], onDelete: SetNull)
+  allocations GearAllocation[]
+
+  @@index([reservationId])
+  @@index([needLineId])
+  @@map("gear_reservation_lines")
+}
+
+model GearAllocation {
+  id                String               @id @default(cuid())
+  leagueId          String
+  reservationLineId String
+  poolStockId       String?
+  gearUnitId        String?
+  status            GearAllocationStatus @default(PENDING)
+  allocatedQty      Int                  @default(0)
+  pickedUpQty       Int                  @default(0)
+  returnedQty       Int                  @default(0)
+  releasedQty       Int                  @default(0)
+  version           Int                  @default(0)
+  allocatedAt       DateTime?
+  pickedUpAt        DateTime?
+  returnedAt        DateTime?
+  releasedAt        DateTime?
+  createdAt         DateTime             @default(now())
+  updatedAt         DateTime             @updatedAt
+  allocatedById     String?
+
+  league             League                  @relation(fields: [leagueId], references: [id], onDelete: Restrict)
+  reservationLine    GearReservationLine     @relation(fields: [reservationLineId], references: [id], onDelete: Restrict)
+  poolStock          GearPoolStock?          @relation(fields: [poolStockId], references: [id], onDelete: Restrict)
+  gearUnit           GearUnit?               @relation(fields: [gearUnitId], references: [id], onDelete: Restrict)
+  allocatedBy        User?                   @relation("GearAllocationAllocator", fields: [allocatedById], references: [id], onDelete: SetNull)
+  handoffs           GearHandoff[]
+  inventoryMovements GearInventoryMovement[]
+
+  @@index([leagueId, status])
+  @@index([reservationLineId])
+  @@index([poolStockId])
+  @@index([gearUnitId])
+  @@map("gear_allocations")
+}
+
+model GearHandoff {
+  id                    String                 @id @default(cuid())
+  leagueId              String
+  reservationId         String?
+  allocationId          String?
+  type                  GearHandoffType
+  returnDisposition     GearReturnDisposition?
+  custodianNameSnapshot String?
+  occurredAt            DateTime               @default(now())
+  notes                 String?
+  createdAt             DateTime               @default(now())
+  handledById           String?
+
+  league             League                  @relation(fields: [leagueId], references: [id], onDelete: Restrict)
+  reservation        GearReservation?        @relation(fields: [reservationId], references: [id], onDelete: Restrict)
+  allocation         GearAllocation?         @relation(fields: [allocationId], references: [id], onDelete: Restrict)
+  handledBy          User?                   @relation("GearHandoffHandler", fields: [handledById], references: [id], onDelete: SetNull)
+  inventoryMovements GearInventoryMovement[]
+
+  @@index([leagueId, occurredAt])
+  @@index([reservationId])
+  @@index([allocationId])
+  @@map("gear_handoffs")
+}
+
+model GearWishlist {
+  id          String             @id @default(cuid())
+  leagueId    String             @unique
+  shareToken  String             @unique
+  status      GearWishlistStatus @default(DRAFT)
+  title       String
+  description String?
+  version     Int                @default(0)
+  publishedAt DateTime?
+  archivedAt  DateTime?
+  createdAt   DateTime           @default(now())
+  updatedAt   DateTime           @updatedAt
+
+  league League             @relation(fields: [leagueId], references: [id], onDelete: Restrict)
+  items  GearWishlistItem[]
+
+  @@index([status])
+  @@map("gear_wishlists")
+}
+
+model GearWishlistItem {
+  id               String   @id @default(cuid())
+  wishlistId       String
+  catalogItemId    String?
+  normalizedKey    String
+  nameSnapshot     String
+  categorySnapshot String?
+  sizeSnapshot     String?
+  description      String?
+  targetQty        Int
+  pledgedQty       Int      @default(0)
+  receivedQty      Int      @default(0)
+  isActive         Boolean  @default(true)
+  createdAt        DateTime @default(now())
+  updatedAt        DateTime @updatedAt
+
+  wishlist    GearWishlist     @relation(fields: [wishlistId], references: [id], onDelete: Restrict)
+  catalogItem GearCatalogItem? @relation(fields: [catalogItemId], references: [id], onDelete: SetNull)
+  pledges     GearPledge[]
+
+  @@index([wishlistId, isActive])
+  @@index([catalogItemId])
+  @@map("gear_wishlist_items")
+}
+
+model GearPledge {
+  id               String           @id @default(cuid())
+  leagueId         String
+  wishlistItemId   String
+  donorName        String
+  donorEmail       String?
+  donorPhone       String?
+  contactConsentAt DateTime?
+  status           GearPledgeStatus @default(PLEDGED)
+  quantity         Int
+  note             String?
+  idempotencyKey   String
+  expiresAt        DateTime?
+  receivedAt       DateTime?
+  createdAt        DateTime         @default(now())
+  updatedAt        DateTime         @updatedAt
+
+  league       League              @relation(fields: [leagueId], references: [id], onDelete: Restrict)
+  wishlistItem GearWishlistItem    @relation(fields: [wishlistItemId], references: [id], onDelete: Restrict)
+  receipts     GearPledgeReceipt[]
+
+  @@unique([leagueId, idempotencyKey])
+  @@index([wishlistItemId, status])
+  @@map("gear_pledges")
+}
+
+model GearPledgeReceipt {
+  id            String   @id @default(cuid())
+  leagueId      String
+  pledgeId      String
+  catalogItemId String?
+  poolStockId   String?
+  gearUnitId    String?
+  quantity      Int
+  receivedAt    DateTime @default(now())
+  notes         String?
+  createdAt     DateTime @default(now())
+
+  league             League                  @relation(fields: [leagueId], references: [id], onDelete: Restrict)
+  pledge             GearPledge              @relation(fields: [pledgeId], references: [id], onDelete: Restrict)
+  catalogItem        GearCatalogItem?        @relation(fields: [catalogItemId], references: [id], onDelete: SetNull)
+  poolStock          GearPoolStock?          @relation(fields: [poolStockId], references: [id], onDelete: Restrict)
+  gearUnit           GearUnit?               @relation(fields: [gearUnitId], references: [id], onDelete: Restrict)
+  inventoryMovements GearInventoryMovement[]
+
+  @@index([leagueId, receivedAt])
+  @@index([pledgeId])
+  @@map("gear_pledge_receipts")
+}
+
+// Immutable operational ledger. `details` deliberately excludes public donor
+// PII; public pledge data remains isolated in GearPledge.
+model GearActivity {
+  id          String                 @id @default(cuid())
+  leagueId    String
+  entityType  GearActivityEntityType
+  entityId    String
+  action      String
+  actorKind   GearActivityActorKind
+  details     Json?
+  occurredAt  DateTime               @default(now())
+  actorUserId String?
+
+  league    League @relation(fields: [leagueId], references: [id], onDelete: Restrict)
+  actorUser User?  @relation("GearActivityActor", fields: [actorUserId], references: [id], onDelete: SetNull)
+
+  @@index([leagueId, entityType, entityId, occurredAt])
+  @@map("gear_activity")
+}
+
+model GearInventoryMovement {
+  id               String                    @id @default(cuid())
+  leagueId         String
+  type             GearInventoryMovementType
+  poolStockId      String?
+  gearUnitId       String?
+  allocationId     String?
+  handoffId        String?
+  pledgeReceiptId  String?
+  quantity         Int
+  beforeLocationId String?
+  afterLocationId  String?
+  beforeCondition  GearCondition?
+  afterCondition   GearCondition?
+  occurredAt       DateTime                  @default(now())
+  notes            String?
+  createdAt        DateTime                  @default(now())
+  recordedById     String?
+
+  league         League               @relation(fields: [leagueId], references: [id], onDelete: Restrict)
+  poolStock      GearPoolStock?       @relation(fields: [poolStockId], references: [id], onDelete: Restrict)
+  gearUnit       GearUnit?            @relation(fields: [gearUnitId], references: [id], onDelete: Restrict)
+  allocation     GearAllocation?      @relation(fields: [allocationId], references: [id], onDelete: Restrict)
+  handoff        GearHandoff?         @relation(fields: [handoffId], references: [id], onDelete: Restrict)
+  pledgeReceipt  GearPledgeReceipt?   @relation(fields: [pledgeReceiptId], references: [id], onDelete: Restrict)
+  beforeLocation GearStorageLocation? @relation("GearMovementBeforeLocation", fields: [beforeLocationId], references: [id], onDelete: SetNull)
+  afterLocation  GearStorageLocation? @relation("GearMovementAfterLocation", fields: [afterLocationId], references: [id], onDelete: SetNull)
+  recordedBy     User?                @relation("GearMovementRecorder", fields: [recordedById], references: [id], onDelete: SetNull)
+
+  @@index([leagueId, occurredAt])
+  @@index([poolStockId])
+  @@index([gearUnitId])
+  @@index([allocationId])
+  @@map("gear_inventory_movements")
+}
+
+model NotificationOutbox {
+  id              String                   @id @default(cuid())
+  leagueId        String
+  recipientUserId String?
+  recipientEmail  String?
+  eventType       String
+  aggregateType   String
+  aggregateId     String
+  payload         Json
+  dedupeKey       String
+  status          NotificationOutboxStatus @default(PENDING)
+  attempts        Int                      @default(0)
+  scheduledAt     DateTime                 @default(now())
+  lockedAt        DateTime?
+  lastAttemptAt   DateTime?
+  sentAt          DateTime?
+  failedAt        DateTime?
+  lastError       String?
+  createdAt       DateTime                 @default(now())
+  updatedAt       DateTime                 @updatedAt
+
+  league        League @relation(fields: [leagueId], references: [id], onDelete: Restrict)
+  recipientUser User?  @relation("NotificationOutboxRecipient", fields: [recipientUserId], references: [id], onDelete: SetNull)
+
+  @@unique([leagueId, dedupeKey])
+  @@index([status, scheduledAt])
+  @@index([leagueId, aggregateType, aggregateId])
+  @@map("notification_outbox")
 }
 
 // Player transfer history model for audit trail

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -211,6 +211,7 @@ model Team {
   gearNeeds          TeamGearNeed[]
   gearReservations   GearReservation[]
 
+  @@unique([leagueId, id])
   @@index([leagueId]) // Optimize league-team queries
   @@index([divisionId]) // Optimize division-team queries
 }
@@ -739,8 +740,8 @@ enum NotificationOutboxStatus {
   CANCELED
 }
 
-// League-owned gear catalog and location projections. Tenant consistency across
-// related rows is enforced by future action transactions.
+// League-owned gear catalog and location projections. Composite tenant keys keep
+// every gear relationship within the same League.
 model GearCatalogItem {
   id            String           @id @default(cuid())
   leagueId      String
@@ -767,6 +768,7 @@ model GearCatalogItem {
   pledgeReceipts   GearPledgeReceipt[]
 
   @@unique([leagueId, normalizedKey])
+  @@unique([leagueId, id])
   @@index([leagueId, isActive])
   @@map("gear_catalog_items")
 }
@@ -790,6 +792,7 @@ model GearStorageLocation {
   movementsAfter  GearInventoryMovement[] @relation("GearMovementAfterLocation")
 
   @@unique([leagueId, normalizedName])
+  @@unique([leagueId, id])
   @@index([leagueId, isActive])
   @@map("gear_storage_locations")
 }
@@ -806,13 +809,14 @@ model GearPoolStock {
   updatedAt      DateTime      @updatedAt
 
   league             League                  @relation(fields: [leagueId], references: [id], onDelete: Restrict)
-  catalogItem        GearCatalogItem         @relation(fields: [catalogItemId], references: [id], onDelete: Restrict)
-  location           GearStorageLocation     @relation(fields: [locationId], references: [id], onDelete: Restrict)
+  catalogItem        GearCatalogItem         @relation(fields: [leagueId, catalogItemId], references: [leagueId, id], onDelete: Restrict)
+  location           GearStorageLocation     @relation(fields: [leagueId, locationId], references: [leagueId, id], onDelete: Restrict)
   allocations        GearAllocation[]
   inventoryMovements GearInventoryMovement[]
   pledgeReceipts     GearPledgeReceipt[]
 
   @@unique([leagueId, catalogItemId, locationId, condition])
+  @@unique([leagueId, id])
   @@index([leagueId, catalogItemId])
   @@index([leagueId, locationId])
   @@map("gear_pool_stocks")
@@ -835,13 +839,14 @@ model GearUnit {
   updatedAt         DateTime       @updatedAt
 
   league             League                  @relation(fields: [leagueId], references: [id], onDelete: Restrict)
-  catalogItem        GearCatalogItem         @relation(fields: [catalogItemId], references: [id], onDelete: Restrict)
-  currentLocation    GearStorageLocation?    @relation("GearUnitCurrentLocation", fields: [currentLocationId], references: [id], onDelete: SetNull)
+  catalogItem        GearCatalogItem         @relation(fields: [leagueId, catalogItemId], references: [leagueId, id], onDelete: Restrict)
+  currentLocation    GearStorageLocation?    @relation("GearUnitCurrentLocation", fields: [leagueId, currentLocationId], references: [leagueId, id], onDelete: Restrict)
   allocations        GearAllocation[]
   inventoryMovements GearInventoryMovement[]
   pledgeReceipts     GearPledgeReceipt[]
 
   @@unique([leagueId, assetTag])
+  @@unique([leagueId, id])
   @@index([leagueId, catalogItemId, status])
   @@index([currentLocationId])
   @@map("gear_units")
@@ -864,16 +869,18 @@ model TeamGearNeed {
   createdById String?
 
   league    League             @relation(fields: [leagueId], references: [id], onDelete: Restrict)
-  team      Team               @relation(fields: [teamId], references: [id], onDelete: Restrict)
+  team      Team               @relation(fields: [leagueId, teamId], references: [leagueId, id], onDelete: Restrict)
   createdBy User?              @relation("GearNeedCreator", fields: [createdById], references: [id], onDelete: SetNull)
   lines     TeamGearNeedLine[]
 
+  @@unique([leagueId, id])
   @@index([leagueId, teamId, status])
   @@map("team_gear_needs")
 }
 
 model TeamGearNeedLine {
   id               String             @id @default(cuid())
+  leagueId         String
   needId           String
   catalogItemId    String?
   nameSnapshot     String
@@ -890,10 +897,11 @@ model TeamGearNeedLine {
   createdAt        DateTime           @default(now())
   updatedAt        DateTime           @updatedAt
 
-  need             TeamGearNeed          @relation(fields: [needId], references: [id], onDelete: Restrict)
-  catalogItem      GearCatalogItem?      @relation(fields: [catalogItemId], references: [id], onDelete: SetNull)
+  need             TeamGearNeed          @relation(fields: [leagueId, needId], references: [leagueId, id], onDelete: Restrict)
+  catalogItem      GearCatalogItem?      @relation(fields: [leagueId, catalogItemId], references: [leagueId, id], onDelete: Restrict)
   reservationLines GearReservationLine[]
 
+  @@unique([leagueId, id])
   @@index([needId, status])
   @@index([catalogItemId])
   @@map("team_gear_need_lines")
@@ -925,12 +933,13 @@ model GearReservation {
   decidedById            String?
 
   league      League                @relation(fields: [leagueId], references: [id], onDelete: Restrict)
-  team        Team                  @relation(fields: [teamId], references: [id], onDelete: Restrict)
+  team        Team                  @relation(fields: [leagueId, teamId], references: [leagueId, id], onDelete: Restrict)
   requestedBy User?                 @relation("GearReservationRequester", fields: [requestedById], references: [id], onDelete: SetNull)
   decidedBy   User?                 @relation("GearReservationDecider", fields: [decidedById], references: [id], onDelete: SetNull)
   lines       GearReservationLine[]
   handoffs    GearHandoff[]
 
+  @@unique([leagueId, id])
   @@index([leagueId, teamId, status])
   @@index([leagueId, requestedStartDate, requestedEndDate])
   @@map("gear_reservations")
@@ -938,6 +947,7 @@ model GearReservation {
 
 model GearReservationLine {
   id            String   @id @default(cuid())
+  leagueId      String
   reservationId String
   catalogItemId String?
   needLineId    String?
@@ -948,44 +958,48 @@ model GearReservationLine {
   createdAt     DateTime @default(now())
   updatedAt     DateTime @updatedAt
 
-  reservation GearReservation   @relation(fields: [reservationId], references: [id], onDelete: Restrict)
-  catalogItem GearCatalogItem?  @relation(fields: [catalogItemId], references: [id], onDelete: SetNull)
-  needLine    TeamGearNeedLine? @relation(fields: [needLineId], references: [id], onDelete: SetNull)
+  reservation GearReservation   @relation(fields: [leagueId, reservationId], references: [leagueId, id], onDelete: Restrict)
+  catalogItem GearCatalogItem?  @relation(fields: [leagueId, catalogItemId], references: [leagueId, id], onDelete: Restrict)
+  needLine    TeamGearNeedLine? @relation(fields: [leagueId, needLineId], references: [leagueId, id], onDelete: Restrict)
   allocations GearAllocation[]
 
+  @@unique([leagueId, id])
   @@index([reservationId])
   @@index([needLineId])
   @@map("gear_reservation_lines")
 }
 
 model GearAllocation {
-  id                String               @id @default(cuid())
-  leagueId          String
-  reservationLineId String
-  poolStockId       String?
-  gearUnitId        String?
-  status            GearAllocationStatus @default(PENDING)
-  allocatedQty      Int                  @default(0)
-  pickedUpQty       Int                  @default(0)
-  returnedQty       Int                  @default(0)
-  releasedQty       Int                  @default(0)
-  version           Int                  @default(0)
-  allocatedAt       DateTime?
-  pickedUpAt        DateTime?
-  returnedAt        DateTime?
-  releasedAt        DateTime?
-  createdAt         DateTime             @default(now())
-  updatedAt         DateTime             @updatedAt
-  allocatedById     String?
+  id                 String               @id @default(cuid())
+  leagueId           String
+  reservationLineId  String
+  poolStockId        String?
+  gearUnitId         String?
+  status             GearAllocationStatus @default(PENDING)
+  allocatedQty       Int                  @default(0)
+  pickedUpQty        Int                  @default(0)
+  returnedQty        Int                  @default(0)
+  releasedQty        Int                  @default(0)
+  effectiveStartDate DateTime?            @db.Date
+  effectiveEndDate   DateTime?            @db.Date
+  version            Int                  @default(0)
+  allocatedAt        DateTime?
+  pickedUpAt         DateTime?
+  returnedAt         DateTime?
+  releasedAt         DateTime?
+  createdAt          DateTime             @default(now())
+  updatedAt          DateTime             @updatedAt
+  allocatedById      String?
 
   league             League                  @relation(fields: [leagueId], references: [id], onDelete: Restrict)
-  reservationLine    GearReservationLine     @relation(fields: [reservationLineId], references: [id], onDelete: Restrict)
-  poolStock          GearPoolStock?          @relation(fields: [poolStockId], references: [id], onDelete: Restrict)
-  gearUnit           GearUnit?               @relation(fields: [gearUnitId], references: [id], onDelete: Restrict)
+  reservationLine    GearReservationLine     @relation(fields: [leagueId, reservationLineId], references: [leagueId, id], onDelete: Restrict)
+  poolStock          GearPoolStock?          @relation(fields: [leagueId, poolStockId], references: [leagueId, id], onDelete: Restrict)
+  gearUnit           GearUnit?               @relation(fields: [leagueId, gearUnitId], references: [leagueId, id], onDelete: Restrict)
   allocatedBy        User?                   @relation("GearAllocationAllocator", fields: [allocatedById], references: [id], onDelete: SetNull)
   handoffs           GearHandoff[]
   inventoryMovements GearInventoryMovement[]
 
+  @@unique([leagueId, id])
   @@index([leagueId, status])
   @@index([reservationLineId])
   @@index([poolStockId])
@@ -1007,11 +1021,12 @@ model GearHandoff {
   handledById           String?
 
   league             League                  @relation(fields: [leagueId], references: [id], onDelete: Restrict)
-  reservation        GearReservation?        @relation(fields: [reservationId], references: [id], onDelete: Restrict)
-  allocation         GearAllocation?         @relation(fields: [allocationId], references: [id], onDelete: Restrict)
+  reservation        GearReservation?        @relation(fields: [leagueId, reservationId], references: [leagueId, id], onDelete: Restrict)
+  allocation         GearAllocation?         @relation(fields: [leagueId, allocationId], references: [leagueId, id], onDelete: Restrict)
   handledBy          User?                   @relation("GearHandoffHandler", fields: [handledById], references: [id], onDelete: SetNull)
   inventoryMovements GearInventoryMovement[]
 
+  @@unique([leagueId, id])
   @@index([leagueId, occurredAt])
   @@index([reservationId])
   @@index([allocationId])
@@ -1034,12 +1049,14 @@ model GearWishlist {
   league League             @relation(fields: [leagueId], references: [id], onDelete: Restrict)
   items  GearWishlistItem[]
 
+  @@unique([leagueId, id])
   @@index([status])
   @@map("gear_wishlists")
 }
 
 model GearWishlistItem {
   id               String   @id @default(cuid())
+  leagueId         String
   wishlistId       String
   catalogItemId    String?
   normalizedKey    String
@@ -1054,10 +1071,11 @@ model GearWishlistItem {
   createdAt        DateTime @default(now())
   updatedAt        DateTime @updatedAt
 
-  wishlist    GearWishlist     @relation(fields: [wishlistId], references: [id], onDelete: Restrict)
-  catalogItem GearCatalogItem? @relation(fields: [catalogItemId], references: [id], onDelete: SetNull)
+  wishlist    GearWishlist     @relation(fields: [leagueId, wishlistId], references: [leagueId, id], onDelete: Restrict)
+  catalogItem GearCatalogItem? @relation(fields: [leagueId, catalogItemId], references: [leagueId, id], onDelete: Restrict)
   pledges     GearPledge[]
 
+  @@unique([leagueId, id])
   @@index([wishlistId, isActive])
   @@index([catalogItemId])
   @@map("gear_wishlist_items")
@@ -1081,10 +1099,11 @@ model GearPledge {
   updatedAt        DateTime         @updatedAt
 
   league       League              @relation(fields: [leagueId], references: [id], onDelete: Restrict)
-  wishlistItem GearWishlistItem    @relation(fields: [wishlistItemId], references: [id], onDelete: Restrict)
+  wishlistItem GearWishlistItem    @relation(fields: [leagueId, wishlistItemId], references: [leagueId, id], onDelete: Restrict)
   receipts     GearPledgeReceipt[]
 
   @@unique([leagueId, idempotencyKey])
+  @@unique([leagueId, id])
   @@index([wishlistItemId, status])
   @@map("gear_pledges")
 }
@@ -1102,12 +1121,13 @@ model GearPledgeReceipt {
   createdAt     DateTime @default(now())
 
   league             League                  @relation(fields: [leagueId], references: [id], onDelete: Restrict)
-  pledge             GearPledge              @relation(fields: [pledgeId], references: [id], onDelete: Restrict)
-  catalogItem        GearCatalogItem?        @relation(fields: [catalogItemId], references: [id], onDelete: SetNull)
-  poolStock          GearPoolStock?          @relation(fields: [poolStockId], references: [id], onDelete: Restrict)
-  gearUnit           GearUnit?               @relation(fields: [gearUnitId], references: [id], onDelete: Restrict)
+  pledge             GearPledge              @relation(fields: [leagueId, pledgeId], references: [leagueId, id], onDelete: Restrict)
+  catalogItem        GearCatalogItem?        @relation(fields: [leagueId, catalogItemId], references: [leagueId, id], onDelete: Restrict)
+  poolStock          GearPoolStock?          @relation(fields: [leagueId, poolStockId], references: [leagueId, id], onDelete: Restrict)
+  gearUnit           GearUnit?               @relation(fields: [leagueId, gearUnitId], references: [leagueId, id], onDelete: Restrict)
   inventoryMovements GearInventoryMovement[]
 
+  @@unique([leagueId, id])
   @@index([leagueId, receivedAt])
   @@index([pledgeId])
   @@map("gear_pledge_receipts")
@@ -1129,6 +1149,7 @@ model GearActivity {
   league    League @relation(fields: [leagueId], references: [id], onDelete: Restrict)
   actorUser User?  @relation("GearActivityActor", fields: [actorUserId], references: [id], onDelete: SetNull)
 
+  @@unique([leagueId, id])
   @@index([leagueId, entityType, entityId, occurredAt])
   @@map("gear_activity")
 }
@@ -1153,15 +1174,16 @@ model GearInventoryMovement {
   recordedById     String?
 
   league         League               @relation(fields: [leagueId], references: [id], onDelete: Restrict)
-  poolStock      GearPoolStock?       @relation(fields: [poolStockId], references: [id], onDelete: Restrict)
-  gearUnit       GearUnit?            @relation(fields: [gearUnitId], references: [id], onDelete: Restrict)
-  allocation     GearAllocation?      @relation(fields: [allocationId], references: [id], onDelete: Restrict)
-  handoff        GearHandoff?         @relation(fields: [handoffId], references: [id], onDelete: Restrict)
-  pledgeReceipt  GearPledgeReceipt?   @relation(fields: [pledgeReceiptId], references: [id], onDelete: Restrict)
-  beforeLocation GearStorageLocation? @relation("GearMovementBeforeLocation", fields: [beforeLocationId], references: [id], onDelete: SetNull)
-  afterLocation  GearStorageLocation? @relation("GearMovementAfterLocation", fields: [afterLocationId], references: [id], onDelete: SetNull)
+  poolStock      GearPoolStock?       @relation(fields: [leagueId, poolStockId], references: [leagueId, id], onDelete: Restrict)
+  gearUnit       GearUnit?            @relation(fields: [leagueId, gearUnitId], references: [leagueId, id], onDelete: Restrict)
+  allocation     GearAllocation?      @relation(fields: [leagueId, allocationId], references: [leagueId, id], onDelete: Restrict)
+  handoff        GearHandoff?         @relation(fields: [leagueId, handoffId], references: [leagueId, id], onDelete: Restrict)
+  pledgeReceipt  GearPledgeReceipt?   @relation(fields: [leagueId, pledgeReceiptId], references: [leagueId, id], onDelete: Restrict)
+  beforeLocation GearStorageLocation? @relation("GearMovementBeforeLocation", fields: [leagueId, beforeLocationId], references: [leagueId, id], onDelete: Restrict)
+  afterLocation  GearStorageLocation? @relation("GearMovementAfterLocation", fields: [leagueId, afterLocationId], references: [leagueId, id], onDelete: Restrict)
   recordedBy     User?                @relation("GearMovementRecorder", fields: [recordedById], references: [id], onDelete: SetNull)
 
+  @@unique([leagueId, id])
   @@index([leagueId, occurredAt])
   @@index([poolStockId])
   @@index([gearUnitId])
@@ -1191,9 +1213,10 @@ model NotificationOutbox {
   updatedAt       DateTime                 @updatedAt
 
   league        League @relation(fields: [leagueId], references: [id], onDelete: Restrict)
-  recipientUser User?  @relation("NotificationOutboxRecipient", fields: [recipientUserId], references: [id], onDelete: SetNull)
+  recipientUser User?  @relation("NotificationOutboxRecipient", fields: [recipientUserId], references: [id], onDelete: Restrict)
 
   @@unique([leagueId, dedupeKey])
+  @@unique([leagueId, id])
   @@index([status, scheduledAt])
   @@index([leagueId, aggregateType, aggregateId])
   @@map("notification_outbox")

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -698,6 +698,12 @@ enum GearInventoryMovementType {
   WRITE_OFF
 }
 
+enum GearInventoryDirection {
+  INCREASE
+  DECREASE
+  NEUTRAL
+}
+
 enum GearWishlistStatus {
   DRAFT
   PUBLISHED
@@ -1158,6 +1164,7 @@ model GearInventoryMovement {
   id               String                    @id @default(cuid())
   leagueId         String
   type             GearInventoryMovementType
+  direction        GearInventoryDirection
   poolStockId      String?
   gearUnitId       String?
   allocationId     String?
@@ -1192,28 +1199,31 @@ model GearInventoryMovement {
 }
 
 model NotificationOutbox {
-  id              String                   @id @default(cuid())
-  leagueId        String
-  recipientUserId String?
-  recipientEmail  String?
-  eventType       String
-  aggregateType   String
-  aggregateId     String
-  payload         Json
-  dedupeKey       String
-  status          NotificationOutboxStatus @default(PENDING)
-  attempts        Int                      @default(0)
-  scheduledAt     DateTime                 @default(now())
-  lockedAt        DateTime?
-  lastAttemptAt   DateTime?
-  sentAt          DateTime?
-  failedAt        DateTime?
-  lastError       String?
-  createdAt       DateTime                 @default(now())
-  updatedAt       DateTime                 @updatedAt
+  id                  String                   @id @default(cuid())
+  leagueId            String
+  recipientUserId     String?
+  // The captured delivery destination survives account deletion; a privileged,
+  // terminal-only retention routine may replace it with a redacted address.
+  recipientEmail      String
+  recipientRedactedAt DateTime?
+  eventType           String
+  aggregateType       String
+  aggregateId         String
+  payload             Json
+  dedupeKey           String
+  status              NotificationOutboxStatus @default(PENDING)
+  attempts            Int                      @default(0)
+  scheduledAt         DateTime                 @default(now())
+  lockedAt            DateTime?
+  lastAttemptAt       DateTime?
+  sentAt              DateTime?
+  failedAt            DateTime?
+  lastError           String?
+  createdAt           DateTime                 @default(now())
+  updatedAt           DateTime                 @updatedAt
 
   league        League @relation(fields: [leagueId], references: [id], onDelete: Restrict)
-  recipientUser User?  @relation("NotificationOutboxRecipient", fields: [recipientUserId], references: [id], onDelete: Restrict)
+  recipientUser User?  @relation("NotificationOutboxRecipient", fields: [recipientUserId], references: [id], onDelete: SetNull)
 
   @@unique([leagueId, dedupeKey])
   @@unique([leagueId, id])

--- a/types/gear.ts
+++ b/types/gear.ts
@@ -55,3 +55,12 @@ export type GearReservationWindow = {
   startDate: string;
   endDate: string;
 };
+
+export type TaggedAllocationWindow = GearReservationWindow & {
+  status: GearAllocationStatus;
+};
+
+export type NotificationRecipient = {
+  userId?: string | null;
+  email?: string | null;
+};

--- a/types/gear.ts
+++ b/types/gear.ts
@@ -28,6 +28,9 @@ export const GEAR_ALLOCATION_STATUSES = [
 ] as const;
 export type GearAllocationStatus = (typeof GEAR_ALLOCATION_STATUSES)[number];
 
+export const GEAR_INVENTORY_DIRECTIONS = ["INCREASE", "DECREASE", "NEUTRAL"] as const;
+export type GearInventoryDirection = (typeof GEAR_INVENTORY_DIRECTIONS)[number];
+
 export type GearPoolAvailability = {
   quantityOnHand: number;
   allocatedQuantity: number;
@@ -61,6 +64,23 @@ export type TaggedAllocationWindow = GearReservationWindow & {
 };
 
 export type NotificationRecipient = {
+  email: string;
   userId?: string | null;
-  email?: string | null;
+};
+
+export type GearActivityDetails = {
+  action: string;
+  summary?: string;
+  metadata?: Record<string, string | number | boolean | null>;
+};
+
+export type GearNotificationPayload = {
+  kind: "GEAR_RESERVATION" | "GEAR_ALLOCATION" | "GEAR_PLEDGE" | "GEAR_WISHLIST";
+  data: Record<string, string | number | boolean | null>;
+};
+
+export type NotificationOutboxRecipientSnapshot = {
+  email: string;
+  userId: string | null;
+  redactedAt: Date | null;
 };

--- a/types/gear.ts
+++ b/types/gear.ts
@@ -1,0 +1,57 @@
+export const GEAR_TRACKING_MODES = ["POOLED", "INDIVIDUAL"] as const;
+export type GearTrackingMode = (typeof GEAR_TRACKING_MODES)[number];
+
+export const GEAR_CONDITIONS = ["NEW", "EXCELLENT", "GOOD", "FAIR", "POOR", "DAMAGED"] as const;
+export type GearCondition = (typeof GEAR_CONDITIONS)[number];
+
+export const GEAR_UNIT_STATUSES = ["AVAILABLE", "RESERVED", "CHECKED_OUT", "MAINTENANCE", "RETIRED", "LOST"] as const;
+export type GearUnitStatus = (typeof GEAR_UNIT_STATUSES)[number];
+
+export const GEAR_RESERVATION_STATUSES = [
+  "DRAFT",
+  "REQUESTED",
+  "APPROVED",
+  "DECLINED",
+  "CANCELED",
+  "FULFILLED",
+  "CLOSED",
+] as const;
+export type GearReservationStatus = (typeof GEAR_RESERVATION_STATUSES)[number];
+
+export const GEAR_ALLOCATION_STATUSES = [
+  "PENDING",
+  "ALLOCATED",
+  "PICKED_UP",
+  "PARTIALLY_RETURNED",
+  "RETURNED",
+  "RELEASED",
+] as const;
+export type GearAllocationStatus = (typeof GEAR_ALLOCATION_STATUSES)[number];
+
+export type GearPoolAvailability = {
+  quantityOnHand: number;
+  allocatedQuantity: number;
+};
+
+export type GearAllocationQuantities = {
+  allocatedQty: number;
+  pickedUpQty: number;
+  returnedQty: number;
+  releasedQty: number;
+};
+
+export type GearCatalogItemDto = {
+  id: string;
+  leagueId: string;
+  normalizedKey: string;
+  name: string;
+  category: string;
+  size: string | null;
+  trackingMode: GearTrackingMode;
+  isActive: boolean;
+};
+
+export type GearReservationWindow = {
+  startDate: string;
+  endDate: string;
+};


### PR DESCRIPTION
## Summary
- add the League-owned gear schema, checked-in migration, local PostgreSQL invariants, immutable ledger records, and durable notification outbox
- add ADR-0006 for ownership, projection/ledger, serializable mutation, and outbox decisions
- add pure gear domain utilities, future action validation schemas, scoped permissions, and focused tests

## Validation
- `bun run test __tests__/lib/utils/gear.test.ts __tests__/lib/utils/validation-gear.test.ts`
- `bun run type-check`
- `DATABASE_URL=... bun run db:generate`
- `bun run adr:lint`
- `bun run adr:check-integrity`
- `bun run check:raw-sql`
- `bunx eslint` on changed TypeScript files

Migration generation used the repository's checked-in migration convention because no live development `DATABASE_URL` was available; no database was reset or modified.