### PR TITLE
feat(gear): add reservations and custody workflows

### DIFF
--- a/__tests__/lib/actions/gear-context.test.ts
+++ b/__tests__/lib/actions/gear-context.test.ts
@@ -9,6 +9,8 @@ const { mockRequireUserId, mockPrisma } = vi.hoisted(() => ({
     gearPoolStock: { findMany: vi.fn() },
     gearUnit: { findMany: vi.fn() },
     gearReservation: { findMany: vi.fn() },
+    teamMember: { findMany: vi.fn() },
+    team: { findMany: vi.fn() },
     gearInventoryMovement: { findMany: vi.fn() },
   },
 }));
@@ -16,7 +18,7 @@ const { mockRequireUserId, mockPrisma } = vi.hoisted(() => ({
 vi.mock("@/lib/auth/session", () => ({ requireUserId: () => mockRequireUserId() }));
 vi.mock("@/lib/db/prisma", () => ({ prisma: mockPrisma }));
 
-import { getGearInventoryContext } from "@/lib/actions/gear-context";
+import { getGearInventoryContext, getGearReservationContext } from "@/lib/actions/gear-context";
 
 const LEAGUE_ID = "cllllllllllllllllllllllll";
 
@@ -28,6 +30,8 @@ beforeEach(() => {
   mockPrisma.gearPoolStock.findMany.mockResolvedValue([]);
   mockPrisma.gearUnit.findMany.mockResolvedValue([]);
   mockPrisma.gearReservation.findMany.mockResolvedValue([]);
+  mockPrisma.teamMember.findMany.mockResolvedValue([]);
+  mockPrisma.team.findMany.mockResolvedValue([]);
   mockPrisma.gearInventoryMovement.findMany.mockResolvedValue([]);
 });
 
@@ -137,5 +141,143 @@ describe("gear inventory context", () => {
         occurredAt: "2026-03-01T12:34:56.789Z",
       }],
     });
+  });
+
+  it("withholds detailed reservations from ordinary league members", async () => {
+      mockPrisma.leagueUser.findFirst.mockResolvedValue({
+        role: "MEMBER",
+        league: { id: LEAGUE_ID, name: "Metro" },
+      });
+
+      const result = await getGearReservationContext(LEAGUE_ID);
+
+      expect(result?.reservations).toEqual([]);
+      expect(mockPrisma.gearReservation.findMany).not.toHaveBeenCalled();
+      expect(mockPrisma.teamMember.findMany).toHaveBeenCalledWith(expect.objectContaining({
+        where: expect.objectContaining({ role: "ADMIN" }),
+      }));
+  });
+
+  it("projects overdue custody from outstanding allocation dates, not requested dates", async () => {
+      const TEAM_ID = "cteeeeeeeeeeeeeeeeeeeeeee";
+      mockPrisma.leagueUser.findFirst.mockResolvedValue({
+        role: "MEMBER",
+        league: { id: LEAGUE_ID, name: "Metro" },
+      });
+      mockPrisma.teamMember.findMany.mockResolvedValue([{ teamId: TEAM_ID }]);
+      mockPrisma.gearReservation.findMany.mockResolvedValue([{
+        id: "crrrrrrrrrrrrrrrrrrrrrrrr",
+        teamId: TEAM_ID,
+        team: { name: "Owning team" },
+        status: "FULFILLED",
+        requestedStartDate: new Date("2027-01-01"),
+        requestedEndDate: new Date("2027-01-03"),
+        custodianNameSnapshot: "Custodian",
+        requestNotes: "Private to team admins",
+        decisionNotes: "Private to league admins",
+        version: 1,
+        lines: [{
+          id: "cliiiiiiiiiiiiiiiiiiiiiiii",
+          nameSnapshot: "Helmet",
+          requestedQty: 1,
+          approvedQty: 1,
+          allocatedQty: 1,
+          allocations: [{
+            id: "caaaaaaaaaaaaaaaaaaaaaaaa",
+            status: "PICKED_UP",
+            allocatedQty: 1,
+            pickedUpQty: 1,
+            returnedQty: 0,
+            releasedQty: 0,
+            effectiveStartDate: new Date("2026-01-01"),
+            effectiveEndDate: new Date("2026-01-02"),
+            poolStockId: null,
+            gearUnitId: null,
+            version: 1,
+            poolStock: null,
+            gearUnit: null,
+          }],
+        }],
+      }]);
+
+      const result = await getGearReservationContext(LEAGUE_ID);
+
+      expect(result?.reservations[0]).toMatchObject({
+        overdue: true,
+        requestNotes: "Private to team admins",
+      });
+      expect(result?.reservations[0]).not.toHaveProperty("decisionNotes");
+  });
+
+  it("flags future reallocation only when overlapping custody exhausts the same pool window", async () => {
+      mockPrisma.leagueUser.findFirst.mockResolvedValue({
+        role: "LEAGUE_ADMIN",
+        league: { id: LEAGUE_ID, name: "Metro" },
+      });
+      mockPrisma.team.findMany.mockResolvedValue([{ id: "cteeeeeeeeeeeeeeeeeeeeeee" }]);
+      mockPrisma.gearReservation.findMany.mockResolvedValue([{
+        id: "crrrrrrrrrrrrrrrrrrrrrrrr",
+        teamId: "cteeeeeeeeeeeeeeeeeeeeeee",
+        team: { name: "Owning team" },
+        status: "APPROVED",
+        requestedStartDate: new Date("2026-09-10"),
+        requestedEndDate: new Date("2026-09-12"),
+        custodianNameSnapshot: "Custodian",
+        requestNotes: null,
+        decisionNotes: null,
+        version: 1,
+        lines: [{
+          id: "cliiiiiiiiiiiiiiiiiiiiiiii",
+          nameSnapshot: "Helmet",
+          requestedQty: 2,
+          approvedQty: 2,
+          allocatedQty: 2,
+          allocations: [{
+            id: "caaaaaaaaaaaaaaaaaaaaaaaa",
+            status: "ALLOCATED",
+            allocatedQty: 2,
+            pickedUpQty: 0,
+            returnedQty: 0,
+            releasedQty: 0,
+            effectiveStartDate: new Date("2026-09-10"),
+            effectiveEndDate: new Date("2026-09-12"),
+            poolStockId: "cstockkkkkkkkkkkkkkkkkkkk",
+            gearUnitId: null,
+            version: 1,
+            poolStock: { location: { name: "Locker" } },
+            gearUnit: null,
+          }],
+        }],
+      }]);
+      mockPrisma.gearPoolStock.findMany.mockResolvedValue([{
+        id: "cstockkkkkkkkkkkkkkkkkkkk",
+        quantityOnHand: 2,
+        allocations: [
+          {
+            id: "caaaaaaaaaaaaaaaaaaaaaaaa",
+            status: "ALLOCATED",
+            allocatedQty: 2,
+            pickedUpQty: 0,
+            returnedQty: 0,
+            releasedQty: 0,
+            effectiveStartDate: new Date("2026-09-10"),
+            effectiveEndDate: new Date("2026-09-12"),
+          },
+          {
+            id: "cbbbbbbbbbbbbbbbbbbbbbbbb",
+            status: "PICKED_UP",
+            allocatedQty: 1,
+            pickedUpQty: 1,
+            returnedQty: 0,
+            releasedQty: 0,
+            effectiveStartDate: new Date("2026-08-01"),
+            effectiveEndDate: new Date("2026-08-03"),
+          },
+        ],
+      }]);
+
+      const result = await getGearReservationContext(LEAGUE_ID);
+
+      expect(result?.reservations[0]?.reallocationWarning).toBe(true);
   });
 });

--- a/__tests__/lib/actions/gear-context.test.ts
+++ b/__tests__/lib/actions/gear-context.test.ts
@@ -8,6 +8,7 @@ const { mockRequireUserId, mockPrisma } = vi.hoisted(() => ({
     gearCatalogItem: { findMany: vi.fn() },
     gearPoolStock: { findMany: vi.fn() },
     gearUnit: { findMany: vi.fn() },
+    gearReservation: { findMany: vi.fn() },
     gearInventoryMovement: { findMany: vi.fn() },
   },
 }));
@@ -26,6 +27,7 @@ beforeEach(() => {
   mockPrisma.gearCatalogItem.findMany.mockResolvedValue([]);
   mockPrisma.gearPoolStock.findMany.mockResolvedValue([]);
   mockPrisma.gearUnit.findMany.mockResolvedValue([]);
+  mockPrisma.gearReservation.findMany.mockResolvedValue([]);
   mockPrisma.gearInventoryMovement.findMany.mockResolvedValue([]);
 });
 

--- a/__tests__/lib/actions/gear-reservations.test.ts
+++ b/__tests__/lib/actions/gear-reservations.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockAuth, mockTx, mockPrisma, recordGearActivity, recordGearInventoryMovement } = vi.hoisted(() => {
+  const transaction = {
+    gearReservation: { findFirst: vi.fn(), updateMany: vi.fn() },
+    gearAllocation: { updateMany: vi.fn(), count: vi.fn() },
+    gearReservationLine: { updateMany: vi.fn() },
+    gearUnit: { updateMany: vi.fn() },
+  };
+  return {
+    mockAuth: { requireUserId: vi.fn(), getUserLeagueRole: vi.fn(), isTeamAdmin: vi.fn() },
+    mockTx: transaction,
+    mockPrisma: { $transaction: vi.fn(async (callback: (tx: typeof transaction) => unknown) => callback(transaction)) },
+    recordGearActivity: vi.fn(),
+    recordGearInventoryMovement: vi.fn(),
+  };
+});
+
+vi.mock("@/lib/auth/session", () => mockAuth);
+vi.mock("@/lib/db/prisma", () => ({ prisma: mockPrisma }));
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("@/lib/services/gear-ledger", () => ({ recordGearActivity, recordGearInventoryMovement }));
+vi.mock("@/lib/services/gear-transaction", () => ({
+  GearConflictError: class GearConflictError extends Error {},
+  gearTransactionOptions: {},
+  withGearSerializableRetry: <T>(run: () => Promise<T>) => run(),
+}));
+
+import { cancelGearReservation } from "@/lib/actions/gear-reservations";
+
+const LEAGUE_ID = "cllllllllllllllllllllllll";
+const RESERVATION_ID = "crrrrrrrrrrrrrrrrrrrrrrrr";
+const ALLOCATION_ID = "caaaaaaaaaaaaaaaaaaaaaaaa";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockAuth.requireUserId.mockResolvedValue("cuserrrrrrrrrrrrrrrrrrrrr");
+  mockAuth.getUserLeagueRole.mockResolvedValue("LEAGUE_ADMIN");
+  mockTx.gearAllocation.updateMany.mockResolvedValue({ count: 1 });
+  mockTx.gearReservationLine.updateMany.mockResolvedValue({ count: 1 });
+  mockTx.gearReservation.updateMany.mockResolvedValue({ count: 1 });
+  mockTx.gearAllocation.count.mockResolvedValue(0);
+  mockTx.gearUnit.updateMany.mockResolvedValue({ count: 1 });
+  mockTx.gearReservation.findFirst.mockResolvedValue({
+    id: RESERVATION_ID,
+    leagueId: LEAGUE_ID,
+    teamId: "cteeeeeeeeeeeeeeeeeeeeeee",
+    status: "APPROVED",
+    version: 3,
+    lines: [{
+      id: "cliiiiiiiiiiiiiiiiiiiiiiii",
+      allocations: [{
+        id: ALLOCATION_ID,
+        status: "ALLOCATED",
+        poolStockId: null,
+        gearUnitId: "cguuuuuuuuuuuuuuuuuuuuuuuu",
+        allocatedQty: 2,
+        pickedUpQty: 0,
+        returnedQty: 0,
+        releasedQty: 0,
+        effectiveStartDate: new Date("2026-09-01"),
+        effectiveEndDate: new Date("2026-09-03"),
+        version: 1,
+      }],
+    }],
+  });
+});
+
+describe("cancelGearReservation", () => {
+  it("releases uncollected allocations, frees tagged projections, and records immutable history", async () => {
+    const result = await cancelGearReservation({
+      leagueId: LEAGUE_ID,
+      reservationId: RESERVATION_ID,
+      expectedVersion: 3,
+    });
+
+    expect(result).toEqual({ success: true, data: { id: RESERVATION_ID } });
+    expect(mockTx.gearAllocation.updateMany).toHaveBeenCalledWith(expect.objectContaining({
+      where: expect.objectContaining({ leagueId: LEAGUE_ID, id: ALLOCATION_ID }),
+      data: expect.objectContaining({ status: "RELEASED", releasedQty: 2 }),
+    }));
+    expect(mockTx.gearUnit.updateMany).toHaveBeenCalled();
+    expect(recordGearInventoryMovement).toHaveBeenCalledWith(mockTx, expect.objectContaining({
+      type: "RELEASE", allocationId: ALLOCATION_ID, leagueId: LEAGUE_ID,
+    }));
+    expect(recordGearActivity).toHaveBeenCalledWith(mockTx, expect.objectContaining({
+      entityType: "ALLOCATION", entityId: ALLOCATION_ID,
+    }));
+  });
+
+  it("refuses cancellation while any equipment remains checked out", async () => {
+    mockTx.gearReservation.findFirst.mockResolvedValueOnce({
+      ...await mockTx.gearReservation.findFirst(),
+      lines: [{
+        id: "cliiiiiiiiiiiiiiiiiiiiiiii",
+        allocations: [{
+          id: ALLOCATION_ID,
+          status: "PICKED_UP",
+          poolStockId: null,
+          gearUnitId: "cguuuuuuuuuuuuuuuuuuuuuuuu",
+          allocatedQty: 1,
+          pickedUpQty: 1,
+          returnedQty: 0,
+          releasedQty: 0,
+          effectiveStartDate: new Date("2026-09-01"),
+          effectiveEndDate: new Date("2026-09-03"),
+          version: 1,
+        }],
+      }],
+    });
+
+    await expect(cancelGearReservation({
+      leagueId: LEAGUE_ID,
+      reservationId: RESERVATION_ID,
+      expectedVersion: 3,
+    })).resolves.toMatchObject({ success: false, error: expect.stringContaining("returned") });
+    expect(mockTx.gearAllocation.updateMany).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/lib/actions/gear-reservations.test.ts
+++ b/__tests__/lib/actions/gear-reservations.test.ts
@@ -2,18 +2,118 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const { mockAuth, mockTx, mockPrisma, recordGearActivity, recordGearInventoryMovement } = vi.hoisted(() => {
   const transaction = {
-    gearReservation: { findFirst: vi.fn(), updateMany: vi.fn() },
-    gearAllocation: { updateMany: vi.fn(), count: vi.fn() },
+    gearReservation: { findFirst: vi.fn(), updateMany: vi.fn(), create: vi.fn() },
+    gearAllocation: { findFirst: vi.fn(), updateMany: vi.fn(), count: vi.fn() },
     gearReservationLine: { updateMany: vi.fn() },
     gearUnit: { findFirst: vi.fn(), updateMany: vi.fn() },
+    gearCatalogItem: { findMany: vi.fn() },
+    teamGearNeedLine: { findMany: vi.fn() },
+    gearHandoff: { create: vi.fn() },
   };
   return {
-    mockAuth: { requireUserId: vi.fn(), getUserLeagueRole: vi.fn(), isTeamAdmin: vi.fn() },
+    mockAuth: {
+      requireUserId: vi.fn(),
+      requireLeagueRole: vi.fn(),
+      getUserLeagueRole: vi.fn(),
+      isTeamAdmin: vi.fn(),
+    },
     mockTx: transaction,
     mockPrisma: { $transaction: vi.fn(async (callback: (tx: typeof transaction) => unknown) => callback(transaction)) },
     recordGearActivity: vi.fn(),
     recordGearInventoryMovement: vi.fn(),
   };
+});
+
+describe("createGearReservation", () => {
+  it("derives an item-backed line snapshot from trusted catalog data", async () => {
+    const catalogItemId = "ccatalogiiiiiiiiiiiiiiiii";
+    mockTx.gearCatalogItem.findMany.mockResolvedValue([{ id: catalogItemId, name: "Trusted helmet" }]);
+
+    const result = await createGearReservation({
+      leagueId: LEAGUE_ID,
+      teamId: "cteeeeeeeeeeeeeeeeeeeeeee",
+      requestedStartDate: "2026-09-01",
+      requestedEndDate: "2026-09-03",
+      custodianNameSnapshot: "Team custodian",
+      lines: [{
+        catalogItemId,
+        nameSnapshot: "Client-controlled name",
+        requestedQty: 1,
+      }],
+    });
+
+    expect(result).toEqual({ success: true, data: { id: RESERVATION_ID } });
+    expect(mockTx.gearReservation.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        lines: {
+          create: [expect.objectContaining({ nameSnapshot: "Trusted helmet" })],
+        },
+      }),
+    }));
+  });
+});
+
+describe("recordGearReturn", () => {
+  function checkedOutTaggedAllocation() {
+    return {
+      id: ALLOCATION_ID,
+      leagueId: LEAGUE_ID,
+      status: "PICKED_UP",
+      allocatedQty: 1,
+      pickedUpQty: 1,
+      returnedQty: 0,
+      releasedQty: 0,
+      version: 2,
+      poolStockId: null,
+      gearUnitId: "cguuuuuuuuuuuuuuuuuuuuuuuu",
+      poolStock: null,
+      gearUnit: {
+        id: "cguuuuuuuuuuuuuuuuuuuuuuuu",
+        version: 3,
+        status: "CHECKED_OUT",
+        currentCondition: "GOOD",
+        currentLocationId: "clocationxxxxxxxxxxxxxxxx",
+      },
+      reservationLine: {
+        reservationId: RESERVATION_ID,
+        reservation: { custodianNameSnapshot: "Team custodian" },
+      },
+    };
+  }
+
+  it("returns a tagged unit to RESERVED when a later active allocation remains", async () => {
+    mockTx.gearAllocation.findFirst.mockResolvedValue(checkedOutTaggedAllocation());
+    mockTx.gearAllocation.count.mockResolvedValue(1);
+
+    const result = await recordGearReturn({
+      leagueId: LEAGUE_ID,
+      allocationId: ALLOCATION_ID,
+      expectedVersion: 2,
+      quantity: 1,
+      returnDisposition: "GOOD",
+      condition: "GOOD",
+    });
+
+    expect(result).toEqual({ success: true, data: { id: ALLOCATION_ID } });
+    expect(mockTx.gearUnit.updateMany).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({ status: "RESERVED", currentCondition: "GOOD" }),
+    }));
+  });
+
+  it("rejects a damaged condition paired with the good return disposition", async () => {
+    mockTx.gearAllocation.findFirst.mockResolvedValue(checkedOutTaggedAllocation());
+
+    await expect(recordGearReturn({
+      leagueId: LEAGUE_ID,
+      allocationId: ALLOCATION_ID,
+      expectedVersion: 2,
+      quantity: 1,
+      returnDisposition: "GOOD",
+      condition: "DAMAGED",
+    })).resolves.toMatchObject({ success: false, error: expect.stringContaining("damaged disposition") });
+
+    expect(mockTx.gearUnit.updateMany).not.toHaveBeenCalled();
+  });
 });
 
 vi.mock("@/lib/auth/session", () => mockAuth);
@@ -26,7 +126,11 @@ vi.mock("@/lib/services/gear-transaction", () => ({
   withGearSerializableRetry: <T>(run: () => Promise<T>) => run(),
 }));
 
-import { cancelGearReservation } from "@/lib/actions/gear-reservations";
+import {
+  cancelGearReservation,
+  createGearReservation,
+  recordGearReturn,
+} from "@/lib/actions/gear-reservations";
 
 const LEAGUE_ID = "cllllllllllllllllllllllll";
 const RESERVATION_ID = "crrrrrrrrrrrrrrrrrrrrrrrr";
@@ -35,10 +139,15 @@ const ALLOCATION_ID = "caaaaaaaaaaaaaaaaaaaaaaaa";
 beforeEach(() => {
   vi.clearAllMocks();
   mockAuth.requireUserId.mockResolvedValue("cuserrrrrrrrrrrrrrrrrrrrr");
+  mockAuth.requireLeagueRole.mockResolvedValue("cuserrrrrrrrrrrrrrrrrrrrr");
   mockAuth.getUserLeagueRole.mockResolvedValue("LEAGUE_ADMIN");
   mockTx.gearAllocation.updateMany.mockResolvedValue({ count: 1 });
   mockTx.gearReservationLine.updateMany.mockResolvedValue({ count: 1 });
   mockTx.gearReservation.updateMany.mockResolvedValue({ count: 1 });
+  mockTx.gearReservation.create.mockResolvedValue({ id: RESERVATION_ID });
+  mockTx.gearCatalogItem.findMany.mockResolvedValue([]);
+  mockTx.teamGearNeedLine.findMany.mockResolvedValue([]);
+  mockTx.gearHandoff.create.mockResolvedValue({ id: "chhhhhhhhhhhhhhhhhhhhhhhh" });
   mockTx.gearAllocation.count.mockResolvedValue(0);
   mockTx.gearUnit.updateMany.mockResolvedValue({ count: 1 });
   mockTx.gearUnit.findFirst.mockResolvedValue({
@@ -84,9 +193,7 @@ describe("cancelGearReservation", () => {
       data: expect.objectContaining({ status: "RELEASED", releasedQty: 2 }),
     }));
     expect(mockTx.gearUnit.updateMany).toHaveBeenCalled();
-    expect(recordGearInventoryMovement).toHaveBeenCalledWith(mockTx, expect.objectContaining({
-      type: "RELEASE", allocationId: ALLOCATION_ID, leagueId: LEAGUE_ID,
-    }));
+    expect(recordGearInventoryMovement).not.toHaveBeenCalled();
     expect(recordGearActivity).toHaveBeenCalledWith(mockTx, expect.objectContaining({
       entityType: "ALLOCATION", entityId: ALLOCATION_ID,
     }));

--- a/__tests__/lib/actions/gear-reservations.test.ts
+++ b/__tests__/lib/actions/gear-reservations.test.ts
@@ -5,7 +5,7 @@ const { mockAuth, mockTx, mockPrisma, recordGearActivity, recordGearInventoryMov
     gearReservation: { findFirst: vi.fn(), updateMany: vi.fn() },
     gearAllocation: { updateMany: vi.fn(), count: vi.fn() },
     gearReservationLine: { updateMany: vi.fn() },
-    gearUnit: { updateMany: vi.fn() },
+    gearUnit: { findFirst: vi.fn(), updateMany: vi.fn() },
   };
   return {
     mockAuth: { requireUserId: vi.fn(), getUserLeagueRole: vi.fn(), isTeamAdmin: vi.fn() },
@@ -41,6 +41,10 @@ beforeEach(() => {
   mockTx.gearReservation.updateMany.mockResolvedValue({ count: 1 });
   mockTx.gearAllocation.count.mockResolvedValue(0);
   mockTx.gearUnit.updateMany.mockResolvedValue({ count: 1 });
+  mockTx.gearUnit.findFirst.mockResolvedValue({
+    id: "cguuuuuuuuuuuuuuuuuuuuuuuu",
+    version: 1,
+  });
   mockTx.gearReservation.findFirst.mockResolvedValue({
     id: RESERVATION_ID,
     leagueId: LEAGUE_ID,

--- a/__tests__/lib/services/gear-transaction.test.ts
+++ b/__tests__/lib/services/gear-transaction.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from "vitest";
+import { GearConflictError, withGearSerializableRetry } from "@/lib/services/gear-transaction";
+
+describe("gear serializable retries", () => {
+  it("uses bounded exponential backoff with deterministic jitter between retryable attempts", async () => {
+    const run = vi.fn()
+      .mockRejectedValueOnce({ code: "P2034" })
+      .mockRejectedValueOnce({ code: "P2034" })
+      .mockResolvedValueOnce("saved");
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    await expect(withGearSerializableRetry(run, { sleep, random: () => 0.5 })).resolves.toBe("saved");
+
+    expect(run).toHaveBeenCalledTimes(3);
+    expect(sleep).toHaveBeenCalledWith(37);
+    expect(sleep).toHaveBeenCalledWith(62);
+  });
+
+  it("returns a user-safe conflict after the retry budget is exhausted", async () => {
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    await expect(withGearSerializableRetry(
+      () => Promise.reject({ code: "P2034" }),
+      { sleep, random: () => 0 },
+    )).rejects.toEqual(expect.objectContaining({ retryExhausted: true }));
+    expect(sleep).toHaveBeenCalledTimes(2);
+    expect(GearConflictError).toBeDefined();
+  });
+});

--- a/__tests__/lib/utils/gear.test.ts
+++ b/__tests__/lib/utils/gear.test.ts
@@ -3,6 +3,8 @@ import {
   allocationIsConsistent,
   allocationRemainingForReturn,
   allocationStatusQuantitiesValid,
+  activeAllocationQuantity,
+  activeAllocationTotal,
   availablePoolQuantity,
   canAllocatePoolStock,
   canTransitionAllocation,
@@ -16,6 +18,8 @@ import {
   normalizeGearAssetTag,
   normalizeGearKey,
   taggedAllocationWindowsConflict,
+  poolAvailabilityConflict,
+  taggedUnitAvailabilityConflict,
 } from "@/lib/utils/gear";
 
 describe("gear utilities", () => {
@@ -45,6 +49,22 @@ describe("gear utilities", () => {
     expect(canAllocatePoolStock(stock, 5)).toBe(true);
     expect(canAllocatePoolStock(stock, 6)).toBe(false);
     expect(canAllocatePoolStock(stock, 0)).toBe(false);
+  });
+
+  it("releases capacity as quantities are returned or released", () => {
+    expect(activeAllocationQuantity({ allocatedQty: 6, pickedUpQty: 6, returnedQty: 2, releasedQty: 0 })).toBe(4);
+    expect(activeAllocationQuantity({ allocatedQty: 6, pickedUpQty: 0, returnedQty: 0, releasedQty: 6 })).toBe(0);
+    expect(activeAllocationTotal([
+      { allocatedQty: 4, pickedUpQty: 4, returnedQty: 1, releasedQty: 0 },
+      { allocatedQty: 2, pickedUpQty: 0, returnedQty: 0, releasedQty: 1 },
+    ])).toBe(4);
+  });
+
+  it("returns user-safe pool, tagged, and overdue availability conflicts", () => {
+    expect(poolAvailabilityConflict({ quantityOnHand: 2, allocatedQuantity: 2 }, 1)?.code).toBe("INSUFFICIENT_POOL_STOCK");
+    expect(taggedUnitAvailabilityConflict("MAINTENANCE", false)?.code).toBe("TAGGED_UNIT_UNAVAILABLE");
+    expect(taggedUnitAvailabilityConflict("CHECKED_OUT", true)?.code).toBe("OVERDUE_CUSTODY");
+    expect(taggedUnitAvailabilityConflict("AVAILABLE", false)).toBeNull();
   });
 
   it("guards allocation quantity accounting", () => {

--- a/__tests__/lib/utils/gear.test.ts
+++ b/__tests__/lib/utils/gear.test.ts
@@ -5,6 +5,7 @@ import {
   allocationStatusQuantitiesValid,
   activeAllocationQuantity,
   activeAllocationTotal,
+  allocationConsumesCapacityForWindow,
   availablePoolQuantity,
   canAllocatePoolStock,
   canTransitionAllocation,
@@ -15,6 +16,7 @@ import {
   isValidInventoryMovementDirection,
   isRetryablePrismaConflict,
   isActiveTaggedAllocationStatus,
+  isOutstandingAllocationOverdue,
   normalizeGearAssetTag,
   normalizeGearKey,
   taggedAllocationWindowsConflict,
@@ -58,6 +60,39 @@ describe("gear utilities", () => {
       { allocatedQty: 4, pickedUpQty: 4, returnedQty: 1, releasedQty: 0 },
       { allocatedQty: 2, pickedUpQty: 0, returnedQty: 0, releasedQty: 1 },
     ])).toBe(4);
+  });
+
+  it("keeps outstanding custody committed past its planned end date", () => {
+    const window = { startDate: "2026-09-10", endDate: "2026-09-12" };
+    expect(allocationConsumesCapacityForWindow({
+      status: "PICKED_UP",
+      allocatedQty: 2,
+      pickedUpQty: 2,
+      returnedQty: 0,
+      releasedQty: 0,
+      effectiveStartDate: new Date("2026-09-01"),
+      effectiveEndDate: new Date("2026-09-03"),
+    }, window)).toBe(true);
+    expect(allocationConsumesCapacityForWindow({
+      status: "ALLOCATED",
+      allocatedQty: 2,
+      pickedUpQty: 0,
+      returnedQty: 0,
+      releasedQty: 0,
+      effectiveStartDate: new Date("2026-09-01"),
+      effectiveEndDate: new Date("2026-09-03"),
+    }, window)).toBe(false);
+  });
+
+  it("marks only outstanding custody overdue after the effective end date", () => {
+    const finalDay = new Date("2026-09-03T00:00:00.000Z");
+    const allocation = { status: "PICKED_UP" as const, effectiveEndDate: finalDay };
+    expect(isOutstandingAllocationOverdue(allocation, finalDay)).toBe(false);
+    expect(isOutstandingAllocationOverdue(allocation, new Date("2026-09-04T00:00:00.000Z"))).toBe(true);
+    expect(isOutstandingAllocationOverdue({
+      status: "ALLOCATED",
+      effectiveEndDate: finalDay,
+    }, new Date("2026-09-04T00:00:00.000Z"))).toBe(false);
   });
 
   it("returns user-safe pool, tagged, and overdue availability conflicts", () => {

--- a/app/(dashboard)/league/[leagueId]/gear/page.tsx
+++ b/app/(dashboard)/league/[leagueId]/gear/page.tsx
@@ -1,4 +1,6 @@
 import { Inventory2Outlined } from "@mui/icons-material";
+import { Button } from "@mui/material";
+import Link from "next/link";
 import { notFound } from "next/navigation";
 import { GearInventoryManager } from "@/components/features/gear/GearInventoryManager";
 import { EmptyState } from "@/components/ui/EmptyState";
@@ -28,6 +30,16 @@ export default async function GearInventoryPage({ params, searchParams }: GearIn
       <PageHeader
         title="Gear inventory"
         subtitle={`${data.league.name} equipment, locations, and current availability.`}
+        actions={
+          <Button
+            component={Link}
+            href={`/league/${leagueId}/gear/reservations`}
+            variant="outlined"
+            sx={{ minHeight: 44 }}
+          >
+            Reservations
+          </Button>
+        }
       />
       {hasInventory || data.canManageInventory ? (
         <GearInventoryManager data={data} />

--- a/app/(dashboard)/league/[leagueId]/gear/page.tsx
+++ b/app/(dashboard)/league/[leagueId]/gear/page.tsx
@@ -1,9 +1,8 @@
 import { Inventory2Outlined } from "@mui/icons-material";
-import { Button } from "@mui/material";
-import Link from "next/link";
 import { notFound } from "next/navigation";
 import { GearInventoryManager } from "@/components/features/gear/GearInventoryManager";
 import { EmptyState } from "@/components/ui/EmptyState";
+import { LinkButton } from "@/components/ui/NextLinkComposites";
 import { PageContainer } from "@/components/ui/PageContainer";
 import { PageHeader } from "@/components/ui/PageHeader";
 import { getGearInventoryContext } from "@/lib/actions/gear-context";
@@ -31,14 +30,13 @@ export default async function GearInventoryPage({ params, searchParams }: GearIn
         title="Gear inventory"
         subtitle={`${data.league.name} equipment, locations, and current availability.`}
         actions={
-          <Button
-            component={Link}
+          <LinkButton
             href={`/league/${leagueId}/gear/reservations`}
             variant="outlined"
             sx={{ minHeight: 44 }}
           >
             Reservations
-          </Button>
+          </LinkButton>
         }
       />
       {hasInventory || data.canManageInventory ? (

--- a/app/(dashboard)/league/[leagueId]/gear/reservations/[reservationId]/page.tsx
+++ b/app/(dashboard)/league/[leagueId]/gear/reservations/[reservationId]/page.tsx
@@ -1,7 +1,7 @@
-import Link from "next/link";
 import { ArrowBackOutlined } from "@mui/icons-material";
-import { Alert, Button, Card, Chip, Divider, Stack, Typography } from "@mui/material";
+import { Alert, Card, Chip, Divider, Stack, Typography } from "@mui/material";
 import { notFound } from "next/navigation";
+import { LinkButton } from "@/components/ui/NextLinkComposites";
 import { PageContainer } from "@/components/ui/PageContainer";
 import { PageHeader } from "@/components/ui/PageHeader";
 import { getGearReservationContext } from "@/lib/actions/gear-context";
@@ -18,9 +18,9 @@ export default async function GearReservationDetailPage({ params }: GearReservat
 
   return (
     <PageContainer maxWidth="md">
-      <Button component={Link} href={`/league/${leagueId}/gear/reservations`} startIcon={<ArrowBackOutlined />} sx={{ minHeight: 44, mb: 1 }}>
+      <LinkButton href={`/league/${leagueId}/gear/reservations`} startIcon={<ArrowBackOutlined />} sx={{ minHeight: 44, mb: 1 }}>
         All reservations
-      </Button>
+      </LinkButton>
       <PageHeader title={`${reservation.teamName} gear reservation`} subtitle={`${reservation.requestedStartDate.slice(0, 10)} to ${reservation.requestedEndDate.slice(0, 10)}`} />
       <Stack spacing={2}>
         {(reservation.overdue || reservation.reallocationWarning) && (

--- a/app/(dashboard)/league/[leagueId]/gear/reservations/[reservationId]/page.tsx
+++ b/app/(dashboard)/league/[leagueId]/gear/reservations/[reservationId]/page.tsx
@@ -1,0 +1,69 @@
+import Link from "next/link";
+import { ArrowBackOutlined } from "@mui/icons-material";
+import { Alert, Button, Card, Chip, Divider, Stack, Typography } from "@mui/material";
+import { notFound } from "next/navigation";
+import { PageContainer } from "@/components/ui/PageContainer";
+import { PageHeader } from "@/components/ui/PageHeader";
+import { getGearReservationContext } from "@/lib/actions/gear-context";
+
+interface GearReservationDetailPageProps {
+  params: Promise<{ leagueId: string; reservationId: string }>;
+}
+
+export default async function GearReservationDetailPage({ params }: GearReservationDetailPageProps) {
+  const { leagueId, reservationId } = await params;
+  const data = await getGearReservationContext(leagueId);
+  const reservation = data?.reservations.find((candidate) => candidate.id === reservationId);
+  if (!data || !reservation) notFound();
+
+  return (
+    <PageContainer maxWidth="md">
+      <Button component={Link} href={`/league/${leagueId}/gear/reservations`} startIcon={<ArrowBackOutlined />} sx={{ minHeight: 44, mb: 1 }}>
+        All reservations
+      </Button>
+      <PageHeader title={`${reservation.teamName} gear reservation`} subtitle={`${reservation.requestedStartDate.slice(0, 10)} to ${reservation.requestedEndDate.slice(0, 10)}`} />
+      <Stack spacing={2}>
+        {(reservation.overdue || reservation.reallocationWarning) && (
+          <Alert severity="warning">
+            {reservation.overdue ? "This custody period is overdue." : "Inventory has changed; this future reservation may need reallocation."}
+          </Alert>
+        )}
+        <Card variant="outlined" sx={{ p: 2 }}>
+          <Stack spacing={1}>
+            <Stack direction="row" justifyContent="space-between" alignItems="center">
+              <Typography variant="h6">Request</Typography>
+              <Chip label={reservation.status.replace("_", " ")} />
+            </Stack>
+            <Typography>Custody contact: {reservation.custodianName}</Typography>
+            {reservation.requestNotes && <Typography variant="body2">{reservation.requestNotes}</Typography>}
+            {data.canManageReservations && reservation.decisionNotes && (
+              <Typography variant="body2">Admin decision: {reservation.decisionNotes}</Typography>
+            )}
+          </Stack>
+        </Card>
+        <Card variant="outlined" sx={{ p: 2 }}>
+          <Typography variant="h6" gutterBottom>Requested items</Typography>
+          <Stack divider={<Divider flexItem />}>
+            {reservation.lines.map((line) => (
+              <Typography key={line.id}>
+                {line.name}: {line.allocatedQty}/{line.approvedQty || line.requestedQty} allocated
+              </Typography>
+            ))}
+          </Stack>
+        </Card>
+        <Card variant="outlined" sx={{ p: 2 }}>
+          <Typography variant="h6" gutterBottom>Custody and ledger</Typography>
+          <Stack divider={<Divider flexItem />}>
+            {reservation.allocations.length === 0 ? (
+              <Typography color="text.secondary">No inventory has been allocated.</Typography>
+            ) : reservation.allocations.map((allocation) => (
+              <Typography key={allocation.id}>
+                {allocation.assetTag ?? allocation.locationName ?? "Pooled stock"}: {allocation.status.replace("_", " ")} ({allocation.returnedQty}/{allocation.pickedUpQty} returned)
+              </Typography>
+            ))}
+          </Stack>
+        </Card>
+      </Stack>
+    </PageContainer>
+  );
+}

--- a/app/(dashboard)/league/[leagueId]/gear/reservations/page.tsx
+++ b/app/(dashboard)/league/[leagueId]/gear/reservations/page.tsx
@@ -1,0 +1,35 @@
+import { AssignmentOutlined } from "@mui/icons-material";
+import { notFound } from "next/navigation";
+import { GearReservationList } from "@/components/features/gear/GearReservationList";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { PageContainer } from "@/components/ui/PageContainer";
+import { PageHeader } from "@/components/ui/PageHeader";
+import { getGearReservationContext } from "@/lib/actions/gear-context";
+
+interface GearReservationsPageProps {
+  params: Promise<{ leagueId: string }>;
+}
+
+export default async function GearReservationsPage({ params }: GearReservationsPageProps) {
+  const { leagueId } = await params;
+  const data = await getGearReservationContext(leagueId);
+  if (!data) notFound();
+
+  return (
+    <PageContainer maxWidth="xl">
+      <PageHeader
+        title="Gear reservations"
+        subtitle={`${data.league.name} equipment requests, custody, and return status.`}
+      />
+      {data.teamIds.length > 0 ? (
+        <GearReservationList data={data} />
+      ) : (
+        <EmptyState
+          icon={<AssignmentOutlined />}
+          title="No team gear access"
+          description="Join a league team to view its equipment reservations."
+        />
+      )}
+    </PageContainer>
+  );
+}

--- a/components/features/gear/GearReservationList.tsx
+++ b/components/features/gear/GearReservationList.tsx
@@ -1,0 +1,85 @@
+import Link from "next/link";
+import { Alert, Box, Button, Card, Chip, Stack, Table, TableBody, TableCell, TableHead, TableRow, Typography } from "@mui/material";
+import type { GearReservationContext } from "@/lib/actions/gear-context";
+
+const statusColor = {
+  DRAFT: "default",
+  REQUESTED: "warning",
+  APPROVED: "info",
+  DECLINED: "error",
+  CANCELED: "default",
+  FULFILLED: "primary",
+  CLOSED: "success",
+} as const;
+
+export function GearReservationList({ data }: { data: GearReservationContext }) {
+  if (data.reservations.length === 0) {
+    return (
+      <Alert severity="info">
+        No gear reservations are visible for your teams yet.
+      </Alert>
+    );
+  }
+
+  return (
+    <>
+      <Box sx={{ display: { xs: "block", md: "none" } }}>
+        <Stack spacing={2}>
+          {data.reservations.map((reservation) => (
+            <Card key={reservation.id} variant="outlined" sx={{ p: 2 }}>
+              <Stack spacing={1}>
+                <Stack direction="row" justifyContent="space-between" alignItems="center">
+                  <Typography fontWeight={700}>{reservation.teamName}</Typography>
+                  <Chip size="small" label={reservation.status.replace("_", " ")} color={statusColor[reservation.status]} />
+                </Stack>
+                <Typography variant="body2">
+                  {reservation.requestedStartDate.slice(0, 10)} to {reservation.requestedEndDate.slice(0, 10)}
+                </Typography>
+                <Typography variant="body2">Custodian: {reservation.custodianName}</Typography>
+                {(reservation.overdue || reservation.reallocationWarning) && (
+                  <Alert severity="warning">
+                    {reservation.overdue ? "Overdue custody requires attention." : "Inventory changed; review this future allocation."}
+                  </Alert>
+                )}
+                <Button component={Link} href={`/league/${data.league.id}/gear/reservations/${reservation.id}`} variant="outlined" sx={{ minHeight: 44 }}>
+                  View reservation
+                </Button>
+              </Stack>
+            </Card>
+          ))}
+        </Stack>
+      </Box>
+      <Table size="small" sx={{ display: { xs: "none", md: "table" } }}>
+        <TableHead>
+          <TableRow>
+            <TableCell>Team</TableCell>
+            <TableCell>Dates</TableCell>
+            <TableCell>Status</TableCell>
+            <TableCell>Custody</TableCell>
+            <TableCell align="right"> </TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {data.reservations.map((reservation) => (
+            <TableRow key={reservation.id}>
+              <TableCell>{reservation.teamName}</TableCell>
+              <TableCell>{reservation.requestedStartDate.slice(0, 10)} to {reservation.requestedEndDate.slice(0, 10)}</TableCell>
+              <TableCell>
+                <Stack direction="row" spacing={1} alignItems="center">
+                  <Chip size="small" label={reservation.status.replace("_", " ")} color={statusColor[reservation.status]} />
+                  {(reservation.overdue || reservation.reallocationWarning) && <Chip size="small" color="warning" label={reservation.overdue ? "Overdue" : "Review"} />}
+                </Stack>
+              </TableCell>
+              <TableCell>{reservation.custodianName}</TableCell>
+              <TableCell align="right">
+                <Button component={Link} href={`/league/${data.league.id}/gear/reservations/${reservation.id}`} sx={{ minHeight: 44 }}>
+                  Details
+                </Button>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </>
+  );
+}

--- a/components/features/gear/GearReservationList.tsx
+++ b/components/features/gear/GearReservationList.tsx
@@ -1,6 +1,6 @@
-import Link from "next/link";
-import { Alert, Box, Button, Card, Chip, Stack, Table, TableBody, TableCell, TableHead, TableRow, Typography } from "@mui/material";
+import { Alert, Box, Card, Chip, Stack, Table, TableBody, TableCell, TableHead, TableRow, Typography } from "@mui/material";
 import type { GearReservationContext } from "@/lib/actions/gear-context";
+import { LinkButton } from "@/components/ui/NextLinkComposites";
 
 const statusColor = {
   DRAFT: "default",
@@ -41,9 +41,9 @@ export function GearReservationList({ data }: { data: GearReservationContext }) 
                     {reservation.overdue ? "Overdue custody requires attention." : "Inventory changed; review this future allocation."}
                   </Alert>
                 )}
-                <Button component={Link} href={`/league/${data.league.id}/gear/reservations/${reservation.id}`} variant="outlined" sx={{ minHeight: 44 }}>
+                <LinkButton href={`/league/${data.league.id}/gear/reservations/${reservation.id}`} variant="outlined" sx={{ minHeight: 44 }}>
                   View reservation
-                </Button>
+                </LinkButton>
               </Stack>
             </Card>
           ))}
@@ -72,9 +72,9 @@ export function GearReservationList({ data }: { data: GearReservationContext }) 
               </TableCell>
               <TableCell>{reservation.custodianName}</TableCell>
               <TableCell align="right">
-                <Button component={Link} href={`/league/${data.league.id}/gear/reservations/${reservation.id}`} sx={{ minHeight: 44 }}>
+                <LinkButton href={`/league/${data.league.id}/gear/reservations/${reservation.id}`} sx={{ minHeight: 44 }}>
                   Details
-                </Button>
+                </LinkButton>
               </TableCell>
             </TableRow>
           ))}

--- a/lib/actions/gear-context.ts
+++ b/lib/actions/gear-context.ts
@@ -2,7 +2,11 @@
 
 import { requireUserId } from "@/lib/auth/session";
 import { prisma } from "@/lib/db/prisma";
-import { activeAllocationQuantity } from "@/lib/utils/gear";
+import {
+  activeAllocationQuantity,
+  allocationConsumesCapacityForWindow,
+  isOutstandingAllocationOverdue,
+} from "@/lib/utils/gear";
 
 export type GearInventoryContext = {
   league: { id: string; name: string };
@@ -303,8 +307,8 @@ export type GearReservationContext = {
 
 /**
  * Reservation visibility is deliberately narrower than inventory visibility:
- * members see only teams they belong to, while league administrators see the
- * association-wide operational queue and decision notes.
+ * only league and owning-team administrators can view custody records, while
+ * league administrators alone see association-wide decision notes.
  */
 export async function getGearReservationContext(leagueId: string): Promise<GearReservationContext | null> {
   const userId = await requireUserId();
@@ -321,7 +325,7 @@ export async function getGearReservationContext(leagueId: string): Promise<GearR
         select: { id: true },
       })
     : await prisma.teamMember.findMany({
-        where: { userId, team: { leagueId, isActive: true } },
+        where: { userId, role: "ADMIN", team: { leagueId, isActive: true } },
         select: { teamId: true },
       });
   const teamIds = teamMemberships.map((membership) => "teamId" in membership ? membership.teamId : membership.id);
@@ -341,7 +345,8 @@ export async function getGearReservationContext(leagueId: string): Promise<GearR
           allocations: {
             select: {
               id: true, status: true, allocatedQty: true, pickedUpQty: true, returnedQty: true,
-              releasedQty: true, poolStockId: true, gearUnitId: true, version: true,
+              releasedQty: true, effectiveStartDate: true, effectiveEndDate: true,
+              poolStockId: true, gearUnitId: true, version: true,
               poolStock: { select: { location: { select: { name: true } } } },
               gearUnit: { select: { assetTag: true } },
             },
@@ -361,20 +366,37 @@ export async function getGearReservationContext(leagueId: string): Promise<GearR
       allocations: {
         where: {
           status: { in: ["PENDING", "ALLOCATED", "PICKED_UP", "PARTIALLY_RETURNED"] },
-          reservationLine: { reservation: { requestedStartDate: { gt: today } } },
         },
-        select: { allocatedQty: true, pickedUpQty: true, returnedQty: true, releasedQty: true },
+        select: {
+          id: true, status: true, allocatedQty: true, pickedUpQty: true, returnedQty: true,
+          releasedQty: true, effectiveStartDate: true, effectiveEndDate: true,
+        },
       },
     },
   });
-  const reallocationWarningByStockId = new Set(
-    poolStocks
-      .filter((stock) => stock.allocations.reduce(
-        (total, allocation) => total + activeAllocationQuantity(allocation),
-        0,
-      ) > stock.quantityOnHand)
-      .map((stock) => stock.id),
-  );
+  const reallocationWarningByAllocationId = new Set<string>();
+  for (const stock of poolStocks) {
+    for (const candidate of stock.allocations) {
+      if (
+        !["PENDING", "ALLOCATED"].includes(candidate.status)
+        || !candidate.effectiveStartDate
+        || !candidate.effectiveEndDate
+      ) continue;
+      const window = {
+        startDate: candidate.effectiveStartDate.toISOString().slice(0, 10),
+        endDate: candidate.effectiveEndDate.toISOString().slice(0, 10),
+      };
+      const otherCommitments = stock.allocations.reduce((total, allocation) => {
+        if (allocation.id === candidate.id || !allocationConsumesCapacityForWindow(allocation, window)) {
+          return total;
+        }
+        return total + activeAllocationQuantity(allocation);
+      }, 0);
+      if (stock.quantityOnHand - otherCommitments < activeAllocationQuantity(candidate)) {
+        reallocationWarningByAllocationId.add(candidate.id);
+      }
+    }
+  }
   return {
     league: membership.league,
     canManageReservations,
@@ -383,9 +405,7 @@ export async function getGearReservationContext(leagueId: string): Promise<GearR
       const activeAllocations = reservation.lines.flatMap((line) => line.allocations)
         .filter((allocation) => ["PENDING", "ALLOCATED", "PICKED_UP", "PARTIALLY_RETURNED"].includes(allocation.status));
       const reallocationWarning = activeAllocations.some((allocation) =>
-        allocation.poolStockId !== null
-        && reservation.requestedStartDate > today
-        && reallocationWarningByStockId.has(allocation.poolStockId),
+        allocation.poolStockId !== null && reallocationWarningByAllocationId.has(allocation.id),
       );
       return {
         id: reservation.id,
@@ -398,7 +418,7 @@ export async function getGearReservationContext(leagueId: string): Promise<GearR
         requestNotes: reservation.requestNotes,
         ...(canManageReservations ? { decisionNotes: reservation.decisionNotes } : {}),
         version: reservation.version,
-        overdue: ["FULFILLED", "APPROVED"].includes(reservation.status) && reservation.requestedEndDate < today,
+        overdue: activeAllocations.some((allocation) => isOutstandingAllocationOverdue(allocation, today)),
         reallocationWarning,
         lines: reservation.lines.map((line) => ({
           id: line.id,

--- a/lib/actions/gear-context.ts
+++ b/lib/actions/gear-context.ts
@@ -2,6 +2,7 @@
 
 import { requireUserId } from "@/lib/auth/session";
 import { prisma } from "@/lib/db/prisma";
+import { activeAllocationQuantity } from "@/lib/utils/gear";
 
 export type GearInventoryContext = {
   league: { id: string; name: string };
@@ -143,7 +144,7 @@ export async function getGearInventoryContext(
         location: { select: { name: true } },
         allocations: {
           where: { status: { in: [...activeAllocationStatuses] } },
-          select: { allocatedQty: true, releasedQty: true },
+          select: { allocatedQty: true, releasedQty: true, returnedQty: true, pickedUpQty: true },
         },
       },
       orderBy: [{ catalogItem: { name: "asc" } }, { location: { name: "asc" } }],
@@ -181,7 +182,7 @@ export async function getGearInventoryContext(
 
   const pooledStock = stocks.map((stock) => {
     const committedQuantity = stock.allocations.reduce(
-      (sum, allocation) => sum + Math.max(0, allocation.allocatedQty - allocation.releasedQty),
+      (sum, allocation) => sum + activeAllocationQuantity(allocation),
       0,
     );
     return {
@@ -257,5 +258,169 @@ export async function getGearInventoryContext(
       hasMore: movements.length > 20,
       search: activitySearch,
     },
+  };
+}
+
+export type GearReservationContext = {
+  league: { id: string; name: string };
+  canManageReservations: boolean;
+  teamIds: string[];
+  reservations: Array<{
+    id: string;
+    teamId: string;
+    teamName: string;
+    status: "DRAFT" | "REQUESTED" | "APPROVED" | "DECLINED" | "CANCELED" | "FULFILLED" | "CLOSED";
+    requestedStartDate: string;
+    requestedEndDate: string;
+    custodianName: string;
+    requestNotes: string | null;
+    decisionNotes?: string | null;
+    version: number;
+    overdue: boolean;
+    reallocationWarning: boolean;
+    lines: Array<{
+      id: string;
+      name: string;
+      requestedQty: number;
+      approvedQty: number;
+      allocatedQty: number;
+    }>;
+    allocations: Array<{
+      id: string;
+      status: "PENDING" | "ALLOCATED" | "PICKED_UP" | "PARTIALLY_RETURNED" | "RETURNED" | "RELEASED";
+      allocatedQty: number;
+      pickedUpQty: number;
+      returnedQty: number;
+      releasedQty: number;
+      poolStockId: string | null;
+      gearUnitId: string | null;
+      assetTag: string | null;
+      locationName: string | null;
+      version: number;
+    }>;
+  }>;
+};
+
+/**
+ * Reservation visibility is deliberately narrower than inventory visibility:
+ * members see only teams they belong to, while league administrators see the
+ * association-wide operational queue and decision notes.
+ */
+export async function getGearReservationContext(leagueId: string): Promise<GearReservationContext | null> {
+  const userId = await requireUserId();
+  const membership = await prisma.leagueUser.findFirst({
+    where: { leagueId, userId, league: { isActive: true } },
+    select: { role: true, league: { select: { id: true, name: true } } },
+  });
+  if (!membership) return null;
+
+  const canManageReservations = membership.role === "LEAGUE_ADMIN";
+  const teamMemberships = canManageReservations
+    ? await prisma.team.findMany({
+        where: { leagueId, isActive: true },
+        select: { id: true },
+      })
+    : await prisma.teamMember.findMany({
+        where: { userId, team: { leagueId, isActive: true } },
+        select: { teamId: true },
+      });
+  const teamIds = teamMemberships.map((membership) => "teamId" in membership ? membership.teamId : membership.id);
+  if (teamIds.length === 0) {
+    return { league: membership.league, canManageReservations, teamIds, reservations: [] };
+  }
+
+  const reservations = await prisma.gearReservation.findMany({
+    where: { leagueId, teamId: { in: teamIds } },
+    select: {
+      id: true, teamId: true, status: true, requestedStartDate: true, requestedEndDate: true,
+      custodianNameSnapshot: true, requestNotes: true, decisionNotes: canManageReservations,
+      version: true, team: { select: { name: true } },
+      lines: {
+        select: {
+          id: true, nameSnapshot: true, requestedQty: true, approvedQty: true, allocatedQty: true,
+          allocations: {
+            select: {
+              id: true, status: true, allocatedQty: true, pickedUpQty: true, returnedQty: true,
+              releasedQty: true, poolStockId: true, gearUnitId: true, version: true,
+              poolStock: { select: { location: { select: { name: true } } } },
+              gearUnit: { select: { assetTag: true } },
+            },
+          },
+        },
+      },
+    },
+    orderBy: [{ requestedStartDate: "asc" }, { createdAt: "desc" }],
+  });
+
+  const today = new Date();
+  const poolStocks = await prisma.gearPoolStock.findMany({
+    where: { leagueId },
+    select: {
+      id: true,
+      quantityOnHand: true,
+      allocations: {
+        where: {
+          status: { in: ["PENDING", "ALLOCATED", "PICKED_UP", "PARTIALLY_RETURNED"] },
+          reservationLine: { reservation: { requestedStartDate: { gt: today } } },
+        },
+        select: { allocatedQty: true, pickedUpQty: true, returnedQty: true, releasedQty: true },
+      },
+    },
+  });
+  const reallocationWarningByStockId = new Set(
+    poolStocks
+      .filter((stock) => stock.allocations.reduce(
+        (total, allocation) => total + activeAllocationQuantity(allocation),
+        0,
+      ) > stock.quantityOnHand)
+      .map((stock) => stock.id),
+  );
+  return {
+    league: membership.league,
+    canManageReservations,
+    teamIds,
+    reservations: reservations.map((reservation) => {
+      const activeAllocations = reservation.lines.flatMap((line) => line.allocations)
+        .filter((allocation) => ["PENDING", "ALLOCATED", "PICKED_UP", "PARTIALLY_RETURNED"].includes(allocation.status));
+      const reallocationWarning = activeAllocations.some((allocation) =>
+        allocation.poolStockId !== null
+        && reservation.requestedStartDate > today
+        && reallocationWarningByStockId.has(allocation.poolStockId),
+      );
+      return {
+        id: reservation.id,
+        teamId: reservation.teamId,
+        teamName: reservation.team.name,
+        status: reservation.status,
+        requestedStartDate: reservation.requestedStartDate.toISOString(),
+        requestedEndDate: reservation.requestedEndDate.toISOString(),
+        custodianName: reservation.custodianNameSnapshot,
+        requestNotes: reservation.requestNotes,
+        ...(canManageReservations ? { decisionNotes: reservation.decisionNotes } : {}),
+        version: reservation.version,
+        overdue: ["FULFILLED", "APPROVED"].includes(reservation.status) && reservation.requestedEndDate < today,
+        reallocationWarning,
+        lines: reservation.lines.map((line) => ({
+          id: line.id,
+          name: line.nameSnapshot,
+          requestedQty: line.requestedQty,
+          approvedQty: line.approvedQty,
+          allocatedQty: line.allocatedQty,
+        })),
+        allocations: reservation.lines.flatMap((line) => line.allocations.map((allocation) => ({
+          id: allocation.id,
+          status: allocation.status,
+          allocatedQty: allocation.allocatedQty,
+          pickedUpQty: allocation.pickedUpQty,
+          returnedQty: allocation.returnedQty,
+          releasedQty: allocation.releasedQty,
+          poolStockId: allocation.poolStockId,
+          gearUnitId: allocation.gearUnitId,
+          assetTag: allocation.gearUnit?.assetTag ?? null,
+          locationName: allocation.poolStock?.location.name ?? null,
+          version: allocation.version,
+        }))),
+      };
+    }),
   };
 }

--- a/lib/actions/gear-inventory.ts
+++ b/lib/actions/gear-inventory.ts
@@ -180,9 +180,14 @@ async function assertNoActiveAllocationsForStock(
   if (delta >= 0) return;
   const committed = await tx.gearAllocation.aggregate({
     where: { leagueId, poolStockId: stockId, status: { in: [...activeAllocationStatuses] } },
-    _sum: { allocatedQty: true, releasedQty: true },
+    _sum: { allocatedQty: true, releasedQty: true, returnedQty: true },
   });
-  const commitment = Math.max(0, (committed._sum.allocatedQty ?? 0) - (committed._sum.releasedQty ?? 0));
+  const commitment = Math.max(
+    0,
+    (committed._sum.allocatedQty ?? 0)
+      - (committed._sum.releasedQty ?? 0)
+      - (committed._sum.returnedQty ?? 0),
+  );
   if (onHand + delta < commitment) {
     invalid(`This reduction would leave fewer items than the ${commitment} currently committed.`);
   }

--- a/lib/actions/gear-reservations.ts
+++ b/lib/actions/gear-reservations.ts
@@ -91,6 +91,9 @@ function invalid(message: string): never {
 
 function actionError(error: unknown): ActionResult<never> {
   if (error instanceof GearConflictError) return { success: false, error: error.message };
+  if (error instanceof Prisma.PrismaClientKnownRequestError && ["P2004", "P2034"].includes(error.code)) {
+    return { success: false, error: "Inventory availability changed. Review the reservation dates and allocations, then try again." };
+  }
   if (error instanceof z.ZodError) return { success: false, error: "Please correct the highlighted reservation fields.", details: error.issues };
   if (error instanceof Error) {
     if (error.message.startsWith("Unauthorized")) return { success: false, error: "You do not have permission to manage this reservation." };
@@ -123,7 +126,11 @@ async function getReservationForMutation(tx: Tx, leagueId: string, reservationId
         include: {
           catalogItem: { select: { trackingMode: true } },
           allocations: {
-            select: { allocatedQty: true, pickedUpQty: true, returnedQty: true, releasedQty: true },
+            select: {
+              id: true, status: true, poolStockId: true, gearUnitId: true,
+              allocatedQty: true, pickedUpQty: true, returnedQty: true, releasedQty: true,
+              effectiveStartDate: true, effectiveEndDate: true, version: true,
+            },
           },
         },
       },
@@ -133,21 +140,31 @@ async function getReservationForMutation(tx: Tx, leagueId: string, reservationId
   return reservation;
 }
 
+function reservationWindow(reservation: {
+  requestedStartDate: Date;
+  requestedEndDate: Date;
+  approvedStartDate: Date | null;
+  approvedEndDate: Date | null;
+}) {
+  return {
+    startDate: reservation.approvedStartDate ?? reservation.requestedStartDate,
+    endDate: reservation.approvedEndDate ?? reservation.requestedEndDate,
+  };
+}
+
 async function activePoolCommitment(
+  leagueId: string,
   tx: Tx,
   poolStockId: string,
   window: { startDate: Date; endDate: Date },
 ) {
   const allocations = await tx.gearAllocation.findMany({
     where: {
+      leagueId,
       poolStockId,
       status: { in: ["PENDING", "ALLOCATED", "PICKED_UP", "PARTIALLY_RETURNED"] },
-      reservationLine: {
-        reservation: {
-          requestedStartDate: { lte: window.endDate },
-          requestedEndDate: { gte: window.startDate },
-        },
-      },
+      effectiveStartDate: { lte: window.endDate },
+      effectiveEndDate: { gte: window.startDate },
     },
     select: { allocatedQty: true, releasedQty: true, returnedQty: true, pickedUpQty: true },
   });
@@ -157,13 +174,13 @@ async function activePoolCommitment(
   );
 }
 
-async function hasOverdueCheckout(tx: Tx, gearUnitId: string) {
+async function hasOverdueCheckout(tx: Tx, leagueId: string, gearUnitId: string) {
   const today = new Date();
   return Boolean(await tx.gearAllocation.findFirst({
     where: {
-      gearUnitId,
+      leagueId, gearUnitId,
       status: { in: ["PICKED_UP", "PARTIALLY_RETURNED"] },
-      reservationLine: { reservation: { requestedEndDate: { lt: today } } },
+      effectiveEndDate: { lt: today },
     },
     select: { id: true },
   }));
@@ -204,6 +221,34 @@ export async function createGearReservation(
       if (validated.lines.some((line) => line.catalogItemId && !itemIds.has(line.catalogItemId))) {
         invalid("A requested catalog item is not available in this league.");
       }
+      const needLineIds = validated.lines
+        .map((line) => line.needLineId)
+        .filter((needLineId): needLineId is string => Boolean(needLineId));
+      const needLines = await tx.teamGearNeedLine.findMany({
+        where: {
+          leagueId: validated.leagueId,
+          id: { in: needLineIds },
+          need: { leagueId: validated.leagueId, teamId: validated.teamId },
+        },
+        select: { id: true, catalogItemId: true, nameSnapshot: true },
+      });
+      const needLineById = new Map(needLines.map((needLine) => [needLine.id, needLine]));
+      if (needLineById.size !== needLineIds.length) {
+        invalid("A selected gear need does not belong to this team in this league.");
+      }
+      const trustedLines = validated.lines.map((line) => {
+        const needLine = line.needLineId ? needLineById.get(line.needLineId) : undefined;
+        if (!needLine) return line;
+        if (line.catalogItemId && line.catalogItemId !== needLine.catalogItemId) {
+          invalid("A selected gear need does not match its catalog item.");
+        }
+        return {
+          ...line,
+          catalogItemId: needLine.catalogItemId ?? "",
+          nameSnapshot: needLine.nameSnapshot,
+          needLineId: needLine.id,
+        };
+      });
       const reservation = await tx.gearReservation.create({
         data: {
           leagueId: validated.leagueId,
@@ -216,7 +261,8 @@ export async function createGearReservation(
           custodianPhoneSnapshot: validated.custodianPhoneSnapshot || null,
           requestNotes: validated.requestNotes || null,
           requestedById: userId,
-          lines: { create: validated.lines.map((line) => ({
+          lines: { create: trustedLines.map((line) => ({
+            leagueId: validated.leagueId,
             catalogItemId: line.catalogItemId || null,
             needLineId: line.needLineId || null,
             nameSnapshot: line.nameSnapshot,
@@ -247,8 +293,56 @@ export async function cancelGearReservation(input: unknown): Promise<ActionResul
       await assertRequestAccess(validated.leagueId, reservation.teamId, userId);
       if (!canTransitionReservation(reservation.status, "CANCELED")) invalid("This reservation can no longer be canceled.");
       if (reservation.version !== validated.expectedVersion) throw new GearConflictError();
+      const activeAllocations = reservation.lines.flatMap((line) => line.allocations)
+        .filter((allocation) => ["PENDING", "ALLOCATED", "PICKED_UP", "PARTIALLY_RETURNED"].includes(allocation.status));
+      if (activeAllocations.some((allocation) => allocation.pickedUpQty > allocation.returnedQty)) {
+        invalid("Checked-out gear must be returned before this reservation can be canceled.");
+      }
+      for (const allocation of activeAllocations) {
+        const release = await tx.gearAllocation.updateMany({
+          where: {
+            id: allocation.id,
+            leagueId: validated.leagueId,
+            version: allocation.version,
+            status: { in: ["PENDING", "ALLOCATED"] },
+          },
+          data: {
+            status: "RELEASED",
+            releasedQty: allocation.allocatedQty,
+            releasedAt: new Date(),
+            version: { increment: 1 },
+          },
+        });
+        if (release.count !== 1) throw new GearConflictError();
+        if (allocation.gearUnitId) {
+          await releaseTaggedUnitIfFree(tx, validated.leagueId, allocation.gearUnitId);
+        }
+        await recordGearInventoryMovement(tx, {
+          leagueId: validated.leagueId,
+          type: "RELEASE",
+          allocationId: allocation.id,
+          poolStockId: allocation.poolStockId,
+          gearUnitId: allocation.gearUnitId,
+          quantity: allocation.allocatedQty,
+          recordedById: userId,
+          notes: "Reservation canceled before pickup.",
+        });
+        await recordGearActivity(tx, {
+          leagueId: validated.leagueId,
+          entityType: "ALLOCATION",
+          entityId: allocation.id,
+          action: "released_by_reservation_cancellation",
+          actorUserId: userId,
+        });
+      }
+      for (const line of reservation.lines) {
+        await tx.gearReservationLine.updateMany({
+          where: { id: line.id, leagueId: validated.leagueId },
+          data: { allocatedQty: 0 },
+        });
+      }
       const update = await tx.gearReservation.updateMany({
-        where: { id: reservation.id, version: reservation.version, status: reservation.status },
+        where: { id: reservation.id, leagueId: validated.leagueId, version: reservation.version, status: reservation.status },
         data: { status: "CANCELED", canceledAt: new Date(), version: { increment: 1 } },
       });
       if (update.count !== 1) throw new GearConflictError();
@@ -326,10 +420,19 @@ export async function approveAndAllocateGearReservation(input: unknown): Promise
       const reservation = await getReservationForMutation(tx, validated.leagueId, validated.reservationId);
       if (!["REQUESTED", "APPROVED"].includes(reservation.status)) invalid("Only requested or approved reservations can receive allocations.");
       if (reservation.version !== validated.expectedVersion) throw new GearConflictError();
+      const currentWindow = reservationWindow(reservation);
       const window = {
-        startDate: new Date(`${validated.approvedStartDate ?? reservation.requestedStartDate.toISOString().slice(0, 10)}T00:00:00.000Z`),
-        endDate: new Date(`${validated.approvedEndDate ?? reservation.requestedEndDate.toISOString().slice(0, 10)}T00:00:00.000Z`),
+        startDate: new Date(`${validated.approvedStartDate ?? currentWindow.startDate.toISOString().slice(0, 10)}T00:00:00.000Z`),
+        endDate: new Date(`${validated.approvedEndDate ?? currentWindow.endDate.toISOString().slice(0, 10)}T00:00:00.000Z`),
       };
+      const activeExistingAllocations = reservation.lines.flatMap((line) => line.allocations)
+        .filter((allocation) => ["PENDING", "ALLOCATED", "PICKED_UP", "PARTIALLY_RETURNED"].includes(allocation.status));
+      if (
+        activeExistingAllocations.length > 0
+        && (window.startDate.getTime() !== currentWindow.startDate.getTime() || window.endDate.getTime() !== currentWindow.endDate.getTime())
+      ) {
+        invalid("Release and reallocate existing inventory before changing approved reservation dates.");
+      }
       if (!datesOverlap(
         { startDate: window.startDate.toISOString().slice(0, 10), endDate: window.endDate.toISOString().slice(0, 10) },
         { startDate: reservation.requestedStartDate.toISOString().slice(0, 10), endDate: reservation.requestedEndDate.toISOString().slice(0, 10) },
@@ -382,7 +485,7 @@ export async function approveAndAllocateGearReservation(input: unknown): Promise
             select: { id: true },
           });
           if (!stock || !location) invalid("The selected pooled stock is not active in this league.");
-          const committed = await activePoolCommitment(tx, stock.id, window);
+          const committed = await activePoolCommitment(validated.leagueId, tx, stock.id, window);
           if (stock.quantityOnHand - committed < (requestedByPoolStock.get(stock.id) ?? 0)) {
             invalid("Not enough matching pooled stock remains for these dates.");
           }
@@ -393,12 +496,14 @@ export async function approveAndAllocateGearReservation(input: unknown): Promise
             select: { id: true, status: true, version: true },
           });
           if (!unit || !["AVAILABLE", "RESERVED"].includes(unit.status)) invalid("The tagged unit is unavailable.");
-          if (await hasOverdueCheckout(tx, unit.id)) invalid("The tagged unit is blocked by an overdue checkout.");
+          if (await hasOverdueCheckout(tx, validated.leagueId, unit.id)) invalid("The tagged unit is blocked by an overdue checkout.");
           const conflicts = await tx.gearAllocation.count({
             where: {
+              leagueId: validated.leagueId,
               gearUnitId: unit.id,
               status: { in: ["PENDING", "ALLOCATED", "PICKED_UP", "PARTIALLY_RETURNED"] },
-              reservationLine: { reservation: { requestedStartDate: { lte: window.endDate }, requestedEndDate: { gte: window.startDate } } },
+              effectiveStartDate: { lte: window.endDate },
+              effectiveEndDate: { gte: window.startDate },
             },
           });
           if (conflicts > 0) invalid("The tagged unit is already allocated for these dates.");
@@ -418,6 +523,8 @@ export async function approveAndAllocateGearReservation(input: unknown): Promise
             gearUnitId: allocation.gearUnitId ?? null,
             status: "ALLOCATED",
             allocatedQty: allocation.quantity,
+            effectiveStartDate: window.startDate,
+            effectiveEndDate: window.endDate,
             allocatedAt: new Date(),
             allocatedById: userId,
           },

--- a/lib/actions/gear-reservations.ts
+++ b/lib/actions/gear-reservations.ts
@@ -1,0 +1,678 @@
+"use server";
+
+import { Prisma, type GearCondition } from "@prisma/client";
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+import { getUserLeagueRole, isTeamAdmin, requireLeagueRole, requireUserId } from "@/lib/auth/session";
+import { prisma } from "@/lib/db/prisma";
+import { recordGearActivity, recordGearInventoryMovement } from "@/lib/services/gear-ledger";
+import {
+  GearConflictError,
+  gearTransactionOptions,
+  withGearSerializableRetry,
+} from "@/lib/services/gear-transaction";
+import {
+  activeAllocationQuantity,
+  canTransitionAllocation,
+  canTransitionReservation,
+  datesOverlap,
+} from "@/lib/utils/gear";
+import { createGearReservationSchema } from "@/lib/utils/validation";
+import type { ActionResult } from "@/lib/actions/gear-inventory";
+
+const gearId = z.string().cuid("Invalid gear identifier");
+const quantity = z.coerce.number().int().min(1);
+const condition = z.enum(["NEW", "EXCELLENT", "GOOD", "FAIR", "POOR", "DAMAGED"]);
+const date = z.string().date();
+
+const reservationCommand = z.object({
+  leagueId: gearId,
+  reservationId: gearId,
+  expectedVersion: z.coerce.number().int().min(0),
+});
+
+const rescheduleSchema = reservationCommand.extend({
+  requestedStartDate: date,
+  requestedEndDate: date,
+}).refine((value) => value.requestedEndDate >= value.requestedStartDate, {
+  path: ["requestedEndDate"],
+  message: "Reservation end date must be on or after the start date.",
+});
+
+const decisionSchema = reservationCommand.extend({
+  decisionNotes: z.string().trim().max(2_000).optional(),
+});
+
+const allocationSchema = reservationCommand.extend({
+  approvedStartDate: date.optional(),
+  approvedEndDate: date.optional(),
+  allocations: z.array(z.object({
+    reservationLineId: gearId,
+    poolStockId: gearId.optional(),
+    gearUnitId: gearId.optional(),
+    quantity,
+  }).refine((value) => Boolean(value.poolStockId) !== Boolean(value.gearUnitId), {
+    message: "Choose either pooled stock or one tagged unit.",
+  })).min(1).max(100),
+}).refine((value) => !value.approvedStartDate || !value.approvedEndDate || value.approvedEndDate >= value.approvedStartDate, {
+  path: ["approvedEndDate"],
+  message: "Approved end date must be on or after the approved start date.",
+});
+
+const allocationCommand = z.object({
+  leagueId: gearId,
+  allocationId: gearId,
+  expectedVersion: z.coerce.number().int().min(0),
+  quantity: quantity.optional(),
+  notes: z.string().trim().max(1_000).optional(),
+});
+
+const returnSchema = allocationCommand.extend({
+  quantity,
+  returnDisposition: z.enum(["GOOD", "DAMAGED", "LOST", "CONSUMED"]),
+  condition: condition.optional(),
+});
+
+type Tx = Prisma.TransactionClient;
+
+function reservationPath(leagueId: string, reservationId?: string) {
+  return reservationId
+    ? `/league/${leagueId}/gear/reservations/${reservationId}`
+    : `/league/${leagueId}/gear/reservations`;
+}
+
+function inventoryPath(leagueId: string) {
+  return `/league/${leagueId}/gear`;
+}
+
+function invalid(message: string): never {
+  throw new Error(`Gear validation: ${message}`);
+}
+
+function actionError(error: unknown): ActionResult<never> {
+  if (error instanceof GearConflictError) return { success: false, error: error.message };
+  if (error instanceof z.ZodError) return { success: false, error: "Please correct the highlighted reservation fields.", details: error.issues };
+  if (error instanceof Error) {
+    if (error.message.startsWith("Unauthorized")) return { success: false, error: "You do not have permission to manage this reservation." };
+    if (error.message.startsWith("Gear validation:")) return { success: false, error: error.message.slice(17) };
+  }
+  return { success: false, error: "Unable to update the gear reservation. Please try again." };
+}
+
+async function assertRequestAccess(
+  leagueId: string,
+  teamId: string,
+  userId: string,
+  allowLeagueAdmin = true,
+): Promise<boolean> {
+  const leagueRole = await getUserLeagueRole(userId, leagueId);
+  if (allowLeagueAdmin && leagueRole === "LEAGUE_ADMIN") return true;
+  const [team, teamAdmin] = await Promise.all([
+    prisma.team.findFirst({ where: { id: teamId, leagueId, isActive: true }, select: { id: true } }),
+    isTeamAdmin(userId, teamId),
+  ]);
+  if (!team || !teamAdmin) throw new Error("Unauthorized: team admin access is required.");
+  return false;
+}
+
+async function getReservationForMutation(tx: Tx, leagueId: string, reservationId: string) {
+  const reservation = await tx.gearReservation.findFirst({
+    where: { id: reservationId, leagueId, league: { isActive: true }, team: { leagueId, isActive: true } },
+    include: {
+      lines: {
+        include: {
+          catalogItem: { select: { trackingMode: true } },
+          allocations: {
+            select: { allocatedQty: true, pickedUpQty: true, returnedQty: true, releasedQty: true },
+          },
+        },
+      },
+    },
+  });
+  if (!reservation) invalid("Reservation not found in this league.");
+  return reservation;
+}
+
+async function activePoolCommitment(
+  tx: Tx,
+  poolStockId: string,
+  window: { startDate: Date; endDate: Date },
+) {
+  const allocations = await tx.gearAllocation.findMany({
+    where: {
+      poolStockId,
+      status: { in: ["PENDING", "ALLOCATED", "PICKED_UP", "PARTIALLY_RETURNED"] },
+      reservationLine: {
+        reservation: {
+          requestedStartDate: { lte: window.endDate },
+          requestedEndDate: { gte: window.startDate },
+        },
+      },
+    },
+    select: { allocatedQty: true, releasedQty: true, returnedQty: true, pickedUpQty: true },
+  });
+  return allocations.reduce(
+    (total, allocation) => total + activeAllocationQuantity(allocation),
+    0,
+  );
+}
+
+async function hasOverdueCheckout(tx: Tx, gearUnitId: string) {
+  const today = new Date();
+  return Boolean(await tx.gearAllocation.findFirst({
+    where: {
+      gearUnitId,
+      status: { in: ["PICKED_UP", "PARTIALLY_RETURNED"] },
+      reservationLine: { reservation: { requestedEndDate: { lt: today } } },
+    },
+    select: { id: true },
+  }));
+}
+
+async function releaseTaggedUnitIfFree(tx: Tx, leagueId: string, gearUnitId: string) {
+  const active = await tx.gearAllocation.count({
+    where: { leagueId, gearUnitId, status: { in: ["PENDING", "ALLOCATED", "PICKED_UP", "PARTIALLY_RETURNED"] } },
+  });
+  if (active === 0) {
+    await tx.gearUnit.updateMany({
+      where: { id: gearUnitId, leagueId, status: "RESERVED" },
+      data: { status: "AVAILABLE", version: { increment: 1 } },
+    });
+  }
+}
+
+export async function createGearReservation(
+  input: z.input<typeof createGearReservationSchema>,
+): Promise<ActionResult<{ id: string }>> {
+  try {
+    const validated = createGearReservationSchema.parse(input);
+    const userId = await requireUserId();
+    await assertRequestAccess(validated.leagueId, validated.teamId, userId);
+    const created = await prisma.$transaction(async (tx) => {
+      const items = await tx.gearCatalogItem.findMany({
+        where: {
+          leagueId: validated.leagueId,
+          id: {
+            in: validated.lines
+              .map((line) => line.catalogItemId)
+              .filter((catalogItemId): catalogItemId is string => Boolean(catalogItemId)),
+          },
+        },
+        select: { id: true },
+      });
+      const itemIds = new Set(items.map((item) => item.id));
+      if (validated.lines.some((line) => line.catalogItemId && !itemIds.has(line.catalogItemId))) {
+        invalid("A requested catalog item is not available in this league.");
+      }
+      const reservation = await tx.gearReservation.create({
+        data: {
+          leagueId: validated.leagueId,
+          teamId: validated.teamId,
+          status: "REQUESTED",
+          requestedStartDate: new Date(`${validated.requestedStartDate}T00:00:00.000Z`),
+          requestedEndDate: new Date(`${validated.requestedEndDate}T00:00:00.000Z`),
+          custodianNameSnapshot: validated.custodianNameSnapshot,
+          custodianEmailSnapshot: validated.custodianEmailSnapshot || null,
+          custodianPhoneSnapshot: validated.custodianPhoneSnapshot || null,
+          requestNotes: validated.requestNotes || null,
+          requestedById: userId,
+          lines: { create: validated.lines.map((line) => ({
+            catalogItemId: line.catalogItemId || null,
+            needLineId: line.needLineId || null,
+            nameSnapshot: line.nameSnapshot,
+            requestedQty: line.requestedQty,
+          })) },
+        },
+        select: { id: true },
+      });
+      await recordGearActivity(tx, {
+        leagueId: validated.leagueId, entityType: "RESERVATION", entityId: reservation.id,
+        action: "requested", actorUserId: userId, details: { teamId: validated.teamId },
+      });
+      return reservation;
+    }, gearTransactionOptions);
+    revalidatePath(reservationPath(validated.leagueId));
+    return { success: true, data: created };
+  } catch (error) {
+    return actionError(error);
+  }
+}
+
+export async function cancelGearReservation(input: unknown): Promise<ActionResult<{ id: string }>> {
+  try {
+    const validated = reservationCommand.parse(input);
+    const userId = await requireUserId();
+    const result = await prisma.$transaction(async (tx) => {
+      const reservation = await getReservationForMutation(tx, validated.leagueId, validated.reservationId);
+      await assertRequestAccess(validated.leagueId, reservation.teamId, userId);
+      if (!canTransitionReservation(reservation.status, "CANCELED")) invalid("This reservation can no longer be canceled.");
+      if (reservation.version !== validated.expectedVersion) throw new GearConflictError();
+      const update = await tx.gearReservation.updateMany({
+        where: { id: reservation.id, version: reservation.version, status: reservation.status },
+        data: { status: "CANCELED", canceledAt: new Date(), version: { increment: 1 } },
+      });
+      if (update.count !== 1) throw new GearConflictError();
+      await recordGearActivity(tx, { leagueId: validated.leagueId, entityType: "RESERVATION", entityId: reservation.id, action: "canceled", actorUserId: userId });
+      return { id: reservation.id };
+    }, gearTransactionOptions);
+    revalidatePath(reservationPath(validated.leagueId));
+    revalidatePath(reservationPath(validated.leagueId, result.id));
+    revalidatePath(inventoryPath(validated.leagueId));
+    return { success: true, data: result };
+  } catch (error) {
+    return actionError(error);
+  }
+}
+
+export async function rescheduleGearReservation(input: unknown): Promise<ActionResult<{ id: string }>> {
+  try {
+    const validated = rescheduleSchema.parse(input);
+    const userId = await requireUserId();
+    const result = await prisma.$transaction(async (tx) => {
+      const reservation = await getReservationForMutation(tx, validated.leagueId, validated.reservationId);
+      await assertRequestAccess(validated.leagueId, reservation.teamId, userId);
+      if (!["DRAFT", "REQUESTED"].includes(reservation.status)) invalid("Only pending reservations can be rescheduled.");
+      if (reservation.version !== validated.expectedVersion) throw new GearConflictError();
+      const update = await tx.gearReservation.updateMany({
+        where: { id: reservation.id, version: reservation.version, status: reservation.status },
+        data: {
+          requestedStartDate: new Date(`${validated.requestedStartDate}T00:00:00.000Z`),
+          requestedEndDate: new Date(`${validated.requestedEndDate}T00:00:00.000Z`),
+          version: { increment: 1 },
+        },
+      });
+      if (update.count !== 1) throw new GearConflictError();
+      await recordGearActivity(tx, { leagueId: validated.leagueId, entityType: "RESERVATION", entityId: reservation.id, action: "rescheduled", actorUserId: userId });
+      return { id: reservation.id };
+    }, gearTransactionOptions);
+    revalidatePath(reservationPath(validated.leagueId));
+    revalidatePath(reservationPath(validated.leagueId, result.id));
+    revalidatePath(inventoryPath(validated.leagueId));
+    return { success: true, data: result };
+  } catch (error) {
+    return actionError(error);
+  }
+}
+
+export async function declineGearReservation(input: unknown): Promise<ActionResult<{ id: string }>> {
+  try {
+    const validated = decisionSchema.parse(input);
+    const userId = await requireLeagueRole(validated.leagueId, "LEAGUE_ADMIN");
+    const result = await prisma.$transaction(async (tx) => {
+      const reservation = await getReservationForMutation(tx, validated.leagueId, validated.reservationId);
+      if (!canTransitionReservation(reservation.status, "DECLINED")) invalid("Only requested reservations can be declined.");
+      if (reservation.version !== validated.expectedVersion) throw new GearConflictError();
+      const update = await tx.gearReservation.updateMany({
+        where: { id: reservation.id, version: reservation.version, status: "REQUESTED" },
+        data: { status: "DECLINED", decisionNotes: validated.decisionNotes || null, decidedById: userId, decidedAt: new Date(), version: { increment: 1 } },
+      });
+      if (update.count !== 1) throw new GearConflictError();
+      await recordGearActivity(tx, { leagueId: validated.leagueId, entityType: "RESERVATION", entityId: reservation.id, action: "declined", actorUserId: userId });
+      return { id: reservation.id };
+    }, gearTransactionOptions);
+    revalidatePath(reservationPath(validated.leagueId));
+    revalidatePath(reservationPath(validated.leagueId, result.id));
+    return { success: true, data: result };
+  } catch (error) {
+    return actionError(error);
+  }
+}
+
+export async function approveAndAllocateGearReservation(input: unknown): Promise<ActionResult<{ id: string }>> {
+  try {
+    const validated = allocationSchema.parse(input);
+    const userId = await requireLeagueRole(validated.leagueId, "LEAGUE_ADMIN");
+    const result = await withGearSerializableRetry(() => prisma.$transaction(async (tx) => {
+      const reservation = await getReservationForMutation(tx, validated.leagueId, validated.reservationId);
+      if (!["REQUESTED", "APPROVED"].includes(reservation.status)) invalid("Only requested or approved reservations can receive allocations.");
+      if (reservation.version !== validated.expectedVersion) throw new GearConflictError();
+      const window = {
+        startDate: new Date(`${validated.approvedStartDate ?? reservation.requestedStartDate.toISOString().slice(0, 10)}T00:00:00.000Z`),
+        endDate: new Date(`${validated.approvedEndDate ?? reservation.requestedEndDate.toISOString().slice(0, 10)}T00:00:00.000Z`),
+      };
+      if (!datesOverlap(
+        { startDate: window.startDate.toISOString().slice(0, 10), endDate: window.endDate.toISOString().slice(0, 10) },
+        { startDate: reservation.requestedStartDate.toISOString().slice(0, 10), endDate: reservation.requestedEndDate.toISOString().slice(0, 10) },
+      )) invalid("Approved dates must overlap the requested reservation dates.");
+
+      const lines = new Map(reservation.lines.map((line) => [line.id, line]));
+      const requestedByLine = new Map<string, number>();
+      const requestedByPoolStock = new Map<string, number>();
+      const requestedTaggedUnits = new Set<string>();
+      for (const allocation of validated.allocations) {
+        const line = lines.get(allocation.reservationLineId);
+        if (!line || !line.catalogItemId) invalid("Each allocation must belong to an item-backed reservation line.");
+        if ((requestedByLine.get(line.id) ?? 0) + allocation.quantity > line.requestedQty) {
+          invalid(`Allocation exceeds the requested quantity for ${line.nameSnapshot}.`);
+        }
+        requestedByLine.set(line.id, (requestedByLine.get(line.id) ?? 0) + allocation.quantity);
+        if (allocation.poolStockId) {
+          requestedByPoolStock.set(
+            allocation.poolStockId,
+            (requestedByPoolStock.get(allocation.poolStockId) ?? 0) + allocation.quantity,
+          );
+        }
+        if (allocation.gearUnitId) {
+          if (requestedTaggedUnits.has(allocation.gearUnitId)) {
+            invalid("A tagged unit may only be allocated once in the same request.");
+          }
+          requestedTaggedUnits.add(allocation.gearUnitId);
+        }
+      }
+      for (const allocation of validated.allocations) {
+        const line = lines.get(allocation.reservationLineId);
+        if (!line) invalid("Reservation line not found.");
+        const catalogItemId = line.catalogItemId;
+        if (!catalogItemId) invalid("Each allocation must belong to an item-backed reservation line.");
+        const activeForLine = line.allocations.reduce(
+          (total, existing) => total + activeAllocationQuantity(existing),
+          0,
+        );
+        if (activeForLine + (requestedByLine.get(line.id) ?? 0) > line.requestedQty) {
+          invalid(`Allocation exceeds the remaining requested quantity for ${line.nameSnapshot}.`);
+        }
+        if (allocation.poolStockId) {
+          if (line.catalogItem?.trackingMode !== "POOLED") invalid("Pooled allocations require a pooled catalog item.");
+          const stock = await tx.gearPoolStock.findFirst({
+            where: { id: allocation.poolStockId, leagueId: validated.leagueId, catalogItemId },
+            select: { id: true, quantityOnHand: true, locationId: true },
+          });
+          const location = stock && await tx.gearStorageLocation.findFirst({
+            where: { id: stock.locationId, leagueId: validated.leagueId, isActive: true },
+            select: { id: true },
+          });
+          if (!stock || !location) invalid("The selected pooled stock is not active in this league.");
+          const committed = await activePoolCommitment(tx, stock.id, window);
+          if (stock.quantityOnHand - committed < (requestedByPoolStock.get(stock.id) ?? 0)) {
+            invalid("Not enough matching pooled stock remains for these dates.");
+          }
+        } else if (allocation.gearUnitId) {
+          if (line.catalogItem?.trackingMode !== "INDIVIDUAL" || allocation.quantity !== 1) invalid("Tagged allocations require exactly one individually tracked item.");
+          const unit = await tx.gearUnit.findFirst({
+            where: { id: allocation.gearUnitId, leagueId: validated.leagueId, catalogItemId },
+            select: { id: true, status: true, version: true },
+          });
+          if (!unit || !["AVAILABLE", "RESERVED"].includes(unit.status)) invalid("The tagged unit is unavailable.");
+          if (await hasOverdueCheckout(tx, unit.id)) invalid("The tagged unit is blocked by an overdue checkout.");
+          const conflicts = await tx.gearAllocation.count({
+            where: {
+              gearUnitId: unit.id,
+              status: { in: ["PENDING", "ALLOCATED", "PICKED_UP", "PARTIALLY_RETURNED"] },
+              reservationLine: { reservation: { requestedStartDate: { lte: window.endDate }, requestedEndDate: { gte: window.startDate } } },
+            },
+          });
+          if (conflicts > 0) invalid("The tagged unit is already allocated for these dates.");
+          const updated = await tx.gearUnit.updateMany({
+            where: { id: unit.id, leagueId: validated.leagueId, version: unit.version, status: unit.status },
+            data: { status: "RESERVED", version: { increment: 1 } },
+          });
+          if (updated.count !== 1) throw new GearConflictError();
+        }
+      }
+      for (const allocation of validated.allocations) {
+        await tx.gearAllocation.create({
+          data: {
+            leagueId: validated.leagueId,
+            reservationLineId: allocation.reservationLineId,
+            poolStockId: allocation.poolStockId ?? null,
+            gearUnitId: allocation.gearUnitId ?? null,
+            status: "ALLOCATED",
+            allocatedQty: allocation.quantity,
+            allocatedAt: new Date(),
+            allocatedById: userId,
+          },
+        });
+      }
+      for (const [lineId, approvedQty] of requestedByLine) {
+        const line = lines.get(lineId);
+        if (!line) invalid("Reservation line not found.");
+        const activeForLine = line.allocations.reduce(
+          (total, existing) => total + activeAllocationQuantity(existing),
+          0,
+        );
+        await tx.gearReservationLine.update({
+          where: { id: lineId },
+          data: {
+            approvedQty: Math.max(line.approvedQty, activeForLine + approvedQty),
+            allocatedQty: activeForLine + approvedQty,
+          },
+        });
+      }
+      const update = await tx.gearReservation.updateMany({
+        where: { id: reservation.id, version: reservation.version, status: reservation.status },
+        data: {
+          status: "APPROVED",
+          approvedStartDate: window.startDate,
+          approvedEndDate: window.endDate,
+          decidedAt: new Date(),
+          decidedById: userId,
+          version: { increment: 1 },
+        },
+      });
+      if (update.count !== 1) throw new GearConflictError();
+      await recordGearActivity(tx, {
+        leagueId: validated.leagueId, entityType: "RESERVATION", entityId: reservation.id,
+        action: "approved_and_allocated", actorUserId: userId, details: { allocationCount: validated.allocations.length },
+      });
+      return { id: reservation.id };
+    }, gearTransactionOptions));
+    revalidatePath(reservationPath(validated.leagueId));
+    revalidatePath(reservationPath(validated.leagueId, result.id));
+    return { success: true, data: result };
+  } catch (error) {
+    return actionError(error);
+  }
+}
+
+export async function releaseGearAllocation(input: unknown): Promise<ActionResult<{ id: string }>> {
+  try {
+    const validated = allocationCommand.parse(input);
+    const userId = await requireLeagueRole(validated.leagueId, "LEAGUE_ADMIN");
+    const result = await prisma.$transaction(async (tx) => {
+      const allocation = await tx.gearAllocation.findFirst({
+        where: { id: validated.allocationId, leagueId: validated.leagueId },
+        include: { reservationLine: { include: { reservation: true } } },
+      });
+      if (!allocation) invalid("Allocation not found in this league.");
+      if (!canTransitionAllocation(allocation.status, "RELEASED") || allocation.pickedUpQty > 0) invalid("Only uncollected allocations can be released.");
+      if (allocation.version !== validated.expectedVersion) throw new GearConflictError();
+      const update = await tx.gearAllocation.updateMany({
+        where: { id: allocation.id, version: allocation.version, status: allocation.status },
+        data: { status: "RELEASED", releasedQty: allocation.allocatedQty, releasedAt: new Date(), version: { increment: 1 } },
+      });
+      if (update.count !== 1) throw new GearConflictError();
+      if (allocation.gearUnitId) await releaseTaggedUnitIfFree(tx, validated.leagueId, allocation.gearUnitId);
+      await recordGearActivity(tx, { leagueId: validated.leagueId, entityType: "ALLOCATION", entityId: allocation.id, action: "released", actorUserId: userId });
+      return { id: allocation.id, reservationId: allocation.reservationLine.reservationId };
+    }, gearTransactionOptions);
+    revalidatePath(reservationPath(validated.leagueId));
+    revalidatePath(reservationPath(validated.leagueId, result.reservationId));
+    revalidatePath(inventoryPath(validated.leagueId));
+    return { success: true, data: { id: result.id } };
+  } catch (error) {
+    return actionError(error);
+  }
+}
+
+export async function recordGearPickup(input: unknown): Promise<ActionResult<{ id: string }>> {
+  try {
+    const validated = allocationCommand.extend({ quantity }).parse(input);
+    const userId = await requireLeagueRole(validated.leagueId, "LEAGUE_ADMIN");
+    const result = await prisma.$transaction(async (tx) => {
+      const allocation = await tx.gearAllocation.findFirst({
+        where: { id: validated.allocationId, leagueId: validated.leagueId },
+        include: { reservationLine: { include: { reservation: true } }, poolStock: true, gearUnit: true },
+      });
+      if (!allocation) invalid("Allocation not found in this league.");
+      if (
+        allocation.status !== "ALLOCATED"
+        || allocation.pickedUpQty !== 0
+        || validated.quantity !== allocation.allocatedQty
+      ) invalid("This allocation must be picked up in full.");
+      if (allocation.version !== validated.expectedVersion) throw new GearConflictError();
+      const update = await tx.gearAllocation.updateMany({
+        where: { id: allocation.id, version: allocation.version, status: "ALLOCATED" },
+        data: { status: "PICKED_UP", pickedUpQty: validated.quantity, pickedUpAt: new Date(), version: { increment: 1 } },
+      });
+      if (update.count !== 1) throw new GearConflictError();
+      if (allocation.gearUnitId) {
+        const unit = allocation.gearUnit;
+        if (!unit) invalid("Tagged unit projection is missing.");
+        const unitUpdate = await tx.gearUnit.updateMany({
+          where: { id: unit.id, leagueId: validated.leagueId, version: unit.version, status: "RESERVED" },
+          data: { status: "CHECKED_OUT", version: { increment: 1 } },
+        });
+        if (unitUpdate.count !== 1) throw new GearConflictError();
+      }
+      const handoff = await tx.gearHandoff.create({
+        data: {
+          leagueId: validated.leagueId, reservationId: allocation.reservationLine.reservationId,
+          allocationId: allocation.id, type: "PICKUP",
+          custodianNameSnapshot: allocation.reservationLine.reservation.custodianNameSnapshot,
+          handledById: userId, notes: validated.notes || null,
+        },
+      });
+      await recordGearInventoryMovement(tx, {
+        leagueId: validated.leagueId, type: "ALLOCATION", quantity: validated.quantity,
+        poolStockId: allocation.poolStockId, gearUnitId: allocation.gearUnitId,
+        allocationId: allocation.id, handoffId: handoff.id, recordedById: userId, notes: validated.notes,
+      });
+      await recordGearActivity(tx, { leagueId: validated.leagueId, entityType: "HANDOFF", entityId: handoff.id, action: "picked_up", actorUserId: userId });
+      const reservationUpdate = await tx.gearReservation.updateMany({
+        where: { id: allocation.reservationLine.reservationId, status: "APPROVED" },
+        data: { status: "FULFILLED", custodyStartedAt: new Date(), version: { increment: 1 } },
+      });
+      void reservationUpdate;
+      return { id: allocation.id, reservationId: allocation.reservationLine.reservationId };
+    }, gearTransactionOptions);
+    revalidatePath(reservationPath(validated.leagueId));
+    revalidatePath(reservationPath(validated.leagueId, result.reservationId));
+    revalidatePath(inventoryPath(validated.leagueId));
+    return { success: true, data: { id: result.id } };
+  } catch (error) {
+    return actionError(error);
+  }
+}
+
+export async function recordGearReturn(input: unknown): Promise<ActionResult<{ id: string }>> {
+  try {
+    const validated = returnSchema.parse(input);
+    const userId = await requireLeagueRole(validated.leagueId, "LEAGUE_ADMIN");
+    const result = await prisma.$transaction(async (tx) => {
+      const allocation = await tx.gearAllocation.findFirst({
+        where: { id: validated.allocationId, leagueId: validated.leagueId },
+        include: {
+          reservationLine: { include: { reservation: true } },
+          poolStock: { include: { location: true } },
+          gearUnit: true,
+        },
+      });
+      if (!allocation) invalid("Allocation not found in this league.");
+      if (!["PICKED_UP", "PARTIALLY_RETURNED"].includes(allocation.status)) invalid("Only checked-out gear can be returned.");
+      if (allocation.version !== validated.expectedVersion) throw new GearConflictError();
+      const remaining = allocation.pickedUpQty - allocation.returnedQty;
+      if (validated.quantity > remaining) invalid("Return quantity exceeds the amount currently in custody.");
+      const returnedQty = allocation.returnedQty + validated.quantity;
+      const nextStatus = returnedQty === allocation.pickedUpQty ? "RETURNED" : "PARTIALLY_RETURNED";
+      const update = await tx.gearAllocation.updateMany({
+        where: { id: allocation.id, version: allocation.version, status: allocation.status },
+        data: { status: nextStatus, returnedQty, returnedAt: new Date(), version: { increment: 1 } },
+      });
+      if (update.count !== 1) throw new GearConflictError();
+      const returnCondition: GearCondition = validated.condition
+        ?? (validated.returnDisposition === "DAMAGED"
+          ? "DAMAGED"
+          : allocation.poolStock?.condition ?? allocation.gearUnit?.currentCondition ?? "GOOD");
+      if (allocation.gearUnit) {
+        const unitStatus = validated.returnDisposition === "LOST"
+          ? "LOST"
+          : validated.returnDisposition === "CONSUMED" ? "RETIRED"
+            : validated.returnDisposition === "DAMAGED" ? "MAINTENANCE" : "AVAILABLE";
+        const unitUpdate = await tx.gearUnit.updateMany({
+          where: { id: allocation.gearUnit.id, leagueId: validated.leagueId, version: allocation.gearUnit.version, status: "CHECKED_OUT" },
+          data: {
+            status: unitStatus,
+            currentCondition: returnCondition,
+            retiredAt: unitStatus === "RETIRED" ? new Date() : undefined,
+            version: { increment: 1 },
+          },
+        });
+        if (unitUpdate.count !== 1) throw new GearConflictError();
+      }
+      if (allocation.poolStock) {
+        if (["LOST", "CONSUMED"].includes(validated.returnDisposition)) {
+          const stockUpdate = await tx.gearPoolStock.updateMany({
+            where: { id: allocation.poolStock.id, leagueId: validated.leagueId, quantityOnHand: { gte: validated.quantity } },
+            data: { quantityOnHand: { decrement: validated.quantity }, version: { increment: 1 } },
+          });
+          if (stockUpdate.count !== 1) throw new GearConflictError("Inventory changed before this loss could be recorded.");
+        } else if (returnCondition !== allocation.poolStock.condition) {
+          const sourceUpdate = await tx.gearPoolStock.updateMany({
+            where: { id: allocation.poolStock.id, leagueId: validated.leagueId, quantityOnHand: { gte: validated.quantity } },
+            data: { quantityOnHand: { decrement: validated.quantity }, version: { increment: 1 } },
+          });
+          if (sourceUpdate.count !== 1) throw new GearConflictError("Inventory changed before this return could be recorded.");
+          await tx.gearPoolStock.upsert({
+            where: {
+              leagueId_catalogItemId_locationId_condition: {
+                leagueId: validated.leagueId,
+                catalogItemId: allocation.poolStock.catalogItemId,
+                locationId: allocation.poolStock.locationId,
+                condition: returnCondition,
+              },
+            },
+            create: {
+              leagueId: validated.leagueId,
+              catalogItemId: allocation.poolStock.catalogItemId,
+              locationId: allocation.poolStock.locationId,
+              condition: returnCondition,
+              quantityOnHand: validated.quantity,
+              version: 1,
+            },
+            update: { quantityOnHand: { increment: validated.quantity }, version: { increment: 1 } },
+          });
+        }
+      }
+      const handoff = await tx.gearHandoff.create({
+        data: {
+          leagueId: validated.leagueId, reservationId: allocation.reservationLine.reservationId,
+          allocationId: allocation.id, type: "RETURN", returnDisposition: validated.returnDisposition,
+          custodianNameSnapshot: allocation.reservationLine.reservation.custodianNameSnapshot,
+          handledById: userId, notes: validated.notes || null,
+        },
+      });
+      await recordGearInventoryMovement(tx, {
+        leagueId: validated.leagueId,
+        type: ["LOST", "CONSUMED"].includes(validated.returnDisposition) ? "WRITE_OFF" : "RETURN",
+        quantity: validated.quantity, poolStockId: allocation.poolStockId, gearUnitId: allocation.gearUnitId,
+        allocationId: allocation.id, handoffId: handoff.id,
+        beforeLocationId: allocation.poolStock?.locationId, afterLocationId: allocation.poolStock?.locationId,
+        beforeCondition: allocation.poolStock?.condition ?? allocation.gearUnit?.currentCondition,
+        afterCondition: returnCondition, recordedById: userId, notes: validated.notes,
+      });
+      await recordGearActivity(tx, {
+        leagueId: validated.leagueId, entityType: "HANDOFF", entityId: handoff.id,
+        action: "returned", actorUserId: userId, details: { quantity: validated.quantity, disposition: validated.returnDisposition },
+      });
+      const openAllocations = await tx.gearAllocation.count({
+        where: {
+          reservationLine: { reservationId: allocation.reservationLine.reservationId },
+          status: { in: ["PENDING", "ALLOCATED", "PICKED_UP", "PARTIALLY_RETURNED"] },
+        },
+      });
+      if (openAllocations === 0) {
+        await tx.gearReservation.updateMany({
+          where: { id: allocation.reservationLine.reservationId, status: "FULFILLED" },
+          data: { status: "CLOSED", custodyEndedAt: new Date(), version: { increment: 1 } },
+        });
+      }
+      return { id: allocation.id, reservationId: allocation.reservationLine.reservationId };
+    }, gearTransactionOptions);
+    revalidatePath(reservationPath(validated.leagueId));
+    revalidatePath(reservationPath(validated.leagueId, result.reservationId));
+    revalidatePath(inventoryPath(validated.leagueId));
+    return { success: true, data: { id: result.id } };
+  } catch (error) {
+    return actionError(error);
+  }
+}

--- a/lib/actions/gear-reservations.ts
+++ b/lib/actions/gear-reservations.ts
@@ -190,11 +190,18 @@ async function releaseTaggedUnitIfFree(tx: Tx, leagueId: string, gearUnitId: str
   const active = await tx.gearAllocation.count({
     where: { leagueId, gearUnitId, status: { in: ["PENDING", "ALLOCATED", "PICKED_UP", "PARTIALLY_RETURNED"] } },
   });
-  if (active === 0) {
-    await tx.gearUnit.updateMany({
-      where: { id: gearUnitId, leagueId, status: "RESERVED" },
+  const unit = active === 0
+    ? await tx.gearUnit.findFirst({
+        where: { id: gearUnitId, leagueId, status: "RESERVED" },
+        select: { id: true, version: true },
+      })
+    : null;
+  if (unit) {
+    const updated = await tx.gearUnit.updateMany({
+      where: { id: unit.id, leagueId, status: "RESERVED", version: unit.version },
       data: { status: "AVAILABLE", version: { increment: 1 } },
     });
+    if (updated.count !== 1) throw new GearConflictError();
   }
 }
 
@@ -273,7 +280,7 @@ export async function createGearReservation(
       });
       await recordGearActivity(tx, {
         leagueId: validated.leagueId, entityType: "RESERVATION", entityId: reservation.id,
-        action: "requested", actorUserId: userId, details: { teamId: validated.teamId },
+        action: "requested", actorUserId: userId, details: { metadata: { teamId: validated.teamId } },
       });
       return reservation;
     }, gearTransactionOptions);
@@ -320,6 +327,7 @@ export async function cancelGearReservation(input: unknown): Promise<ActionResul
         await recordGearInventoryMovement(tx, {
           leagueId: validated.leagueId,
           type: "RELEASE",
+          direction: "NEUTRAL",
           allocationId: allocation.id,
           poolStockId: allocation.poolStockId,
           gearUnitId: allocation.gearUnitId,
@@ -559,7 +567,8 @@ export async function approveAndAllocateGearReservation(input: unknown): Promise
       if (update.count !== 1) throw new GearConflictError();
       await recordGearActivity(tx, {
         leagueId: validated.leagueId, entityType: "RESERVATION", entityId: reservation.id,
-        action: "approved_and_allocated", actorUserId: userId, details: { allocationCount: validated.allocations.length },
+        action: "approved_and_allocated", actorUserId: userId,
+        details: { metadata: { allocationCount: validated.allocations.length } },
       });
       return { id: reservation.id };
     }, gearTransactionOptions));
@@ -641,8 +650,11 @@ export async function recordGearPickup(input: unknown): Promise<ActionResult<{ i
       });
       await recordGearInventoryMovement(tx, {
         leagueId: validated.leagueId, type: "ALLOCATION", quantity: validated.quantity,
+        direction: "DECREASE",
         poolStockId: allocation.poolStockId, gearUnitId: allocation.gearUnitId,
         allocationId: allocation.id, handoffId: handoff.id, recordedById: userId, notes: validated.notes,
+        beforeLocationId: allocation.poolStock?.locationId ?? allocation.gearUnit?.currentLocationId,
+        beforeCondition: allocation.poolStock?.condition ?? allocation.gearUnit?.currentCondition,
       });
       await recordGearActivity(tx, { leagueId: validated.leagueId, entityType: "HANDOFF", entityId: handoff.id, action: "picked_up", actorUserId: userId });
       const reservationUpdate = await tx.gearReservation.updateMany({
@@ -751,15 +763,20 @@ export async function recordGearReturn(input: unknown): Promise<ActionResult<{ i
       await recordGearInventoryMovement(tx, {
         leagueId: validated.leagueId,
         type: ["LOST", "CONSUMED"].includes(validated.returnDisposition) ? "WRITE_OFF" : "RETURN",
+        direction: ["LOST", "CONSUMED"].includes(validated.returnDisposition) ? "DECREASE" : "INCREASE",
         quantity: validated.quantity, poolStockId: allocation.poolStockId, gearUnitId: allocation.gearUnitId,
         allocationId: allocation.id, handoffId: handoff.id,
-        beforeLocationId: allocation.poolStock?.locationId, afterLocationId: allocation.poolStock?.locationId,
+        beforeLocationId: allocation.poolStock?.locationId ?? allocation.gearUnit?.currentLocationId,
+        afterLocationId: ["LOST", "CONSUMED"].includes(validated.returnDisposition)
+          ? null
+          : allocation.poolStock?.locationId ?? allocation.gearUnit?.currentLocationId,
         beforeCondition: allocation.poolStock?.condition ?? allocation.gearUnit?.currentCondition,
         afterCondition: returnCondition, recordedById: userId, notes: validated.notes,
       });
       await recordGearActivity(tx, {
         leagueId: validated.leagueId, entityType: "HANDOFF", entityId: handoff.id,
-        action: "returned", actorUserId: userId, details: { quantity: validated.quantity, disposition: validated.returnDisposition },
+        action: "returned", actorUserId: userId,
+        details: { metadata: { quantity: validated.quantity, disposition: validated.returnDisposition } },
       });
       const openAllocations = await tx.gearAllocation.count({
         where: {

--- a/lib/actions/gear-reservations.ts
+++ b/lib/actions/gear-reservations.ts
@@ -13,12 +13,15 @@ import {
 } from "@/lib/services/gear-transaction";
 import {
   activeAllocationQuantity,
+  allocationConsumesCapacityForWindow,
   canTransitionAllocation,
   canTransitionReservation,
   datesOverlap,
+  isOutstandingAllocationOverdue,
 } from "@/lib/utils/gear";
 import { createGearReservationSchema } from "@/lib/utils/validation";
 import type { ActionResult } from "@/lib/actions/gear-inventory";
+import { logGearInventoryFailure } from "@/lib/utils/gear-observability";
 
 const gearId = z.string().cuid("Invalid gear identifier");
 const quantity = z.coerce.number().int().min(1);
@@ -89,8 +92,19 @@ function invalid(message: string): never {
   throw new Error(`Gear validation: ${message}`);
 }
 
-function actionError(error: unknown): ActionResult<never> {
-  if (error instanceof GearConflictError) return { success: false, error: error.message };
+function actionError(error: unknown, action: string, input?: unknown): ActionResult<never> {
+  const leagueId = typeof input === "object" && input !== null && "leagueId" in input && typeof input.leagueId === "string"
+    ? input.leagueId
+    : undefined;
+  if (error instanceof GearConflictError) {
+    const incidentId = error.retryExhausted ? logGearInventoryFailure(action, leagueId, error) : undefined;
+    return {
+      success: false,
+      error: incidentId
+        ? "Reservation availability could not be saved after concurrent updates. Please try again."
+        : error.message,
+    };
+  }
   if (error instanceof Prisma.PrismaClientKnownRequestError && ["P2004", "P2034"].includes(error.code)) {
     return { success: false, error: "Inventory availability changed. Review the reservation dates and allocations, then try again." };
   }
@@ -99,7 +113,8 @@ function actionError(error: unknown): ActionResult<never> {
     if (error.message.startsWith("Unauthorized")) return { success: false, error: "You do not have permission to manage this reservation." };
     if (error.message.startsWith("Gear validation:")) return { success: false, error: error.message.slice(17) };
   }
-  return { success: false, error: "Unable to update the gear reservation. Please try again." };
+  const incidentId = logGearInventoryFailure(action, leagueId, error);
+  return { success: false, error: `Unable to update the gear reservation. Please try again. Reference: ${incidentId}` };
 }
 
 async function assertRequestAccess(
@@ -163,27 +178,42 @@ async function activePoolCommitment(
       leagueId,
       poolStockId,
       status: { in: ["PENDING", "ALLOCATED", "PICKED_UP", "PARTIALLY_RETURNED"] },
-      effectiveStartDate: { lte: window.endDate },
-      effectiveEndDate: { gte: window.startDate },
+      OR: [
+        { status: { in: ["PICKED_UP", "PARTIALLY_RETURNED"] } },
+        {
+          status: { in: ["PENDING", "ALLOCATED"] },
+          effectiveStartDate: { lte: window.endDate },
+          effectiveEndDate: { gte: window.startDate },
+        },
+      ],
     },
-    select: { allocatedQty: true, releasedQty: true, returnedQty: true, pickedUpQty: true },
+    select: {
+     status: true, allocatedQty: true, releasedQty: true, returnedQty: true, pickedUpQty: true,
+     effectiveStartDate: true, effectiveEndDate: true,
+    },
   });
   return allocations.reduce(
-    (total, allocation) => total + activeAllocationQuantity(allocation),
+    (total, allocation) => total + (
+     allocationConsumesCapacityForWindow(allocation, {
+       startDate: window.startDate.toISOString().slice(0, 10),
+       endDate: window.endDate.toISOString().slice(0, 10),
+     })
+       ? activeAllocationQuantity(allocation)
+       : 0
+    ),
     0,
   );
 }
 
 async function hasOverdueCheckout(tx: Tx, leagueId: string, gearUnitId: string) {
-  const today = new Date();
-  return Boolean(await tx.gearAllocation.findFirst({
+  const checkedOutAllocations = await tx.gearAllocation.findMany({
     where: {
-      leagueId, gearUnitId,
-      status: { in: ["PICKED_UP", "PARTIALLY_RETURNED"] },
-      effectiveEndDate: { lt: today },
+     leagueId, gearUnitId,
+     status: { in: ["PICKED_UP", "PARTIALLY_RETURNED"] },
     },
-    select: { id: true },
-  }));
+    select: { status: true, effectiveEndDate: true },
+  });
+  return checkedOutAllocations.some((allocation) => isOutstandingAllocationOverdue(allocation));
 }
 
 async function releaseTaggedUnitIfFree(tx: Tx, leagueId: string, gearUnitId: string) {
@@ -205,6 +235,119 @@ async function releaseTaggedUnitIfFree(tx: Tx, leagueId: string, gearUnitId: str
   }
 }
 
+async function reconcileReservationAfterTerminalAllocation(
+  tx: Tx,
+  leagueId: string,
+  reservationId: string,
+) {
+  const reservation = await tx.gearReservation.findFirst({
+    where: { id: reservationId, leagueId },
+    select: {
+      id: true,
+      status: true,
+      version: true,
+      lines: {
+        select: {
+          id: true,
+          allocations: {
+            select: {
+              status: true,
+              allocatedQty: true,
+              pickedUpQty: true,
+              returnedQty: true,
+              releasedQty: true,
+            },
+          },
+        },
+      },
+    },
+  });
+  if (!reservation) invalid("Reservation not found in this league.");
+
+  const allocations = reservation.lines.flatMap((line) => line.allocations);
+  await Promise.all(reservation.lines.map((line) => tx.gearReservationLine.updateMany({
+    where: { id: line.id, leagueId, reservationId },
+    data: { allocatedQty: line.allocations.reduce((total, allocation) => total + activeAllocationQuantity(allocation), 0) },
+  })));
+
+  const hasActiveAllocation = allocations.some((allocation) =>
+    ["PENDING", "ALLOCATED", "PICKED_UP", "PARTIALLY_RETURNED"].includes(allocation.status),
+  );
+  const hasOutstandingCustody = allocations.some((allocation) =>
+    ["PICKED_UP", "PARTIALLY_RETURNED"].includes(allocation.status)
+      && allocation.pickedUpQty > allocation.returnedQty,
+  );
+  if (reservation.status === "FULFILLED" && !hasActiveAllocation && !hasOutstandingCustody) {
+    const closed = await tx.gearReservation.updateMany({
+      where: { id: reservation.id, leagueId, status: "FULFILLED", version: reservation.version },
+      data: { status: "CLOSED", custodyEndedAt: new Date(), version: { increment: 1 } },
+    });
+    if (closed.count !== 1) throw new GearConflictError();
+  }
+}
+
+async function releaseUncollectedAllocation(
+  tx: Tx,
+  allocation: {
+    id: string;
+    leagueId: string;
+    gearUnitId: string | null;
+    allocatedQty: number;
+    pickedUpQty: number;
+    status: "PENDING" | "ALLOCATED" | "PICKED_UP" | "PARTIALLY_RETURNED" | "RETURNED" | "RELEASED";
+    version: number;
+  },
+  actorUserId: string,
+  action: string,
+) {
+  if (!canTransitionAllocation(allocation.status, "RELEASED") || allocation.pickedUpQty > 0) {
+    invalid("Only uncollected allocations can be released.");
+  }
+  const release = await tx.gearAllocation.updateMany({
+    where: {
+      id: allocation.id,
+      leagueId: allocation.leagueId,
+      version: allocation.version,
+      status: allocation.status,
+    },
+    data: {
+      status: "RELEASED",
+      releasedQty: allocation.allocatedQty,
+      releasedAt: new Date(),
+      version: { increment: 1 },
+    },
+  });
+  if (release.count !== 1) throw new GearConflictError();
+  if (allocation.gearUnitId) await releaseTaggedUnitIfFree(tx, allocation.leagueId, allocation.gearUnitId);
+  await recordGearActivity(tx, {
+    leagueId: allocation.leagueId,
+    entityType: "ALLOCATION",
+    entityId: allocation.id,
+    action,
+    actorUserId,
+  });
+}
+
+function returnConditionFor(
+  returnDisposition: "GOOD" | "DAMAGED" | "LOST" | "CONSUMED",
+  requestedCondition: GearCondition | undefined,
+  currentCondition: GearCondition,
+): GearCondition {
+  if (["LOST", "CONSUMED"].includes(returnDisposition) && requestedCondition) {
+    invalid("A lost or consumed item cannot be assigned a return condition.");
+  }
+  if (returnDisposition === "DAMAGED") {
+    if (requestedCondition && requestedCondition !== "DAMAGED") {
+      invalid("Damaged returns must be recorded with a damaged condition.");
+    }
+    return "DAMAGED";
+  }
+  if (requestedCondition === "DAMAGED") {
+    invalid("Use the damaged disposition when an item returns damaged.");
+  }
+  return requestedCondition ?? currentCondition;
+}
+
 export async function createGearReservation(
   input: z.input<typeof createGearReservationSchema>,
 ): Promise<ActionResult<{ id: string }>> {
@@ -222,7 +365,7 @@ export async function createGearReservation(
               .filter((catalogItemId): catalogItemId is string => Boolean(catalogItemId)),
           },
         },
-        select: { id: true },
+        select: { id: true, name: true },
       });
       const itemIds = new Set(items.map((item) => item.id));
       if (validated.lines.some((line) => line.catalogItemId && !itemIds.has(line.catalogItemId))) {
@@ -239,20 +382,28 @@ export async function createGearReservation(
         },
         select: { id: true, catalogItemId: true, nameSnapshot: true },
       });
+      const catalogById = new Map(items.map((item) => [item.id, item]));
       const needLineById = new Map(needLines.map((needLine) => [needLine.id, needLine]));
       if (needLineById.size !== needLineIds.length) {
         invalid("A selected gear need does not belong to this team in this league.");
       }
       const trustedLines = validated.lines.map((line) => {
         const needLine = line.needLineId ? needLineById.get(line.needLineId) : undefined;
-        if (!needLine) return line;
+        if (!needLine) {
+          const catalogItem = line.catalogItemId ? catalogById.get(line.catalogItemId) : undefined;
+          return {
+            ...line,
+            nameSnapshot: catalogItem?.name ?? line.nameSnapshot,
+          };
+        }
         if (line.catalogItemId && line.catalogItemId !== needLine.catalogItemId) {
           invalid("A selected gear need does not match its catalog item.");
         }
+        const catalogItem = needLine.catalogItemId ? catalogById.get(needLine.catalogItemId) : undefined;
         return {
           ...line,
           catalogItemId: needLine.catalogItemId ?? "",
-          nameSnapshot: needLine.nameSnapshot,
+          nameSnapshot: catalogItem?.name ?? needLine.nameSnapshot,
           needLineId: needLine.id,
         };
       });
@@ -287,7 +438,7 @@ export async function createGearReservation(
     revalidatePath(reservationPath(validated.leagueId));
     return { success: true, data: created };
   } catch (error) {
-    return actionError(error);
+    return actionError(error, "create-reservation", input);
   }
 }
 
@@ -306,49 +457,14 @@ export async function cancelGearReservation(input: unknown): Promise<ActionResul
         invalid("Checked-out gear must be returned before this reservation can be canceled.");
       }
       for (const allocation of activeAllocations) {
-        const release = await tx.gearAllocation.updateMany({
-          where: {
-            id: allocation.id,
-            leagueId: validated.leagueId,
-            version: allocation.version,
-            status: { in: ["PENDING", "ALLOCATED"] },
-          },
-          data: {
-            status: "RELEASED",
-            releasedQty: allocation.allocatedQty,
-            releasedAt: new Date(),
-            version: { increment: 1 },
-          },
-        });
-        if (release.count !== 1) throw new GearConflictError();
-        if (allocation.gearUnitId) {
-          await releaseTaggedUnitIfFree(tx, validated.leagueId, allocation.gearUnitId);
-        }
-        await recordGearInventoryMovement(tx, {
-          leagueId: validated.leagueId,
-          type: "RELEASE",
-          direction: "NEUTRAL",
-          allocationId: allocation.id,
-          poolStockId: allocation.poolStockId,
-          gearUnitId: allocation.gearUnitId,
-          quantity: allocation.allocatedQty,
-          recordedById: userId,
-          notes: "Reservation canceled before pickup.",
-        });
-        await recordGearActivity(tx, {
-          leagueId: validated.leagueId,
-          entityType: "ALLOCATION",
-          entityId: allocation.id,
-          action: "released_by_reservation_cancellation",
-          actorUserId: userId,
-        });
+        await releaseUncollectedAllocation(
+          tx,
+          { ...allocation, leagueId: validated.leagueId },
+          userId,
+          "released_by_reservation_cancellation",
+        );
       }
-      for (const line of reservation.lines) {
-        await tx.gearReservationLine.updateMany({
-          where: { id: line.id, leagueId: validated.leagueId },
-          data: { allocatedQty: 0 },
-        });
-      }
+      await reconcileReservationAfterTerminalAllocation(tx, validated.leagueId, reservation.id);
       const update = await tx.gearReservation.updateMany({
         where: { id: reservation.id, leagueId: validated.leagueId, version: reservation.version, status: reservation.status },
         data: { status: "CANCELED", canceledAt: new Date(), version: { increment: 1 } },
@@ -362,7 +478,7 @@ export async function cancelGearReservation(input: unknown): Promise<ActionResul
     revalidatePath(inventoryPath(validated.leagueId));
     return { success: true, data: result };
   } catch (error) {
-    return actionError(error);
+    return actionError(error, "cancel-reservation", input);
   }
 }
 
@@ -392,7 +508,7 @@ export async function rescheduleGearReservation(input: unknown): Promise<ActionR
     revalidatePath(inventoryPath(validated.leagueId));
     return { success: true, data: result };
   } catch (error) {
-    return actionError(error);
+    return actionError(error, "reschedule-reservation", input);
   }
 }
 
@@ -416,7 +532,7 @@ export async function declineGearReservation(input: unknown): Promise<ActionResu
     revalidatePath(reservationPath(validated.leagueId, result.id));
     return { success: true, data: result };
   } catch (error) {
-    return actionError(error);
+    return actionError(error, "decline-reservation", input);
   }
 }
 
@@ -576,7 +692,7 @@ export async function approveAndAllocateGearReservation(input: unknown): Promise
     revalidatePath(reservationPath(validated.leagueId, result.id));
     return { success: true, data: result };
   } catch (error) {
-    return actionError(error);
+    return actionError(error, "approve-and-allocate-reservation", input);
   }
 }
 
@@ -590,15 +706,13 @@ export async function releaseGearAllocation(input: unknown): Promise<ActionResul
         include: { reservationLine: { include: { reservation: true } } },
       });
       if (!allocation) invalid("Allocation not found in this league.");
-      if (!canTransitionAllocation(allocation.status, "RELEASED") || allocation.pickedUpQty > 0) invalid("Only uncollected allocations can be released.");
       if (allocation.version !== validated.expectedVersion) throw new GearConflictError();
-      const update = await tx.gearAllocation.updateMany({
-        where: { id: allocation.id, version: allocation.version, status: allocation.status },
-        data: { status: "RELEASED", releasedQty: allocation.allocatedQty, releasedAt: new Date(), version: { increment: 1 } },
-      });
-      if (update.count !== 1) throw new GearConflictError();
-      if (allocation.gearUnitId) await releaseTaggedUnitIfFree(tx, validated.leagueId, allocation.gearUnitId);
-      await recordGearActivity(tx, { leagueId: validated.leagueId, entityType: "ALLOCATION", entityId: allocation.id, action: "released", actorUserId: userId });
+      await releaseUncollectedAllocation(tx, allocation, userId, "released");
+      await reconcileReservationAfterTerminalAllocation(
+        tx,
+        validated.leagueId,
+        allocation.reservationLine.reservationId,
+      );
       return { id: allocation.id, reservationId: allocation.reservationLine.reservationId };
     }, gearTransactionOptions);
     revalidatePath(reservationPath(validated.leagueId));
@@ -606,7 +720,7 @@ export async function releaseGearAllocation(input: unknown): Promise<ActionResul
     revalidatePath(inventoryPath(validated.leagueId));
     return { success: true, data: { id: result.id } };
   } catch (error) {
-    return actionError(error);
+    return actionError(error, "release-allocation", input);
   }
 }
 
@@ -625,6 +739,12 @@ export async function recordGearPickup(input: unknown): Promise<ActionResult<{ i
         || allocation.pickedUpQty !== 0
         || validated.quantity !== allocation.allocatedQty
       ) invalid("This allocation must be picked up in full.");
+      if (isOutstandingAllocationOverdue({
+        status: "PICKED_UP",
+        effectiveEndDate: allocation.effectiveEndDate,
+      })) {
+        invalid("This allocation is past its due date and cannot be checked out.");
+      }
       if (allocation.version !== validated.expectedVersion) throw new GearConflictError();
       const update = await tx.gearAllocation.updateMany({
         where: { id: allocation.id, version: allocation.version, status: "ALLOCATED" },
@@ -669,7 +789,7 @@ export async function recordGearPickup(input: unknown): Promise<ActionResult<{ i
     revalidatePath(inventoryPath(validated.leagueId));
     return { success: true, data: { id: result.id } };
   } catch (error) {
-    return actionError(error);
+    return actionError(error, "record-pickup", input);
   }
 }
 
@@ -691,6 +811,11 @@ export async function recordGearReturn(input: unknown): Promise<ActionResult<{ i
       if (allocation.version !== validated.expectedVersion) throw new GearConflictError();
       const remaining = allocation.pickedUpQty - allocation.returnedQty;
       if (validated.quantity > remaining) invalid("Return quantity exceeds the amount currently in custody.");
+      const returnCondition = returnConditionFor(
+        validated.returnDisposition,
+        validated.condition,
+        allocation.poolStock?.condition ?? allocation.gearUnit?.currentCondition ?? "GOOD",
+      );
       const returnedQty = allocation.returnedQty + validated.quantity;
       const nextStatus = returnedQty === allocation.pickedUpQty ? "RETURNED" : "PARTIALLY_RETURNED";
       const update = await tx.gearAllocation.updateMany({
@@ -698,15 +823,22 @@ export async function recordGearReturn(input: unknown): Promise<ActionResult<{ i
         data: { status: nextStatus, returnedQty, returnedAt: new Date(), version: { increment: 1 } },
       });
       if (update.count !== 1) throw new GearConflictError();
-      const returnCondition: GearCondition = validated.condition
-        ?? (validated.returnDisposition === "DAMAGED"
-          ? "DAMAGED"
-          : allocation.poolStock?.condition ?? allocation.gearUnit?.currentCondition ?? "GOOD");
       if (allocation.gearUnit) {
+        const hasFutureAllocation = returnedQty === allocation.pickedUpQty
+          && await tx.gearAllocation.count({
+            where: {
+              leagueId: validated.leagueId,
+              gearUnitId: allocation.gearUnit.id,
+              id: { not: allocation.id },
+              status: { in: ["PENDING", "ALLOCATED", "PICKED_UP", "PARTIALLY_RETURNED"] },
+            },
+          }) > 0;
         const unitStatus = validated.returnDisposition === "LOST"
           ? "LOST"
           : validated.returnDisposition === "CONSUMED" ? "RETIRED"
-            : validated.returnDisposition === "DAMAGED" ? "MAINTENANCE" : "AVAILABLE";
+            : returnCondition === "DAMAGED" ? "MAINTENANCE"
+              : returnedQty < allocation.pickedUpQty ? "CHECKED_OUT"
+                : hasFutureAllocation ? "RESERVED" : "AVAILABLE";
         const unitUpdate = await tx.gearUnit.updateMany({
           where: { id: allocation.gearUnit.id, leagueId: validated.leagueId, version: allocation.gearUnit.version, status: "CHECKED_OUT" },
           data: {
@@ -778,18 +910,11 @@ export async function recordGearReturn(input: unknown): Promise<ActionResult<{ i
         action: "returned", actorUserId: userId,
         details: { metadata: { quantity: validated.quantity, disposition: validated.returnDisposition } },
       });
-      const openAllocations = await tx.gearAllocation.count({
-        where: {
-          reservationLine: { reservationId: allocation.reservationLine.reservationId },
-          status: { in: ["PENDING", "ALLOCATED", "PICKED_UP", "PARTIALLY_RETURNED"] },
-        },
-      });
-      if (openAllocations === 0) {
-        await tx.gearReservation.updateMany({
-          where: { id: allocation.reservationLine.reservationId, status: "FULFILLED" },
-          data: { status: "CLOSED", custodyEndedAt: new Date(), version: { increment: 1 } },
-        });
-      }
+      await reconcileReservationAfterTerminalAllocation(
+        tx,
+        validated.leagueId,
+        allocation.reservationLine.reservationId,
+      );
       return { id: allocation.id, reservationId: allocation.reservationLine.reservationId };
     }, gearTransactionOptions);
     revalidatePath(reservationPath(validated.leagueId));
@@ -797,6 +922,6 @@ export async function recordGearReturn(input: unknown): Promise<ActionResult<{ i
     revalidatePath(inventoryPath(validated.leagueId));
     return { success: true, data: { id: result.id } };
   } catch (error) {
-    return actionError(error);
+    return actionError(error, "record-return", input);
   }
 }

--- a/lib/services/gear-ledger.ts
+++ b/lib/services/gear-ledger.ts
@@ -29,6 +29,8 @@ export type GearMovementInput = {
   recordedById: string;
   poolStockId?: string | null;
   gearUnitId?: string | null;
+  allocationId?: string | null;
+  handoffId?: string | null;
   beforeLocationId?: string | null;
   afterLocationId?: string | null;
   beforeCondition?: "NEW" | "EXCELLENT" | "GOOD" | "FAIR" | "POOR" | "DAMAGED" | null;

--- a/lib/services/gear-transaction.ts
+++ b/lib/services/gear-transaction.ts
@@ -2,6 +2,13 @@ import { Prisma } from "@prisma/client";
 import { isRetryablePrismaConflict } from "@/lib/utils/gear";
 
 const MAX_ATTEMPTS = 3;
+const RETRY_BASE_DELAY_MS = 25;
+const RETRY_MAX_DELAY_MS = 250;
+
+export type GearRetryDependencies = {
+  sleep?: (delayMs: number) => Promise<void>;
+  random?: () => number;
+};
 
 export class GearConflictError extends Error {
   constructor(
@@ -15,7 +22,10 @@ export class GearConflictError extends Error {
 
 export async function withGearSerializableRetry<T>(
   run: () => Promise<T>,
+  dependencies: GearRetryDependencies = {},
 ): Promise<T> {
+  const sleep = dependencies.sleep ?? ((delayMs: number) => new Promise<void>((resolve) => setTimeout(resolve, delayMs)));
+  const random = dependencies.random ?? Math.random;
   for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt += 1) {
     try {
       return await run();
@@ -26,6 +36,9 @@ export async function withGearSerializableRetry<T>(
         }
         throw error;
       }
+      const exponentialDelay = Math.min(RETRY_MAX_DELAY_MS, RETRY_BASE_DELAY_MS * (2 ** (attempt - 1)));
+      const jitter = Math.floor(Math.max(0, Math.min(1, random())) * RETRY_BASE_DELAY_MS);
+      await sleep(Math.min(RETRY_MAX_DELAY_MS, exponentialDelay + jitter));
     }
   }
 

--- a/lib/utils/gear.ts
+++ b/lib/utils/gear.ts
@@ -67,6 +67,50 @@ export function activeAllocationTotal(allocations: GearAllocationQuantities[]): 
   return allocations.reduce((total, allocation) => total + activeAllocationQuantity(allocation), 0);
 }
 
+type CapacityAllocation = GearAllocationQuantities & {
+  status: GearAllocationStatus;
+  effectiveStartDate?: Date | string | null;
+  effectiveEndDate?: Date | string | null;
+};
+
+function dateOnly(value: Date | string): string {
+  return typeof value === "string" ? value.slice(0, 10) : value.toISOString().slice(0, 10);
+}
+
+/**
+ * Checked-out gear continues to consume capacity until it is reconciled, even
+ * after its planned reservation window. Planned allocations only block overlap.
+ */
+export function allocationConsumesCapacityForWindow(
+  allocation: CapacityAllocation,
+  window: GearReservationWindow,
+): boolean {
+  if (activeAllocationQuantity(allocation) === 0) return false;
+  if (["PICKED_UP", "PARTIALLY_RETURNED"].includes(allocation.status)) return true;
+  if (!["PENDING", "ALLOCATED"].includes(allocation.status)) return false;
+  if (!allocation.effectiveStartDate || !allocation.effectiveEndDate) return false;
+  return datesOverlap(
+    {
+      startDate: dateOnly(allocation.effectiveStartDate),
+      endDate: dateOnly(allocation.effectiveEndDate),
+    },
+    window,
+  );
+}
+
+/** Date-only due dates become overdue only after the final effective date. */
+export function isOutstandingAllocationOverdue(
+  allocation: Pick<CapacityAllocation, "status" | "effectiveEndDate">,
+  today = new Date(),
+): boolean {
+  return (
+    ["PICKED_UP", "PARTIALLY_RETURNED"].includes(allocation.status) &&
+    allocation.effectiveEndDate !== null &&
+    allocation.effectiveEndDate !== undefined &&
+    dateOnly(allocation.effectiveEndDate) < dateOnly(today)
+  );
+}
+
 export function canAllocatePoolStock(stock: GearPoolAvailability, quantity: number): boolean {
   return Number.isSafeInteger(quantity) && quantity > 0 && quantity <= availablePoolQuantity(stock);
 }

--- a/lib/utils/gear.ts
+++ b/lib/utils/gear.ts
@@ -55,6 +55,18 @@ export function availablePoolQuantity(stock: GearPoolAvailability): number {
   return Math.max(0, stock.quantityOnHand - stock.allocatedQuantity);
 }
 
+/**
+ * Allocations continue to exist after a partial return, but only the portion
+ * still outside stock should reserve capacity.
+ */
+export function activeAllocationQuantity(allocation: GearAllocationQuantities): number {
+  return Math.max(0, allocation.allocatedQty - allocation.releasedQty - allocation.returnedQty);
+}
+
+export function activeAllocationTotal(allocations: GearAllocationQuantities[]): number {
+  return allocations.reduce((total, allocation) => total + activeAllocationQuantity(allocation), 0);
+}
+
 export function canAllocatePoolStock(stock: GearPoolAvailability, quantity: number): boolean {
   return Number.isSafeInteger(quantity) && quantity > 0 && quantity <= availablePoolQuantity(stock);
 }
@@ -182,6 +194,45 @@ export function canTransitionUnit(from: GearUnitStatus, to: GearUnitStatus): boo
 
 export function requiresTaggedUnit(mode: GearTrackingMode): boolean {
   return mode === "INDIVIDUAL";
+}
+
+export type GearAvailabilityConflict = {
+  code: "INSUFFICIENT_POOL_STOCK" | "TAGGED_UNIT_UNAVAILABLE" | "OVERDUE_CUSTODY";
+  message: string;
+  entityId?: string;
+};
+
+export function poolAvailabilityConflict(
+  stock: GearPoolAvailability,
+  requestedQuantity: number,
+  entityId?: string,
+): GearAvailabilityConflict | null {
+  if (canAllocatePoolStock(stock, requestedQuantity)) return null;
+  return {
+    code: "INSUFFICIENT_POOL_STOCK",
+    entityId,
+    message: `Only ${availablePoolQuantity(stock)} matching item${availablePoolQuantity(stock) === 1 ? "" : "s"} are available.`,
+  };
+}
+
+export function taggedUnitAvailabilityConflict(
+  status: GearUnitStatus,
+  hasOverdueCheckout: boolean,
+  entityId?: string,
+): GearAvailabilityConflict | null {
+  if (hasOverdueCheckout) {
+    return {
+      code: "OVERDUE_CUSTODY",
+      entityId,
+      message: "This tagged item is still checked out past its due date.",
+    };
+  }
+  if (status === "AVAILABLE" || status === "RESERVED") return null;
+  return {
+    code: "TAGGED_UNIT_UNAVAILABLE",
+    entityId,
+    message: "This tagged item is unavailable for the requested dates.",
+  };
 }
 
 export function isRetryablePrismaConflict(error: unknown): boolean {


### PR DESCRIPTION
## Summary
- add tenant-scoped gear reservation, allocation, pickup, partial-return, and custody lifecycle Server Actions with serializable availability checks
- add immutable handoff, movement, and activity records plus condition/loss projections
- add role-aware reservation list/detail routes and inventory navigation

## Validation
- `bun run test __tests__/lib/utils/gear.test.ts __tests__/lib/actions/gear-context.test.ts`
- `bun run type-check`
- changed-file ESLint
- `bun run check:raw-sql`
- `bun run adr:check lib/actions/gear-reservations.ts lib/actions/gear-context.ts lib/actions/gear-inventory.ts lib/utils/gear.ts`