### PR TITLE
feat(gear): add association inventory management

### DIFF
--- a/__tests__/components/features/gear/GearInventoryManager.test.tsx
+++ b/__tests__/components/features/gear/GearInventoryManager.test.tsx
@@ -4,17 +4,21 @@ import { GearInventoryManager } from "@/components/features/gear/GearInventoryMa
 import type { GearInventoryContext } from "@/lib/actions/gear-context";
 
 vi.mock("next/navigation", () => ({ useRouter: () => ({ refresh: vi.fn() }) }));
+const { mockCreateGearStorageLocation } = vi.hoisted(() => ({
+  mockCreateGearStorageLocation: vi.fn(),
+}));
 vi.mock("@/lib/actions/gear-inventory", () => ({
   adjustGearPoolStock: vi.fn(),
   archiveGearCatalogItem: vi.fn(),
   archiveGearStorageLocation: vi.fn(),
   changeGearUnitCondition: vi.fn(),
   createGearCatalogItem: vi.fn(),
-  createGearStorageLocation: vi.fn(),
+  createGearStorageLocation: (...args: unknown[]) => mockCreateGearStorageLocation(...args),
   createGearUnit: vi.fn(),
   retireGearUnit: vi.fn(),
   transferGearPoolStock: vi.fn(),
   transferGearUnit: vi.fn(),
+  unretireGearUnit: vi.fn(),
   updateGearCatalogItem: vi.fn(),
   updateGearStorageLocation: vi.fn(),
   updateGearUnit: vi.fn(),
@@ -28,10 +32,28 @@ const emptyAdminData: GearInventoryContext = {
   catalogItems: [],
   pooledStock: [],
   units: [],
-  recentActivity: [],
+  recentActivity: { items: [], page: 1, hasMore: false, search: "" },
 };
 
 describe("GearInventoryManager", () => {
+  it("renders and focuses a returned dialog error without closing the dialog", async () => {
+    mockCreateGearStorageLocation.mockResolvedValue({
+      success: false,
+      error: "Please correct the highlighted inventory fields.",
+      details: [{ path: ["name"], message: "Required" }],
+    });
+    render(<GearInventoryManager data={emptyAdminData} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Location" }));
+    fireEvent.change(screen.getByRole("textbox", { name: "Location name" }), { target: { value: "Locker" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    const error = await screen.findByRole("alert");
+    expect(error).toHaveTextContent("name: Required");
+    expect(screen.getByRole("dialog", { name: "Add storage location" })).toBeVisible();
+    expect(error).toHaveFocus();
+  });
+
   it("shows an explicit accessible empty state and 44px admin controls", () => {
     render(<GearInventoryManager data={emptyAdminData} />);
 
@@ -49,5 +71,48 @@ describe("GearInventoryManager", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Location" }));
     expect(screen.getByRole("dialog", { name: "Add storage location" })).toBeVisible();
+  });
+
+  it("keeps edit and condition details visible for reserved mobile unit cards", () => {
+    render(<GearInventoryManager data={{
+      ...emptyAdminData,
+      units: [{
+        id: "cunittttttttttttttttttttt",
+        catalogItemId: "caaaaaaaaaaaaaaaaaaaaaaaa",
+        catalogName: "Helmet",
+        assetTag: "TAG42",
+        status: "RESERVED",
+        currentCondition: "GOOD",
+        currentLocationId: "clocationxxxxxxxxxxxxxxxx",
+        currentLocationName: "Locker",
+        version: 1,
+      }],
+      summary: { ...emptyAdminData.summary, taggedUnits: 1 },
+    }} />);
+
+    expect(screen.getByText(/TAG42.*Locker.*Good/)).toBeVisible();
+    expect(screen.getAllByRole("button", { name: "Edit" })).not.toHaveLength(0);
+  });
+
+  it("uses explicit filtered collection lengths for no-search-result copy", () => {
+    render(<GearInventoryManager data={{
+      ...emptyAdminData,
+      pooledStock: [{
+        id: "cstockkkkkkkkkkkkkkkkkkkkk",
+        catalogItemId: "caaaaaaaaaaaaaaaaaaaaaaaa",
+        catalogName: "Helmet",
+        category: "Safety",
+        locationId: "clocationxxxxxxxxxxxxxxxx",
+        locationName: "Locker",
+        condition: "GOOD",
+        quantityOnHand: 2,
+        committedQuantity: 0,
+        availableQuantity: 2,
+        version: 1,
+      }],
+    }} />);
+
+    fireEvent.change(screen.getByRole("textbox", { name: "Search inventory" }), { target: { value: "No match" } });
+    expect(screen.getByText("No pooled inventory matches this search.")).toBeVisible();
   });
 });

--- a/__tests__/components/features/gear/GearInventoryManager.test.tsx
+++ b/__tests__/components/features/gear/GearInventoryManager.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { GearInventoryManager } from "@/components/features/gear/GearInventoryManager";
+import type { GearInventoryContext } from "@/lib/actions/gear-context";
+
+vi.mock("next/navigation", () => ({ useRouter: () => ({ refresh: vi.fn() }) }));
+vi.mock("@/lib/actions/gear-inventory", () => ({
+  adjustGearPoolStock: vi.fn(),
+  archiveGearCatalogItem: vi.fn(),
+  archiveGearStorageLocation: vi.fn(),
+  changeGearUnitCondition: vi.fn(),
+  createGearCatalogItem: vi.fn(),
+  createGearStorageLocation: vi.fn(),
+  createGearUnit: vi.fn(),
+  retireGearUnit: vi.fn(),
+  transferGearPoolStock: vi.fn(),
+  transferGearUnit: vi.fn(),
+  updateGearCatalogItem: vi.fn(),
+  updateGearStorageLocation: vi.fn(),
+  updateGearUnit: vi.fn(),
+}));
+
+const emptyAdminData: GearInventoryContext = {
+  league: { id: "cllllllllllllllllllllllll", name: "Metro" },
+  canManageInventory: true,
+  summary: { pooledOnHand: 0, pooledAvailable: 0, taggedUnits: 0, taggedAvailable: 0 },
+  locations: [],
+  catalogItems: [],
+  pooledStock: [],
+  units: [],
+  recentActivity: [],
+};
+
+describe("GearInventoryManager", () => {
+  it("shows an explicit accessible empty state and 44px admin controls", () => {
+    render(<GearInventoryManager data={emptyAdminData} />);
+
+    expect(screen.getByRole("status")).toHaveTextContent("Start by adding a storage location");
+    expect(screen.getByRole("button", { name: "Location" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Catalog item" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Tagged unit" })).toBeVisible();
+    expect(screen.getByRole("textbox", { name: "Search inventory" })).toBeVisible();
+  });
+});

--- a/__tests__/components/features/gear/GearInventoryManager.test.tsx
+++ b/__tests__/components/features/gear/GearInventoryManager.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { GearInventoryManager } from "@/components/features/gear/GearInventoryManager";
 import type { GearInventoryContext } from "@/lib/actions/gear-context";
@@ -38,7 +38,16 @@ describe("GearInventoryManager", () => {
     expect(screen.getByRole("status")).toHaveTextContent("Start by adding a storage location");
     expect(screen.getByRole("button", { name: "Location" })).toBeVisible();
     expect(screen.getByRole("button", { name: "Catalog item" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Pooled stock" })).toBeVisible();
     expect(screen.getByRole("button", { name: "Tagged unit" })).toBeVisible();
     expect(screen.getByRole("textbox", { name: "Search inventory" })).toBeVisible();
+
+    fireEvent.click(screen.getByRole("button", { name: "Pooled stock" }));
+    expect(screen.getByRole("dialog", { name: "Adjust pooled stock" })).toBeVisible();
+    expect(screen.getByRole("spinbutton", { name: "Initial quantity" })).toBeVisible();
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    fireEvent.click(screen.getByRole("button", { name: "Location" }));
+    expect(screen.getByRole("dialog", { name: "Add storage location" })).toBeVisible();
   });
 });

--- a/__tests__/lib/actions/gear-context.test.ts
+++ b/__tests__/lib/actions/gear-context.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockRequireUserId, mockPrisma } = vi.hoisted(() => ({
+  mockRequireUserId: vi.fn(),
+  mockPrisma: {
+    leagueUser: { findFirst: vi.fn() },
+    gearStorageLocation: { findMany: vi.fn() },
+    gearCatalogItem: { findMany: vi.fn() },
+    gearPoolStock: { findMany: vi.fn() },
+    gearUnit: { findMany: vi.fn() },
+    gearInventoryMovement: { findMany: vi.fn() },
+  },
+}));
+
+vi.mock("@/lib/auth/session", () => ({ requireUserId: () => mockRequireUserId() }));
+vi.mock("@/lib/db/prisma", () => ({ prisma: mockPrisma }));
+
+import { getGearInventoryContext } from "@/lib/actions/gear-context";
+
+const LEAGUE_ID = "cllllllllllllllllllllllll";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockRequireUserId.mockResolvedValue("cuserrrrrrrrrrrrrrrrrrrrr");
+  mockPrisma.gearStorageLocation.findMany.mockResolvedValue([]);
+  mockPrisma.gearCatalogItem.findMany.mockResolvedValue([]);
+  mockPrisma.gearPoolStock.findMany.mockResolvedValue([]);
+  mockPrisma.gearUnit.findMany.mockResolvedValue([]);
+  mockPrisma.gearInventoryMovement.findMany.mockResolvedValue([]);
+});
+
+describe("gear inventory context", () => {
+  it("returns null outside the requested league", async () => {
+    mockPrisma.leagueUser.findFirst.mockResolvedValue(null);
+    await expect(getGearInventoryContext(LEAGUE_ID)).resolves.toBeNull();
+    expect(mockPrisma.gearPoolStock.findMany).not.toHaveBeenCalled();
+  });
+
+  it("redacts private storage notes and admin activity for league members", async () => {
+    mockPrisma.leagueUser.findFirst.mockResolvedValue({
+      role: "MEMBER",
+      league: { id: LEAGUE_ID, name: "Metro" },
+    });
+    mockPrisma.gearStorageLocation.findMany.mockResolvedValue([
+      { id: "clocationxxxxxxxxxxxxxxxx", name: "Locker", address: null, privateNotes: null, isActive: true },
+    ]);
+
+    const result = await getGearInventoryContext(LEAGUE_ID);
+
+    expect(result?.canManageInventory).toBe(false);
+    expect(result?.locations[0]).not.toHaveProperty("privateNotes");
+    expect(mockPrisma.gearStorageLocation.findMany).toHaveBeenCalledWith(expect.objectContaining({
+      where: { leagueId: LEAGUE_ID },
+      select: expect.objectContaining({ privateNotes: false }),
+    }));
+    expect(mockPrisma.gearInventoryMovement.findMany).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/lib/actions/gear-context.test.ts
+++ b/__tests__/lib/actions/gear-context.test.ts
@@ -49,10 +49,91 @@ describe("gear inventory context", () => {
 
     expect(result?.canManageInventory).toBe(false);
     expect(result?.locations[0]).not.toHaveProperty("privateNotes");
+    expect(result?.locations[0]).not.toHaveProperty("address");
     expect(mockPrisma.gearStorageLocation.findMany).toHaveBeenCalledWith(expect.objectContaining({
       where: { leagueId: LEAGUE_ID },
-      select: expect.objectContaining({ privateNotes: false }),
+      select: expect.objectContaining({ address: false, privateNotes: false }),
     }));
     expect(mockPrisma.gearInventoryMovement.findMany).not.toHaveBeenCalled();
+  });
+
+  it("does not serialize sensitive unit lifecycle fields to a member Flight payload", async () => {
+    mockPrisma.leagueUser.findFirst.mockResolvedValue({
+      role: "MEMBER",
+      league: { id: LEAGUE_ID, name: "Metro" },
+    });
+    mockPrisma.gearUnit.findMany.mockResolvedValue([{
+      id: "cunittttttttttttttttttttt",
+      catalogItemId: "caaaaaaaaaaaaaaaaaaaaaaaa",
+      assetTag: "TAG42",
+      serialNumber: "SERIAL-PRIVATE",
+      status: "AVAILABLE",
+      currentCondition: "GOOD",
+      currentLocationId: "clocationxxxxxxxxxxxxxxxx",
+      acquiredAt: new Date("2026-01-01T00:00:00.000Z"),
+      retiredAt: new Date("2026-02-01T00:00:00.000Z"),
+      version: 7,
+      notes: "Private service record",
+      catalogItem: { name: "Helmet" },
+      currentLocation: { name: "Locker" },
+    }]);
+
+    const result = await getGearInventoryContext(LEAGUE_ID);
+    const serialized = JSON.stringify(result);
+
+    expect(result?.units[0]).not.toHaveProperty("serialNumber");
+    expect(result?.units[0]).not.toHaveProperty("acquiredAt");
+    expect(result?.units[0]).not.toHaveProperty("retiredAt");
+    expect(result?.units[0]).not.toHaveProperty("notes");
+    expect(result?.units[0]).not.toHaveProperty("version");
+    expect(serialized).not.toContain("SERIAL-PRIVATE");
+    expect(serialized).not.toContain("Private service record");
+  });
+
+  it("returns paginated, searchable movement identity only to administrators", async () => {
+    mockPrisma.leagueUser.findFirst.mockResolvedValue({
+      role: "LEAGUE_ADMIN",
+      league: { id: LEAGUE_ID, name: "Metro" },
+    });
+    mockPrisma.gearInventoryMovement.findMany.mockResolvedValue([{
+      id: "cmovementxxxxxxxxxxxxxxxx",
+      type: "ADJUSTMENT",
+      direction: "DECREASE",
+      quantity: 1,
+      poolStockId: null,
+      gearUnitId: "cunittttttttttttttttttttt",
+      beforeCondition: "GOOD",
+      afterCondition: null,
+      occurredAt: new Date("2026-03-01T12:34:56.789Z"),
+      notes: "Inspection failed",
+      beforeLocation: { name: "Locker" },
+      afterLocation: null,
+      poolStock: null,
+      gearUnit: { assetTag: "TAG42", catalogItem: { name: "Helmet" } },
+      recordedBy: { name: "Alex Admin" },
+    }]);
+
+    const result = await getGearInventoryContext(LEAGUE_ID, {
+      activityPage: 2,
+      activitySearch: "helmet",
+    });
+
+    expect(mockPrisma.gearInventoryMovement.findMany).toHaveBeenCalledWith(expect.objectContaining({
+      skip: 20,
+      take: 21,
+      where: expect.objectContaining({ leagueId: LEAGUE_ID }),
+    }));
+    expect(result?.recentActivity).toMatchObject({
+      page: 2,
+      search: "helmet",
+      items: [{
+        catalogName: "Helmet",
+        assetTag: "TAG42",
+        direction: "DECREASE",
+        beforeCondition: "GOOD",
+        actorName: "Alex Admin",
+        occurredAt: "2026-03-01T12:34:56.789Z",
+      }],
+    });
   });
 });

--- a/__tests__/lib/actions/gear-inventory.test.ts
+++ b/__tests__/lib/actions/gear-inventory.test.ts
@@ -116,4 +116,29 @@ describe("gear inventory actions", () => {
     expect(result).toEqual({ success: false, error: "Inventory cannot fall below zero." });
     expect(tx.gearInventoryMovement.create).not.toHaveBeenCalled();
   });
+
+  it("records a valid reduction as a positive outbound movement", async () => {
+    tx.gearCatalogItem.findFirst.mockResolvedValue({ id: CATALOG_ID, trackingMode: "POOLED" });
+    tx.gearPoolStock.findUnique.mockResolvedValue({ id: "cstockkkkkkkkkkkkkkkkkkkkk", quantityOnHand: 5, version: 3 });
+    tx.gearAllocation.aggregate.mockResolvedValue({ _sum: { allocatedQty: 0, releasedQty: 0 } });
+    tx.gearPoolStock.updateMany.mockResolvedValue({ count: 1 });
+
+    const result = await adjustGearPoolStock({
+      leagueId: LEAGUE_ID,
+      catalogItemId: CATALOG_ID,
+      locationId: LOCATION_ID,
+      condition: "GOOD",
+      quantityDelta: -2,
+      expectedVersion: 3,
+    });
+
+    expect(result.success).toBe(true);
+    expect(tx.gearInventoryMovement.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        quantity: 2,
+        beforeLocationId: LOCATION_ID,
+        afterLocationId: null,
+      }),
+    }));
+  });
 });

--- a/__tests__/lib/actions/gear-inventory.test.ts
+++ b/__tests__/lib/actions/gear-inventory.test.ts
@@ -136,6 +136,7 @@ describe("gear inventory actions", () => {
     expect(tx.gearInventoryMovement.create).toHaveBeenCalledWith(expect.objectContaining({
       data: expect.objectContaining({
         quantity: 2,
+        direction: "DECREASE",
         beforeLocationId: LOCATION_ID,
         afterLocationId: null,
       }),

--- a/__tests__/lib/actions/gear-inventory.test.ts
+++ b/__tests__/lib/actions/gear-inventory.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+
+const { mockRequireLeagueRole, mockPrisma, tx } = vi.hoisted(() => {
+  const tx = {
+    gearCatalogItem: { create: vi.fn(), findFirst: vi.fn(), count: vi.fn() },
+    gearStorageLocation: { findFirst: vi.fn(), create: vi.fn(), update: vi.fn() },
+    gearPoolStock: { findUnique: vi.fn(), create: vi.fn(), updateMany: vi.fn(), upsert: vi.fn() },
+    gearAllocation: { aggregate: vi.fn(), count: vi.fn() },
+    gearUnit: { create: vi.fn(), findFirst: vi.fn(), update: vi.fn(), count: vi.fn() },
+    gearInventoryMovement: { create: vi.fn(), count: vi.fn() },
+    gearActivity: { create: vi.fn() },
+  };
+  return {
+    tx,
+    mockRequireLeagueRole: vi.fn(),
+    mockPrisma: { $transaction: vi.fn((callback: (client: typeof tx) => unknown) => callback(tx)) },
+  };
+});
+
+vi.mock("@/lib/auth/session", () => ({
+  requireLeagueRole: (...args: unknown[]) => mockRequireLeagueRole(...args),
+}));
+vi.mock("@/lib/db/prisma", () => ({ prisma: mockPrisma }));
+
+import {
+  adjustGearPoolStock,
+  createGearCatalogItem,
+  createGearUnit,
+} from "@/lib/actions/gear-inventory";
+import { revalidatePath } from "next/cache";
+
+const LEAGUE_ID = "cllllllllllllllllllllllll";
+const CATALOG_ID = "caaaaaaaaaaaaaaaaaaaaaaaa";
+const LOCATION_ID = "cbbbbbbbbbbbbbbbbbbbbbbbb";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockRequireLeagueRole.mockResolvedValue("cuserrrrrrrrrrrrrrrrrrrrr");
+  tx.gearCatalogItem.create.mockResolvedValue({ id: CATALOG_ID });
+  tx.gearCatalogItem.findFirst.mockResolvedValue({ id: CATALOG_ID, trackingMode: "INDIVIDUAL" });
+  tx.gearStorageLocation.findFirst.mockResolvedValue({ id: LOCATION_ID });
+  tx.gearUnit.create.mockResolvedValue({ id: "cunittttttttttttttttttttt" });
+  tx.gearActivity.create.mockResolvedValue({});
+  tx.gearInventoryMovement.create.mockResolvedValue({});
+});
+
+describe("gear inventory actions", () => {
+  it("requires a league admin before creating catalog items", async () => {
+    mockRequireLeagueRole.mockRejectedValue(new Error("Unauthorized"));
+
+    const result = await createGearCatalogItem({
+      leagueId: LEAGUE_ID,
+      name: "Youth Helmet",
+      category: "Safety",
+      trackingMode: "POOLED",
+    });
+
+    expect(result).toEqual({ success: false, error: "League admin access is required." });
+    expect(tx.gearCatalogItem.create).not.toHaveBeenCalled();
+  });
+
+  it("creates a catalog activity record in the same transaction", async () => {
+    const result = await createGearCatalogItem({
+      leagueId: LEAGUE_ID,
+      name: "Youth Helmet",
+      category: "Safety",
+      trackingMode: "POOLED",
+    });
+
+    expect(result.success).toBe(true);
+    expect(tx.gearCatalogItem.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({ leagueId: LEAGUE_ID, normalizedKey: "youth helmet safety" }),
+    }));
+    expect(tx.gearActivity.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({ entityType: "CATALOG_ITEM", entityId: CATALOG_ID, action: "created" }),
+    }));
+    expect(revalidatePath).toHaveBeenCalledWith(`/league/${LEAGUE_ID}/gear`);
+  });
+
+  it("normalizes an individually tagged unit and records receipt movement and activity", async () => {
+    const result = await createGearUnit({
+      leagueId: LEAGUE_ID,
+      catalogItemId: CATALOG_ID,
+      currentLocationId: LOCATION_ID,
+      assetTag: " tag 42 ",
+      currentCondition: "GOOD",
+    });
+
+    expect(result.success).toBe(true);
+    expect(tx.gearUnit.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({ assetTag: "TAG42", currentLocationId: LOCATION_ID }),
+    }));
+    expect(tx.gearInventoryMovement.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({ type: "RECEIPT", gearUnitId: "cunittttttttttttttttttttt" }),
+    }));
+    expect(tx.gearActivity.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({ entityType: "UNIT", action: "created" }),
+    }));
+  });
+
+  it("rejects a negative pooled-stock adjustment before it creates a movement", async () => {
+    tx.gearCatalogItem.findFirst.mockResolvedValue({ id: CATALOG_ID, trackingMode: "POOLED" });
+    tx.gearPoolStock.findUnique.mockResolvedValue({ id: "cstockkkkkkkkkkkkkkkkkkkkk", quantityOnHand: 2, version: 3 });
+
+    const result = await adjustGearPoolStock({
+      leagueId: LEAGUE_ID,
+      catalogItemId: CATALOG_ID,
+      locationId: LOCATION_ID,
+      condition: "GOOD",
+      quantityDelta: -3,
+      expectedVersion: 3,
+    });
+
+    expect(result).toEqual({ success: false, error: "Inventory cannot fall below zero." });
+    expect(tx.gearInventoryMovement.create).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/lib/actions/gear-inventory.test.ts
+++ b/__tests__/lib/actions/gear-inventory.test.ts
@@ -4,11 +4,11 @@ vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
 
 const { mockRequireLeagueRole, mockPrisma, tx } = vi.hoisted(() => {
   const tx = {
-    gearCatalogItem: { create: vi.fn(), findFirst: vi.fn(), count: vi.fn() },
+    gearCatalogItem: { create: vi.fn(), findFirst: vi.fn(), update: vi.fn(), count: vi.fn() },
     gearStorageLocation: { findFirst: vi.fn(), create: vi.fn(), update: vi.fn() },
-    gearPoolStock: { findUnique: vi.fn(), create: vi.fn(), updateMany: vi.fn(), upsert: vi.fn() },
+    gearPoolStock: { findUnique: vi.fn(), create: vi.fn(), updateMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
     gearAllocation: { aggregate: vi.fn(), count: vi.fn() },
-    gearUnit: { create: vi.fn(), findFirst: vi.fn(), update: vi.fn(), count: vi.fn() },
+    gearUnit: { create: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), count: vi.fn() },
     gearInventoryMovement: { create: vi.fn(), count: vi.fn() },
     gearActivity: { create: vi.fn() },
   };
@@ -26,8 +26,11 @@ vi.mock("@/lib/db/prisma", () => ({ prisma: mockPrisma }));
 
 import {
   adjustGearPoolStock,
+  archiveGearCatalogItem,
   createGearCatalogItem,
   createGearUnit,
+  unretireGearUnit,
+  updateGearUnit,
 } from "@/lib/actions/gear-inventory";
 import { revalidatePath } from "next/cache";
 
@@ -44,6 +47,10 @@ beforeEach(() => {
   tx.gearUnit.create.mockResolvedValue({ id: "cunittttttttttttttttttttt" });
   tx.gearActivity.create.mockResolvedValue({});
   tx.gearInventoryMovement.create.mockResolvedValue({});
+  tx.gearPoolStock.count.mockResolvedValue(0);
+  tx.gearUnit.count.mockResolvedValue(0);
+  tx.gearInventoryMovement.count.mockResolvedValue(0);
+  tx.gearAllocation.count.mockResolvedValue(0);
 });
 
 describe("gear inventory actions", () => {
@@ -139,7 +146,68 @@ describe("gear inventory actions", () => {
         direction: "DECREASE",
         beforeLocationId: LOCATION_ID,
         afterLocationId: null,
+        beforeCondition: "GOOD",
+        afterCondition: null,
       }),
+    }));
+  });
+
+  it("refuses to archive catalog items with pooled stock or immutable history", async () => {
+    tx.gearCatalogItem.findFirst.mockResolvedValue({ id: CATALOG_ID });
+    tx.gearPoolStock.count.mockResolvedValue(1);
+
+    const result = await archiveGearCatalogItem({ leagueId: LEAGUE_ID, catalogItemId: CATALOG_ID });
+
+    expect(result).toEqual({
+      success: false,
+      error: "Catalog items with stock, active units, commitments, or inventory history cannot be archived.",
+    });
+    expect(tx.gearCatalogItem.update).not.toHaveBeenCalled();
+  });
+
+  it("rejects stale tagged-unit edits using the expected version", async () => {
+    tx.gearUnit.findFirst.mockResolvedValue({ id: "cunittttttttttttttttttttt", status: "AVAILABLE", version: 3 });
+    tx.gearUnit.updateMany.mockResolvedValue({ count: 0 });
+
+    const result = await updateGearUnit({
+      leagueId: LEAGUE_ID,
+      unitId: "cunittttttttttttttttttttt",
+      expectedVersion: 3,
+      assetTag: "TAG42",
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error: "Inventory changed while saving. Please review the latest inventory and try again.",
+    });
+    expect(tx.gearUnit.updateMany).toHaveBeenCalledWith(expect.objectContaining({
+      where: expect.objectContaining({ leagueId: LEAGUE_ID, version: 3 }),
+    }));
+  });
+
+  it("returns retired tagged units through a new receipt and activity record", async () => {
+    tx.gearUnit.findFirst.mockResolvedValue({ id: "cunittttttttttttttttttttt", status: "RETIRED", version: 4 });
+    tx.gearUnit.updateMany.mockResolvedValue({ count: 1 });
+
+    const result = await unretireGearUnit({
+      leagueId: LEAGUE_ID,
+      unitId: "cunittttttttttttttttttttt",
+      expectedVersion: 4,
+      destinationLocationId: LOCATION_ID,
+      condition: "GOOD",
+      notes: "Inspection cleared the unit.",
+    });
+
+    expect(result.success).toBe(true);
+    expect(tx.gearUnit.updateMany).toHaveBeenCalledWith(expect.objectContaining({
+      where: expect.objectContaining({ version: 4 }),
+      data: expect.objectContaining({ status: "AVAILABLE", currentLocationId: LOCATION_ID }),
+    }));
+    expect(tx.gearInventoryMovement.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({ type: "RECEIPT", direction: "INCREASE", gearUnitId: "cunittttttttttttttttttttt" }),
+    }));
+    expect(tx.gearActivity.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({ action: "unretired" }),
     }));
   });
 });

--- a/app/(dashboard)/league/[leagueId]/gear/page.tsx
+++ b/app/(dashboard)/league/[leagueId]/gear/page.tsx
@@ -1,0 +1,37 @@
+import { Inventory2Outlined } from "@mui/icons-material";
+import { notFound } from "next/navigation";
+import { GearInventoryManager } from "@/components/features/gear/GearInventoryManager";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { PageContainer } from "@/components/ui/PageContainer";
+import { PageHeader } from "@/components/ui/PageHeader";
+import { getGearInventoryContext } from "@/lib/actions/gear-context";
+
+interface GearInventoryPageProps {
+  params: Promise<{ leagueId: string }>;
+}
+
+export default async function GearInventoryPage({ params }: GearInventoryPageProps) {
+  const { leagueId } = await params;
+  const data = await getGearInventoryContext(leagueId);
+  if (!data) notFound();
+
+  const hasInventory = data.catalogItems.length > 0 || data.locations.length > 0 || data.units.length > 0 || data.pooledStock.length > 0;
+
+  return (
+    <PageContainer maxWidth="xl">
+      <PageHeader
+        title="Gear inventory"
+        subtitle={`${data.league.name} equipment, locations, and current availability.`}
+      />
+      {hasInventory || data.canManageInventory ? (
+        <GearInventoryManager data={data} />
+      ) : (
+        <EmptyState
+          icon={<Inventory2Outlined />}
+          title="No association gear is available yet"
+          description="League administrators can add locations and catalog items when equipment is ready to track."
+        />
+      )}
+    </PageContainer>
+  );
+}

--- a/app/(dashboard)/league/[leagueId]/gear/page.tsx
+++ b/app/(dashboard)/league/[leagueId]/gear/page.tsx
@@ -8,14 +8,20 @@ import { getGearInventoryContext } from "@/lib/actions/gear-context";
 
 interface GearInventoryPageProps {
   params: Promise<{ leagueId: string }>;
+  searchParams: Promise<{ activityPage?: string; activitySearch?: string }>;
 }
 
-export default async function GearInventoryPage({ params }: GearInventoryPageProps) {
+export default async function GearInventoryPage({ params, searchParams }: GearInventoryPageProps) {
   const { leagueId } = await params;
-  const data = await getGearInventoryContext(leagueId);
+  const query = await searchParams;
+  const activityPage = Number.parseInt(query.activityPage ?? "1", 10);
+  const data = await getGearInventoryContext(leagueId, {
+    activityPage: Number.isFinite(activityPage) ? activityPage : 1,
+    activitySearch: query.activitySearch,
+  });
   if (!data) notFound();
 
-  const hasInventory = data.catalogItems.length > 0 || data.locations.length > 0 || data.units.length > 0 || data.pooledStock.length > 0;
+  const hasInventory = data.units.length > 0 || data.pooledStock.length > 0;
 
   return (
     <PageContainer maxWidth="xl">

--- a/components/features/gear/GearInventoryManager.tsx
+++ b/components/features/gear/GearInventoryManager.tsx
@@ -63,6 +63,10 @@ function conditionLabel(value: string) {
   return value.charAt(0) + value.slice(1).toLowerCase();
 }
 
+function formatActivityTimestamp(value: string) {
+  return `${value.slice(0, 16).replace("T", " ")} UTC`;
+}
+
 function statusColor(status: string) {
   if (status === "AVAILABLE") return "success";
   if (status === "RETIRED" || status === "LOST") return "default";
@@ -153,6 +157,9 @@ export function GearInventoryManager({ data }: Props) {
             <Button variant="outlined" startIcon={<Add />} onClick={() => setDialog({ kind: "catalog" })} sx={{ minHeight: 44 }}>
               Catalog item
             </Button>
+            <Button variant="outlined" startIcon={<Add />} onClick={() => setDialog({ kind: "adjust" })} sx={{ minHeight: 44 }}>
+              Pooled stock
+            </Button>
             <Button variant="contained" startIcon={<Add />} onClick={() => setDialog({ kind: "unit" })} sx={{ minHeight: 44 }}>
               Tagged unit
             </Button>
@@ -234,7 +241,7 @@ export function GearInventoryManager({ data }: Props) {
             ))}
           </InventorySection>
           <InventorySection title="Recent inventory activity" empty="No inventory movements have been recorded.">
-            {data.recentActivity.map((activity) => <Card key={activity.id} variant="outlined"><CardContent><Typography fontWeight={700}>{conditionLabel(activity.type)} · {activity.quantity}</Typography><Typography variant="body2" color="text.secondary">{activity.beforeLocationName ?? "—"} <SwapHoriz fontSize="inherit" /> {activity.afterLocationName ?? "—"} · {new Date(activity.occurredAt).toLocaleString()}</Typography>{activity.notes ? <Typography variant="body2">{activity.notes}</Typography> : null}</CardContent></Card>)}
+            {data.recentActivity.map((activity) => <Card key={activity.id} variant="outlined"><CardContent><Typography fontWeight={700}>{conditionLabel(activity.type)} · {activity.quantity}</Typography><Typography variant="body2" color="text.secondary">{activity.beforeLocationName ?? "—"} <SwapHoriz fontSize="inherit" /> {activity.afterLocationName ?? "—"} · {formatActivityTimestamp(activity.occurredAt)}</Typography>{activity.notes ? <Typography variant="body2">{activity.notes}</Typography> : null}</CardContent></Card>)}
           </InventorySection>
         </>
       ) : null}
@@ -260,7 +267,8 @@ function GearDialog({ dialog, close, data, pending, submit }: {
   if (!dialog) return null;
   const unitCatalog = data.catalogItems.filter((item) => item.trackingMode === "INDIVIDUAL" && item.isActive);
   const pooledCatalog = data.catalogItems.filter((item) => item.trackingMode === "POOLED" && item.isActive);
-  return <Dialog open onClose={close} fullWidth maxWidth="sm" PaperProps={{ component: "form", onSubmit: (event: React.FormEvent<HTMLFormElement>) => {
+  const title = dialog.kind === "location" ? `${dialog.location ? "Edit" : "Add"} storage location` : dialog.kind === "catalog" ? `${dialog.item ? "Edit" : "Add"} catalog item` : dialog.kind === "adjust" ? "Adjust pooled stock" : dialog.kind === "pool-transfer" ? "Transfer pooled stock" : dialog.kind === "unit-transfer" ? "Transfer tagged unit" : dialog.kind === "unit-condition" ? "Change unit condition" : dialog.kind === "unit-retire" ? "Retire tagged unit" : `${dialog.unit ? "Edit" : "Add"} tagged unit`;
+  return <Dialog open onClose={close} fullWidth maxWidth="sm" aria-labelledby="gear-inventory-dialog-title" PaperProps={{ component: "form", onSubmit: (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault(); const form = new FormData(event.currentTarget);
     const value = (key: string) => String(form.get(key) ?? "");
     if (dialog.kind === "location") submit(() => dialog.location ? updateGearStorageLocation({ leagueId: data.league.id, locationId: dialog.location.id, name: value("name"), address: value("address"), privateNotes: value("privateNotes") }) : createGearStorageLocation({ leagueId: data.league.id, name: value("name"), address: value("address"), privateNotes: value("privateNotes") }));
@@ -272,11 +280,11 @@ function GearDialog({ dialog, close, data, pending, submit }: {
     if (dialog.kind === "unit-condition") submit(() => changeGearUnitCondition({ leagueId: data.league.id, unitId: dialog.unit.id, condition: value("condition") as typeof conditions[number], notes: value("notes") }));
     if (dialog.kind === "unit-retire") submit(() => retireGearUnit({ leagueId: data.league.id, unitId: dialog.unit.id, notes: value("notes") }));
   } }}>
-    <DialogTitle>{dialog.kind === "location" ? `${dialog.location ? "Edit" : "Add"} storage location` : dialog.kind === "catalog" ? `${dialog.item ? "Edit" : "Add"} catalog item` : dialog.kind === "adjust" ? "Adjust pooled stock" : dialog.kind === "pool-transfer" ? "Transfer pooled stock" : dialog.kind === "unit-transfer" ? "Transfer tagged unit" : dialog.kind === "unit-condition" ? "Change unit condition" : dialog.kind === "unit-retire" ? "Retire tagged unit" : `${dialog.unit ? "Edit" : "Add"} tagged unit`}</DialogTitle>
+    <DialogTitle id="gear-inventory-dialog-title">{title}</DialogTitle>
     <DialogContent><Stack spacing={2} sx={{ pt: 1 }}>
       {dialog.kind === "location" ? <><TextField required name="name" label="Location name" defaultValue={dialog.location?.name} inputProps={{ maxLength: 120 }} /><TextField name="address" label="Address" defaultValue={dialog.location?.address ?? ""} /><TextField name="privateNotes" label="Admin-only notes" defaultValue={dialog.location?.privateNotes ?? ""} multiline minRows={2} /></> : null}
       {dialog.kind === "catalog" ? <><TextField required name="name" label="Item name" defaultValue={dialog.item?.name} /><TextField required name="category" label="Category" defaultValue={dialog.item?.category} /><TextField name="size" label="Size" defaultValue={dialog.item?.size ?? ""} /><TextField name="brand" label="Brand" defaultValue={dialog.item?.brand ?? ""} /><TextField name="model" label="Model" defaultValue={dialog.item?.model ?? ""} /><TextField name="description" label="Description" defaultValue={dialog.item?.description ?? ""} multiline minRows={2} /><SelectField name="trackingMode" label="Tracking mode" defaultValue={dialog.item?.trackingMode ?? "POOLED"} options={[["POOLED", "Pooled stock"], ["INDIVIDUAL", "Individually tagged"]]} /></> : null}
-      {dialog.kind === "adjust" ? <><SelectField name="catalogItemId" label="Catalog item" defaultValue={dialog.stock?.catalogItemId ?? pooledCatalog[0]?.id ?? ""} options={pooledCatalog.map((item) => [item.id, item.name])} /><SelectField name="locationId" label="Storage location" defaultValue={dialog.stock?.locationId ?? data.locations.find((location) => location.isActive)?.id ?? ""} options={data.locations.filter((location) => location.isActive).map((location) => [location.id, location.name])} /><SelectField name="condition" label="Condition" defaultValue={dialog.stock?.condition ?? "GOOD"} options={conditions.map((condition) => [condition, conditionLabel(condition)])} /><TextField required name="quantityDelta" type="number" label="Adjustment (+/-)" inputProps={{ step: 1 }} /><input type="hidden" name="expectedVersion" value={dialog.stock?.version ?? 0} /><TextField name="notes" label="Reason / notes" multiline minRows={2} /></> : null}
+      {dialog.kind === "adjust" ? <><SelectField name="catalogItemId" label="Catalog item" defaultValue={dialog.stock?.catalogItemId ?? pooledCatalog[0]?.id ?? ""} options={pooledCatalog.map((item) => [item.id, item.name])} /><SelectField name="locationId" label="Storage location" defaultValue={dialog.stock?.locationId ?? data.locations.find((location) => location.isActive)?.id ?? ""} options={data.locations.filter((location) => location.isActive).map((location) => [location.id, location.name])} /><SelectField name="condition" label="Condition" defaultValue={dialog.stock?.condition ?? "GOOD"} options={conditions.map((condition) => [condition, conditionLabel(condition)])} /><TextField required name="quantityDelta" type="number" label={dialog.stock ? "Adjustment (+/-)" : "Initial quantity"} inputProps={{ step: 1, min: dialog.stock ? undefined : 1 }} /><input type="hidden" name="expectedVersion" value={dialog.stock?.version ?? 0} /><TextField name="notes" label="Reason / notes" multiline minRows={2} /></> : null}
       {dialog.kind === "pool-transfer" ? <><Typography>{dialog.stock.catalogName}: {dialog.stock.quantityOnHand} on hand at {dialog.stock.locationName}</Typography><SelectField name="destinationLocationId" label="Destination" defaultValue="" options={data.locations.filter((location) => location.isActive && location.id !== dialog.stock.locationId).map((location) => [location.id, location.name])} /><TextField required name="quantity" type="number" label="Quantity" inputProps={{ min: 1, max: dialog.stock.availableQuantity }} /><TextField name="notes" label="Notes" /></> : null}
       {dialog.kind === "unit" ? <><>{!dialog.unit ? <><SelectField name="catalogItemId" label="Catalog item" defaultValue={unitCatalog[0]?.id ?? ""} options={unitCatalog.map((item) => [item.id, item.name])} /><SelectField name="currentLocationId" label="Storage location" defaultValue={data.locations.find((location) => location.isActive)?.id ?? ""} options={data.locations.filter((location) => location.isActive).map((location) => [location.id, location.name])} /><SelectField name="currentCondition" label="Condition" defaultValue="GOOD" options={conditions.map((condition) => [condition, conditionLabel(condition)])} /></> : null}</><TextField required name="assetTag" label="Asset tag" defaultValue={dialog.unit?.assetTag ?? ""} /><TextField name="serialNumber" label="Serial number" defaultValue={dialog.unit?.serialNumber ?? ""} /><TextField name="acquiredAt" label="Acquired date" type="date" defaultValue={dialog.unit?.acquiredAt?.slice(0, 10) ?? ""} InputLabelProps={{ shrink: true }} /><TextField name="notes" label="Notes" defaultValue={dialog.unit?.notes ?? ""} multiline minRows={2} /></> : null}
       {dialog.kind === "unit-transfer" ? <><Typography>{dialog.unit.catalogName} · {dialog.unit.assetTag}</Typography><SelectField name="destinationLocationId" label="Destination" defaultValue="" options={data.locations.filter((location) => location.isActive && location.id !== dialog.unit.currentLocationId).map((location) => [location.id, location.name])} /><TextField name="notes" label="Notes" /></> : null}

--- a/components/features/gear/GearInventoryManager.tsx
+++ b/components/features/gear/GearInventoryManager.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState, useTransition } from "react";
+import { useEffect, useMemo, useRef, useState, useTransition } from "react";
 import {
   Alert,
   Box,
@@ -41,6 +41,7 @@ import {
   retireGearUnit,
   transferGearPoolStock,
   transferGearUnit,
+  unretireGearUnit,
   updateGearCatalogItem,
   updateGearStorageLocation,
   updateGearUnit,
@@ -55,7 +56,8 @@ type DialogState =
   | { kind: "unit"; unit?: GearInventoryContext["units"][number] }
   | { kind: "unit-transfer"; unit: GearInventoryContext["units"][number] }
   | { kind: "unit-condition"; unit: GearInventoryContext["units"][number] }
-  | { kind: "unit-retire"; unit: GearInventoryContext["units"][number] };
+  | { kind: "unit-retire"; unit: GearInventoryContext["units"][number] }
+  | { kind: "unit-unretire"; unit: GearInventoryContext["units"][number] };
 
 const conditions = ["NEW", "EXCELLENT", "GOOD", "FAIR", "POOR", "DAMAGED"] as const;
 
@@ -92,6 +94,8 @@ export function GearInventoryManager({ data }: Props) {
   const [dialog, setDialog] = useState<DialogState | null>(null);
   const [search, setSearch] = useState("");
   const [feedback, setFeedback] = useState<string | null>(null);
+  const [dialogError, setDialogError] = useState<string | null>(null);
+  const [activitySearch, setActivitySearch] = useState(data.recentActivity.search);
 
   const filteredStock = useMemo(() => {
     const query = search.trim().toLowerCase();
@@ -108,15 +112,27 @@ export function GearInventoryManager({ data }: Props) {
     );
   }, [data.units, search]);
 
-  function submit(run: () => Promise<{ success: boolean; error?: string }>) {
+  function submit(run: () => Promise<{ success: boolean; error?: string; details?: unknown }>) {
     setFeedback(null);
+    setDialogError(null);
     startTransition(async () => {
       const result = await run();
       if (result.success) {
         setDialog(null);
         router.refresh();
       } else {
-        setFeedback(result.error ?? "Unable to save inventory.");
+        const fieldDetails = Array.isArray(result.details)
+          ? result.details
+              .map((detail) => typeof detail === "object" && detail !== null && "path" in detail && "message" in detail
+                ? `${Array.isArray(detail.path) ? detail.path.join(".") : "Field"}: ${String(detail.message)}`
+                : null)
+              .filter(Boolean)
+              .join(" ")
+          : "";
+        const message = [result.error ?? "Unable to save inventory.", fieldDetails].filter(Boolean).join(" ");
+        setFeedback(message);
+        setDialogError(message);
+        if ((result.error ?? "").startsWith("Inventory changed while saving")) router.refresh();
       }
     });
   }
@@ -125,9 +141,16 @@ export function GearInventoryManager({ data }: Props) {
     submit(run);
   }
 
+  function navigateActivity(page: number, value = activitySearch) {
+    const params = new URLSearchParams();
+    if (value.trim()) params.set("activitySearch", value.trim());
+    if (page > 1) params.set("activityPage", String(page));
+    router.push(`${window.location.pathname}${params.size ? `?${params.toString()}` : ""}`);
+  }
+
   return (
     <Stack spacing={3}>
-      {feedback ? <Alert severity="error" onClose={() => setFeedback(null)}>{feedback}</Alert> : null}
+      {feedback && !dialog ? <Alert severity="error" onClose={() => setFeedback(null)}>{feedback}</Alert> : null}
       <Box
         sx={{
           display: "grid",
@@ -166,13 +189,13 @@ export function GearInventoryManager({ data }: Props) {
           </Stack>
         ) : null}
       </Stack>
-      {data.catalogItems.length === 0 && data.locations.length === 0 && data.pooledStock.length === 0 && data.units.length === 0 ? (
+      {data.pooledStock.length === 0 && data.units.length === 0 ? (
         <Alert severity="info" role="status">
           Start by adding a storage location and catalog item, then record your first inventory.
         </Alert>
       ) : null}
 
-      <InventorySection title="Pooled stock" empty="No pooled inventory matches this search.">
+      <InventorySection title="Pooled stock" empty="No pooled inventory matches this search." count={filteredStock.length}>
         {filteredStock.map((stock) => (
           <Card key={stock.id} variant="outlined" sx={{ display: { xs: "block", md: "none" } }}>
             <CardContent>
@@ -206,14 +229,14 @@ export function GearInventoryManager({ data }: Props) {
         </TableContainer>
       </InventorySection>
 
-      <InventorySection title="Tagged units" empty="No tagged units match this search.">
+      <InventorySection title="Tagged units" empty="No tagged units match this search." count={filteredUnits.length}>
         {filteredUnits.map((unit) => (
           <Card key={unit.id} variant="outlined" sx={{ display: { xs: "block", md: "none" } }}>
             <CardContent>
               <Stack spacing={1}>
                 <Stack direction="row" justifyContent="space-between"><Typography fontWeight={700}>{unit.catalogName}</Typography><Chip size="small" label={conditionLabel(unit.status)} color={statusColor(unit.status)} /></Stack>
-                <Typography variant="body2" color="text.secondary">{unit.assetTag ?? "No asset tag"} · {unit.currentLocationName ?? "No location"}</Typography>
-                {data.canManageInventory && ["AVAILABLE", "MAINTENANCE"].includes(unit.status) ? <UnitActions unit={unit} open={setDialog} /> : null}
+                <Typography variant="body2" color="text.secondary">{unit.assetTag ?? "No asset tag"} · {unit.currentLocationName ?? "No location"} · {conditionLabel(unit.currentCondition)}</Typography>
+                {data.canManageInventory ? <UnitActions unit={unit} open={setDialog} /> : null}
               </Stack>
             </CardContent>
           </Card>
@@ -230,44 +253,57 @@ export function GearInventoryManager({ data }: Props) {
 
       {data.canManageInventory ? (
         <>
-          <InventorySection title="Storage locations" empty="No storage locations have been created.">
+          <InventorySection title="Storage locations" empty="No storage locations have been created." count={data.locations.length}>
             {data.locations.map((location) => (
               <Card key={location.id} variant="outlined"><CardContent><Stack direction={{ xs: "column", sm: "row" }} justifyContent="space-between" spacing={1}><Box><Typography fontWeight={700}>{location.name}</Typography><Typography variant="body2" color="text.secondary">{location.address ?? "No address"}</Typography>{location.privateNotes ? <Typography variant="body2" sx={{ mt: 1 }}>Admin note: {location.privateNotes}</Typography> : null}</Box><Stack direction="row"><Button aria-label={`Edit ${location.name}`} onClick={() => setDialog({ kind: "location", location })}><Edit /></Button>{location.isActive ? <Button aria-label={`Archive ${location.name}`} onClick={() => archive(() => archiveGearStorageLocation({ leagueId: data.league.id, locationId: location.id }))}><Archive /></Button> : null}</Stack></Stack></CardContent></Card>
             ))}
           </InventorySection>
-          <InventorySection title="Catalog" empty="No catalog items have been created.">
+          <InventorySection title="Catalog" empty="No catalog items have been created." count={data.catalogItems.length}>
             {data.catalogItems.map((item) => (
               <Card key={item.id} variant="outlined"><CardContent><Stack direction={{ xs: "column", sm: "row" }} justifyContent="space-between" spacing={1}><Box><Typography fontWeight={700}>{item.name}</Typography><Typography variant="body2" color="text.secondary">{item.category}{item.size ? ` · ${item.size}` : ""} · {conditionLabel(item.trackingMode)}</Typography></Box><Stack direction="row"><Button aria-label={`Edit ${item.name}`} onClick={() => setDialog({ kind: "catalog", item })}><Edit /></Button>{item.isActive ? <Button aria-label={`Archive ${item.name}`} onClick={() => archive(() => archiveGearCatalogItem({ leagueId: data.league.id, catalogItemId: item.id }))}><Archive /></Button> : null}</Stack></Stack></CardContent></Card>
             ))}
           </InventorySection>
-          <InventorySection title="Recent inventory activity" empty="No inventory movements have been recorded.">
-            {data.recentActivity.map((activity) => <Card key={activity.id} variant="outlined"><CardContent><Typography fontWeight={700}>{conditionLabel(activity.type)} · {activity.quantity}</Typography><Typography variant="body2" color="text.secondary">{activity.beforeLocationName ?? "—"} <SwapHoriz fontSize="inherit" /> {activity.afterLocationName ?? "—"} · {formatActivityTimestamp(activity.occurredAt)}</Typography>{activity.notes ? <Typography variant="body2">{activity.notes}</Typography> : null}</CardContent></Card>)}
+          <Stack spacing={1.5}>
+            <Typography variant="h5" component="h2">Recent inventory activity</Typography>
+            <Stack direction={{ xs: "column", sm: "row" }} spacing={1}>
+              <TextField label="Search activity" value={activitySearch} onChange={(event) => setActivitySearch(event.target.value)} />
+              <Button variant="outlined" onClick={() => navigateActivity(1)} sx={{ minHeight: 44 }}>Search</Button>
+            </Stack>
+          <InventorySection title="Movement results" empty={data.recentActivity.search ? "No inventory movements match this search." : "No inventory movements have been recorded."} count={data.recentActivity.items.length}>
+            {data.recentActivity.items.map((activity) => <Card key={activity.id} variant="outlined"><CardContent><Typography fontWeight={700}>{activity.catalogName ?? "Inventory item"}{activity.assetTag ? ` · ${activity.assetTag}` : ""} · {conditionLabel(activity.type)} {activity.direction.toLowerCase()} · {activity.quantity}</Typography><Typography variant="body2" color="text.secondary">{activity.beforeLocationName ?? "—"} <SwapHoriz fontSize="inherit" /> {activity.afterLocationName ?? "—"} · {conditionLabel(activity.beforeCondition ?? "—")} → {conditionLabel(activity.afterCondition ?? "—")} · {formatActivityTimestamp(activity.occurredAt)}{activity.actorName ? ` · ${activity.actorName}` : ""}</Typography>{activity.notes ? <Typography variant="body2">{activity.notes}</Typography> : null}</CardContent></Card>)}
+            <Stack direction="row" spacing={1}>
+              <Button disabled={data.recentActivity.page === 1} onClick={() => navigateActivity(data.recentActivity.page - 1)} sx={{ minHeight: 44 }}>Previous</Button>
+              <Button disabled={!data.recentActivity.hasMore} onClick={() => navigateActivity(data.recentActivity.page + 1)} sx={{ minHeight: 44 }}>Next</Button>
+            </Stack>
           </InventorySection>
+          </Stack>
         </>
       ) : null}
 
-      <GearDialog dialog={dialog} close={() => setDialog(null)} data={data} pending={isPending} submit={submit} />
+      <GearDialog dialog={dialog} close={() => { setDialog(null); setDialogError(null); }} data={data} pending={isPending} error={dialogError} submit={submit} />
     </Stack>
   );
 }
 
-function InventorySection({ title, empty, children }: { title: string; empty: string; children: React.ReactNode }) {
-  const entries = Array.isArray(children) ? children : [children];
-  return <Stack spacing={1.5}><Typography variant="h5" component="h2">{title}</Typography>{entries.length ? entries : <Typography color="text.secondary">{empty}</Typography>}</Stack>;
+function InventorySection({ title, empty, count, children }: { title: string; empty: string; count: number; children: React.ReactNode }) {
+  return <Stack spacing={1.5}><Typography variant="h5" component="h2">{title}</Typography>{count > 0 ? children : <Typography color="text.secondary">{empty}</Typography>}</Stack>;
 }
 
 function UnitActions({ unit, open }: { unit: GearInventoryContext["units"][number]; open: (state: DialogState) => void }) {
-  return <Stack direction="row" spacing={0.5}><Button size="small" onClick={() => open({ kind: "unit", unit })}>Edit</Button>{["AVAILABLE", "MAINTENANCE"].includes(unit.status) ? <><Button size="small" onClick={() => open({ kind: "unit-transfer", unit })}>Transfer</Button><Button size="small" onClick={() => open({ kind: "unit-condition", unit })}>Condition</Button><Button size="small" color="error" onClick={() => open({ kind: "unit-retire", unit })}>Retire</Button></> : null}</Stack>;
+  return <Stack direction="row" spacing={0.5}><>{!["RETIRED", "LOST"].includes(unit.status) ? <Button size="small" onClick={() => open({ kind: "unit", unit })}>Edit</Button> : null}</>{["AVAILABLE", "MAINTENANCE"].includes(unit.status) ? <><Button size="small" onClick={() => open({ kind: "unit-transfer", unit })}>Transfer</Button><Button size="small" onClick={() => open({ kind: "unit-condition", unit })}>Condition</Button><Button size="small" color="error" onClick={() => open({ kind: "unit-retire", unit })}>Retire</Button></> : null}{unit.status === "RETIRED" ? <Button size="small" onClick={() => open({ kind: "unit-unretire", unit })}>Return to inventory</Button> : null}</Stack>;
 }
 
-function GearDialog({ dialog, close, data, pending, submit }: {
+function GearDialog({ dialog, close, data, pending, error, submit }: {
   dialog: DialogState | null; close: () => void; data: GearInventoryContext; pending: boolean;
-  submit: (run: () => Promise<{ success: boolean; error?: string }>) => void;
+  error: string | null;
+  submit: (run: () => Promise<{ success: boolean; error?: string; details?: unknown }>) => void;
 }) {
+  const errorRef = useRef<HTMLDivElement>(null);
+  useEffect(() => { if (error) errorRef.current?.focus(); }, [error]);
   if (!dialog) return null;
   const unitCatalog = data.catalogItems.filter((item) => item.trackingMode === "INDIVIDUAL" && item.isActive);
   const pooledCatalog = data.catalogItems.filter((item) => item.trackingMode === "POOLED" && item.isActive);
-  const title = dialog.kind === "location" ? `${dialog.location ? "Edit" : "Add"} storage location` : dialog.kind === "catalog" ? `${dialog.item ? "Edit" : "Add"} catalog item` : dialog.kind === "adjust" ? "Adjust pooled stock" : dialog.kind === "pool-transfer" ? "Transfer pooled stock" : dialog.kind === "unit-transfer" ? "Transfer tagged unit" : dialog.kind === "unit-condition" ? "Change unit condition" : dialog.kind === "unit-retire" ? "Retire tagged unit" : `${dialog.unit ? "Edit" : "Add"} tagged unit`;
+  const title = dialog.kind === "location" ? `${dialog.location ? "Edit" : "Add"} storage location` : dialog.kind === "catalog" ? `${dialog.item ? "Edit" : "Add"} catalog item` : dialog.kind === "adjust" ? "Adjust pooled stock" : dialog.kind === "pool-transfer" ? "Transfer pooled stock" : dialog.kind === "unit-transfer" ? "Transfer tagged unit" : dialog.kind === "unit-condition" ? "Change unit condition" : dialog.kind === "unit-retire" ? "Retire tagged unit" : dialog.kind === "unit-unretire" ? "Return tagged unit to inventory" : `${dialog.unit ? "Edit" : "Add"} tagged unit`;
   return <Dialog open onClose={close} fullWidth maxWidth="sm" aria-labelledby="gear-inventory-dialog-title" PaperProps={{ component: "form", onSubmit: (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault(); const form = new FormData(event.currentTarget);
     const value = (key: string) => String(form.get(key) ?? "");
@@ -275,13 +311,15 @@ function GearDialog({ dialog, close, data, pending, submit }: {
     if (dialog.kind === "catalog") submit(() => dialog.item ? updateGearCatalogItem({ leagueId: data.league.id, catalogItemId: dialog.item.id, name: value("name"), category: value("category"), size: value("size"), brand: value("brand"), model: value("model"), description: value("description"), trackingMode: value("trackingMode") }) : createGearCatalogItem({ leagueId: data.league.id, name: value("name"), category: value("category"), size: value("size"), brand: value("brand"), model: value("model"), description: value("description"), trackingMode: value("trackingMode") as "POOLED" | "INDIVIDUAL" }));
     if (dialog.kind === "adjust") submit(() => adjustGearPoolStock({ leagueId: data.league.id, catalogItemId: value("catalogItemId"), locationId: value("locationId"), condition: value("condition") as typeof conditions[number], quantityDelta: Number(value("quantityDelta")), expectedVersion: Number(value("expectedVersion")), notes: value("notes") }));
     if (dialog.kind === "pool-transfer") submit(() => transferGearPoolStock({ leagueId: data.league.id, catalogItemId: dialog.stock.catalogItemId, sourceLocationId: dialog.stock.locationId, destinationLocationId: value("destinationLocationId"), condition: dialog.stock.condition, quantity: Number(value("quantity")), expectedSourceVersion: dialog.stock.version, notes: value("notes") }));
-    if (dialog.kind === "unit") submit(() => dialog.unit ? updateGearUnit({ leagueId: data.league.id, unitId: dialog.unit.id, assetTag: value("assetTag"), serialNumber: value("serialNumber"), acquiredAt: value("acquiredAt"), notes: value("notes") }) : createGearUnit({ leagueId: data.league.id, catalogItemId: value("catalogItemId"), currentLocationId: value("currentLocationId"), assetTag: value("assetTag"), serialNumber: value("serialNumber"), currentCondition: value("currentCondition") as typeof conditions[number], acquiredAt: value("acquiredAt"), notes: value("notes") }));
-    if (dialog.kind === "unit-transfer") submit(() => transferGearUnit({ leagueId: data.league.id, unitId: dialog.unit.id, destinationLocationId: value("destinationLocationId"), notes: value("notes") }));
-    if (dialog.kind === "unit-condition") submit(() => changeGearUnitCondition({ leagueId: data.league.id, unitId: dialog.unit.id, condition: value("condition") as typeof conditions[number], notes: value("notes") }));
-    if (dialog.kind === "unit-retire") submit(() => retireGearUnit({ leagueId: data.league.id, unitId: dialog.unit.id, notes: value("notes") }));
+    if (dialog.kind === "unit") submit(() => dialog.unit ? updateGearUnit({ leagueId: data.league.id, unitId: dialog.unit.id, expectedVersion: dialog.unit.version ?? -1, assetTag: value("assetTag"), serialNumber: value("serialNumber"), acquiredAt: value("acquiredAt"), notes: value("notes") }) : createGearUnit({ leagueId: data.league.id, catalogItemId: value("catalogItemId"), currentLocationId: value("currentLocationId"), assetTag: value("assetTag"), serialNumber: value("serialNumber"), currentCondition: value("currentCondition") as typeof conditions[number], acquiredAt: value("acquiredAt"), notes: value("notes") }));
+    if (dialog.kind === "unit-transfer") submit(() => transferGearUnit({ leagueId: data.league.id, unitId: dialog.unit.id, expectedVersion: dialog.unit.version ?? -1, destinationLocationId: value("destinationLocationId"), notes: value("notes") }));
+    if (dialog.kind === "unit-condition") submit(() => changeGearUnitCondition({ leagueId: data.league.id, unitId: dialog.unit.id, expectedVersion: dialog.unit.version ?? -1, condition: value("condition") as typeof conditions[number], notes: value("notes") }));
+    if (dialog.kind === "unit-retire") submit(() => retireGearUnit({ leagueId: data.league.id, unitId: dialog.unit.id, expectedVersion: dialog.unit.version ?? -1, notes: value("notes") }));
+    if (dialog.kind === "unit-unretire") submit(() => unretireGearUnit({ leagueId: data.league.id, unitId: dialog.unit.id, expectedVersion: dialog.unit.version ?? -1, destinationLocationId: value("destinationLocationId"), condition: value("condition") as typeof conditions[number], notes: value("notes") }));
   } }}>
     <DialogTitle id="gear-inventory-dialog-title">{title}</DialogTitle>
     <DialogContent><Stack spacing={2} sx={{ pt: 1 }}>
+      {error ? <Alert ref={errorRef} severity="error" role="alert" tabIndex={-1}>{error}</Alert> : null}
       {dialog.kind === "location" ? <><TextField required name="name" label="Location name" defaultValue={dialog.location?.name} inputProps={{ maxLength: 120 }} /><TextField name="address" label="Address" defaultValue={dialog.location?.address ?? ""} /><TextField name="privateNotes" label="Admin-only notes" defaultValue={dialog.location?.privateNotes ?? ""} multiline minRows={2} /></> : null}
       {dialog.kind === "catalog" ? <><TextField required name="name" label="Item name" defaultValue={dialog.item?.name} /><TextField required name="category" label="Category" defaultValue={dialog.item?.category} /><TextField name="size" label="Size" defaultValue={dialog.item?.size ?? ""} /><TextField name="brand" label="Brand" defaultValue={dialog.item?.brand ?? ""} /><TextField name="model" label="Model" defaultValue={dialog.item?.model ?? ""} /><TextField name="description" label="Description" defaultValue={dialog.item?.description ?? ""} multiline minRows={2} /><SelectField name="trackingMode" label="Tracking mode" defaultValue={dialog.item?.trackingMode ?? "POOLED"} options={[["POOLED", "Pooled stock"], ["INDIVIDUAL", "Individually tagged"]]} /></> : null}
       {dialog.kind === "adjust" ? <><SelectField name="catalogItemId" label="Catalog item" defaultValue={dialog.stock?.catalogItemId ?? pooledCatalog[0]?.id ?? ""} options={pooledCatalog.map((item) => [item.id, item.name])} /><SelectField name="locationId" label="Storage location" defaultValue={dialog.stock?.locationId ?? data.locations.find((location) => location.isActive)?.id ?? ""} options={data.locations.filter((location) => location.isActive).map((location) => [location.id, location.name])} /><SelectField name="condition" label="Condition" defaultValue={dialog.stock?.condition ?? "GOOD"} options={conditions.map((condition) => [condition, conditionLabel(condition)])} /><TextField required name="quantityDelta" type="number" label={dialog.stock ? "Adjustment (+/-)" : "Initial quantity"} inputProps={{ step: 1, min: dialog.stock ? undefined : 1 }} /><input type="hidden" name="expectedVersion" value={dialog.stock?.version ?? 0} /><TextField name="notes" label="Reason / notes" multiline minRows={2} /></> : null}
@@ -290,6 +328,7 @@ function GearDialog({ dialog, close, data, pending, submit }: {
       {dialog.kind === "unit-transfer" ? <><Typography>{dialog.unit.catalogName} · {dialog.unit.assetTag}</Typography><SelectField name="destinationLocationId" label="Destination" defaultValue="" options={data.locations.filter((location) => location.isActive && location.id !== dialog.unit.currentLocationId).map((location) => [location.id, location.name])} /><TextField name="notes" label="Notes" /></> : null}
       {dialog.kind === "unit-condition" ? <><Typography>{dialog.unit.catalogName} · {dialog.unit.assetTag}</Typography><SelectField name="condition" label="New condition" defaultValue={dialog.unit.currentCondition} options={conditions.map((condition) => [condition, conditionLabel(condition)])} /><TextField name="notes" label="Notes" /></> : null}
       {dialog.kind === "unit-retire" ? <><Alert severity="warning">This will remove the unit from active inventory.</Alert><TextField required name="notes" label="Retirement reason" multiline minRows={2} /></> : null}
+      {dialog.kind === "unit-unretire" ? <><Alert severity="info">This creates a new receipt and activity record; retirement history is preserved.</Alert><SelectField name="destinationLocationId" label="Destination" defaultValue={data.locations.find((location) => location.isActive)?.id ?? ""} options={data.locations.filter((location) => location.isActive).map((location) => [location.id, location.name])} /><SelectField name="condition" label="Current condition" defaultValue={dialog.unit.currentCondition} options={conditions.map((condition) => [condition, conditionLabel(condition)])} /><TextField required name="notes" label="Return reason" multiline minRows={2} /></> : null}
     </Stack></DialogContent>
     <DialogActions><Button onClick={close} disabled={pending}>Cancel</Button><Button type="submit" variant="contained" disabled={pending} sx={{ minHeight: 44 }}>{pending ? "Saving…" : "Save"}</Button></DialogActions>
   </Dialog>;

--- a/components/features/gear/GearInventoryManager.tsx
+++ b/components/features/gear/GearInventoryManager.tsx
@@ -1,0 +1,292 @@
+"use client";
+
+import { useMemo, useState, useTransition } from "react";
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Chip,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { Add, Archive, Edit, SwapHoriz } from "@mui/icons-material";
+import { useRouter } from "next/navigation";
+import type { GearInventoryContext } from "@/lib/actions/gear-context";
+import {
+  adjustGearPoolStock,
+  archiveGearCatalogItem,
+  archiveGearStorageLocation,
+  changeGearUnitCondition,
+  createGearCatalogItem,
+  createGearStorageLocation,
+  createGearUnit,
+  retireGearUnit,
+  transferGearPoolStock,
+  transferGearUnit,
+  updateGearCatalogItem,
+  updateGearStorageLocation,
+  updateGearUnit,
+} from "@/lib/actions/gear-inventory";
+
+type Props = { data: GearInventoryContext };
+type DialogState =
+  | { kind: "location"; location?: GearInventoryContext["locations"][number] }
+  | { kind: "catalog"; item?: GearInventoryContext["catalogItems"][number] }
+  | { kind: "adjust"; stock?: GearInventoryContext["pooledStock"][number] }
+  | { kind: "pool-transfer"; stock: GearInventoryContext["pooledStock"][number] }
+  | { kind: "unit"; unit?: GearInventoryContext["units"][number] }
+  | { kind: "unit-transfer"; unit: GearInventoryContext["units"][number] }
+  | { kind: "unit-condition"; unit: GearInventoryContext["units"][number] }
+  | { kind: "unit-retire"; unit: GearInventoryContext["units"][number] };
+
+const conditions = ["NEW", "EXCELLENT", "GOOD", "FAIR", "POOR", "DAMAGED"] as const;
+
+function conditionLabel(value: string) {
+  return value.charAt(0) + value.slice(1).toLowerCase();
+}
+
+function statusColor(status: string) {
+  if (status === "AVAILABLE") return "success";
+  if (status === "RETIRED" || status === "LOST") return "default";
+  if (status === "MAINTENANCE") return "warning";
+  return "info";
+}
+
+function MetricCard({ label, value, helper }: { label: string; value: number; helper: string }) {
+  return (
+    <Card variant="outlined">
+      <CardContent>
+        <Typography variant="overline" color="text.secondary">{label}</Typography>
+        <Typography variant="h4" component="p">{value}</Typography>
+        <Typography variant="body2" color="text.secondary">{helper}</Typography>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function GearInventoryManager({ data }: Props) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [dialog, setDialog] = useState<DialogState | null>(null);
+  const [search, setSearch] = useState("");
+  const [feedback, setFeedback] = useState<string | null>(null);
+
+  const filteredStock = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    if (!query) return data.pooledStock;
+    return data.pooledStock.filter((stock) =>
+      `${stock.catalogName} ${stock.category} ${stock.locationName} ${stock.condition}`.toLowerCase().includes(query),
+    );
+  }, [data.pooledStock, search]);
+  const filteredUnits = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    if (!query) return data.units;
+    return data.units.filter((unit) =>
+      `${unit.catalogName} ${unit.assetTag ?? ""} ${unit.status} ${unit.currentLocationName ?? ""}`.toLowerCase().includes(query),
+    );
+  }, [data.units, search]);
+
+  function submit(run: () => Promise<{ success: boolean; error?: string }>) {
+    setFeedback(null);
+    startTransition(async () => {
+      const result = await run();
+      if (result.success) {
+        setDialog(null);
+        router.refresh();
+      } else {
+        setFeedback(result.error ?? "Unable to save inventory.");
+      }
+    });
+  }
+
+  function archive(run: () => Promise<{ success: boolean; error?: string }>) {
+    submit(run);
+  }
+
+  return (
+    <Stack spacing={3}>
+      {feedback ? <Alert severity="error" onClose={() => setFeedback(null)}>{feedback}</Alert> : null}
+      <Box
+        sx={{
+          display: "grid",
+          gridTemplateColumns: { xs: "repeat(2, minmax(0, 1fr))", md: "repeat(4, minmax(0, 1fr))" },
+          gap: 2,
+        }}
+      >
+        <MetricCard label="Pooled on hand" value={data.summary.pooledOnHand} helper="All locations" />
+        <MetricCard label="Pooled available" value={data.summary.pooledAvailable} helper="After commitments" />
+        <MetricCard label="Tagged units" value={data.summary.taggedUnits} helper="Tracked individually" />
+        <MetricCard label="Ready units" value={data.summary.taggedAvailable} helper="Available to assign" />
+      </Box>
+
+      <Stack direction={{ xs: "column", sm: "row" }} spacing={1} justifyContent="space-between">
+        <TextField
+          label="Search inventory"
+          value={search}
+          onChange={(event) => setSearch(event.target.value)}
+          inputProps={{ "aria-label": "Search inventory" }}
+          sx={{ minWidth: { sm: 280 } }}
+        />
+        {data.canManageInventory ? (
+          <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+            <Button variant="outlined" startIcon={<Add />} onClick={() => setDialog({ kind: "location" })} sx={{ minHeight: 44 }}>
+              Location
+            </Button>
+            <Button variant="outlined" startIcon={<Add />} onClick={() => setDialog({ kind: "catalog" })} sx={{ minHeight: 44 }}>
+              Catalog item
+            </Button>
+            <Button variant="contained" startIcon={<Add />} onClick={() => setDialog({ kind: "unit" })} sx={{ minHeight: 44 }}>
+              Tagged unit
+            </Button>
+          </Stack>
+        ) : null}
+      </Stack>
+      {data.catalogItems.length === 0 && data.locations.length === 0 && data.pooledStock.length === 0 && data.units.length === 0 ? (
+        <Alert severity="info" role="status">
+          Start by adding a storage location and catalog item, then record your first inventory.
+        </Alert>
+      ) : null}
+
+      <InventorySection title="Pooled stock" empty="No pooled inventory matches this search.">
+        {filteredStock.map((stock) => (
+          <Card key={stock.id} variant="outlined" sx={{ display: { xs: "block", md: "none" } }}>
+            <CardContent>
+              <Stack spacing={1}>
+                <Typography fontWeight={700}>{stock.catalogName}</Typography>
+                <Typography variant="body2" color="text.secondary">{stock.locationName} · {conditionLabel(stock.condition)}</Typography>
+                <Typography>{stock.availableQuantity} available of {stock.quantityOnHand}</Typography>
+                {data.canManageInventory ? (
+                  <Stack direction="row" spacing={1}>
+                    <Button size="small" onClick={() => setDialog({ kind: "adjust", stock })}>Adjust</Button>
+                    <Button size="small" onClick={() => setDialog({ kind: "pool-transfer", stock })}>Transfer</Button>
+                  </Stack>
+                ) : null}
+              </Stack>
+            </CardContent>
+          </Card>
+        ))}
+        <TableContainer component={Card} variant="outlined" sx={{ display: { xs: "none", md: "block" } }}>
+          <Table aria-label="Pooled inventory">
+            <TableHead><TableRow><TableCell>Item</TableCell><TableCell>Location</TableCell><TableCell>Condition</TableCell><TableCell align="right">On hand</TableCell><TableCell align="right">Committed</TableCell><TableCell align="right">Available</TableCell>{data.canManageInventory ? <TableCell /> : null}</TableRow></TableHead>
+            <TableBody>
+              {filteredStock.map((stock) => (
+                <TableRow key={stock.id}>
+                  <TableCell>{stock.catalogName}</TableCell><TableCell>{stock.locationName}</TableCell><TableCell>{conditionLabel(stock.condition)}</TableCell>
+                  <TableCell align="right">{stock.quantityOnHand}</TableCell><TableCell align="right">{stock.committedQuantity}</TableCell><TableCell align="right">{stock.availableQuantity}</TableCell>
+                  {data.canManageInventory ? <TableCell align="right"><Button size="small" onClick={() => setDialog({ kind: "adjust", stock })}>Adjust</Button><Button size="small" onClick={() => setDialog({ kind: "pool-transfer", stock })}>Transfer</Button></TableCell> : null}
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </InventorySection>
+
+      <InventorySection title="Tagged units" empty="No tagged units match this search.">
+        {filteredUnits.map((unit) => (
+          <Card key={unit.id} variant="outlined" sx={{ display: { xs: "block", md: "none" } }}>
+            <CardContent>
+              <Stack spacing={1}>
+                <Stack direction="row" justifyContent="space-between"><Typography fontWeight={700}>{unit.catalogName}</Typography><Chip size="small" label={conditionLabel(unit.status)} color={statusColor(unit.status)} /></Stack>
+                <Typography variant="body2" color="text.secondary">{unit.assetTag ?? "No asset tag"} · {unit.currentLocationName ?? "No location"}</Typography>
+                {data.canManageInventory && ["AVAILABLE", "MAINTENANCE"].includes(unit.status) ? <UnitActions unit={unit} open={setDialog} /> : null}
+              </Stack>
+            </CardContent>
+          </Card>
+        ))}
+        <TableContainer component={Card} variant="outlined" sx={{ display: { xs: "none", md: "block" } }}>
+          <Table aria-label="Tagged gear units">
+            <TableHead><TableRow><TableCell>Item</TableCell><TableCell>Asset tag</TableCell><TableCell>Location</TableCell><TableCell>Condition</TableCell><TableCell>Status</TableCell>{data.canManageInventory ? <TableCell /> : null}</TableRow></TableHead>
+            <TableBody>{filteredUnits.map((unit) => (
+              <TableRow key={unit.id}><TableCell>{unit.catalogName}</TableCell><TableCell>{unit.assetTag ?? "—"}</TableCell><TableCell>{unit.currentLocationName ?? "—"}</TableCell><TableCell>{conditionLabel(unit.currentCondition)}</TableCell><TableCell><Chip size="small" label={conditionLabel(unit.status)} color={statusColor(unit.status)} /></TableCell>{data.canManageInventory ? <TableCell><UnitActions unit={unit} open={setDialog} /></TableCell> : null}</TableRow>
+            ))}</TableBody>
+          </Table>
+        </TableContainer>
+      </InventorySection>
+
+      {data.canManageInventory ? (
+        <>
+          <InventorySection title="Storage locations" empty="No storage locations have been created.">
+            {data.locations.map((location) => (
+              <Card key={location.id} variant="outlined"><CardContent><Stack direction={{ xs: "column", sm: "row" }} justifyContent="space-between" spacing={1}><Box><Typography fontWeight={700}>{location.name}</Typography><Typography variant="body2" color="text.secondary">{location.address ?? "No address"}</Typography>{location.privateNotes ? <Typography variant="body2" sx={{ mt: 1 }}>Admin note: {location.privateNotes}</Typography> : null}</Box><Stack direction="row"><Button aria-label={`Edit ${location.name}`} onClick={() => setDialog({ kind: "location", location })}><Edit /></Button>{location.isActive ? <Button aria-label={`Archive ${location.name}`} onClick={() => archive(() => archiveGearStorageLocation({ leagueId: data.league.id, locationId: location.id }))}><Archive /></Button> : null}</Stack></Stack></CardContent></Card>
+            ))}
+          </InventorySection>
+          <InventorySection title="Catalog" empty="No catalog items have been created.">
+            {data.catalogItems.map((item) => (
+              <Card key={item.id} variant="outlined"><CardContent><Stack direction={{ xs: "column", sm: "row" }} justifyContent="space-between" spacing={1}><Box><Typography fontWeight={700}>{item.name}</Typography><Typography variant="body2" color="text.secondary">{item.category}{item.size ? ` · ${item.size}` : ""} · {conditionLabel(item.trackingMode)}</Typography></Box><Stack direction="row"><Button aria-label={`Edit ${item.name}`} onClick={() => setDialog({ kind: "catalog", item })}><Edit /></Button>{item.isActive ? <Button aria-label={`Archive ${item.name}`} onClick={() => archive(() => archiveGearCatalogItem({ leagueId: data.league.id, catalogItemId: item.id }))}><Archive /></Button> : null}</Stack></Stack></CardContent></Card>
+            ))}
+          </InventorySection>
+          <InventorySection title="Recent inventory activity" empty="No inventory movements have been recorded.">
+            {data.recentActivity.map((activity) => <Card key={activity.id} variant="outlined"><CardContent><Typography fontWeight={700}>{conditionLabel(activity.type)} · {activity.quantity}</Typography><Typography variant="body2" color="text.secondary">{activity.beforeLocationName ?? "—"} <SwapHoriz fontSize="inherit" /> {activity.afterLocationName ?? "—"} · {new Date(activity.occurredAt).toLocaleString()}</Typography>{activity.notes ? <Typography variant="body2">{activity.notes}</Typography> : null}</CardContent></Card>)}
+          </InventorySection>
+        </>
+      ) : null}
+
+      <GearDialog dialog={dialog} close={() => setDialog(null)} data={data} pending={isPending} submit={submit} />
+    </Stack>
+  );
+}
+
+function InventorySection({ title, empty, children }: { title: string; empty: string; children: React.ReactNode }) {
+  const entries = Array.isArray(children) ? children : [children];
+  return <Stack spacing={1.5}><Typography variant="h5" component="h2">{title}</Typography>{entries.length ? entries : <Typography color="text.secondary">{empty}</Typography>}</Stack>;
+}
+
+function UnitActions({ unit, open }: { unit: GearInventoryContext["units"][number]; open: (state: DialogState) => void }) {
+  return <Stack direction="row" spacing={0.5}><Button size="small" onClick={() => open({ kind: "unit", unit })}>Edit</Button>{["AVAILABLE", "MAINTENANCE"].includes(unit.status) ? <><Button size="small" onClick={() => open({ kind: "unit-transfer", unit })}>Transfer</Button><Button size="small" onClick={() => open({ kind: "unit-condition", unit })}>Condition</Button><Button size="small" color="error" onClick={() => open({ kind: "unit-retire", unit })}>Retire</Button></> : null}</Stack>;
+}
+
+function GearDialog({ dialog, close, data, pending, submit }: {
+  dialog: DialogState | null; close: () => void; data: GearInventoryContext; pending: boolean;
+  submit: (run: () => Promise<{ success: boolean; error?: string }>) => void;
+}) {
+  if (!dialog) return null;
+  const unitCatalog = data.catalogItems.filter((item) => item.trackingMode === "INDIVIDUAL" && item.isActive);
+  const pooledCatalog = data.catalogItems.filter((item) => item.trackingMode === "POOLED" && item.isActive);
+  return <Dialog open onClose={close} fullWidth maxWidth="sm" PaperProps={{ component: "form", onSubmit: (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault(); const form = new FormData(event.currentTarget);
+    const value = (key: string) => String(form.get(key) ?? "");
+    if (dialog.kind === "location") submit(() => dialog.location ? updateGearStorageLocation({ leagueId: data.league.id, locationId: dialog.location.id, name: value("name"), address: value("address"), privateNotes: value("privateNotes") }) : createGearStorageLocation({ leagueId: data.league.id, name: value("name"), address: value("address"), privateNotes: value("privateNotes") }));
+    if (dialog.kind === "catalog") submit(() => dialog.item ? updateGearCatalogItem({ leagueId: data.league.id, catalogItemId: dialog.item.id, name: value("name"), category: value("category"), size: value("size"), brand: value("brand"), model: value("model"), description: value("description"), trackingMode: value("trackingMode") }) : createGearCatalogItem({ leagueId: data.league.id, name: value("name"), category: value("category"), size: value("size"), brand: value("brand"), model: value("model"), description: value("description"), trackingMode: value("trackingMode") as "POOLED" | "INDIVIDUAL" }));
+    if (dialog.kind === "adjust") submit(() => adjustGearPoolStock({ leagueId: data.league.id, catalogItemId: value("catalogItemId"), locationId: value("locationId"), condition: value("condition") as typeof conditions[number], quantityDelta: Number(value("quantityDelta")), expectedVersion: Number(value("expectedVersion")), notes: value("notes") }));
+    if (dialog.kind === "pool-transfer") submit(() => transferGearPoolStock({ leagueId: data.league.id, catalogItemId: dialog.stock.catalogItemId, sourceLocationId: dialog.stock.locationId, destinationLocationId: value("destinationLocationId"), condition: dialog.stock.condition, quantity: Number(value("quantity")), expectedSourceVersion: dialog.stock.version, notes: value("notes") }));
+    if (dialog.kind === "unit") submit(() => dialog.unit ? updateGearUnit({ leagueId: data.league.id, unitId: dialog.unit.id, assetTag: value("assetTag"), serialNumber: value("serialNumber"), acquiredAt: value("acquiredAt"), notes: value("notes") }) : createGearUnit({ leagueId: data.league.id, catalogItemId: value("catalogItemId"), currentLocationId: value("currentLocationId"), assetTag: value("assetTag"), serialNumber: value("serialNumber"), currentCondition: value("currentCondition") as typeof conditions[number], acquiredAt: value("acquiredAt"), notes: value("notes") }));
+    if (dialog.kind === "unit-transfer") submit(() => transferGearUnit({ leagueId: data.league.id, unitId: dialog.unit.id, destinationLocationId: value("destinationLocationId"), notes: value("notes") }));
+    if (dialog.kind === "unit-condition") submit(() => changeGearUnitCondition({ leagueId: data.league.id, unitId: dialog.unit.id, condition: value("condition") as typeof conditions[number], notes: value("notes") }));
+    if (dialog.kind === "unit-retire") submit(() => retireGearUnit({ leagueId: data.league.id, unitId: dialog.unit.id, notes: value("notes") }));
+  } }}>
+    <DialogTitle>{dialog.kind === "location" ? `${dialog.location ? "Edit" : "Add"} storage location` : dialog.kind === "catalog" ? `${dialog.item ? "Edit" : "Add"} catalog item` : dialog.kind === "adjust" ? "Adjust pooled stock" : dialog.kind === "pool-transfer" ? "Transfer pooled stock" : dialog.kind === "unit-transfer" ? "Transfer tagged unit" : dialog.kind === "unit-condition" ? "Change unit condition" : dialog.kind === "unit-retire" ? "Retire tagged unit" : `${dialog.unit ? "Edit" : "Add"} tagged unit`}</DialogTitle>
+    <DialogContent><Stack spacing={2} sx={{ pt: 1 }}>
+      {dialog.kind === "location" ? <><TextField required name="name" label="Location name" defaultValue={dialog.location?.name} inputProps={{ maxLength: 120 }} /><TextField name="address" label="Address" defaultValue={dialog.location?.address ?? ""} /><TextField name="privateNotes" label="Admin-only notes" defaultValue={dialog.location?.privateNotes ?? ""} multiline minRows={2} /></> : null}
+      {dialog.kind === "catalog" ? <><TextField required name="name" label="Item name" defaultValue={dialog.item?.name} /><TextField required name="category" label="Category" defaultValue={dialog.item?.category} /><TextField name="size" label="Size" defaultValue={dialog.item?.size ?? ""} /><TextField name="brand" label="Brand" defaultValue={dialog.item?.brand ?? ""} /><TextField name="model" label="Model" defaultValue={dialog.item?.model ?? ""} /><TextField name="description" label="Description" defaultValue={dialog.item?.description ?? ""} multiline minRows={2} /><SelectField name="trackingMode" label="Tracking mode" defaultValue={dialog.item?.trackingMode ?? "POOLED"} options={[["POOLED", "Pooled stock"], ["INDIVIDUAL", "Individually tagged"]]} /></> : null}
+      {dialog.kind === "adjust" ? <><SelectField name="catalogItemId" label="Catalog item" defaultValue={dialog.stock?.catalogItemId ?? pooledCatalog[0]?.id ?? ""} options={pooledCatalog.map((item) => [item.id, item.name])} /><SelectField name="locationId" label="Storage location" defaultValue={dialog.stock?.locationId ?? data.locations.find((location) => location.isActive)?.id ?? ""} options={data.locations.filter((location) => location.isActive).map((location) => [location.id, location.name])} /><SelectField name="condition" label="Condition" defaultValue={dialog.stock?.condition ?? "GOOD"} options={conditions.map((condition) => [condition, conditionLabel(condition)])} /><TextField required name="quantityDelta" type="number" label="Adjustment (+/-)" inputProps={{ step: 1 }} /><input type="hidden" name="expectedVersion" value={dialog.stock?.version ?? 0} /><TextField name="notes" label="Reason / notes" multiline minRows={2} /></> : null}
+      {dialog.kind === "pool-transfer" ? <><Typography>{dialog.stock.catalogName}: {dialog.stock.quantityOnHand} on hand at {dialog.stock.locationName}</Typography><SelectField name="destinationLocationId" label="Destination" defaultValue="" options={data.locations.filter((location) => location.isActive && location.id !== dialog.stock.locationId).map((location) => [location.id, location.name])} /><TextField required name="quantity" type="number" label="Quantity" inputProps={{ min: 1, max: dialog.stock.availableQuantity }} /><TextField name="notes" label="Notes" /></> : null}
+      {dialog.kind === "unit" ? <><>{!dialog.unit ? <><SelectField name="catalogItemId" label="Catalog item" defaultValue={unitCatalog[0]?.id ?? ""} options={unitCatalog.map((item) => [item.id, item.name])} /><SelectField name="currentLocationId" label="Storage location" defaultValue={data.locations.find((location) => location.isActive)?.id ?? ""} options={data.locations.filter((location) => location.isActive).map((location) => [location.id, location.name])} /><SelectField name="currentCondition" label="Condition" defaultValue="GOOD" options={conditions.map((condition) => [condition, conditionLabel(condition)])} /></> : null}</><TextField required name="assetTag" label="Asset tag" defaultValue={dialog.unit?.assetTag ?? ""} /><TextField name="serialNumber" label="Serial number" defaultValue={dialog.unit?.serialNumber ?? ""} /><TextField name="acquiredAt" label="Acquired date" type="date" defaultValue={dialog.unit?.acquiredAt?.slice(0, 10) ?? ""} InputLabelProps={{ shrink: true }} /><TextField name="notes" label="Notes" defaultValue={dialog.unit?.notes ?? ""} multiline minRows={2} /></> : null}
+      {dialog.kind === "unit-transfer" ? <><Typography>{dialog.unit.catalogName} · {dialog.unit.assetTag}</Typography><SelectField name="destinationLocationId" label="Destination" defaultValue="" options={data.locations.filter((location) => location.isActive && location.id !== dialog.unit.currentLocationId).map((location) => [location.id, location.name])} /><TextField name="notes" label="Notes" /></> : null}
+      {dialog.kind === "unit-condition" ? <><Typography>{dialog.unit.catalogName} · {dialog.unit.assetTag}</Typography><SelectField name="condition" label="New condition" defaultValue={dialog.unit.currentCondition} options={conditions.map((condition) => [condition, conditionLabel(condition)])} /><TextField name="notes" label="Notes" /></> : null}
+      {dialog.kind === "unit-retire" ? <><Alert severity="warning">This will remove the unit from active inventory.</Alert><TextField required name="notes" label="Retirement reason" multiline minRows={2} /></> : null}
+    </Stack></DialogContent>
+    <DialogActions><Button onClick={close} disabled={pending}>Cancel</Button><Button type="submit" variant="contained" disabled={pending} sx={{ minHeight: 44 }}>{pending ? "Saving…" : "Save"}</Button></DialogActions>
+  </Dialog>;
+}
+
+function SelectField({ name, label, defaultValue, options }: { name: string; label: string; defaultValue: string; options: Array<readonly [string, string]> }) {
+  return <FormControl fullWidth required><InputLabel id={`${name}-label`}>{label}</InputLabel><Select labelId={`${name}-label`} name={name} label={label} defaultValue={defaultValue}>{options.map(([value, optionLabel]) => <MenuItem key={value} value={value}>{optionLabel}</MenuItem>)}</Select></FormControl>;
+}

--- a/lib/actions/gear-context.ts
+++ b/lib/actions/gear-context.ts
@@ -1,0 +1,207 @@
+"use server";
+
+import { requireUserId } from "@/lib/auth/session";
+import { prisma } from "@/lib/db/prisma";
+
+export type GearInventoryContext = {
+  league: { id: string; name: string };
+  canManageInventory: boolean;
+  summary: {
+    pooledOnHand: number;
+    pooledAvailable: number;
+    taggedUnits: number;
+    taggedAvailable: number;
+  };
+  locations: Array<{
+    id: string;
+    name: string;
+    address: string | null;
+    privateNotes?: string | null;
+    isActive: boolean;
+  }>;
+  catalogItems: Array<{
+    id: string;
+    name: string;
+    category: string;
+    size: string | null;
+    brand: string | null;
+    model: string | null;
+    description: string | null;
+    trackingMode: "POOLED" | "INDIVIDUAL";
+    isActive: boolean;
+  }>;
+  pooledStock: Array<{
+    id: string;
+    catalogItemId: string;
+    catalogName: string;
+    category: string;
+    locationId: string;
+    locationName: string;
+    condition: "NEW" | "EXCELLENT" | "GOOD" | "FAIR" | "POOR" | "DAMAGED";
+    quantityOnHand: number;
+    committedQuantity: number;
+    availableQuantity: number;
+    version: number;
+  }>;
+  units: Array<{
+    id: string;
+    catalogItemId: string;
+    catalogName: string;
+    assetTag: string | null;
+    serialNumber: string | null;
+    status: "AVAILABLE" | "RESERVED" | "CHECKED_OUT" | "MAINTENANCE" | "RETIRED" | "LOST";
+    currentCondition: "NEW" | "EXCELLENT" | "GOOD" | "FAIR" | "POOR" | "DAMAGED";
+    currentLocationId: string | null;
+    currentLocationName: string | null;
+    acquiredAt: string | null;
+    retiredAt: string | null;
+    notes?: string | null;
+  }>;
+  recentActivity: Array<{
+    id: string;
+    type: string;
+    quantity: number;
+    poolStockId: string | null;
+    gearUnitId: string | null;
+    beforeLocationName: string | null;
+    afterLocationName: string | null;
+    occurredAt: string;
+    notes: string | null;
+  }>;
+};
+
+const activeAllocationStatuses = ["PENDING", "ALLOCATED", "PICKED_UP", "PARTIALLY_RETURNED"] as const;
+
+/** Returns only records in the caller's league and redacts admin-only operational notes. */
+export async function getGearInventoryContext(leagueId: string): Promise<GearInventoryContext | null> {
+  const userId = await requireUserId();
+  const membership = await prisma.leagueUser.findFirst({
+    where: { leagueId, userId, league: { isActive: true } },
+    select: { role: true, league: { select: { id: true, name: true } } },
+  });
+  if (!membership) return null;
+
+  const canManageInventory = membership.role === "LEAGUE_ADMIN";
+  const [locations, catalogItems, stocks, units, movements] = await Promise.all([
+    prisma.gearStorageLocation.findMany({
+      where: { leagueId },
+      select: {
+        id: true, name: true, address: true, privateNotes: canManageInventory,
+        isActive: true,
+      },
+      orderBy: [{ isActive: "desc" }, { name: "asc" }],
+    }),
+    prisma.gearCatalogItem.findMany({
+      where: { leagueId },
+      select: {
+        id: true, name: true, category: true, size: true, brand: true, model: true,
+        description: true, trackingMode: true, isActive: true,
+      },
+      orderBy: [{ isActive: "desc" }, { category: "asc" }, { name: "asc" }],
+    }),
+    prisma.gearPoolStock.findMany({
+      where: { leagueId },
+      select: {
+        id: true, catalogItemId: true, locationId: true, condition: true, quantityOnHand: true, version: true,
+        catalogItem: { select: { name: true, category: true } },
+        location: { select: { name: true } },
+        allocations: {
+          where: { status: { in: [...activeAllocationStatuses] } },
+          select: { allocatedQty: true, releasedQty: true },
+        },
+      },
+      orderBy: [{ catalogItem: { name: "asc" } }, { location: { name: "asc" } }],
+    }),
+    prisma.gearUnit.findMany({
+      where: { leagueId },
+      select: {
+        id: true, catalogItemId: true, assetTag: true, serialNumber: true, status: true,
+        currentCondition: true, currentLocationId: true, acquiredAt: true, retiredAt: true,
+        notes: canManageInventory,
+        catalogItem: { select: { name: true } },
+        currentLocation: { select: { name: true } },
+      },
+      orderBy: [{ status: "asc" }, { assetTag: "asc" }],
+    }),
+    canManageInventory
+      ? prisma.gearInventoryMovement.findMany({
+          where: { leagueId },
+          select: {
+            id: true, type: true, quantity: true, poolStockId: true, gearUnitId: true,
+            occurredAt: true, notes: true,
+            beforeLocation: { select: { name: true } },
+            afterLocation: { select: { name: true } },
+          },
+          orderBy: { occurredAt: "desc" },
+          take: 20,
+        })
+      : Promise.resolve([]),
+  ]);
+
+  const pooledStock = stocks.map((stock) => {
+    const committedQuantity = stock.allocations.reduce(
+      (sum, allocation) => sum + Math.max(0, allocation.allocatedQty - allocation.releasedQty),
+      0,
+    );
+    return {
+      id: stock.id,
+      catalogItemId: stock.catalogItemId,
+      catalogName: stock.catalogItem.name,
+      category: stock.catalogItem.category,
+      locationId: stock.locationId,
+      locationName: stock.location.name,
+      condition: stock.condition,
+      quantityOnHand: stock.quantityOnHand,
+      committedQuantity,
+      availableQuantity: Math.max(0, stock.quantityOnHand - committedQuantity),
+      version: stock.version,
+    };
+  });
+
+  const taggedUnits = units.map((unit) => ({
+    id: unit.id,
+    catalogItemId: unit.catalogItemId,
+    catalogName: unit.catalogItem.name,
+    assetTag: unit.assetTag,
+    serialNumber: unit.serialNumber,
+    status: unit.status,
+    currentCondition: unit.currentCondition,
+    currentLocationId: unit.currentLocationId,
+    currentLocationName: unit.currentLocation?.name ?? null,
+    acquiredAt: unit.acquiredAt?.toISOString() ?? null,
+    retiredAt: unit.retiredAt?.toISOString() ?? null,
+    ...(canManageInventory ? { notes: unit.notes } : {}),
+  }));
+
+  return {
+    league: membership.league,
+    canManageInventory,
+    summary: {
+      pooledOnHand: pooledStock.reduce((sum, stock) => sum + stock.quantityOnHand, 0),
+      pooledAvailable: pooledStock.reduce((sum, stock) => sum + stock.availableQuantity, 0),
+      taggedUnits: taggedUnits.length,
+      taggedAvailable: taggedUnits.filter((unit) => unit.status === "AVAILABLE").length,
+    },
+    locations: locations.map((location) => ({
+      id: location.id,
+      name: location.name,
+      address: location.address,
+      isActive: location.isActive,
+      ...(canManageInventory ? { privateNotes: location.privateNotes } : {}),
+    })),
+    catalogItems,
+    pooledStock,
+    units: taggedUnits,
+    recentActivity: movements.map((movement) => ({
+      id: movement.id,
+      type: movement.type,
+      quantity: movement.quantity,
+      poolStockId: movement.poolStockId,
+      gearUnitId: movement.gearUnitId,
+      beforeLocationName: movement.beforeLocation?.name ?? null,
+      afterLocationName: movement.afterLocation?.name ?? null,
+      occurredAt: movement.occurredAt.toISOString(),
+      notes: movement.notes,
+    })),
+  };
+}

--- a/lib/actions/gear-context.ts
+++ b/lib/actions/gear-context.ts
@@ -15,7 +15,7 @@ export type GearInventoryContext = {
   locations: Array<{
     id: string;
     name: string;
-    address: string | null;
+    address?: string | null;
     privateNotes?: string | null;
     isActive: boolean;
   }>;
@@ -48,32 +48,47 @@ export type GearInventoryContext = {
     catalogItemId: string;
     catalogName: string;
     assetTag: string | null;
-    serialNumber: string | null;
+    serialNumber?: string | null;
     status: "AVAILABLE" | "RESERVED" | "CHECKED_OUT" | "MAINTENANCE" | "RETIRED" | "LOST";
     currentCondition: "NEW" | "EXCELLENT" | "GOOD" | "FAIR" | "POOR" | "DAMAGED";
     currentLocationId: string | null;
     currentLocationName: string | null;
-    acquiredAt: string | null;
-    retiredAt: string | null;
+    acquiredAt?: string | null;
+    retiredAt?: string | null;
     notes?: string | null;
+    version?: number;
   }>;
-  recentActivity: Array<{
-    id: string;
-    type: string;
-    quantity: number;
-    poolStockId: string | null;
-    gearUnitId: string | null;
-    beforeLocationName: string | null;
-    afterLocationName: string | null;
-    occurredAt: string;
-    notes: string | null;
-  }>;
+  recentActivity: {
+    items: Array<{
+      id: string;
+      type: string;
+      direction: "INCREASE" | "DECREASE" | "NEUTRAL";
+      quantity: number;
+      poolStockId: string | null;
+      gearUnitId: string | null;
+      catalogName: string | null;
+      assetTag: string | null;
+      beforeLocationName: string | null;
+      afterLocationName: string | null;
+      beforeCondition: "NEW" | "EXCELLENT" | "GOOD" | "FAIR" | "POOR" | "DAMAGED" | null;
+      afterCondition: "NEW" | "EXCELLENT" | "GOOD" | "FAIR" | "POOR" | "DAMAGED" | null;
+      actorName: string | null;
+      occurredAt: string;
+      notes: string | null;
+    }>;
+    page: number;
+    hasMore: boolean;
+    search: string;
+  };
 };
 
 const activeAllocationStatuses = ["PENDING", "ALLOCATED", "PICKED_UP", "PARTIALLY_RETURNED"] as const;
 
 /** Returns only records in the caller's league and redacts admin-only operational notes. */
-export async function getGearInventoryContext(leagueId: string): Promise<GearInventoryContext | null> {
+export async function getGearInventoryContext(
+  leagueId: string,
+  options?: { activityPage?: number; activitySearch?: string },
+): Promise<GearInventoryContext | null> {
   const userId = await requireUserId();
   const membership = await prisma.leagueUser.findFirst({
     where: { leagueId, userId, league: { isActive: true } },
@@ -82,11 +97,32 @@ export async function getGearInventoryContext(leagueId: string): Promise<GearInv
   if (!membership) return null;
 
   const canManageInventory = membership.role === "LEAGUE_ADMIN";
+  const activityPage = Math.max(1, Math.floor(options?.activityPage ?? 1));
+  const activitySearch = options?.activitySearch?.trim().slice(0, 100) ?? "";
+  const activityWhere = {
+    leagueId,
+    ...(activitySearch
+      ? {
+          OR: [
+            { notes: { contains: activitySearch, mode: "insensitive" as const } },
+            { poolStock: { catalogItem: { name: { contains: activitySearch, mode: "insensitive" as const } } } },
+            {
+              gearUnit: {
+                OR: [
+                  { assetTag: { contains: activitySearch, mode: "insensitive" as const } },
+                  { catalogItem: { name: { contains: activitySearch, mode: "insensitive" as const } } },
+                ],
+              },
+            },
+          ],
+        }
+      : {}),
+  };
   const [locations, catalogItems, stocks, units, movements] = await Promise.all([
     prisma.gearStorageLocation.findMany({
       where: { leagueId },
       select: {
-        id: true, name: true, address: true, privateNotes: canManageInventory,
+        id: true, name: true, address: canManageInventory, privateNotes: canManageInventory,
         isActive: true,
       },
       orderBy: [{ isActive: "desc" }, { name: "asc" }],
@@ -115,8 +151,9 @@ export async function getGearInventoryContext(leagueId: string): Promise<GearInv
     prisma.gearUnit.findMany({
       where: { leagueId },
       select: {
-        id: true, catalogItemId: true, assetTag: true, serialNumber: true, status: true,
-        currentCondition: true, currentLocationId: true, acquiredAt: true, retiredAt: true,
+        id: true, catalogItemId: true, assetTag: true, serialNumber: canManageInventory, status: true,
+        currentCondition: true, currentLocationId: true, acquiredAt: canManageInventory, retiredAt: canManageInventory,
+        version: canManageInventory,
         notes: canManageInventory,
         catalogItem: { select: { name: true } },
         currentLocation: { select: { name: true } },
@@ -125,15 +162,19 @@ export async function getGearInventoryContext(leagueId: string): Promise<GearInv
     }),
     canManageInventory
       ? prisma.gearInventoryMovement.findMany({
-          where: { leagueId },
+          where: activityWhere,
           select: {
             id: true, type: true, quantity: true, poolStockId: true, gearUnitId: true,
-            occurredAt: true, notes: true,
+            direction: true, beforeCondition: true, afterCondition: true, occurredAt: true, notes: true,
             beforeLocation: { select: { name: true } },
             afterLocation: { select: { name: true } },
+            poolStock: { select: { catalogItem: { select: { name: true } } } },
+            gearUnit: { select: { assetTag: true, catalogItem: { select: { name: true } } } },
+            recordedBy: { select: { name: true } },
           },
           orderBy: { occurredAt: "desc" },
-          take: 20,
+          skip: (activityPage - 1) * 20,
+          take: 21,
         })
       : Promise.resolve([]),
   ]);
@@ -163,14 +204,17 @@ export async function getGearInventoryContext(leagueId: string): Promise<GearInv
     catalogItemId: unit.catalogItemId,
     catalogName: unit.catalogItem.name,
     assetTag: unit.assetTag,
-    serialNumber: unit.serialNumber,
+    ...(canManageInventory ? {
+      serialNumber: unit.serialNumber,
+      acquiredAt: unit.acquiredAt?.toISOString() ?? null,
+      retiredAt: unit.retiredAt?.toISOString() ?? null,
+      notes: unit.notes,
+      version: unit.version,
+    } : {}),
     status: unit.status,
     currentCondition: unit.currentCondition,
     currentLocationId: unit.currentLocationId,
     currentLocationName: unit.currentLocation?.name ?? null,
-    acquiredAt: unit.acquiredAt?.toISOString() ?? null,
-    retiredAt: unit.retiredAt?.toISOString() ?? null,
-    ...(canManageInventory ? { notes: unit.notes } : {}),
   }));
 
   return {
@@ -185,23 +229,33 @@ export async function getGearInventoryContext(leagueId: string): Promise<GearInv
     locations: locations.map((location) => ({
       id: location.id,
       name: location.name,
-      address: location.address,
       isActive: location.isActive,
-      ...(canManageInventory ? { privateNotes: location.privateNotes } : {}),
+      ...(canManageInventory ? { address: location.address, privateNotes: location.privateNotes } : {}),
     })),
     catalogItems,
     pooledStock,
     units: taggedUnits,
-    recentActivity: movements.map((movement) => ({
+    recentActivity: {
+      items: movements.slice(0, 20).map((movement) => ({
       id: movement.id,
       type: movement.type,
+      direction: movement.direction,
       quantity: movement.quantity,
       poolStockId: movement.poolStockId,
       gearUnitId: movement.gearUnitId,
+      catalogName: movement.poolStock?.catalogItem.name ?? movement.gearUnit?.catalogItem.name ?? null,
+      assetTag: movement.gearUnit?.assetTag ?? null,
       beforeLocationName: movement.beforeLocation?.name ?? null,
       afterLocationName: movement.afterLocation?.name ?? null,
+      beforeCondition: movement.beforeCondition,
+      afterCondition: movement.afterCondition,
+      actorName: movement.recordedBy?.name ?? null,
       occurredAt: movement.occurredAt.toISOString(),
       notes: movement.notes,
-    })),
+      })),
+      page: activityPage,
+      hasMore: movements.length > 20,
+      search: activitySearch,
+    },
   };
 }

--- a/lib/actions/gear-inventory.ts
+++ b/lib/actions/gear-inventory.ts
@@ -143,13 +143,14 @@ async function ensureActiveCatalog(
 
 async function assertNoActiveAllocationsForStock(
   tx: Prisma.TransactionClient,
+  leagueId: string,
   stockId: string,
   onHand: number,
   delta: number,
 ) {
   if (delta >= 0) return;
   const committed = await tx.gearAllocation.aggregate({
-    where: { poolStockId: stockId, status: { in: [...activeAllocationStatuses] } },
+    where: { leagueId, poolStockId: stockId, status: { in: [...activeAllocationStatuses] } },
     _sum: { allocatedQty: true, releasedQty: true },
   });
   const commitment = Math.max(0, (committed._sum.allocatedQty ?? 0) - (committed._sum.releasedQty ?? 0));
@@ -158,9 +159,9 @@ async function assertNoActiveAllocationsForStock(
   }
 }
 
-async function assertUnitCanMove(tx: Prisma.TransactionClient, unitId: string) {
+async function assertUnitCanMove(tx: Prisma.TransactionClient, leagueId: string, unitId: string) {
   const commitments = await tx.gearAllocation.count({
-    where: { gearUnitId: unitId, status: { in: [...activeAllocationStatuses] } },
+    where: { leagueId, gearUnitId: unitId, status: { in: [...activeAllocationStatuses] } },
   });
   if (commitments > 0) invalid("This unit has an active commitment and cannot be changed.");
 }
@@ -389,7 +390,13 @@ export async function adjustGearPoolStock(
       } else {
         if (current.version !== validated.expectedVersion) throw new GearConflictError();
         if (current.quantityOnHand + validated.quantityDelta < 0) invalid("Inventory cannot fall below zero.");
-        await assertNoActiveAllocationsForStock(tx, current.id, current.quantityOnHand, validated.quantityDelta);
+        await assertNoActiveAllocationsForStock(
+          tx,
+          validated.leagueId,
+          current.id,
+          current.quantityOnHand,
+          validated.quantityDelta,
+        );
         const result = await tx.gearPoolStock.updateMany({
           where: { id: current.id, version: current.version },
           data: { quantityOnHand: { increment: validated.quantityDelta }, version: { increment: 1 } },
@@ -399,7 +406,11 @@ export async function adjustGearPoolStock(
       }
       await recordGearInventoryMovement(tx, {
         leagueId: validated.leagueId, type: "ADJUSTMENT", poolStockId: current.id,
-        quantity: validated.quantityDelta, afterLocationId: validated.locationId,
+        // Movements always record a positive physical quantity. A source-only
+        // location is an outbound adjustment; a destination-only one is inbound.
+        quantity: Math.abs(validated.quantityDelta),
+        beforeLocationId: validated.quantityDelta < 0 ? validated.locationId : null,
+        afterLocationId: validated.quantityDelta > 0 ? validated.locationId : null,
         afterCondition: validated.condition, recordedById: userId, notes: validated.notes,
       });
       await recordGearActivity(tx, {
@@ -434,7 +445,13 @@ export async function transferGearPoolStock(input: unknown): Promise<ActionResul
       });
       if (!source || source.version !== validated.expectedSourceVersion) throw new GearConflictError();
       if (source.quantityOnHand < validated.quantity) invalid("Not enough stock is available at the source location.");
-      await assertNoActiveAllocationsForStock(tx, source.id, source.quantityOnHand, -validated.quantity);
+      await assertNoActiveAllocationsForStock(
+        tx,
+        validated.leagueId,
+        source.id,
+        source.quantityOnHand,
+        -validated.quantity,
+      );
       const sourceUpdate = await tx.gearPoolStock.updateMany({
         where: { id: source.id, version: source.version },
         data: { quantityOnHand: { decrement: validated.quantity }, version: { increment: 1 } },
@@ -560,7 +577,7 @@ export async function transferGearUnit(input: unknown): Promise<ActionResult<{ i
       });
       if (!existing) invalid("Tagged unit not found.");
       if (!["AVAILABLE", "MAINTENANCE"].includes(existing.status)) invalid("Only available or maintenance units can be transferred.");
-      await assertUnitCanMove(tx, existing.id);
+      await assertUnitCanMove(tx, validated.leagueId, existing.id);
       await ensureActiveLocation(tx, validated.leagueId, validated.destinationLocationId);
       if (existing.currentLocationId === validated.destinationLocationId) invalid("Choose a different destination location.");
       const updated = await tx.gearUnit.update({
@@ -598,7 +615,7 @@ export async function changeGearUnitCondition(input: unknown): Promise<ActionRes
       });
       if (!existing) invalid("Tagged unit not found.");
       if (!["AVAILABLE", "MAINTENANCE"].includes(existing.status)) invalid("Only available or maintenance units can have their condition changed.");
-      await assertUnitCanMove(tx, existing.id);
+      await assertUnitCanMove(tx, validated.leagueId, existing.id);
       if (existing.currentCondition === validated.condition) invalid("Choose a different condition.");
       const updated = await tx.gearUnit.update({
         where: { id: existing.id },
@@ -635,7 +652,7 @@ export async function retireGearUnit(input: unknown): Promise<ActionResult<{ id:
       });
       if (!existing) invalid("Tagged unit not found.");
       if (!["AVAILABLE", "MAINTENANCE"].includes(existing.status)) invalid("Only available or maintenance units can be retired.");
-      await assertUnitCanMove(tx, existing.id);
+      await assertUnitCanMove(tx, validated.leagueId, existing.id);
       const updated = await tx.gearUnit.update({
         where: { id: existing.id },
         data: { status: "RETIRED", retiredAt: new Date(), currentLocationId: null, version: { increment: 1 } },

--- a/lib/actions/gear-inventory.ts
+++ b/lib/actions/gear-inventory.ts
@@ -1,0 +1,660 @@
+"use server";
+
+import { Prisma, type GearCondition, type GearUnitStatus } from "@prisma/client";
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+import { requireLeagueRole } from "@/lib/auth/session";
+import { prisma } from "@/lib/db/prisma";
+import {
+  adjustGearPoolStockSchema,
+  createGearCatalogItemSchema,
+  createGearStorageLocationSchema,
+  createGearUnitSchema,
+} from "@/lib/utils/validation";
+import { normalizeGearAssetTag, normalizeGearKey } from "@/lib/utils/gear";
+import { recordGearActivity, recordGearInventoryMovement } from "@/lib/services/gear-ledger";
+import {
+  GearConflictError,
+  gearTransactionOptions,
+  withGearSerializableRetry,
+} from "@/lib/services/gear-transaction";
+
+export type ActionResult<T> =
+  | { success: true; data: T }
+  | { success: false; error: string; details?: unknown };
+
+const gearIdSchema = z.string().cuid("Invalid gear identifier");
+const conditionSchema = z.enum(["NEW", "EXCELLENT", "GOOD", "FAIR", "POOR", "DAMAGED"]);
+const activeAllocationStatuses = ["PENDING", "ALLOCATED", "PICKED_UP", "PARTIALLY_RETURNED"] as const;
+
+const updateLocationSchema = createGearStorageLocationSchema
+  .omit({ leagueId: true })
+  .partial()
+  .extend({ leagueId: gearIdSchema, locationId: gearIdSchema })
+  .refine((input) => Object.keys(input).some((key) => !["leagueId", "locationId"].includes(key)), {
+    message: "Provide at least one location field to update",
+  });
+const locationCommandSchema = z.object({ leagueId: gearIdSchema, locationId: gearIdSchema });
+
+const updateCatalogSchema = createGearCatalogItemSchema
+  .omit({ leagueId: true, trackingMode: true })
+  .partial()
+  .extend({
+    leagueId: gearIdSchema,
+    catalogItemId: gearIdSchema,
+    trackingMode: z.enum(["POOLED", "INDIVIDUAL"]).optional(),
+  })
+  .refine((input) => Object.keys(input).some((key) => !["leagueId", "catalogItemId"].includes(key)), {
+    message: "Provide at least one catalog field to update",
+  });
+const catalogCommandSchema = z.object({ leagueId: gearIdSchema, catalogItemId: gearIdSchema });
+
+const transferPoolStockSchema = z.object({
+  leagueId: gearIdSchema,
+  catalogItemId: gearIdSchema,
+  sourceLocationId: gearIdSchema,
+  destinationLocationId: gearIdSchema,
+  condition: conditionSchema,
+  quantity: z.coerce.number().int().min(1),
+  expectedSourceVersion: z.coerce.number().int().min(0),
+  notes: z.string().trim().max(1_000).optional(),
+}).refine((input) => input.sourceLocationId !== input.destinationLocationId, {
+  message: "Choose a different destination location",
+  path: ["destinationLocationId"],
+});
+
+const unitCommandSchema = z.object({ leagueId: gearIdSchema, unitId: gearIdSchema });
+const updateUnitSchema = createGearUnitSchema
+  .omit({ leagueId: true, catalogItemId: true, currentLocationId: true, currentCondition: true })
+  .partial()
+  .extend({ leagueId: gearIdSchema, unitId: gearIdSchema })
+  .refine((input) => Object.keys(input).some((key) => !["leagueId", "unitId"].includes(key)), {
+    message: "Provide at least one unit field to update",
+  });
+const transferUnitSchema = z.object({
+  leagueId: gearIdSchema,
+  unitId: gearIdSchema,
+  destinationLocationId: gearIdSchema,
+  notes: z.string().trim().max(1_000).optional(),
+});
+const changeUnitConditionSchema = z.object({
+  leagueId: gearIdSchema,
+  unitId: gearIdSchema,
+  condition: conditionSchema,
+  notes: z.string().trim().max(1_000).optional(),
+});
+const retireUnitSchema = z.object({
+  leagueId: gearIdSchema,
+  unitId: gearIdSchema,
+  notes: z.string().trim().min(1, "A retirement reason is required").max(1_000),
+});
+
+function gearPath(leagueId: string) {
+  return `/league/${leagueId}/gear`;
+}
+
+function messageForGearError(error: unknown): ActionResult<never> {
+  if (error instanceof GearConflictError) return { success: false, error: error.message };
+  if (error instanceof z.ZodError) {
+    return { success: false, error: "Please correct the highlighted inventory fields.", details: error.issues };
+  }
+  if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002") {
+    return { success: false, error: "That name or asset tag is already used in this league." };
+  }
+  if (error instanceof Error) {
+    if (error.message.startsWith("Unauthorized")) return { success: false, error: "League admin access is required." };
+    if (error.message.startsWith("Gear validation:")) return { success: false, error: error.message.slice(17) };
+  }
+  return { success: false, error: "Unable to update gear inventory. Please try again." };
+}
+
+function invalid(message: string): never {
+  throw new Error(`Gear validation: ${message}`);
+}
+
+async function ensureActiveLocation(
+  tx: Prisma.TransactionClient,
+  leagueId: string,
+  locationId: string,
+) {
+  const location = await tx.gearStorageLocation.findFirst({
+    where: { id: locationId, leagueId, isActive: true },
+    select: { id: true },
+  });
+  if (!location) invalid("The selected active storage location was not found.");
+  return location;
+}
+
+async function ensureActiveCatalog(
+  tx: Prisma.TransactionClient,
+  leagueId: string,
+  catalogItemId: string,
+  trackingMode?: "POOLED" | "INDIVIDUAL",
+) {
+  const item = await tx.gearCatalogItem.findFirst({
+    where: { id: catalogItemId, leagueId, isActive: true },
+    select: { id: true, trackingMode: true },
+  });
+  if (!item || (trackingMode && item.trackingMode !== trackingMode)) {
+    invalid("The selected active catalog item has an incompatible tracking mode.");
+  }
+  return item;
+}
+
+async function assertNoActiveAllocationsForStock(
+  tx: Prisma.TransactionClient,
+  stockId: string,
+  onHand: number,
+  delta: number,
+) {
+  if (delta >= 0) return;
+  const committed = await tx.gearAllocation.aggregate({
+    where: { poolStockId: stockId, status: { in: [...activeAllocationStatuses] } },
+    _sum: { allocatedQty: true, releasedQty: true },
+  });
+  const commitment = Math.max(0, (committed._sum.allocatedQty ?? 0) - (committed._sum.releasedQty ?? 0));
+  if (onHand + delta < commitment) {
+    invalid(`This reduction would leave fewer items than the ${commitment} currently committed.`);
+  }
+}
+
+async function assertUnitCanMove(tx: Prisma.TransactionClient, unitId: string) {
+  const commitments = await tx.gearAllocation.count({
+    where: { gearUnitId: unitId, status: { in: [...activeAllocationStatuses] } },
+  });
+  if (commitments > 0) invalid("This unit has an active commitment and cannot be changed.");
+}
+
+export async function createGearStorageLocation(
+  input: z.input<typeof createGearStorageLocationSchema>,
+): Promise<ActionResult<{ id: string }>> {
+  try {
+    const validated = createGearStorageLocationSchema.parse(input);
+    const userId = await requireLeagueRole(validated.leagueId, "LEAGUE_ADMIN");
+    const location = await prisma.$transaction(async (tx) => {
+      const created = await tx.gearStorageLocation.create({
+        data: { ...validated, normalizedName: normalizeGearKey(validated.name) },
+        select: { id: true },
+      });
+      await recordGearActivity(tx, {
+        leagueId: validated.leagueId, entityType: "STORAGE_LOCATION", entityId: created.id,
+        action: "created", actorUserId: userId, details: { name: validated.name },
+      });
+      return created;
+    }, gearTransactionOptions);
+    revalidatePath(gearPath(validated.leagueId));
+    return { success: true, data: location };
+  } catch (error) {
+    return messageForGearError(error);
+  }
+}
+
+export async function updateGearStorageLocation(input: unknown): Promise<ActionResult<{ id: string }>> {
+  try {
+    const validated = updateLocationSchema.parse(input);
+    const userId = await requireLeagueRole(validated.leagueId, "LEAGUE_ADMIN");
+    const location = await prisma.$transaction(async (tx) => {
+      const existing = await tx.gearStorageLocation.findFirst({
+        where: { id: validated.locationId, leagueId: validated.leagueId },
+        select: { id: true },
+      });
+      if (!existing) invalid("Storage location not found.");
+      const { leagueId, locationId, name, ...changes } = validated;
+      const updated = await tx.gearStorageLocation.update({
+        where: { id: existing.id },
+        data: { ...changes, ...(name ? { name, normalizedName: normalizeGearKey(name) } : {}) },
+        select: { id: true },
+      });
+      await recordGearActivity(tx, {
+        leagueId, entityType: "STORAGE_LOCATION", entityId: updated.id, action: "updated",
+        actorUserId: userId, details: { fields: Object.keys(changes), ...(name ? { name } : {}) },
+      });
+      return updated;
+    }, gearTransactionOptions);
+    revalidatePath(gearPath(validated.leagueId));
+    return { success: true, data: location };
+  } catch (error) {
+    return messageForGearError(error);
+  }
+}
+
+export async function archiveGearStorageLocation(input: unknown): Promise<ActionResult<{ id: string }>> {
+  try {
+    const { leagueId, locationId } = locationCommandSchema.parse(input);
+    const userId = await requireLeagueRole(leagueId, "LEAGUE_ADMIN");
+    const location = await prisma.$transaction(async (tx) => {
+      const existing = await tx.gearStorageLocation.findFirst({
+        where: { id: locationId, leagueId, isActive: true }, select: { id: true },
+      });
+      if (!existing) invalid("Active storage location not found.");
+      const [stock, units, allocations] = await Promise.all([
+        tx.gearPoolStock.count({ where: { leagueId, locationId, quantityOnHand: { gt: 0 } } }),
+        tx.gearUnit.count({ where: { leagueId, currentLocationId: locationId, status: { notIn: ["RETIRED", "LOST"] } } }),
+        tx.gearAllocation.count({
+          where: {
+            leagueId, status: { in: [...activeAllocationStatuses] },
+            OR: [{ poolStock: { locationId } }, { gearUnit: { currentLocationId: locationId } }],
+          },
+        }),
+      ]);
+      if (stock || units || allocations) {
+        invalid("Move or resolve all active stock, units, and commitments before archiving this location.");
+      }
+      const archived = await tx.gearStorageLocation.update({
+        where: { id: existing.id }, data: { isActive: false, archivedAt: new Date() }, select: { id: true },
+      });
+      await recordGearActivity(tx, {
+        leagueId, entityType: "STORAGE_LOCATION", entityId: archived.id, action: "archived", actorUserId: userId,
+      });
+      return archived;
+    }, gearTransactionOptions);
+    revalidatePath(gearPath(leagueId));
+    return { success: true, data: location };
+  } catch (error) {
+    return messageForGearError(error);
+  }
+}
+
+export async function createGearCatalogItem(
+  input: z.input<typeof createGearCatalogItemSchema>,
+): Promise<ActionResult<{ id: string }>> {
+  try {
+    const validated = createGearCatalogItemSchema.parse(input);
+    const userId = await requireLeagueRole(validated.leagueId, "LEAGUE_ADMIN");
+    const item = await prisma.$transaction(async (tx) => {
+      const created = await tx.gearCatalogItem.create({
+        data: { ...validated, normalizedKey: normalizeGearKey([validated.name, validated.category, validated.size ?? ""].join(" ")) },
+        select: { id: true },
+      });
+      await recordGearActivity(tx, {
+        leagueId: validated.leagueId, entityType: "CATALOG_ITEM", entityId: created.id,
+        action: "created", actorUserId: userId, details: { trackingMode: validated.trackingMode },
+      });
+      return created;
+    }, gearTransactionOptions);
+    revalidatePath(gearPath(validated.leagueId));
+    return { success: true, data: item };
+  } catch (error) {
+    return messageForGearError(error);
+  }
+}
+
+export async function updateGearCatalogItem(input: unknown): Promise<ActionResult<{ id: string }>> {
+  try {
+    const validated = updateCatalogSchema.parse(input);
+    const userId = await requireLeagueRole(validated.leagueId, "LEAGUE_ADMIN");
+    const item = await prisma.$transaction(async (tx) => {
+      const existing = await tx.gearCatalogItem.findFirst({
+        where: { id: validated.catalogItemId, leagueId: validated.leagueId },
+        select: { id: true, trackingMode: true, name: true, category: true, size: true },
+      });
+      if (!existing) invalid("Catalog item not found.");
+      if (validated.trackingMode && validated.trackingMode !== existing.trackingMode) {
+        const [stocks, units, movements] = await Promise.all([
+          tx.gearPoolStock.count({ where: { catalogItemId: existing.id } }),
+          tx.gearUnit.count({ where: { catalogItemId: existing.id } }),
+          tx.gearInventoryMovement.count({
+            where: { OR: [{ poolStock: { catalogItemId: existing.id } }, { gearUnit: { catalogItemId: existing.id } }] },
+          }),
+        ]);
+        if (stocks || units || movements) invalid("Tracking mode cannot change after inventory or movement history exists.");
+      }
+      const { leagueId, catalogItemId, name, category, size, ...changes } = validated;
+      const updated = await tx.gearCatalogItem.update({
+        where: { id: existing.id },
+        data: {
+          ...changes,
+          ...(name ? { name } : {}),
+          ...(category ? { category } : {}),
+          ...(size !== undefined ? { size } : {}),
+          ...(name || category || size !== undefined
+            ? {
+                normalizedKey: normalizeGearKey([
+                  name ?? existing.name,
+                  category ?? existing.category,
+                  size ?? existing.size ?? "",
+                ].join(" ")),
+              }
+            : {}),
+        },
+        select: { id: true },
+      });
+      await recordGearActivity(tx, {
+        leagueId, entityType: "CATALOG_ITEM", entityId: updated.id, action: "updated",
+        actorUserId: userId, details: { trackingMode: validated.trackingMode ?? existing.trackingMode },
+      });
+      return updated;
+    }, gearTransactionOptions);
+    revalidatePath(gearPath(validated.leagueId));
+    return { success: true, data: item };
+  } catch (error) {
+    return messageForGearError(error);
+  }
+}
+
+export async function archiveGearCatalogItem(input: unknown): Promise<ActionResult<{ id: string }>> {
+  try {
+    const { leagueId, catalogItemId } = catalogCommandSchema.parse(input);
+    const userId = await requireLeagueRole(leagueId, "LEAGUE_ADMIN");
+    const item = await prisma.$transaction(async (tx) => {
+      const existing = await tx.gearCatalogItem.findFirst({
+        where: { id: catalogItemId, leagueId, isActive: true }, select: { id: true },
+      });
+      if (!existing) invalid("Active catalog item not found.");
+      const archived = await tx.gearCatalogItem.update({
+        where: { id: existing.id }, data: { isActive: false, archivedAt: new Date() }, select: { id: true },
+      });
+      await recordGearActivity(tx, {
+        leagueId, entityType: "CATALOG_ITEM", entityId: archived.id, action: "archived", actorUserId: userId,
+      });
+      return archived;
+    }, gearTransactionOptions);
+    revalidatePath(gearPath(leagueId));
+    return { success: true, data: item };
+  } catch (error) {
+    return messageForGearError(error);
+  }
+}
+
+export async function adjustGearPoolStock(
+  input: z.input<typeof adjustGearPoolStockSchema>,
+): Promise<ActionResult<{ id: string; quantityOnHand: number; version: number }>> {
+  try {
+    const validated = adjustGearPoolStockSchema.parse(input);
+    const userId = await requireLeagueRole(validated.leagueId, "LEAGUE_ADMIN");
+    const stock = await withGearSerializableRetry(() => prisma.$transaction(async (tx) => {
+      await Promise.all([
+        ensureActiveCatalog(tx, validated.leagueId, validated.catalogItemId, "POOLED"),
+        ensureActiveLocation(tx, validated.leagueId, validated.locationId),
+      ]);
+      let current = await tx.gearPoolStock.findUnique({
+        where: { leagueId_catalogItemId_locationId_condition: {
+          leagueId: validated.leagueId, catalogItemId: validated.catalogItemId,
+          locationId: validated.locationId, condition: validated.condition,
+        } },
+        select: { id: true, quantityOnHand: true, version: true },
+      });
+      if (!current) {
+        if (validated.quantityDelta < 0 || validated.expectedVersion !== 0) {
+          invalid("This stock row no longer exists. Refresh inventory and try again.");
+        }
+        current = await tx.gearPoolStock.create({
+          data: {
+            leagueId: validated.leagueId, catalogItemId: validated.catalogItemId,
+            locationId: validated.locationId, condition: validated.condition,
+            quantityOnHand: validated.quantityDelta, version: 1,
+          },
+          select: { id: true, quantityOnHand: true, version: true },
+        });
+      } else {
+        if (current.version !== validated.expectedVersion) throw new GearConflictError();
+        if (current.quantityOnHand + validated.quantityDelta < 0) invalid("Inventory cannot fall below zero.");
+        await assertNoActiveAllocationsForStock(tx, current.id, current.quantityOnHand, validated.quantityDelta);
+        const result = await tx.gearPoolStock.updateMany({
+          where: { id: current.id, version: current.version },
+          data: { quantityOnHand: { increment: validated.quantityDelta }, version: { increment: 1 } },
+        });
+        if (result.count !== 1) throw new GearConflictError();
+        current = { ...current, quantityOnHand: current.quantityOnHand + validated.quantityDelta, version: current.version + 1 };
+      }
+      await recordGearInventoryMovement(tx, {
+        leagueId: validated.leagueId, type: "ADJUSTMENT", poolStockId: current.id,
+        quantity: validated.quantityDelta, afterLocationId: validated.locationId,
+        afterCondition: validated.condition, recordedById: userId, notes: validated.notes,
+      });
+      await recordGearActivity(tx, {
+        leagueId: validated.leagueId, entityType: "POOL_STOCK", entityId: current.id,
+        action: "adjusted", actorUserId: userId, details: { quantityDelta: validated.quantityDelta, condition: validated.condition },
+      });
+      return current;
+    }, gearTransactionOptions));
+    revalidatePath(gearPath(validated.leagueId));
+    return { success: true, data: stock };
+  } catch (error) {
+    return messageForGearError(error);
+  }
+}
+
+export async function transferGearPoolStock(input: unknown): Promise<ActionResult<{ sourceId: string; destinationId: string }>> {
+  try {
+    const validated = transferPoolStockSchema.parse(input);
+    const userId = await requireLeagueRole(validated.leagueId, "LEAGUE_ADMIN");
+    const transfer = await withGearSerializableRetry(() => prisma.$transaction(async (tx) => {
+      await Promise.all([
+        ensureActiveCatalog(tx, validated.leagueId, validated.catalogItemId, "POOLED"),
+        ensureActiveLocation(tx, validated.leagueId, validated.sourceLocationId),
+        ensureActiveLocation(tx, validated.leagueId, validated.destinationLocationId),
+      ]);
+      const source = await tx.gearPoolStock.findUnique({
+        where: { leagueId_catalogItemId_locationId_condition: {
+          leagueId: validated.leagueId, catalogItemId: validated.catalogItemId,
+          locationId: validated.sourceLocationId, condition: validated.condition,
+        } },
+        select: { id: true, quantityOnHand: true, version: true },
+      });
+      if (!source || source.version !== validated.expectedSourceVersion) throw new GearConflictError();
+      if (source.quantityOnHand < validated.quantity) invalid("Not enough stock is available at the source location.");
+      await assertNoActiveAllocationsForStock(tx, source.id, source.quantityOnHand, -validated.quantity);
+      const sourceUpdate = await tx.gearPoolStock.updateMany({
+        where: { id: source.id, version: source.version },
+        data: { quantityOnHand: { decrement: validated.quantity }, version: { increment: 1 } },
+      });
+      if (sourceUpdate.count !== 1) throw new GearConflictError();
+      const destination = await tx.gearPoolStock.upsert({
+        where: { leagueId_catalogItemId_locationId_condition: {
+          leagueId: validated.leagueId, catalogItemId: validated.catalogItemId,
+          locationId: validated.destinationLocationId, condition: validated.condition,
+        } },
+        create: {
+          leagueId: validated.leagueId, catalogItemId: validated.catalogItemId,
+          locationId: validated.destinationLocationId, condition: validated.condition,
+          quantityOnHand: validated.quantity, version: 1,
+        },
+        update: { quantityOnHand: { increment: validated.quantity }, version: { increment: 1 } },
+        select: { id: true },
+      });
+      await recordGearInventoryMovement(tx, {
+        leagueId: validated.leagueId, type: "TRANSFER", poolStockId: source.id, quantity: validated.quantity,
+        beforeLocationId: validated.sourceLocationId, afterLocationId: validated.destinationLocationId,
+        beforeCondition: validated.condition, afterCondition: validated.condition,
+        recordedById: userId, notes: validated.notes,
+      });
+      await recordGearActivity(tx, {
+        leagueId: validated.leagueId, entityType: "POOL_STOCK", entityId: source.id,
+        action: "transferred", actorUserId: userId,
+        details: { quantity: validated.quantity, destinationLocationId: validated.destinationLocationId },
+      });
+      return { sourceId: source.id, destinationId: destination.id };
+    }, gearTransactionOptions));
+    revalidatePath(gearPath(validated.leagueId));
+    return { success: true, data: transfer };
+  } catch (error) {
+    return messageForGearError(error);
+  }
+}
+
+export async function createGearUnit(
+  input: z.input<typeof createGearUnitSchema>,
+): Promise<ActionResult<{ id: string }>> {
+  try {
+    const validated = createGearUnitSchema.parse(input);
+    const userId = await requireLeagueRole(validated.leagueId, "LEAGUE_ADMIN");
+    const unit = await prisma.$transaction(async (tx) => {
+      await ensureActiveCatalog(tx, validated.leagueId, validated.catalogItemId, "INDIVIDUAL");
+      const assetTag = validated.assetTag ? normalizeGearAssetTag(validated.assetTag) : "";
+      if (!assetTag) invalid("An asset tag is required for individually tracked gear.");
+      const locationId = validated.currentLocationId || null;
+      if (!locationId) invalid("An active storage location is required for a new unit.");
+      await ensureActiveLocation(tx, validated.leagueId, locationId);
+      const created = await tx.gearUnit.create({
+        data: {
+          leagueId: validated.leagueId, catalogItemId: validated.catalogItemId, currentLocationId: locationId,
+          assetTag, serialNumber: validated.serialNumber || null, currentCondition: validated.currentCondition,
+          acquiredAt: validated.acquiredAt ? new Date(`${validated.acquiredAt}T00:00:00.000Z`) : null,
+          notes: validated.notes || null,
+        },
+        select: { id: true },
+      });
+      await recordGearInventoryMovement(tx, {
+        leagueId: validated.leagueId, type: "RECEIPT", gearUnitId: created.id, quantity: 1,
+        afterLocationId: locationId, afterCondition: validated.currentCondition, recordedById: userId,
+      });
+      await recordGearActivity(tx, {
+        leagueId: validated.leagueId, entityType: "UNIT", entityId: created.id, action: "created",
+        actorUserId: userId, details: { assetTag },
+      });
+      return created;
+    }, gearTransactionOptions);
+    revalidatePath(gearPath(validated.leagueId));
+    return { success: true, data: unit };
+  } catch (error) {
+    return messageForGearError(error);
+  }
+}
+
+export async function updateGearUnit(input: unknown): Promise<ActionResult<{ id: string }>> {
+  try {
+    const validated = updateUnitSchema.parse(input);
+    const userId = await requireLeagueRole(validated.leagueId, "LEAGUE_ADMIN");
+    const unit = await prisma.$transaction(async (tx) => {
+      const existing = await tx.gearUnit.findFirst({
+        where: { id: validated.unitId, leagueId: validated.leagueId },
+        select: { id: true, status: true },
+      });
+      if (!existing) invalid("Tagged unit not found.");
+      if (existing.status === "RETIRED" || existing.status === "LOST") invalid("Retired or lost units cannot be edited.");
+      const { leagueId, unitId, assetTag, acquiredAt, ...changes } = validated;
+      if (assetTag !== undefined && !normalizeGearAssetTag(assetTag)) {
+        invalid("An asset tag is required for individually tracked gear.");
+      }
+      const updated = await tx.gearUnit.update({
+        where: { id: existing.id },
+        data: {
+          ...changes,
+          ...(assetTag !== undefined ? { assetTag: assetTag ? normalizeGearAssetTag(assetTag) : null } : {}),
+          ...(acquiredAt !== undefined ? { acquiredAt: acquiredAt ? new Date(`${acquiredAt}T00:00:00.000Z`) : null } : {}),
+          version: { increment: 1 },
+        },
+        select: { id: true },
+      });
+      await recordGearActivity(tx, {
+        leagueId, entityType: "UNIT", entityId: updated.id, action: "updated", actorUserId: userId,
+      });
+      return updated;
+    }, gearTransactionOptions);
+    revalidatePath(gearPath(validated.leagueId));
+    return { success: true, data: unit };
+  } catch (error) {
+    return messageForGearError(error);
+  }
+}
+
+export async function transferGearUnit(input: unknown): Promise<ActionResult<{ id: string }>> {
+  try {
+    const validated = transferUnitSchema.parse(input);
+    const userId = await requireLeagueRole(validated.leagueId, "LEAGUE_ADMIN");
+    const unit = await prisma.$transaction(async (tx) => {
+      const existing = await tx.gearUnit.findFirst({
+        where: { id: validated.unitId, leagueId: validated.leagueId },
+        select: { id: true, status: true, currentLocationId: true, currentCondition: true },
+      });
+      if (!existing) invalid("Tagged unit not found.");
+      if (!["AVAILABLE", "MAINTENANCE"].includes(existing.status)) invalid("Only available or maintenance units can be transferred.");
+      await assertUnitCanMove(tx, existing.id);
+      await ensureActiveLocation(tx, validated.leagueId, validated.destinationLocationId);
+      if (existing.currentLocationId === validated.destinationLocationId) invalid("Choose a different destination location.");
+      const updated = await tx.gearUnit.update({
+        where: { id: existing.id },
+        data: { currentLocationId: validated.destinationLocationId, version: { increment: 1 } },
+        select: { id: true },
+      });
+      await recordGearInventoryMovement(tx, {
+        leagueId: validated.leagueId, type: "TRANSFER", gearUnitId: updated.id, quantity: 1,
+        beforeLocationId: existing.currentLocationId, afterLocationId: validated.destinationLocationId,
+        beforeCondition: existing.currentCondition, afterCondition: existing.currentCondition,
+        recordedById: userId, notes: validated.notes,
+      });
+      await recordGearActivity(tx, {
+        leagueId: validated.leagueId, entityType: "UNIT", entityId: updated.id, action: "transferred",
+        actorUserId: userId, details: { destinationLocationId: validated.destinationLocationId },
+      });
+      return updated;
+    }, gearTransactionOptions);
+    revalidatePath(gearPath(validated.leagueId));
+    return { success: true, data: unit };
+  } catch (error) {
+    return messageForGearError(error);
+  }
+}
+
+export async function changeGearUnitCondition(input: unknown): Promise<ActionResult<{ id: string }>> {
+  try {
+    const validated = changeUnitConditionSchema.parse(input);
+    const userId = await requireLeagueRole(validated.leagueId, "LEAGUE_ADMIN");
+    const unit = await prisma.$transaction(async (tx) => {
+      const existing = await tx.gearUnit.findFirst({
+        where: { id: validated.unitId, leagueId: validated.leagueId },
+        select: { id: true, status: true, currentLocationId: true, currentCondition: true },
+      });
+      if (!existing) invalid("Tagged unit not found.");
+      if (!["AVAILABLE", "MAINTENANCE"].includes(existing.status)) invalid("Only available or maintenance units can have their condition changed.");
+      await assertUnitCanMove(tx, existing.id);
+      if (existing.currentCondition === validated.condition) invalid("Choose a different condition.");
+      const updated = await tx.gearUnit.update({
+        where: { id: existing.id },
+        data: { currentCondition: validated.condition, version: { increment: 1 } },
+        select: { id: true },
+      });
+      await recordGearInventoryMovement(tx, {
+        leagueId: validated.leagueId, type: "ADJUSTMENT", gearUnitId: updated.id, quantity: 1,
+        beforeLocationId: existing.currentLocationId, afterLocationId: existing.currentLocationId,
+        beforeCondition: existing.currentCondition, afterCondition: validated.condition,
+        recordedById: userId, notes: validated.notes,
+      });
+      await recordGearActivity(tx, {
+        leagueId: validated.leagueId, entityType: "UNIT", entityId: updated.id, action: "condition_changed",
+        actorUserId: userId, details: { from: existing.currentCondition, to: validated.condition },
+      });
+      return updated;
+    }, gearTransactionOptions);
+    revalidatePath(gearPath(validated.leagueId));
+    return { success: true, data: unit };
+  } catch (error) {
+    return messageForGearError(error);
+  }
+}
+
+export async function retireGearUnit(input: unknown): Promise<ActionResult<{ id: string }>> {
+  try {
+    const validated = retireUnitSchema.parse(input);
+    const userId = await requireLeagueRole(validated.leagueId, "LEAGUE_ADMIN");
+    const unit = await prisma.$transaction(async (tx) => {
+      const existing = await tx.gearUnit.findFirst({
+        where: { id: validated.unitId, leagueId: validated.leagueId },
+        select: { id: true, status: true, currentLocationId: true, currentCondition: true },
+      });
+      if (!existing) invalid("Tagged unit not found.");
+      if (!["AVAILABLE", "MAINTENANCE"].includes(existing.status)) invalid("Only available or maintenance units can be retired.");
+      await assertUnitCanMove(tx, existing.id);
+      const updated = await tx.gearUnit.update({
+        where: { id: existing.id },
+        data: { status: "RETIRED", retiredAt: new Date(), currentLocationId: null, version: { increment: 1 } },
+        select: { id: true },
+      });
+      await recordGearInventoryMovement(tx, {
+        leagueId: validated.leagueId, type: "WRITE_OFF", gearUnitId: updated.id, quantity: 1,
+        beforeLocationId: existing.currentLocationId, beforeCondition: existing.currentCondition,
+        afterCondition: existing.currentCondition, recordedById: userId, notes: validated.notes,
+      });
+      await recordGearActivity(tx, {
+        leagueId: validated.leagueId, entityType: "UNIT", entityId: updated.id, action: "retired",
+        actorUserId: userId, details: { reason: validated.notes },
+      });
+      return updated;
+    }, gearTransactionOptions);
+    revalidatePath(gearPath(validated.leagueId));
+    return { success: true, data: unit };
+  } catch (error) {
+    return messageForGearError(error);
+  }
+}

--- a/lib/actions/gear-inventory.ts
+++ b/lib/actions/gear-inventory.ts
@@ -179,7 +179,7 @@ export async function createGearStorageLocation(
       });
       await recordGearActivity(tx, {
         leagueId: validated.leagueId, entityType: "STORAGE_LOCATION", entityId: created.id,
-        action: "created", actorUserId: userId, details: { name: validated.name },
+        action: "created", actorUserId: userId,
       });
       return created;
     }, gearTransactionOptions);
@@ -208,7 +208,8 @@ export async function updateGearStorageLocation(input: unknown): Promise<ActionR
       });
       await recordGearActivity(tx, {
         leagueId, entityType: "STORAGE_LOCATION", entityId: updated.id, action: "updated",
-        actorUserId: userId, details: { fields: Object.keys(changes), ...(name ? { name } : {}) },
+        actorUserId: userId,
+        details: { metadata: { updatedFieldCount: Object.keys(changes).length + (name ? 1 : 0) } },
       });
       return updated;
     }, gearTransactionOptions);
@@ -269,7 +270,8 @@ export async function createGearCatalogItem(
       });
       await recordGearActivity(tx, {
         leagueId: validated.leagueId, entityType: "CATALOG_ITEM", entityId: created.id,
-        action: "created", actorUserId: userId, details: { trackingMode: validated.trackingMode },
+        action: "created", actorUserId: userId,
+        details: { metadata: { trackingMode: validated.trackingMode } },
       });
       return created;
     }, gearTransactionOptions);
@@ -322,7 +324,8 @@ export async function updateGearCatalogItem(input: unknown): Promise<ActionResul
       });
       await recordGearActivity(tx, {
         leagueId, entityType: "CATALOG_ITEM", entityId: updated.id, action: "updated",
-        actorUserId: userId, details: { trackingMode: validated.trackingMode ?? existing.trackingMode },
+        actorUserId: userId,
+        details: { metadata: { trackingMode: validated.trackingMode ?? existing.trackingMode } },
       });
       return updated;
     }, gearTransactionOptions);
@@ -409,13 +412,15 @@ export async function adjustGearPoolStock(
         // Movements always record a positive physical quantity. A source-only
         // location is an outbound adjustment; a destination-only one is inbound.
         quantity: Math.abs(validated.quantityDelta),
+        direction: validated.quantityDelta > 0 ? "INCREASE" : "DECREASE",
         beforeLocationId: validated.quantityDelta < 0 ? validated.locationId : null,
         afterLocationId: validated.quantityDelta > 0 ? validated.locationId : null,
         afterCondition: validated.condition, recordedById: userId, notes: validated.notes,
       });
       await recordGearActivity(tx, {
         leagueId: validated.leagueId, entityType: "POOL_STOCK", entityId: current.id,
-        action: "adjusted", actorUserId: userId, details: { quantityDelta: validated.quantityDelta, condition: validated.condition },
+        action: "adjusted", actorUserId: userId,
+        details: { metadata: { quantityDelta: validated.quantityDelta, condition: validated.condition } },
       });
       return current;
     }, gearTransactionOptions));
@@ -472,6 +477,7 @@ export async function transferGearPoolStock(input: unknown): Promise<ActionResul
       });
       await recordGearInventoryMovement(tx, {
         leagueId: validated.leagueId, type: "TRANSFER", poolStockId: source.id, quantity: validated.quantity,
+        direction: "NEUTRAL",
         beforeLocationId: validated.sourceLocationId, afterLocationId: validated.destinationLocationId,
         beforeCondition: validated.condition, afterCondition: validated.condition,
         recordedById: userId, notes: validated.notes,
@@ -479,7 +485,7 @@ export async function transferGearPoolStock(input: unknown): Promise<ActionResul
       await recordGearActivity(tx, {
         leagueId: validated.leagueId, entityType: "POOL_STOCK", entityId: source.id,
         action: "transferred", actorUserId: userId,
-        details: { quantity: validated.quantity, destinationLocationId: validated.destinationLocationId },
+        details: { metadata: { quantity: validated.quantity, destinationLocationId: validated.destinationLocationId } },
       });
       return { sourceId: source.id, destinationId: destination.id };
     }, gearTransactionOptions));
@@ -514,11 +520,13 @@ export async function createGearUnit(
       });
       await recordGearInventoryMovement(tx, {
         leagueId: validated.leagueId, type: "RECEIPT", gearUnitId: created.id, quantity: 1,
+        direction: "INCREASE",
         afterLocationId: locationId, afterCondition: validated.currentCondition, recordedById: userId,
       });
       await recordGearActivity(tx, {
         leagueId: validated.leagueId, entityType: "UNIT", entityId: created.id, action: "created",
-        actorUserId: userId, details: { assetTag },
+        actorUserId: userId,
+        details: { metadata: { condition: validated.currentCondition } },
       });
       return created;
     }, gearTransactionOptions);
@@ -587,13 +595,15 @@ export async function transferGearUnit(input: unknown): Promise<ActionResult<{ i
       });
       await recordGearInventoryMovement(tx, {
         leagueId: validated.leagueId, type: "TRANSFER", gearUnitId: updated.id, quantity: 1,
+        direction: "NEUTRAL",
         beforeLocationId: existing.currentLocationId, afterLocationId: validated.destinationLocationId,
         beforeCondition: existing.currentCondition, afterCondition: existing.currentCondition,
         recordedById: userId, notes: validated.notes,
       });
       await recordGearActivity(tx, {
         leagueId: validated.leagueId, entityType: "UNIT", entityId: updated.id, action: "transferred",
-        actorUserId: userId, details: { destinationLocationId: validated.destinationLocationId },
+        actorUserId: userId,
+        details: { metadata: { destinationLocationId: validated.destinationLocationId } },
       });
       return updated;
     }, gearTransactionOptions);
@@ -624,13 +634,20 @@ export async function changeGearUnitCondition(input: unknown): Promise<ActionRes
       });
       await recordGearInventoryMovement(tx, {
         leagueId: validated.leagueId, type: "ADJUSTMENT", gearUnitId: updated.id, quantity: 1,
-        beforeLocationId: existing.currentLocationId, afterLocationId: existing.currentLocationId,
-        beforeCondition: existing.currentCondition, afterCondition: validated.condition,
+        direction: "DECREASE",
+        beforeLocationId: existing.currentLocationId, beforeCondition: existing.currentCondition,
+        recordedById: userId, notes: validated.notes,
+      });
+      await recordGearInventoryMovement(tx, {
+        leagueId: validated.leagueId, type: "ADJUSTMENT", gearUnitId: updated.id, quantity: 1,
+        direction: "INCREASE",
+        afterLocationId: existing.currentLocationId, afterCondition: validated.condition,
         recordedById: userId, notes: validated.notes,
       });
       await recordGearActivity(tx, {
         leagueId: validated.leagueId, entityType: "UNIT", entityId: updated.id, action: "condition_changed",
-        actorUserId: userId, details: { from: existing.currentCondition, to: validated.condition },
+        actorUserId: userId,
+        details: { metadata: { fromCondition: existing.currentCondition, toCondition: validated.condition } },
       });
       return updated;
     }, gearTransactionOptions);
@@ -660,12 +677,13 @@ export async function retireGearUnit(input: unknown): Promise<ActionResult<{ id:
       });
       await recordGearInventoryMovement(tx, {
         leagueId: validated.leagueId, type: "WRITE_OFF", gearUnitId: updated.id, quantity: 1,
+        direction: "DECREASE",
         beforeLocationId: existing.currentLocationId, beforeCondition: existing.currentCondition,
         afterCondition: existing.currentCondition, recordedById: userId, notes: validated.notes,
       });
       await recordGearActivity(tx, {
         leagueId: validated.leagueId, entityType: "UNIT", entityId: updated.id, action: "retired",
-        actorUserId: userId, details: { reason: validated.notes },
+        actorUserId: userId,
       });
       return updated;
     }, gearTransactionOptions);

--- a/lib/actions/gear-inventory.ts
+++ b/lib/actions/gear-inventory.ts
@@ -18,6 +18,7 @@ import {
   gearTransactionOptions,
   withGearSerializableRetry,
 } from "@/lib/services/gear-transaction";
+import { logGearInventoryFailure } from "@/lib/utils/gear-observability";
 
 export type ActionResult<T> =
   | { success: true; data: T }
@@ -64,37 +65,64 @@ const transferPoolStockSchema = z.object({
 });
 
 const unitCommandSchema = z.object({ leagueId: gearIdSchema, unitId: gearIdSchema });
+const expectedVersionSchema = z.coerce.number().int().min(0);
 const updateUnitSchema = createGearUnitSchema
   .omit({ leagueId: true, catalogItemId: true, currentLocationId: true, currentCondition: true })
   .partial()
-  .extend({ leagueId: gearIdSchema, unitId: gearIdSchema })
-  .refine((input) => Object.keys(input).some((key) => !["leagueId", "unitId"].includes(key)), {
+  .extend({ leagueId: gearIdSchema, unitId: gearIdSchema, expectedVersion: expectedVersionSchema })
+  .refine((input) => Object.keys(input).some((key) => !["leagueId", "unitId", "expectedVersion"].includes(key)), {
     message: "Provide at least one unit field to update",
   });
 const transferUnitSchema = z.object({
   leagueId: gearIdSchema,
   unitId: gearIdSchema,
   destinationLocationId: gearIdSchema,
+  expectedVersion: expectedVersionSchema,
   notes: z.string().trim().max(1_000).optional(),
 });
 const changeUnitConditionSchema = z.object({
   leagueId: gearIdSchema,
   unitId: gearIdSchema,
   condition: conditionSchema,
+  expectedVersion: expectedVersionSchema,
   notes: z.string().trim().max(1_000).optional(),
 });
 const retireUnitSchema = z.object({
   leagueId: gearIdSchema,
   unitId: gearIdSchema,
+  expectedVersion: expectedVersionSchema,
   notes: z.string().trim().min(1, "A retirement reason is required").max(1_000),
+});
+const unretireUnitSchema = z.object({
+  leagueId: gearIdSchema,
+  unitId: gearIdSchema,
+  expectedVersion: expectedVersionSchema,
+  destinationLocationId: gearIdSchema,
+  condition: conditionSchema,
+  notes: z.string().trim().min(1, "An unretirement reason is required").max(1_000),
 });
 
 function gearPath(leagueId: string) {
   return `/league/${leagueId}/gear`;
 }
 
-function messageForGearError(error: unknown): ActionResult<never> {
-  if (error instanceof GearConflictError) return { success: false, error: error.message };
+function messageForGearError(
+  error: unknown,
+  action = "unknown",
+  input?: unknown,
+): ActionResult<never> {
+  const leagueId = typeof input === "object" && input !== null && "leagueId" in input && typeof input.leagueId === "string"
+    ? input.leagueId
+    : undefined;
+  if (error instanceof GearConflictError) {
+    const incidentId = error.retryExhausted ? logGearInventoryFailure(action, leagueId, error) : undefined;
+    return {
+      success: false,
+      error: incidentId
+        ? "Inventory could not be saved after concurrent updates. Please try again."
+        : error.message,
+    };
+  }
   if (error instanceof z.ZodError) {
     return { success: false, error: "Please correct the highlighted inventory fields.", details: error.issues };
   }
@@ -105,7 +133,8 @@ function messageForGearError(error: unknown): ActionResult<never> {
     if (error.message.startsWith("Unauthorized")) return { success: false, error: "League admin access is required." };
     if (error.message.startsWith("Gear validation:")) return { success: false, error: error.message.slice(17) };
   }
-  return { success: false, error: "Unable to update gear inventory. Please try again." };
+  const incidentId = logGearInventoryFailure(action, leagueId, error);
+  return { success: false, error: `Unable to update gear inventory. Please try again. Reference: ${incidentId}` };
 }
 
 function invalid(message: string): never {
@@ -186,7 +215,7 @@ export async function createGearStorageLocation(
     revalidatePath(gearPath(validated.leagueId));
     return { success: true, data: location };
   } catch (error) {
-    return messageForGearError(error);
+    return messageForGearError(error, "create-storage-location", input);
   }
 }
 
@@ -216,7 +245,7 @@ export async function updateGearStorageLocation(input: unknown): Promise<ActionR
     revalidatePath(gearPath(validated.leagueId));
     return { success: true, data: location };
   } catch (error) {
-    return messageForGearError(error);
+    return messageForGearError(error, "update-storage-location", input);
   }
 }
 
@@ -253,7 +282,7 @@ export async function archiveGearStorageLocation(input: unknown): Promise<Action
     revalidatePath(gearPath(leagueId));
     return { success: true, data: location };
   } catch (error) {
-    return messageForGearError(error);
+    return messageForGearError(error, "archive-storage-location", input);
   }
 }
 
@@ -278,7 +307,7 @@ export async function createGearCatalogItem(
     revalidatePath(gearPath(validated.leagueId));
     return { success: true, data: item };
   } catch (error) {
-    return messageForGearError(error);
+    return messageForGearError(error, "create-catalog-item", input);
   }
 }
 
@@ -332,7 +361,7 @@ export async function updateGearCatalogItem(input: unknown): Promise<ActionResul
     revalidatePath(gearPath(validated.leagueId));
     return { success: true, data: item };
   } catch (error) {
-    return messageForGearError(error);
+    return messageForGearError(error, "update-catalog-item", input);
   }
 }
 
@@ -345,6 +374,40 @@ export async function archiveGearCatalogItem(input: unknown): Promise<ActionResu
         where: { id: catalogItemId, leagueId, isActive: true }, select: { id: true },
       });
       if (!existing) invalid("Active catalog item not found.");
+      const [stock, liveUnits, movements, commitments] = await Promise.all([
+        tx.gearPoolStock.count({
+          where: { leagueId, catalogItemId: existing.id, quantityOnHand: { gt: 0 } },
+        }),
+        tx.gearUnit.count({
+          where: {
+            leagueId,
+            catalogItemId: existing.id,
+            status: { notIn: ["RETIRED", "LOST"] },
+          },
+        }),
+        tx.gearInventoryMovement.count({
+          where: {
+            leagueId,
+            OR: [
+              { poolStock: { catalogItemId: existing.id } },
+              { gearUnit: { catalogItemId: existing.id } },
+            ],
+          },
+        }),
+        tx.gearAllocation.count({
+          where: {
+            leagueId,
+            status: { in: [...activeAllocationStatuses] },
+            OR: [
+              { poolStock: { catalogItemId: existing.id } },
+              { gearUnit: { catalogItemId: existing.id } },
+            ],
+          },
+        }),
+      ]);
+      if (stock || liveUnits || movements || commitments) {
+        invalid("Catalog items with stock, active units, commitments, or inventory history cannot be archived.");
+      }
       const archived = await tx.gearCatalogItem.update({
         where: { id: existing.id }, data: { isActive: false, archivedAt: new Date() }, select: { id: true },
       });
@@ -356,7 +419,7 @@ export async function archiveGearCatalogItem(input: unknown): Promise<ActionResu
     revalidatePath(gearPath(leagueId));
     return { success: true, data: item };
   } catch (error) {
-    return messageForGearError(error);
+    return messageForGearError(error, "archive-catalog-item", input);
   }
 }
 
@@ -415,7 +478,9 @@ export async function adjustGearPoolStock(
         direction: validated.quantityDelta > 0 ? "INCREASE" : "DECREASE",
         beforeLocationId: validated.quantityDelta < 0 ? validated.locationId : null,
         afterLocationId: validated.quantityDelta > 0 ? validated.locationId : null,
-        afterCondition: validated.condition, recordedById: userId, notes: validated.notes,
+        beforeCondition: validated.quantityDelta < 0 ? validated.condition : null,
+        afterCondition: validated.quantityDelta > 0 ? validated.condition : null,
+        recordedById: userId, notes: validated.notes,
       });
       await recordGearActivity(tx, {
         leagueId: validated.leagueId, entityType: "POOL_STOCK", entityId: current.id,
@@ -427,7 +492,7 @@ export async function adjustGearPoolStock(
     revalidatePath(gearPath(validated.leagueId));
     return { success: true, data: stock };
   } catch (error) {
-    return messageForGearError(error);
+    return messageForGearError(error, "adjust-pooled-stock", input);
   }
 }
 
@@ -492,7 +557,7 @@ export async function transferGearPoolStock(input: unknown): Promise<ActionResul
     revalidatePath(gearPath(validated.leagueId));
     return { success: true, data: transfer };
   } catch (error) {
-    return messageForGearError(error);
+    return messageForGearError(error, "transfer-pooled-stock", input);
   }
 }
 
@@ -533,7 +598,7 @@ export async function createGearUnit(
     revalidatePath(gearPath(validated.leagueId));
     return { success: true, data: unit };
   } catch (error) {
-    return messageForGearError(error);
+    return messageForGearError(error, "create-unit", input);
   }
 }
 
@@ -544,33 +609,33 @@ export async function updateGearUnit(input: unknown): Promise<ActionResult<{ id:
     const unit = await prisma.$transaction(async (tx) => {
       const existing = await tx.gearUnit.findFirst({
         where: { id: validated.unitId, leagueId: validated.leagueId },
-        select: { id: true, status: true },
+        select: { id: true, status: true, version: true },
       });
       if (!existing) invalid("Tagged unit not found.");
       if (existing.status === "RETIRED" || existing.status === "LOST") invalid("Retired or lost units cannot be edited.");
-      const { leagueId, unitId, assetTag, acquiredAt, ...changes } = validated;
+      const { leagueId, unitId, expectedVersion, assetTag, acquiredAt, ...changes } = validated;
       if (assetTag !== undefined && !normalizeGearAssetTag(assetTag)) {
         invalid("An asset tag is required for individually tracked gear.");
       }
-      const updated = await tx.gearUnit.update({
-        where: { id: existing.id },
+      const updated = await tx.gearUnit.updateMany({
+        where: { id: existing.id, leagueId, version: expectedVersion },
         data: {
           ...changes,
           ...(assetTag !== undefined ? { assetTag: assetTag ? normalizeGearAssetTag(assetTag) : null } : {}),
           ...(acquiredAt !== undefined ? { acquiredAt: acquiredAt ? new Date(`${acquiredAt}T00:00:00.000Z`) : null } : {}),
           version: { increment: 1 },
         },
-        select: { id: true },
       });
+      if (updated.count !== 1) throw new GearConflictError();
       await recordGearActivity(tx, {
-        leagueId, entityType: "UNIT", entityId: updated.id, action: "updated", actorUserId: userId,
+        leagueId, entityType: "UNIT", entityId: existing.id, action: "updated", actorUserId: userId,
       });
-      return updated;
+      return { id: existing.id };
     }, gearTransactionOptions);
     revalidatePath(gearPath(validated.leagueId));
     return { success: true, data: unit };
   } catch (error) {
-    return messageForGearError(error);
+    return messageForGearError(error, "update-unit", input);
   }
 }
 
@@ -581,36 +646,36 @@ export async function transferGearUnit(input: unknown): Promise<ActionResult<{ i
     const unit = await prisma.$transaction(async (tx) => {
       const existing = await tx.gearUnit.findFirst({
         where: { id: validated.unitId, leagueId: validated.leagueId },
-        select: { id: true, status: true, currentLocationId: true, currentCondition: true },
+        select: { id: true, status: true, currentLocationId: true, currentCondition: true, version: true },
       });
       if (!existing) invalid("Tagged unit not found.");
       if (!["AVAILABLE", "MAINTENANCE"].includes(existing.status)) invalid("Only available or maintenance units can be transferred.");
       await assertUnitCanMove(tx, validated.leagueId, existing.id);
       await ensureActiveLocation(tx, validated.leagueId, validated.destinationLocationId);
       if (existing.currentLocationId === validated.destinationLocationId) invalid("Choose a different destination location.");
-      const updated = await tx.gearUnit.update({
-        where: { id: existing.id },
+      const updated = await tx.gearUnit.updateMany({
+        where: { id: existing.id, leagueId: validated.leagueId, version: validated.expectedVersion },
         data: { currentLocationId: validated.destinationLocationId, version: { increment: 1 } },
-        select: { id: true },
       });
+      if (updated.count !== 1) throw new GearConflictError();
       await recordGearInventoryMovement(tx, {
-        leagueId: validated.leagueId, type: "TRANSFER", gearUnitId: updated.id, quantity: 1,
+        leagueId: validated.leagueId, type: "TRANSFER", gearUnitId: existing.id, quantity: 1,
         direction: "NEUTRAL",
         beforeLocationId: existing.currentLocationId, afterLocationId: validated.destinationLocationId,
         beforeCondition: existing.currentCondition, afterCondition: existing.currentCondition,
         recordedById: userId, notes: validated.notes,
       });
       await recordGearActivity(tx, {
-        leagueId: validated.leagueId, entityType: "UNIT", entityId: updated.id, action: "transferred",
+        leagueId: validated.leagueId, entityType: "UNIT", entityId: existing.id, action: "transferred",
         actorUserId: userId,
         details: { metadata: { destinationLocationId: validated.destinationLocationId } },
       });
-      return updated;
+      return { id: existing.id };
     }, gearTransactionOptions);
     revalidatePath(gearPath(validated.leagueId));
     return { success: true, data: unit };
   } catch (error) {
-    return messageForGearError(error);
+    return messageForGearError(error, "transfer-unit", input);
   }
 }
 
@@ -621,40 +686,40 @@ export async function changeGearUnitCondition(input: unknown): Promise<ActionRes
     const unit = await prisma.$transaction(async (tx) => {
       const existing = await tx.gearUnit.findFirst({
         where: { id: validated.unitId, leagueId: validated.leagueId },
-        select: { id: true, status: true, currentLocationId: true, currentCondition: true },
+        select: { id: true, status: true, currentLocationId: true, currentCondition: true, version: true },
       });
       if (!existing) invalid("Tagged unit not found.");
       if (!["AVAILABLE", "MAINTENANCE"].includes(existing.status)) invalid("Only available or maintenance units can have their condition changed.");
       await assertUnitCanMove(tx, validated.leagueId, existing.id);
       if (existing.currentCondition === validated.condition) invalid("Choose a different condition.");
-      const updated = await tx.gearUnit.update({
-        where: { id: existing.id },
+      const updated = await tx.gearUnit.updateMany({
+        where: { id: existing.id, leagueId: validated.leagueId, version: validated.expectedVersion },
         data: { currentCondition: validated.condition, version: { increment: 1 } },
-        select: { id: true },
       });
+      if (updated.count !== 1) throw new GearConflictError();
       await recordGearInventoryMovement(tx, {
-        leagueId: validated.leagueId, type: "ADJUSTMENT", gearUnitId: updated.id, quantity: 1,
+        leagueId: validated.leagueId, type: "ADJUSTMENT", gearUnitId: existing.id, quantity: 1,
         direction: "DECREASE",
         beforeLocationId: existing.currentLocationId, beforeCondition: existing.currentCondition,
         recordedById: userId, notes: validated.notes,
       });
       await recordGearInventoryMovement(tx, {
-        leagueId: validated.leagueId, type: "ADJUSTMENT", gearUnitId: updated.id, quantity: 1,
+        leagueId: validated.leagueId, type: "ADJUSTMENT", gearUnitId: existing.id, quantity: 1,
         direction: "INCREASE",
         afterLocationId: existing.currentLocationId, afterCondition: validated.condition,
         recordedById: userId, notes: validated.notes,
       });
       await recordGearActivity(tx, {
-        leagueId: validated.leagueId, entityType: "UNIT", entityId: updated.id, action: "condition_changed",
+        leagueId: validated.leagueId, entityType: "UNIT", entityId: existing.id, action: "condition_changed",
         actorUserId: userId,
         details: { metadata: { fromCondition: existing.currentCondition, toCondition: validated.condition } },
       });
-      return updated;
+      return { id: existing.id };
     }, gearTransactionOptions);
     revalidatePath(gearPath(validated.leagueId));
     return { success: true, data: unit };
   } catch (error) {
-    return messageForGearError(error);
+    return messageForGearError(error, "change-unit-condition", input);
   }
 }
 
@@ -665,31 +730,89 @@ export async function retireGearUnit(input: unknown): Promise<ActionResult<{ id:
     const unit = await prisma.$transaction(async (tx) => {
       const existing = await tx.gearUnit.findFirst({
         where: { id: validated.unitId, leagueId: validated.leagueId },
-        select: { id: true, status: true, currentLocationId: true, currentCondition: true },
+        select: { id: true, status: true, currentLocationId: true, currentCondition: true, version: true },
       });
       if (!existing) invalid("Tagged unit not found.");
       if (!["AVAILABLE", "MAINTENANCE"].includes(existing.status)) invalid("Only available or maintenance units can be retired.");
       await assertUnitCanMove(tx, validated.leagueId, existing.id);
-      const updated = await tx.gearUnit.update({
-        where: { id: existing.id },
+      const updated = await tx.gearUnit.updateMany({
+        where: { id: existing.id, leagueId: validated.leagueId, version: validated.expectedVersion },
         data: { status: "RETIRED", retiredAt: new Date(), currentLocationId: null, version: { increment: 1 } },
-        select: { id: true },
       });
+      if (updated.count !== 1) throw new GearConflictError();
       await recordGearInventoryMovement(tx, {
-        leagueId: validated.leagueId, type: "WRITE_OFF", gearUnitId: updated.id, quantity: 1,
+        leagueId: validated.leagueId, type: "WRITE_OFF", gearUnitId: existing.id, quantity: 1,
         direction: "DECREASE",
         beforeLocationId: existing.currentLocationId, beforeCondition: existing.currentCondition,
-        afterCondition: existing.currentCondition, recordedById: userId, notes: validated.notes,
+        recordedById: userId, notes: validated.notes,
       });
       await recordGearActivity(tx, {
-        leagueId: validated.leagueId, entityType: "UNIT", entityId: updated.id, action: "retired",
+        leagueId: validated.leagueId, entityType: "UNIT", entityId: existing.id, action: "retired",
         actorUserId: userId,
       });
-      return updated;
+      return { id: existing.id };
     }, gearTransactionOptions);
     revalidatePath(gearPath(validated.leagueId));
     return { success: true, data: unit };
   } catch (error) {
-    return messageForGearError(error);
+    return messageForGearError(error, "retire-unit", input);
+  }
+}
+
+export async function unretireGearUnit(input: unknown): Promise<ActionResult<{ id: string }>> {
+  try {
+    const validated = unretireUnitSchema.parse(input);
+    const userId = await requireLeagueRole(validated.leagueId, "LEAGUE_ADMIN");
+    const unit = await prisma.$transaction(async (tx) => {
+      const existing = await tx.gearUnit.findFirst({
+        where: { id: validated.unitId, leagueId: validated.leagueId },
+        select: { id: true, status: true, version: true },
+      });
+      if (!existing) invalid("Tagged unit not found.");
+      if (existing.status !== "RETIRED") invalid("Only retired units can be returned to inventory.");
+      await ensureActiveLocation(tx, validated.leagueId, validated.destinationLocationId);
+      const updated = await tx.gearUnit.updateMany({
+        where: { id: existing.id, leagueId: validated.leagueId, version: validated.expectedVersion },
+        data: {
+          status: "AVAILABLE",
+          currentLocationId: validated.destinationLocationId,
+          currentCondition: validated.condition,
+          retiredAt: null,
+          version: { increment: 1 },
+        },
+      });
+      if (updated.count !== 1) throw new GearConflictError();
+      await recordGearInventoryMovement(tx, {
+        leagueId: validated.leagueId,
+        type: "RECEIPT",
+        direction: "INCREASE",
+        gearUnitId: existing.id,
+        quantity: 1,
+        afterLocationId: validated.destinationLocationId,
+        afterCondition: validated.condition,
+        recordedById: userId,
+        notes: validated.notes,
+      });
+      await recordGearActivity(tx, {
+        leagueId: validated.leagueId,
+        entityType: "UNIT",
+        entityId: existing.id,
+        action: "unretired",
+        actorUserId: userId,
+        details: {
+          summary: "Unit returned to active inventory after retirement.",
+          metadata: {
+            destinationLocationId: validated.destinationLocationId,
+            condition: validated.condition,
+            retirementReversed: true,
+          },
+        },
+      });
+      return { id: existing.id };
+    }, gearTransactionOptions);
+    revalidatePath(gearPath(validated.leagueId));
+    return { success: true, data: unit };
+  } catch (error) {
+    return messageForGearError(error, "unretire-unit", input);
   }
 }

--- a/lib/services/gear-ledger.ts
+++ b/lib/services/gear-ledger.ts
@@ -1,0 +1,46 @@
+import type { GearActivityEntityType, GearInventoryMovementType, Prisma } from "@prisma/client";
+
+type GearTransaction = Prisma.TransactionClient;
+
+export type GearActivityInput = {
+  leagueId: string;
+  entityType: GearActivityEntityType;
+  entityId: string;
+  action: string;
+  actorUserId: string;
+  details?: Prisma.InputJsonValue;
+};
+
+export type GearMovementInput = {
+  leagueId: string;
+  type: GearInventoryMovementType;
+  quantity: number;
+  recordedById: string;
+  poolStockId?: string | null;
+  gearUnitId?: string | null;
+  beforeLocationId?: string | null;
+  afterLocationId?: string | null;
+  beforeCondition?: "NEW" | "EXCELLENT" | "GOOD" | "FAIR" | "POOR" | "DAMAGED" | null;
+  afterCondition?: "NEW" | "EXCELLENT" | "GOOD" | "FAIR" | "POOR" | "DAMAGED" | null;
+  notes?: string | null;
+};
+
+/** Ledger helpers are intentionally plain functions so mutations can include them atomically. */
+export async function recordGearActivity(
+  tx: GearTransaction,
+  input: GearActivityInput,
+): Promise<void> {
+  await tx.gearActivity.create({
+    data: {
+      ...input,
+      actorKind: "USER",
+    },
+  });
+}
+
+export async function recordGearInventoryMovement(
+  tx: GearTransaction,
+  input: GearMovementInput,
+): Promise<void> {
+  await tx.gearInventoryMovement.create({ data: input });
+}

--- a/lib/services/gear-ledger.ts
+++ b/lib/services/gear-ledger.ts
@@ -1,4 +1,14 @@
-import type { GearActivityEntityType, GearInventoryMovementType, Prisma } from "@prisma/client";
+import type {
+  GearActivityEntityType,
+  GearInventoryDirection,
+  GearInventoryMovementType,
+  Prisma,
+} from "@prisma/client";
+import type { GearActivityDetails } from "@/types/gear";
+import {
+  gearActivityDetailsSchema,
+  recordGearInventoryMovementSchema,
+} from "@/lib/utils/validation";
 
 type GearTransaction = Prisma.TransactionClient;
 
@@ -8,12 +18,13 @@ export type GearActivityInput = {
   entityId: string;
   action: string;
   actorUserId: string;
-  details?: Prisma.InputJsonValue;
+  details?: Omit<GearActivityDetails, "action">;
 };
 
 export type GearMovementInput = {
   leagueId: string;
   type: GearInventoryMovementType;
+  direction: GearInventoryDirection;
   quantity: number;
   recordedById: string;
   poolStockId?: string | null;
@@ -30,9 +41,14 @@ export async function recordGearActivity(
   tx: GearTransaction,
   input: GearActivityInput,
 ): Promise<void> {
+  const details = gearActivityDetailsSchema.parse({
+    action: input.action,
+    ...input.details,
+  });
   await tx.gearActivity.create({
     data: {
       ...input,
+      details,
       actorKind: "USER",
     },
   });
@@ -42,5 +58,14 @@ export async function recordGearInventoryMovement(
   tx: GearTransaction,
   input: GearMovementInput,
 ): Promise<void> {
+  recordGearInventoryMovementSchema.parse({
+    leagueId: input.leagueId,
+    type: input.type,
+    direction: input.direction,
+    poolStockId: input.poolStockId ?? "",
+    gearUnitId: input.gearUnitId ?? "",
+    quantity: input.quantity,
+    notes: input.notes ?? undefined,
+  });
   await tx.gearInventoryMovement.create({ data: input });
 }

--- a/lib/services/gear-transaction.ts
+++ b/lib/services/gear-transaction.ts
@@ -4,7 +4,10 @@ import { isRetryablePrismaConflict } from "@/lib/utils/gear";
 const MAX_ATTEMPTS = 3;
 
 export class GearConflictError extends Error {
-  constructor(message = "Inventory changed while saving. Please review the latest inventory and try again.") {
+  constructor(
+    message = "Inventory changed while saving. Please review the latest inventory and try again.",
+    readonly retryExhausted = false,
+  ) {
     super(message);
     this.name = "GearConflictError";
   }
@@ -19,7 +22,7 @@ export async function withGearSerializableRetry<T>(
     } catch (error) {
       if (!isRetryablePrismaConflict(error) || attempt === MAX_ATTEMPTS) {
         if (isRetryablePrismaConflict(error)) {
-          throw new GearConflictError();
+          throw new GearConflictError(undefined, true);
         }
         throw error;
       }

--- a/lib/services/gear-transaction.ts
+++ b/lib/services/gear-transaction.ts
@@ -1,0 +1,36 @@
+import { Prisma } from "@prisma/client";
+import { isRetryablePrismaConflict } from "@/lib/utils/gear";
+
+const MAX_ATTEMPTS = 3;
+
+export class GearConflictError extends Error {
+  constructor(message = "Inventory changed while saving. Please review the latest inventory and try again.") {
+    super(message);
+    this.name = "GearConflictError";
+  }
+}
+
+export async function withGearSerializableRetry<T>(
+  run: () => Promise<T>,
+): Promise<T> {
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt += 1) {
+    try {
+      return await run();
+    } catch (error) {
+      if (!isRetryablePrismaConflict(error) || attempt === MAX_ATTEMPTS) {
+        if (isRetryablePrismaConflict(error)) {
+          throw new GearConflictError();
+        }
+        throw error;
+      }
+    }
+  }
+
+  throw new GearConflictError();
+}
+
+export const gearTransactionOptions = {
+  isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
+  maxWait: 5_000,
+  timeout: 10_000,
+};

--- a/lib/utils/gear-observability.ts
+++ b/lib/utils/gear-observability.ts
@@ -1,0 +1,16 @@
+import { sanitizeErrorForLogging } from "@/lib/utils/error-handling";
+
+export function logGearInventoryFailure(
+  action: string,
+  leagueId: string | undefined,
+  error: unknown,
+): string {
+  const incidentId = crypto.randomUUID();
+  console.error("Gear inventory action failed", {
+    action,
+    leagueId: leagueId ?? "unknown",
+    incidentId,
+    error: sanitizeErrorForLogging(error),
+  });
+  return incidentId;
+}

--- a/lib/utils/validation.ts
+++ b/lib/utils/validation.ts
@@ -2079,7 +2079,7 @@ const gearDateSchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Date must be YYY
 const gearQuantitySchema = z.coerce.number().int("Quantity must be a whole number").min(1, "Quantity must be at least 1");
 const gearOptionalQuantitySchema = z.coerce.number().int("Quantity must be a whole number").min(0);
 const gearCuidSchema = z.string().cuid("Invalid gear identifier");
-const gearAttributesSchema = z.record(z.string().max(80), z.unknown()).optional();
+const gearAttributesSchema = z.record(z.string().max(80), z.json()).optional();
 
 export const createGearCatalogItemSchema = z.object({
   leagueId: gearCuidSchema,


### PR DESCRIPTION
## Summary
- add league-scoped pooled and tagged inventory actions with serializable ledger transactions
- add protected inventory page with responsive management controls and activity display
- add focused coverage for authorization, ledger writes, negative stock, tenant isolation, and redaction

## Validation
- `bun run test __tests__/lib/actions/gear-inventory.test.ts __tests__/lib/actions/gear-context.test.ts __tests__/components/features/gear/GearInventoryManager.test.tsx`
- `bun run type-check`
- `bun run check:raw-sql`
- changed-file ESLint
- `bun run adr:check -- ...`