### PR TITLE
feat(gear): add needs, wishlist, and pledge workflows

### DIFF
--- a/__tests__/components/features/gear/GearNeedsList.test.tsx
+++ b/__tests__/components/features/gear/GearNeedsList.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { GearNeedsList } from "@/components/features/gear/GearNeedsList";
+
+describe("GearNeedsList", () => {
+  it("distinguishes need progress from an inventory reservation", () => {
+    render(
+      <GearNeedsList
+        leagueId="league-1"
+        needs={[{
+          id: "need-1",
+          title: "Goalie starter set",
+          teamName: "U12 Comets",
+          status: "SUBMITTED",
+          submittedAt: "2026-08-16T00:00:00.000Z",
+          createdAt: "2026-08-16T00:00:00.000Z",
+          requestedQuantity: 4,
+          fulfilledQuantity: 1,
+          priority: "HIGH",
+        }]}
+      />,
+    );
+
+    expect(screen.getAllByText("Goalie starter set")).toHaveLength(2);
+    expect(screen.getByText("1 of 4 fulfilled")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "View need" })).toHaveAttribute(
+      "href",
+      "/league/league-1/gear/needs/need-1",
+    );
+  });
+});

--- a/__tests__/components/features/gear/GearPledgeForm.test.tsx
+++ b/__tests__/components/features/gear/GearPledgeForm.test.tsx
@@ -3,6 +3,18 @@ import { describe, expect, it, vi } from "vitest";
 import { GearPledgeForm } from "@/components/features/gear/GearPledgeForm";
 
 describe("GearPledgeForm", () => {
+  it("explains that an email address or phone number is required", () => {
+    render(
+      <GearPledgeForm
+        token="a-valid-share-token"
+        items={[{ id: "item-1", name: "Helmet", targetQty: 2, pledgedQty: 0, receivedQty: 0 }]}
+        submit={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Include at least one contact method: email or phone.")).toBeInTheDocument();
+  });
+
   it("rotates its idempotency key after a successful pledge", async () => {
     const submit = vi.fn().mockResolvedValue({ success: true });
     const { container } = render(

--- a/__tests__/components/features/gear/GearPledgeForm.test.tsx
+++ b/__tests__/components/features/gear/GearPledgeForm.test.tsx
@@ -1,0 +1,34 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { GearPledgeForm } from "@/components/features/gear/GearPledgeForm";
+
+describe("GearPledgeForm", () => {
+  it("rotates its idempotency key after a successful pledge", async () => {
+    const submit = vi.fn().mockResolvedValue({ success: true });
+    const { container } = render(
+      <GearPledgeForm
+        token="a-valid-share-token"
+        items={[{ id: "item-1", name: "Helmet", targetQty: 2, pledgedQty: 0, receivedQty: 0 }]}
+        submit={submit}
+      />,
+    );
+    const form = container.querySelector("form");
+    if (!form) throw new Error("Expected pledge form");
+
+    const submitPledge = async () => {
+      fireEvent.change(screen.getByRole("spinbutton"), { target: { value: "1" } });
+      fireEvent.change(screen.getByRole("textbox", { name: /your name/i }), { target: { value: "Donor" } });
+      fireEvent.click(screen.getByLabelText(/I agree/));
+      fireEvent.submit(form);
+      await waitFor(() => expect(submit).toHaveBeenCalled());
+    };
+
+    await submitPledge();
+    const firstKey = submit.mock.calls[0][0].idempotencyKey;
+    await waitFor(() => expect(screen.getByText(/Thank you/)).toBeInTheDocument());
+
+    await submitPledge();
+    const secondKey = submit.mock.calls[1][0].idempotencyKey;
+    expect(secondKey).not.toBe(firstKey);
+  });
+});

--- a/__tests__/components/features/gear/GearWorkflowAdminActions.test.tsx
+++ b/__tests__/components/features/gear/GearWorkflowAdminActions.test.tsx
@@ -1,0 +1,85 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { GearNeedActions } from "@/components/features/gear/GearNeedActions";
+import { GearNeedCreateForm } from "@/components/features/gear/GearNeedCreateForm";
+import { GearPledgeAdminActions } from "@/components/features/gear/GearPledgeAdminActions";
+import { GearWishlistEditor } from "@/components/features/gear/GearWishlistEditor";
+
+const mocks = vi.hoisted(() => ({
+  refresh: vi.fn(),
+  cancelNeed: vi.fn().mockResolvedValue({ success: true }),
+  declinePledge: vi.fn().mockResolvedValue({ success: true }),
+}));
+
+vi.mock("next/navigation", () => ({ useRouter: () => ({ refresh: mocks.refresh }) }));
+vi.mock("@/lib/actions/gear-needs", () => ({
+  cancelTeamGearNeed: mocks.cancelNeed,
+  submitTeamGearNeed: vi.fn(),
+  approveTeamGearNeed: vi.fn(),
+  fulfillTeamGearNeed: vi.fn(),
+  createTeamGearNeed: vi.fn(),
+}));
+vi.mock("@/lib/actions/gear-pledges", () => ({
+  declineGearPledge: mocks.declinePledge,
+  receiveGearPledge: vi.fn(),
+}));
+vi.mock("@/lib/actions/gear-wishlist", () => ({ saveGearWishlist: vi.fn() }));
+
+describe("gear workflow admin UI", () => {
+  it("uses named team options rather than opaque IDs", () => {
+    render(<GearNeedCreateForm leagueId="league-1" teams={[{ id: "team-cuid", name: "U12 Comets" }]} />);
+
+    expect(screen.getByText("U12 Comets")).toBeInTheDocument();
+    expect(screen.queryByText("team-cuid")).not.toBeInTheDocument();
+  });
+
+  it("renders only granted need operations and refreshes after a transition", async () => {
+    mocks.refresh.mockClear();
+    render(
+      <GearNeedActions
+        leagueId="league-1"
+        needId="need-1"
+        expectedVersion={3}
+        status="SUBMITTED"
+        capabilities={{ canSubmit: false, canCancel: true, canApprove: false, canFulfill: false }}
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: "Approve need" })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Cancel need" }));
+
+    await waitFor(() => expect(mocks.cancelNeed).toHaveBeenCalledWith({
+      leagueId: "league-1", needId: "need-1", expectedVersion: 3,
+    }));
+    expect(mocks.refresh).toHaveBeenCalled();
+  });
+
+  it("wires private pledge decline with the version guard", async () => {
+    mocks.refresh.mockClear();
+    mocks.declinePledge.mockClear();
+    render(
+      <GearPledgeAdminActions
+        leagueId="league-1"
+        pledgeId="pledge-1"
+        pledgeVersion={4}
+        status="PLEDGED"
+        catalogItems={[]}
+        locations={[]}
+        poolStock={[]}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Decline pledge" }));
+    await waitFor(() => expect(mocks.declinePledge).toHaveBeenCalledWith({
+      leagueId: "league-1", pledgeId: "pledge-1", expectedVersion: 4,
+    }));
+    expect(mocks.refresh).toHaveBeenCalled();
+  });
+
+  it("provides a first-campaign editor when no wishlist exists", () => {
+    render(<GearWishlistEditor leagueId="league-1" catalogItems={[]} />);
+
+    expect(screen.getByRole("button", { name: "Save draft" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Save and publish" })).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/features/gear/GearWorkflowAdminActions.test.tsx
+++ b/__tests__/components/features/gear/GearWorkflowAdminActions.test.tsx
@@ -9,6 +9,8 @@ const mocks = vi.hoisted(() => ({
   refresh: vi.fn(),
   cancelNeed: vi.fn().mockResolvedValue({ success: true }),
   declinePledge: vi.fn().mockResolvedValue({ success: true }),
+  expirePledge: vi.fn().mockResolvedValue({ success: true }),
+  correctReceipt: vi.fn().mockResolvedValue({ success: true }),
 }));
 
 vi.mock("next/navigation", () => ({ useRouter: () => ({ refresh: mocks.refresh }) }));
@@ -21,6 +23,8 @@ vi.mock("@/lib/actions/gear-needs", () => ({
 }));
 vi.mock("@/lib/actions/gear-pledges", () => ({
   declineGearPledge: mocks.declinePledge,
+  expireGearPledge: mocks.expirePledge,
+  correctGearPledgeReceipt: mocks.correctReceipt,
   receiveGearPledge: vi.fn(),
 }));
 vi.mock("@/lib/actions/gear-wishlist", () => ({ saveGearWishlist: vi.fn() }));
@@ -64,8 +68,11 @@ describe("gear workflow admin UI", () => {
         pledgeVersion={4}
         status="PLEDGED"
         catalogItems={[]}
+        pooledCatalogItems={[]}
         locations={[]}
         poolStock={[]}
+        remainingQuantity={1}
+        receipts={[]}
       />,
     );
 

--- a/__tests__/components/features/gear/PublicGearWishlist.test.tsx
+++ b/__tests__/components/features/gear/PublicGearWishlist.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { PublicGearWishlist } from "@/components/features/gear/PublicGearWishlist";
+
+describe("PublicGearWishlist", () => {
+  it("renders only curated public item snapshots", () => {
+    render(
+      <PublicGearWishlist
+        data={{
+          associationName: "North Stars",
+          title: "Gear wish list",
+          description: "Help our skaters.",
+          items: [{
+            id: "item-1",
+            name: "Youth helmet",
+            category: "Protection",
+            size: "Medium",
+            description: "CSA approved",
+            targetQty: 10,
+            pledgedQty: 4,
+            receivedQty: 2,
+          }],
+        }}
+      />,
+    );
+
+    expect(screen.getByText("North Stars")).toBeInTheDocument();
+    expect(screen.getByText("Youth helmet")).toBeInTheDocument();
+    expect(screen.getByText(/Target: 10/)).toBeInTheDocument();
+    expect(screen.queryByText(/team/i)).not.toBeInTheDocument();
+  });
+});

--- a/__tests__/lib/actions/gear-layer-four.test.ts
+++ b/__tests__/lib/actions/gear-layer-four.test.ts
@@ -21,6 +21,7 @@ const {
     gearWishlistItem: { update: vi.fn(), updateMany: vi.fn(), create: vi.fn() },
     gearPledge: { findFirst: vi.fn(), findUnique: vi.fn(), create: vi.fn(), updateMany: vi.fn() },
     gearPledgeReceipt: { aggregate: vi.fn(), create: vi.fn() },
+    gearPledgeReceiptCommand: { findUnique: vi.fn(), create: vi.fn() },
     gearPoolStock: { findFirst: vi.fn(), update: vi.fn() },
     gearStorageLocation: { findFirst: vi.fn() },
     gearUnit: { findMany: vi.fn(), create: vi.fn() },
@@ -44,6 +45,7 @@ const {
       teamGearNeed: { findFirst: vi.fn(), findMany: vi.fn() },
       gearWishlist: { findFirst: vi.fn() },
       gearPledge: { findFirst: vi.fn() },
+      gearPledgeReceiptCommand: { findUnique: vi.fn() },
     },
   };
 });
@@ -65,16 +67,19 @@ vi.mock("@/lib/utils/durable-rate-limit", () => ({
 import {
   createTeamGearNeed,
   getGearNeedDetail,
+  getGearNeedsContext,
   submitTeamGearNeed,
 } from "@/lib/actions/gear-needs";
 import {
   getPublicGearWishlist,
   rotateGearWishlistShareToken,
+  saveGearWishlist,
 } from "@/lib/actions/gear-wishlist";
 import {
   createPublicGearPledge,
   receiveGearPledge,
 } from "@/lib/actions/gear-pledges";
+import { queueGearOutboxForRecipients } from "@/lib/services/gear-outbox";
 
 const LEAGUE_ID = "cllllllllllllllllllllllll";
 const TEAM_ID = "cttttttttttttttttttttttt";
@@ -94,6 +99,7 @@ beforeEach(() => {
   mockGetUserLeagueRole.mockResolvedValue("TEAM_ADMIN");
   mockIsTeamAdmin.mockResolvedValue(true);
   mockPrisma.team.findFirst.mockResolvedValue({ id: TEAM_ID });
+  mockPrisma.teamMember.findMany.mockResolvedValue([]);
   mockCheckRateLimit.mockResolvedValue({ allowed: true });
   mockGetClientIp.mockResolvedValue("203.0.113.42");
   tx.gearActivity.create.mockResolvedValue({});
@@ -102,6 +108,8 @@ beforeEach(() => {
   tx.teamMember.findMany.mockResolvedValue([{ userId: USER_ID }]);
   tx.gearWishlistItem.update.mockResolvedValue({});
   tx.gearPledge.updateMany.mockResolvedValue({ count: 1 });
+  tx.gearPledgeReceiptCommand.findUnique.mockResolvedValue(null);
+  tx.gearPledgeReceiptCommand.create.mockResolvedValue({ id: "creceipt-command000000001" });
 });
 
 describe("Layer 4 gear actions", () => {
@@ -161,6 +169,40 @@ describe("Layer 4 gear actions", () => {
     }));
   });
 
+  it("derives need operation capabilities from current team and league roles", async () => {
+    mockPrisma.teamMember.findMany.mockResolvedValue([{ team: { id: TEAM_ID, name: "Scoped Team" } }]);
+    mockPrisma.teamGearNeed.findMany.mockResolvedValue([
+      {
+        id: NEED_ID, teamId: TEAM_ID, title: "Need", notes: null, status: "DRAFT", version: 0,
+        submittedAt: null, approvedAt: null, fulfilledAt: null, canceledAt: null, createdAt: new Date("2026-01-01"),
+        team: { name: "Scoped Team" }, lines: [],
+      },
+    ]);
+
+    const teamContext = await getGearNeedsContext(LEAGUE_ID);
+    expect(teamContext?.needs[0]).toMatchObject({
+      canSubmit: true, canCancel: true, canApprove: false, canFulfill: false,
+      capabilities: { canSubmit: true, canCancel: true, canApprove: false, canFulfill: false },
+    });
+
+    mockGetUserLeagueRole.mockResolvedValue("LEAGUE_ADMIN");
+    mockPrisma.team.findMany.mockResolvedValue([{ id: TEAM_ID, name: "Scoped Team" }]);
+    mockPrisma.teamMember.findMany.mockResolvedValue([]);
+    mockPrisma.teamGearNeed.findMany.mockResolvedValue([
+      {
+        id: NEED_ID, teamId: TEAM_ID, title: "Need", notes: null, status: "SUBMITTED", version: 1,
+        submittedAt: new Date("2026-01-02"), approvedAt: null, fulfilledAt: null, canceledAt: null,
+        createdAt: new Date("2026-01-01"), team: { name: "Scoped Team" }, lines: [],
+      },
+    ]);
+
+    const leagueContext = await getGearNeedsContext(LEAGUE_ID);
+    expect(leagueContext?.needs[0]).toMatchObject({
+      canSubmit: false, canCancel: false, canApprove: true, canFulfill: false,
+      capabilities: { canSubmit: false, canCancel: false, canApprove: true, canFulfill: false },
+    });
+  });
+
   it("submits only from draft and atomically queues the league-admin notification", async () => {
     tx.teamGearNeed.findFirst.mockResolvedValue({
       id: NEED_ID, leagueId: LEAGUE_ID, teamId: TEAM_ID, status: "DRAFT", version: 2,
@@ -184,7 +226,7 @@ describe("Layer 4 gear actions", () => {
         eventType: "gear.need.submitted",
         aggregateType: "NEED",
         aggregateId: NEED_ID,
-        dedupeKey: `gear.need.submitted:${NEED_ID}:${USER_ID}`,
+        dedupeKey: `gear.need.submitted:${NEED_ID}:v3:${USER_ID}`,
       })],
     }));
   });
@@ -235,6 +277,64 @@ describe("Layer 4 gear actions", () => {
     expect(tx.leagueUser.findMany).toHaveBeenCalled();
   });
 
+  it("recycles an archived projection into a fresh campaign with a rotated token and reset items", async () => {
+    tx.gearWishlist.findUnique.mockResolvedValue({
+      id: WISHLIST_ID,
+      shareToken: "old-token",
+      status: "ARCHIVED",
+      version: 7,
+      items: [{ id: "colditem00000000000000000", normalizedKey: "old", targetQty: 1, pledgedQty: 1, receivedQty: 1, isActive: false }],
+    });
+    tx.gearCatalogItem.findMany.mockResolvedValue([]);
+    tx.gearWishlist.updateMany.mockResolvedValue({ count: 1 });
+    tx.gearWishlistItem.updateMany.mockResolvedValue({ count: 1 });
+    tx.gearWishlistItem.create.mockResolvedValue({ id: WISHLIST_ITEM_ID });
+
+    const result = await saveGearWishlist({
+      leagueId: LEAGUE_ID,
+      expectedVersion: 7,
+      title: "Autumn drive",
+      description: "New campaign",
+      publish: true,
+      items: [{ nameSnapshot: "New helmet", targetQty: 5 }],
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.success && result.data.shareToken).not.toBe("old-token");
+    expect(tx.gearWishlist.updateMany).toHaveBeenCalledWith(expect.objectContaining({
+      where: { id: WISHLIST_ID, version: 7, status: "ARCHIVED" },
+      data: expect.objectContaining({ status: "PUBLISHED", archivedAt: null }),
+    }));
+    expect(tx.gearWishlistItem.updateMany).toHaveBeenCalledWith(expect.objectContaining({
+      data: { isActive: false },
+    }));
+    expect(tx.gearWishlistItem.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({ leagueId: LEAGUE_ID, wishlistId: WISHLIST_ID, nameSnapshot: "New helmet" }),
+    }));
+  });
+
+  it("keeps distinct outbox occurrences while deduplicating recipients within each occurrence", async () => {
+    const outboxTx = {
+      notificationOutbox: { createMany: vi.fn().mockResolvedValue({ count: 1 }) },
+    };
+    const event = {
+      leagueId: LEAGUE_ID,
+      eventType: "gear.wishlist.published",
+      aggregateType: "WISHLIST" as const,
+      aggregateId: WISHLIST_ID,
+      payload: { wishlistId: WISHLIST_ID },
+    };
+    await queueGearOutboxForRecipients(outboxTx as never, { ...event, occurrenceKey: "v1" }, [USER_ID, USER_ID]);
+    await queueGearOutboxForRecipients(outboxTx as never, { ...event, occurrenceKey: "v2" }, [USER_ID]);
+
+    expect(outboxTx.notificationOutbox.createMany).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      data: [expect.objectContaining({ dedupeKey: `gear.wishlist.published:${WISHLIST_ID}:v1:${USER_ID}` })],
+    }));
+    expect(outboxTx.notificationOutbox.createMany).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      data: [expect.objectContaining({ dedupeKey: `gear.wishlist.published:${WISHLIST_ID}:v2:${USER_ID}` })],
+    }));
+  });
+
   it("handles honeypot, idempotency, and rate limits without creating a pledge", async () => {
     const common = {
       wishlistToken: "t".repeat(32), wishlistItemId: WISHLIST_ITEM_ID, donorName: "Donor",
@@ -263,7 +363,7 @@ describe("Layer 4 gear actions", () => {
 
   it("records pooled pledge receipt stock, ledger activity, and outbox atomically", async () => {
     tx.gearPledge.findFirst.mockResolvedValue({
-      id: PLEDGE_ID, quantity: 2, wishlistItem: { id: WISHLIST_ITEM_ID, catalogItemId: CATALOG_ID },
+      id: PLEDGE_ID, version: 0, quantity: 2, wishlistItem: { id: WISHLIST_ITEM_ID, catalogItemId: CATALOG_ID },
     });
     tx.gearPledgeReceipt.aggregate.mockResolvedValue({ _sum: { quantity: 0 } });
     tx.gearPoolStock.findFirst.mockResolvedValue({
@@ -273,6 +373,7 @@ describe("Layer 4 gear actions", () => {
 
     const result = await receiveGearPledge({
       leagueId: LEAGUE_ID, pledgeId: PLEDGE_ID, poolStockId: STOCK_ID, quantity: 2,
+      expectedVersion: 0, idempotencyKey: "r".repeat(16),
     });
     expect(result.success).toBe(true);
     expect(tx.gearPoolStock.update).toHaveBeenCalledWith(expect.objectContaining({
@@ -290,9 +391,34 @@ describe("Layer 4 gear actions", () => {
     }));
   });
 
+  it("returns a saved receipt command on retry without touching inventory again", async () => {
+    tx.gearPledgeReceiptCommand.findUnique.mockResolvedValue({
+      resultingStatus: "RECEIVED",
+      resultingVersion: 3,
+      receipts: [{ id: "creceipt00000000000000001" }],
+    });
+
+    const result = await receiveGearPledge({
+      leagueId: LEAGUE_ID, pledgeId: PLEDGE_ID, poolStockId: STOCK_ID, quantity: 2,
+      expectedVersion: 2, idempotencyKey: "z".repeat(16),
+    });
+
+    expect(result).toEqual({
+      success: true,
+      data: {
+        receiptId: "creceipt00000000000000001",
+        receiptIds: ["creceipt00000000000000001"],
+        pledgeStatus: "RECEIVED",
+        pledgeVersion: 3,
+      },
+    });
+    expect(tx.gearPoolStock.update).not.toHaveBeenCalled();
+    expect(tx.gearPledgeReceipt.create).not.toHaveBeenCalled();
+  });
+
   it("creates a tagged unit, receipt, movement, and activity for every unique asset tag", async () => {
     tx.gearPledge.findFirst.mockResolvedValue({
-      id: PLEDGE_ID, quantity: 2, wishlistItem: { id: WISHLIST_ITEM_ID, catalogItemId: CATALOG_ID },
+      id: PLEDGE_ID, version: 0, quantity: 2, wishlistItem: { id: WISHLIST_ITEM_ID, catalogItemId: CATALOG_ID },
     });
     tx.gearPledgeReceipt.aggregate.mockResolvedValue({ _sum: { quantity: 0 } });
     tx.gearCatalogItem.findFirst.mockResolvedValue({ id: CATALOG_ID });
@@ -308,6 +434,7 @@ describe("Layer 4 gear actions", () => {
     const result = await receiveGearPledge({
       leagueId: LEAGUE_ID, pledgeId: PLEDGE_ID, catalogItemId: CATALOG_ID,
       assetTags: [" tag 1 ", "tag 2"], locationId: LOCATION_ID, condition: "GOOD", quantity: 2,
+      expectedVersion: 0, idempotencyKey: "r".repeat(16),
     });
     expect(result.success).toBe(true);
     expect(tx.gearUnit.create).toHaveBeenCalledTimes(2);
@@ -322,6 +449,7 @@ describe("Layer 4 gear actions", () => {
     const duplicate = await receiveGearPledge({
       leagueId: LEAGUE_ID, pledgeId: PLEDGE_ID, catalogItemId: CATALOG_ID,
       assetTags: ["tag 1", "TAG1"], locationId: LOCATION_ID, condition: "GOOD", quantity: 2,
+      expectedVersion: 0, idempotencyKey: "s".repeat(16),
     });
     expect(duplicate).toEqual({ success: false, error: "Each received asset tag must be unique." });
   });

--- a/__tests__/lib/actions/gear-layer-four.test.ts
+++ b/__tests__/lib/actions/gear-layer-four.test.ts
@@ -27,6 +27,7 @@ const {
     gearUnit: { findMany: vi.fn(), create: vi.fn() },
     gearInventoryMovement: { create: vi.fn() },
     notificationOutbox: { createMany: vi.fn() },
+    user: { findMany: vi.fn() },
     leagueUser: { findMany: vi.fn() },
     teamMember: { findMany: vi.fn() },
   };
@@ -106,6 +107,7 @@ beforeEach(() => {
   tx.gearInventoryMovement.create.mockResolvedValue({});
   tx.leagueUser.findMany.mockResolvedValue([{ userId: USER_ID }]);
   tx.teamMember.findMany.mockResolvedValue([{ userId: USER_ID }]);
+  tx.user.findMany.mockResolvedValue([{ id: USER_ID, email: "admin@example.com" }]);
   tx.gearWishlistItem.update.mockResolvedValue({});
   tx.gearPledge.updateMany.mockResolvedValue({ count: 1 });
   tx.gearPledgeReceiptCommand.findUnique.mockResolvedValue(null);
@@ -316,13 +318,14 @@ describe("Layer 4 gear actions", () => {
   it("keeps distinct outbox occurrences while deduplicating recipients within each occurrence", async () => {
     const outboxTx = {
       notificationOutbox: { createMany: vi.fn().mockResolvedValue({ count: 1 }) },
+      user: { findMany: vi.fn().mockResolvedValue([{ id: USER_ID, email: "admin@example.com" }]) },
     };
     const event = {
       leagueId: LEAGUE_ID,
       eventType: "gear.wishlist.published",
       aggregateType: "WISHLIST" as const,
       aggregateId: WISHLIST_ID,
-      payload: { wishlistId: WISHLIST_ID },
+      payload: { kind: "GEAR_WISHLIST" as const, data: { wishlistId: WISHLIST_ID } },
     };
     await queueGearOutboxForRecipients(outboxTx as never, { ...event, occurrenceKey: "v1" }, [USER_ID, USER_ID]);
     await queueGearOutboxForRecipients(outboxTx as never, { ...event, occurrenceKey: "v2" }, [USER_ID]);

--- a/__tests__/lib/actions/gear-layer-four.test.ts
+++ b/__tests__/lib/actions/gear-layer-four.test.ts
@@ -1,0 +1,328 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+
+const {
+  mockRequireUserId,
+  mockRequireLeagueRole,
+  mockGetUserLeagueRole,
+  mockIsTeamAdmin,
+  mockCheckRateLimit,
+  mockGetClientIp,
+  mockPrisma,
+  tx,
+} = vi.hoisted(() => {
+  const tx = {
+    teamGearNeed: { create: vi.fn(), findFirst: vi.fn(), updateMany: vi.fn() },
+    teamGearNeedLine: { update: vi.fn(), updateMany: vi.fn() },
+    gearCatalogItem: { findMany: vi.fn(), findFirst: vi.fn() },
+    gearActivity: { create: vi.fn() },
+    gearWishlist: { findUnique: vi.fn(), create: vi.fn(), updateMany: vi.fn() },
+    gearWishlistItem: { update: vi.fn(), updateMany: vi.fn(), create: vi.fn() },
+    gearPledge: { findFirst: vi.fn(), findUnique: vi.fn(), create: vi.fn(), updateMany: vi.fn() },
+    gearPledgeReceipt: { aggregate: vi.fn(), create: vi.fn() },
+    gearPoolStock: { findFirst: vi.fn(), update: vi.fn() },
+    gearStorageLocation: { findFirst: vi.fn() },
+    gearUnit: { findMany: vi.fn(), create: vi.fn() },
+    gearInventoryMovement: { create: vi.fn() },
+    notificationOutbox: { createMany: vi.fn() },
+    leagueUser: { findMany: vi.fn() },
+    teamMember: { findMany: vi.fn() },
+  };
+  return {
+    tx,
+    mockRequireUserId: vi.fn(),
+    mockRequireLeagueRole: vi.fn(),
+    mockGetUserLeagueRole: vi.fn(),
+    mockIsTeamAdmin: vi.fn(),
+    mockCheckRateLimit: vi.fn(),
+    mockGetClientIp: vi.fn(),
+    mockPrisma: {
+      $transaction: vi.fn((callback: (client: typeof tx) => unknown) => callback(tx)),
+      team: { findFirst: vi.fn(), findMany: vi.fn() },
+      teamMember: { findMany: vi.fn() },
+      teamGearNeed: { findFirst: vi.fn(), findMany: vi.fn() },
+      gearWishlist: { findFirst: vi.fn() },
+      gearPledge: { findFirst: vi.fn() },
+    },
+  };
+});
+
+vi.mock("@/lib/auth/session", () => ({
+  requireUserId: (...args: unknown[]) => mockRequireUserId(...args),
+  requireLeagueRole: (...args: unknown[]) => mockRequireLeagueRole(...args),
+  getUserLeagueRole: (...args: unknown[]) => mockGetUserLeagueRole(...args),
+  isTeamAdmin: (...args: unknown[]) => mockIsTeamAdmin(...args),
+}));
+vi.mock("@/lib/db/prisma", () => ({ prisma: mockPrisma }));
+vi.mock("@/lib/utils/durable-rate-limit", () => ({
+  RATE_LIMITS: { GEAR_PLEDGE_PER_IP: { limit: 10, windowSec: 3600 } },
+  checkRateLimit: (...args: unknown[]) => mockCheckRateLimit(...args),
+  getClientIp: (...args: unknown[]) => mockGetClientIp(...args),
+  rateLimitMessage: () => "Too many requests — try again in 1 minute.",
+}));
+
+import {
+  createTeamGearNeed,
+  getGearNeedDetail,
+  submitTeamGearNeed,
+} from "@/lib/actions/gear-needs";
+import {
+  getPublicGearWishlist,
+  rotateGearWishlistShareToken,
+} from "@/lib/actions/gear-wishlist";
+import {
+  createPublicGearPledge,
+  receiveGearPledge,
+} from "@/lib/actions/gear-pledges";
+
+const LEAGUE_ID = "cllllllllllllllllllllllll";
+const TEAM_ID = "cttttttttttttttttttttttt";
+const NEED_ID = "cnnnnnnnnnnnnnnnnnnnnnnn";
+const CATALOG_ID = "ccccccccccccccccccccccccc";
+const LOCATION_ID = "clocccccccccccccccccccccc";
+const STOCK_ID = "cstockkkkkkkkkkkkkkkkkkkkk";
+const WISHLIST_ID = "cwwwwwwwwwwwwwwwwwwwwwwww";
+const WISHLIST_ITEM_ID = "cwiiiiiiiiiiiiiiiiiiiiiii";
+const PLEDGE_ID = "cpppppppppppppppppppppppp";
+const USER_ID = "cuuuuuuuuuuuuuuuuuuuuuuuu";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockRequireUserId.mockResolvedValue(USER_ID);
+  mockRequireLeagueRole.mockResolvedValue(USER_ID);
+  mockGetUserLeagueRole.mockResolvedValue("TEAM_ADMIN");
+  mockIsTeamAdmin.mockResolvedValue(true);
+  mockPrisma.team.findFirst.mockResolvedValue({ id: TEAM_ID });
+  mockCheckRateLimit.mockResolvedValue({ allowed: true });
+  mockGetClientIp.mockResolvedValue("203.0.113.42");
+  tx.gearActivity.create.mockResolvedValue({});
+  tx.gearInventoryMovement.create.mockResolvedValue({});
+  tx.leagueUser.findMany.mockResolvedValue([{ userId: USER_ID }]);
+  tx.teamMember.findMany.mockResolvedValue([{ userId: USER_ID }]);
+  tx.gearWishlistItem.update.mockResolvedValue({});
+  tx.gearPledge.updateMany.mockResolvedValue({ count: 1 });
+});
+
+describe("Layer 4 gear actions", () => {
+  it("scopes free-text and catalog-backed need lines and creates no reservation", async () => {
+    tx.gearCatalogItem.findMany.mockResolvedValue([
+      { id: CATALOG_ID, name: "Official Helmet", category: "Safety", size: "Youth", trackingMode: "POOLED" },
+    ]);
+    tx.teamGearNeed.create.mockResolvedValue({ id: NEED_ID, version: 0 });
+
+    const result = await createTeamGearNeed({
+      leagueId: LEAGUE_ID,
+      teamId: TEAM_ID,
+      title: "Spring equipment",
+      lines: [
+        { catalogItemId: CATALOG_ID, nameSnapshot: "Client supplied", requestedQty: 3 },
+        { nameSnapshot: "Tape rolls", categorySnapshot: "Supplies", requestedQty: 8 },
+      ],
+    });
+
+    expect(result).toEqual({ success: true, data: { id: NEED_ID, version: 0 } });
+    expect(tx.teamGearNeed.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        leagueId: LEAGUE_ID,
+        teamId: TEAM_ID,
+        lines: { create: expect.arrayContaining([
+          expect.objectContaining({ catalogItemId: CATALOG_ID, nameSnapshot: "Official Helmet", trackingMode: "POOLED" }),
+          expect.objectContaining({ catalogItemId: null, nameSnapshot: "Tape rolls", categorySnapshot: "Supplies" }),
+        ]) },
+      }),
+    }));
+    expect((tx as Record<string, unknown>).gearReservation).toBeUndefined();
+  });
+
+  it("guards need submission by state and scopes detail reads to the requested league", async () => {
+    tx.teamGearNeed.findFirst.mockResolvedValue({
+      id: NEED_ID, leagueId: LEAGUE_ID, teamId: TEAM_ID, status: "SUBMITTED", version: 2,
+      createdById: USER_ID, lines: [],
+    });
+
+    const transition = await submitTeamGearNeed({
+      leagueId: LEAGUE_ID, needId: NEED_ID, expectedVersion: 2,
+    });
+    expect(transition).toEqual({
+      success: false,
+      error: "This gear need cannot transition from submitted to submitted.",
+    });
+    expect(tx.teamGearNeed.updateMany).not.toHaveBeenCalled();
+
+    mockPrisma.teamGearNeed.findFirst.mockResolvedValue({
+      id: NEED_ID, teamId: TEAM_ID, title: "Need", notes: null, status: "DRAFT", version: 0,
+      submittedAt: null, approvedAt: null, fulfilledAt: null, canceledAt: null, createdAt: new Date("2026-01-01"),
+      team: { name: "Scoped Team" }, lines: [],
+    });
+    await getGearNeedDetail(LEAGUE_ID, NEED_ID);
+    expect(mockPrisma.teamGearNeed.findFirst).toHaveBeenCalledWith(expect.objectContaining({
+      where: expect.objectContaining({ id: NEED_ID, leagueId: LEAGUE_ID }),
+    }));
+  });
+
+  it("submits only from draft and atomically queues the league-admin notification", async () => {
+    tx.teamGearNeed.findFirst.mockResolvedValue({
+      id: NEED_ID, leagueId: LEAGUE_ID, teamId: TEAM_ID, status: "DRAFT", version: 2,
+      createdById: USER_ID, lines: [],
+    });
+    tx.teamGearNeed.updateMany.mockResolvedValue({ count: 1 });
+
+    const result = await submitTeamGearNeed({
+      leagueId: LEAGUE_ID, needId: NEED_ID, expectedVersion: 2,
+    });
+
+    expect(result).toEqual(expect.objectContaining({
+      success: true,
+      data: expect.objectContaining({ status: "SUBMITTED", version: 3 }),
+    }));
+    expect(tx.teamGearNeed.updateMany).toHaveBeenCalledWith(expect.objectContaining({
+      where: { id: NEED_ID, version: 2, status: "DRAFT" },
+    }));
+    expect(tx.notificationOutbox.createMany).toHaveBeenCalledWith(expect.objectContaining({
+      data: [expect.objectContaining({
+        eventType: "gear.need.submitted",
+        aggregateType: "NEED",
+        aggregateId: NEED_ID,
+        dedupeKey: `gear.need.submitted:${NEED_ID}:${USER_ID}`,
+      })],
+    }));
+  });
+
+  it("returns only public wishlist data with the association name and rejects unpublished tokens", async () => {
+    mockPrisma.gearWishlist.findFirst.mockResolvedValue({
+      league: { name: "Open League" },
+      title: "Community gear drive",
+      description: "Help our players",
+      items: [{
+        id: WISHLIST_ITEM_ID, nameSnapshot: "Helmet", categorySnapshot: "Safety", sizeSnapshot: "Youth",
+        description: null, targetQty: 5, pledgedQty: 6, receivedQty: 1,
+      }],
+    });
+    const projection = await getPublicGearWishlist("t".repeat(32));
+    expect(projection).toEqual({
+      associationName: "Open League",
+      title: "Community gear drive",
+      description: "Help our players",
+      items: [expect.objectContaining({ id: WISHLIST_ITEM_ID, remainingQty: 0 })],
+    });
+    expect(projection).not.toHaveProperty("leagueId");
+    expect(projection).not.toHaveProperty("shareToken");
+
+    mockPrisma.gearWishlist.findFirst.mockResolvedValue(null);
+    await expect(getPublicGearWishlist("t".repeat(32))).resolves.toBeNull();
+    expect(mockPrisma.gearWishlist.findFirst).toHaveBeenLastCalledWith(expect.objectContaining({
+      where: expect.objectContaining({ status: "PUBLISHED" }),
+    }));
+  });
+
+  it("rotates a wishlist token with optimistic version protection and transactional outbox", async () => {
+    tx.gearWishlist.findUnique.mockResolvedValue({
+      id: WISHLIST_ID, status: "PUBLISHED", version: 4,
+    });
+    tx.gearWishlist.updateMany.mockResolvedValue({ count: 1 });
+
+    const result = await rotateGearWishlistShareToken({
+      leagueId: LEAGUE_ID, expectedVersion: 4,
+    });
+
+    expect(result.success).toBe(true);
+    expect(tx.gearWishlist.updateMany).toHaveBeenCalledWith(expect.objectContaining({
+      where: { id: WISHLIST_ID, version: 4, status: "PUBLISHED" },
+      data: expect.objectContaining({ version: { increment: 1 } }),
+    }));
+    expect(tx.gearActivity.create).toHaveBeenCalled();
+    expect(tx.leagueUser.findMany).toHaveBeenCalled();
+  });
+
+  it("handles honeypot, idempotency, and rate limits without creating a pledge", async () => {
+    const common = {
+      wishlistToken: "t".repeat(32), wishlistItemId: WISHLIST_ITEM_ID, donorName: "Donor",
+      quantity: 1, idempotencyKey: "i".repeat(16),
+    };
+    await expect(createPublicGearPledge({ ...common, website: "spam" })).resolves.toEqual({
+      success: true, data: { id: null, status: "PLEDGED" },
+    });
+    expect(mockPrisma.gearPledge.findFirst).not.toHaveBeenCalled();
+
+    await expect(createPublicGearPledge(common)).resolves.toEqual({
+      success: false, error: "Contact consent is required to submit a pledge.",
+    });
+
+    mockPrisma.gearPledge.findFirst.mockResolvedValue({ id: PLEDGE_ID, status: "PLEDGED" });
+    await expect(createPublicGearPledge({ ...common, contactConsent: true })).resolves.toEqual({
+      success: true, data: { id: PLEDGE_ID, status: "PLEDGED" },
+    });
+
+    mockPrisma.gearPledge.findFirst.mockResolvedValue(null);
+    mockCheckRateLimit.mockResolvedValue({ allowed: false, retryAfterSec: 60 });
+    await expect(createPublicGearPledge({ ...common, contactConsent: true })).resolves.toEqual({
+      success: false, error: "Too many requests — try again in 1 minute.",
+    });
+  });
+
+  it("records pooled pledge receipt stock, ledger activity, and outbox atomically", async () => {
+    tx.gearPledge.findFirst.mockResolvedValue({
+      id: PLEDGE_ID, quantity: 2, wishlistItem: { id: WISHLIST_ITEM_ID, catalogItemId: CATALOG_ID },
+    });
+    tx.gearPledgeReceipt.aggregate.mockResolvedValue({ _sum: { quantity: 0 } });
+    tx.gearPoolStock.findFirst.mockResolvedValue({
+      id: STOCK_ID, catalogItemId: CATALOG_ID, locationId: LOCATION_ID, condition: "GOOD",
+    });
+    tx.gearPledgeReceipt.create.mockResolvedValue({ id: "creceipt00000000000000001" });
+
+    const result = await receiveGearPledge({
+      leagueId: LEAGUE_ID, pledgeId: PLEDGE_ID, poolStockId: STOCK_ID, quantity: 2,
+    });
+    expect(result.success).toBe(true);
+    expect(tx.gearPoolStock.update).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({ quantityOnHand: { increment: 2 } }),
+    }));
+    expect(tx.gearInventoryMovement.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({ type: "RECEIPT", poolStockId: STOCK_ID }),
+    }));
+    expect(tx.notificationOutbox.createMany).toHaveBeenCalledWith(expect.objectContaining({
+      data: [expect.objectContaining({
+        eventType: "gear.pledge.received",
+        aggregateType: "PLEDGE",
+        aggregateId: PLEDGE_ID,
+      })],
+    }));
+  });
+
+  it("creates a tagged unit, receipt, movement, and activity for every unique asset tag", async () => {
+    tx.gearPledge.findFirst.mockResolvedValue({
+      id: PLEDGE_ID, quantity: 2, wishlistItem: { id: WISHLIST_ITEM_ID, catalogItemId: CATALOG_ID },
+    });
+    tx.gearPledgeReceipt.aggregate.mockResolvedValue({ _sum: { quantity: 0 } });
+    tx.gearCatalogItem.findFirst.mockResolvedValue({ id: CATALOG_ID });
+    tx.gearStorageLocation.findFirst.mockResolvedValue({ id: LOCATION_ID });
+    tx.gearUnit.findMany.mockResolvedValue([]);
+    tx.gearUnit.create
+      .mockResolvedValueOnce({ id: "cunit111111111111111111111" })
+      .mockResolvedValueOnce({ id: "cunit222222222222222222222" });
+    tx.gearPledgeReceipt.create
+      .mockResolvedValueOnce({ id: "creceipt1111111111111111111" })
+      .mockResolvedValueOnce({ id: "creceipt2222222222222222222" });
+
+    const result = await receiveGearPledge({
+      leagueId: LEAGUE_ID, pledgeId: PLEDGE_ID, catalogItemId: CATALOG_ID,
+      assetTags: [" tag 1 ", "tag 2"], locationId: LOCATION_ID, condition: "GOOD", quantity: 2,
+    });
+    expect(result.success).toBe(true);
+    expect(tx.gearUnit.create).toHaveBeenCalledTimes(2);
+    expect(tx.gearUnit.create).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      data: expect.objectContaining({ assetTag: "TAG1", currentLocationId: LOCATION_ID }),
+    }));
+    expect(tx.gearPledgeReceipt.create).toHaveBeenCalledTimes(2);
+    expect(tx.gearInventoryMovement.create).toHaveBeenCalledTimes(2);
+    expect(tx.gearActivity.create).toHaveBeenCalledTimes(3);
+    expect(tx.notificationOutbox.createMany).toHaveBeenCalled();
+
+    const duplicate = await receiveGearPledge({
+      leagueId: LEAGUE_ID, pledgeId: PLEDGE_ID, catalogItemId: CATALOG_ID,
+      assetTags: ["tag 1", "TAG1"], locationId: LOCATION_ID, condition: "GOOD", quantity: 2,
+    });
+    expect(duplicate).toEqual({ success: false, error: "Each received asset tag must be unique." });
+  });
+});

--- a/__tests__/lib/actions/gear-layer-four.test.ts
+++ b/__tests__/lib/actions/gear-layer-four.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
@@ -14,17 +15,18 @@ const {
 } = vi.hoisted(() => {
   const tx = {
     teamGearNeed: { create: vi.fn(), findFirst: vi.fn(), updateMany: vi.fn() },
+    teamGearNeedCommand: { findUnique: vi.fn(), create: vi.fn() },
     teamGearNeedLine: { update: vi.fn(), updateMany: vi.fn() },
     gearCatalogItem: { findMany: vi.fn(), findFirst: vi.fn() },
     gearActivity: { create: vi.fn() },
     gearWishlist: { findUnique: vi.fn(), create: vi.fn(), updateMany: vi.fn() },
-    gearWishlistItem: { update: vi.fn(), updateMany: vi.fn(), create: vi.fn() },
+    gearWishlistItem: { findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), create: vi.fn() },
     gearPledge: { findFirst: vi.fn(), findUnique: vi.fn(), create: vi.fn(), updateMany: vi.fn() },
-    gearPledgeReceipt: { aggregate: vi.fn(), create: vi.fn() },
+    gearPledgeReceipt: { aggregate: vi.fn(), findFirst: vi.fn(), create: vi.fn() },
     gearPledgeReceiptCommand: { findUnique: vi.fn(), create: vi.fn() },
-    gearPoolStock: { findFirst: vi.fn(), update: vi.fn() },
+    gearPoolStock: { findFirst: vi.fn(), upsert: vi.fn(), update: vi.fn(), updateMany: vi.fn() },
     gearStorageLocation: { findFirst: vi.fn() },
-    gearUnit: { findMany: vi.fn(), create: vi.fn() },
+    gearUnit: { findMany: vi.fn(), create: vi.fn(), updateMany: vi.fn() },
     gearInventoryMovement: { create: vi.fn() },
     notificationOutbox: { createMany: vi.fn() },
     user: { findMany: vi.fn() },
@@ -44,8 +46,9 @@ const {
       team: { findFirst: vi.fn(), findMany: vi.fn() },
       teamMember: { findMany: vi.fn() },
       teamGearNeed: { findFirst: vi.fn(), findMany: vi.fn() },
+      teamGearNeedCommand: { findUnique: vi.fn() },
       gearWishlist: { findFirst: vi.fn() },
-      gearPledge: { findFirst: vi.fn() },
+      gearPledge: { findFirst: vi.fn(), findMany: vi.fn() },
       gearPledgeReceiptCommand: { findUnique: vi.fn() },
     },
   };
@@ -78,6 +81,9 @@ import {
 } from "@/lib/actions/gear-wishlist";
 import {
   createPublicGearPledge,
+  correctGearPledgeReceipt,
+  getGearPledgeAdminContext,
+  redactGearPledgePii,
   receiveGearPledge,
 } from "@/lib/actions/gear-pledges";
 import { queueGearOutboxForRecipients } from "@/lib/services/gear-outbox";
@@ -112,6 +118,7 @@ beforeEach(() => {
   tx.gearPledge.updateMany.mockResolvedValue({ count: 1 });
   tx.gearPledgeReceiptCommand.findUnique.mockResolvedValue(null);
   tx.gearPledgeReceiptCommand.create.mockResolvedValue({ id: "creceipt-command000000001" });
+  tx.teamGearNeedCommand.findUnique.mockResolvedValue(null);
 });
 
 describe("Layer 4 gear actions", () => {
@@ -124,6 +131,7 @@ describe("Layer 4 gear actions", () => {
     const result = await createTeamGearNeed({
       leagueId: LEAGUE_ID,
       teamId: TEAM_ID,
+      idempotencyKey: "n".repeat(16),
       title: "Spring equipment",
       lines: [
         { catalogItemId: CATALOG_ID, nameSnapshot: "Client supplied", requestedQty: 3 },
@@ -142,7 +150,30 @@ describe("Layer 4 gear actions", () => {
         ]) },
       }),
     }));
+    expect(tx.teamGearNeedCommand.create).toHaveBeenCalledWith({
+      data: {
+        leagueId: LEAGUE_ID,
+        teamId: TEAM_ID,
+        idempotencyKey: "n".repeat(16),
+        needId: NEED_ID,
+      },
+    });
     expect((tx as Record<string, unknown>).gearReservation).toBeUndefined();
+  });
+
+  it("replays a persisted league/team-scoped create-need command without creating another draft", async () => {
+    tx.teamGearNeedCommand.findUnique.mockResolvedValue({
+      need: { id: NEED_ID, version: 2 },
+    });
+
+    await expect(createTeamGearNeed({
+      leagueId: LEAGUE_ID,
+      teamId: TEAM_ID,
+      idempotencyKey: "n".repeat(16),
+      title: "Spring equipment",
+      lines: [{ nameSnapshot: "Tape", requestedQty: 1 }],
+    })).resolves.toEqual({ success: true, data: { id: NEED_ID, version: 2 } });
+    expect(tx.teamGearNeed.create).not.toHaveBeenCalled();
   });
 
   it("guards need submission by state and scopes detail reads to the requested league", async () => {
@@ -341,15 +372,15 @@ describe("Layer 4 gear actions", () => {
   it("handles honeypot, idempotency, and rate limits without creating a pledge", async () => {
     const common = {
       wishlistToken: "t".repeat(32), wishlistItemId: WISHLIST_ITEM_ID, donorName: "Donor",
-      quantity: 1, idempotencyKey: "i".repeat(16),
+      donorEmail: "donor@example.com", quantity: 1, idempotencyKey: "i".repeat(16),
     };
     await expect(createPublicGearPledge({ ...common, website: "spam" })).resolves.toEqual({
-      success: true, data: { id: null, status: "PLEDGED" },
+      success: false, error: "Unable to submit the pledge. Please try again.",
     });
     expect(mockPrisma.gearPledge.findFirst).not.toHaveBeenCalled();
 
-    await expect(createPublicGearPledge(common)).resolves.toEqual({
-      success: false, error: "Contact consent is required to submit a pledge.",
+    await expect(createPublicGearPledge({ ...common, donorEmail: "" })).resolves.toMatchObject({
+      success: false, error: "Please correct the highlighted pledge fields.",
     });
 
     mockPrisma.gearPledge.findFirst.mockResolvedValue({ id: PLEDGE_ID, status: "PLEDGED" });
@@ -362,6 +393,61 @@ describe("Layer 4 gear actions", () => {
     await expect(createPublicGearPledge({ ...common, contactConsent: true })).resolves.toEqual({
       success: false, error: "Too many requests — try again in 1 minute.",
     });
+    expect(mockCheckRateLimit.mock.calls.at(-1)?.[0]).not.toContain("t".repeat(32));
+  });
+
+  it("caps public pledges at the current outstanding target in the serializable transaction", async () => {
+    mockPrisma.gearPledge.findFirst.mockResolvedValue(null);
+    tx.gearWishlistItem.findFirst.mockResolvedValue({
+      id: WISHLIST_ITEM_ID,
+      targetQty: 5,
+      pledgedQty: 4,
+      receivedQty: 0,
+      wishlist: { leagueId: LEAGUE_ID },
+    });
+    tx.gearPledge.findUnique.mockResolvedValue(null);
+    tx.gearWishlistItem.update.mockResolvedValue({
+      id: WISHLIST_ITEM_ID,
+      targetQty: 5,
+      pledgedQty: 4,
+      receivedQty: 0,
+      wishlist: { leagueId: LEAGUE_ID },
+    });
+
+    const result = await createPublicGearPledge({
+      wishlistToken: "t".repeat(32),
+      wishlistItemId: WISHLIST_ITEM_ID,
+      donorName: "Donor",
+      donorPhone: "555-0100",
+      contactConsent: true,
+      quantity: 2,
+      idempotencyKey: "q".repeat(16),
+    });
+
+    expect(result).toEqual({ success: false, error: "Pledge quantity exceeds the remaining wishlist target." });
+    expect(tx.gearWishlistItem.update).toHaveBeenCalledWith(expect.objectContaining({
+      data: { pledgedQty: { increment: 0 } },
+    }));
+    expect(tx.gearPledge.create).not.toHaveBeenCalled();
+  });
+
+  it("fails closed for anonymous pledges without a trusted client address", async () => {
+    mockPrisma.gearPledge.findFirst.mockResolvedValue(null);
+    mockGetClientIp.mockResolvedValue(null);
+
+    await expect(createPublicGearPledge({
+      wishlistToken: "t".repeat(32),
+      wishlistItemId: WISHLIST_ITEM_ID,
+      donorName: "Donor",
+      donorPhone: "555-0100",
+      contactConsent: true,
+      quantity: 1,
+      idempotencyKey: "a".repeat(16),
+    })).resolves.toEqual({
+      success: false,
+      error: "Unable to submit the pledge. Please try again.",
+    });
+    expect(mockCheckRateLimit).not.toHaveBeenCalled();
   });
 
   it("records pooled pledge receipt stock, ledger activity, and outbox atomically", async () => {
@@ -395,16 +481,29 @@ describe("Layer 4 gear actions", () => {
   });
 
   it("returns a saved receipt command on retry without touching inventory again", async () => {
+    const input = {
+      leagueId: LEAGUE_ID, pledgeId: PLEDGE_ID, poolStockId: STOCK_ID, quantity: 2,
+      expectedVersion: 2, idempotencyKey: "z".repeat(16),
+    };
     tx.gearPledgeReceiptCommand.findUnique.mockResolvedValue({
+      payloadHash: createHash("sha256").update(JSON.stringify({
+        leagueId: LEAGUE_ID,
+        pledgeId: PLEDGE_ID,
+        expectedVersion: 2,
+        poolStockId: STOCK_ID,
+        catalogItemId: null,
+        locationId: null,
+        condition: null,
+        quantity: 2,
+        notes: null,
+        assetTags: [],
+      })).digest("hex"),
       resultingStatus: "RECEIVED",
       resultingVersion: 3,
       receipts: [{ id: "creceipt00000000000000001" }],
     });
 
-    const result = await receiveGearPledge({
-      leagueId: LEAGUE_ID, pledgeId: PLEDGE_ID, poolStockId: STOCK_ID, quantity: 2,
-      expectedVersion: 2, idempotencyKey: "z".repeat(16),
-    });
+    const result = await receiveGearPledge(input);
 
     expect(result).toEqual({
       success: true,
@@ -417,6 +516,116 @@ describe("Layer 4 gear actions", () => {
     });
     expect(tx.gearPoolStock.update).not.toHaveBeenCalled();
     expect(tx.gearPledgeReceipt.create).not.toHaveBeenCalled();
+  });
+
+  it("rejects a receipt operation key replayed with a different payload", async () => {
+    tx.gearPledgeReceiptCommand.findUnique.mockResolvedValue({
+      payloadHash: "different",
+      resultingStatus: "RECEIVED",
+      resultingVersion: 3,
+      receipts: [{ id: "creceipt00000000000000001" }],
+    });
+
+    await expect(receiveGearPledge({
+      leagueId: LEAGUE_ID, pledgeId: PLEDGE_ID, poolStockId: STOCK_ID, quantity: 2,
+      expectedVersion: 2, idempotencyKey: "z".repeat(16),
+    })).resolves.toEqual({
+      success: false,
+      error: "This receipt operation key was already used with different details.",
+    });
+  });
+
+  it("creates a first pooled stock receipt through its catalog-location-condition composite", async () => {
+    tx.gearPledge.findFirst.mockResolvedValue({
+      id: PLEDGE_ID, version: 0, quantity: 1, wishlistItem: { id: WISHLIST_ITEM_ID, catalogItemId: CATALOG_ID },
+    });
+    tx.gearPledgeReceipt.aggregate.mockResolvedValue({ _sum: { quantity: 0 } });
+    tx.gearCatalogItem.findFirst.mockResolvedValue({ id: CATALOG_ID });
+    tx.gearStorageLocation.findFirst.mockResolvedValue({ id: LOCATION_ID });
+    tx.gearPoolStock.upsert.mockResolvedValue({
+      id: STOCK_ID, catalogItemId: CATALOG_ID, locationId: LOCATION_ID, condition: "FAIR",
+    });
+    tx.gearPledgeReceipt.create.mockResolvedValue({ id: "creceipt00000000000000001" });
+
+    await expect(receiveGearPledge({
+      leagueId: LEAGUE_ID, pledgeId: PLEDGE_ID, catalogItemId: CATALOG_ID,
+      locationId: LOCATION_ID, condition: "FAIR", quantity: 1,
+      expectedVersion: 0, idempotencyKey: "n".repeat(16),
+    })).resolves.toMatchObject({ success: true });
+    expect(tx.gearPoolStock.upsert).toHaveBeenCalledWith(expect.objectContaining({
+      where: { leagueId_catalogItemId_locationId_condition: {
+        leagueId: LEAGUE_ID, catalogItemId: CATALOG_ID, locationId: LOCATION_ID, condition: "FAIR",
+      } },
+    }));
+  });
+
+  it("compensates a receipt without mutating its history and returns the pledge to pledged", async () => {
+    tx.gearPledgeReceipt.findFirst.mockResolvedValue({
+      id: "creceipt00000000000000001",
+      pledgeId: PLEDGE_ID,
+      catalogItemId: CATALOG_ID,
+      poolStockId: STOCK_ID,
+      gearUnitId: null,
+      quantity: 2,
+      correction: null,
+      pledge: {
+        status: "RECEIVED",
+        version: 3,
+        wishlistItem: { id: WISHLIST_ITEM_ID, receivedQty: 2 },
+      },
+    });
+    tx.gearPoolStock.updateMany.mockResolvedValue({ count: 1 });
+    tx.gearPledgeReceipt.create.mockResolvedValue({ id: "ccorrection000000000000001" });
+
+    const result = await correctGearPledgeReceipt({
+      leagueId: LEAGUE_ID,
+      pledgeId: PLEDGE_ID,
+      receiptId: "creceipt00000000000000001",
+      expectedVersion: 3,
+      reason: "Duplicate entry",
+    });
+
+    expect(result).toMatchObject({ success: true, data: { pledgeStatus: "PLEDGED", pledgeVersion: 4 } });
+    expect(tx.gearPledgeReceipt.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        correctionOfReceiptId: "creceipt00000000000000001",
+        correctionReason: "Duplicate entry",
+      }),
+    }));
+    expect(tx.gearInventoryMovement.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({ type: "ADJUSTMENT", direction: "DECREASE" }),
+    }));
+  });
+
+  it("redacts terminal pledge PII and omits redacted values from admin projections", async () => {
+    tx.gearPledge.findFirst.mockResolvedValue({
+      id: PLEDGE_ID,
+      leagueId: LEAGUE_ID,
+      wishlistItemId: WISHLIST_ITEM_ID,
+      status: "RECEIVED",
+      version: 3,
+      piiRedactionStatus: "PENDING",
+    });
+    tx.gearPledge.updateMany.mockResolvedValue({ count: 1 });
+
+    await expect(redactGearPledgePii({
+      leagueId: LEAGUE_ID, pledgeId: PLEDGE_ID, expectedVersion: 3,
+    })).resolves.toEqual({ success: true, data: { id: PLEDGE_ID, version: 4 } });
+    expect(tx.gearPledge.updateMany).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({ donorName: null, donorEmail: null, donorPhone: null, note: null }),
+    }));
+
+    mockPrisma.gearPledge.findMany.mockResolvedValue([{
+      id: PLEDGE_ID, version: 4, wishlistItemId: WISHLIST_ITEM_ID,
+      donorName: "Donor", donorEmail: "donor@example.com", donorPhone: "555-0100",
+      contactConsentAt: new Date(), status: "RECEIVED", quantity: 1, note: "private",
+      expiresAt: null, receivedAt: new Date(), piiRedactionStatus: "REDACTED", piiRedactedAt: new Date(),
+      createdAt: new Date(), wishlistItem: { nameSnapshot: "Helmet", categorySnapshot: null, sizeSnapshot: null },
+      receipts: [],
+    }]);
+    await expect(getGearPledgeAdminContext(LEAGUE_ID)).resolves.toEqual([
+      expect.objectContaining({ donorName: null, donorEmail: null, donorPhone: null, note: null }),
+    ]);
   });
 
   it("creates a tagged unit, receipt, movement, and activity for every unique asset tag", async () => {

--- a/__tests__/lib/utils/durable-rate-limit.test.ts
+++ b/__tests__/lib/utils/durable-rate-limit.test.ts
@@ -39,6 +39,7 @@ beforeEach(() => {
 afterEach(() => {
   randomSpy.mockRestore();
   vi.useRealTimers();
+  vi.unstubAllEnvs();
 });
 
 describe("checkRateLimit", () => {
@@ -164,22 +165,24 @@ describe("rateLimitMessage", () => {
 });
 
 describe("getClientIp", () => {
-  it("prefers the first x-forwarded-for hop", async () => {
+  it("does not trust arbitrary proxy headers outside Vercel", async () => {
+    vi.stubEnv("VERCEL", "");
     mocks.headers.mockResolvedValue(
       new Headers({ "x-forwarded-for": "1.2.3.4, 10.0.0.1", "x-real-ip": "5.6.7.8" })
+    );
+    expect(await getClientIp()).toBeNull();
+  });
+
+  it("uses the Vercel-provided client address only in a verified Vercel context", async () => {
+    vi.stubEnv("VERCEL", "1");
+    mocks.headers.mockResolvedValue(
+      new Headers({ "x-vercel-forwarded-for": "1.2.3.4", "x-forwarded-for": "spoofed" }),
     );
     expect(await getClientIp()).toBe("1.2.3.4");
   });
 
-  it("falls back to x-real-ip, then cf-connecting-ip", async () => {
-    mocks.headers.mockResolvedValue(new Headers({ "x-real-ip": "5.6.7.8" }));
-    expect(await getClientIp()).toBe("5.6.7.8");
-
-    mocks.headers.mockResolvedValue(new Headers({ "cf-connecting-ip": "9.9.9.9" }));
-    expect(await getClientIp()).toBe("9.9.9.9");
-  });
-
-  it("returns null when no IP header is present so callers can skip per-IP checks", async () => {
+  it("returns null when no trusted IP header is present so public callers fail closed", async () => {
+    vi.stubEnv("VERCEL", "1");
     mocks.headers.mockResolvedValue(new Headers());
     expect(await getClientIp()).toBeNull();
   });

--- a/__tests__/lib/utils/validation-gear.test.ts
+++ b/__tests__/lib/utils/validation-gear.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  createTeamGearNeedSchema,
   createGearPledgeSchema,
   createGearReservationSchema,
   gearActivityDetailsSchema,
@@ -104,6 +105,7 @@ describe("gear validation schemas", () => {
         wishlistToken: "a".repeat(16),
         wishlistItemId: ITEM_ID,
         donorName: "A donor",
+        donorEmail: "donor@example.com",
         quantity: 1,
         idempotencyKey: "b".repeat(16),
       }).success,
@@ -113,9 +115,35 @@ describe("gear validation schemas", () => {
         wishlistToken: "a".repeat(16),
         wishlistItemId: ITEM_ID,
         donorName: "A donor",
+        donorEmail: "donor@example.com",
         quantity: 1,
         idempotencyKey: "short",
       }).success,
     ).toBe(false);
+    expect(
+      createGearPledgeSchema.safeParse({
+        wishlistToken: "a".repeat(16),
+        wishlistItemId: ITEM_ID,
+        donorName: "A donor",
+        quantity: 1,
+        idempotencyKey: "b".repeat(16),
+      }).success,
+    ).toBe(false);
+  });
+
+  it("requires a stable idempotency key for gear-need creation", () => {
+    expect(createTeamGearNeedSchema.safeParse({
+      leagueId: ITEM_ID,
+      teamId: ITEM_ID,
+      idempotencyKey: "n".repeat(16),
+      title: "Equipment",
+      lines: [{ nameSnapshot: "Tape", requestedQty: 1 }],
+    }).success).toBe(true);
+    expect(createTeamGearNeedSchema.safeParse({
+      leagueId: ITEM_ID,
+      teamId: ITEM_ID,
+      title: "Equipment",
+      lines: [{ nameSnapshot: "Tape", requestedQty: 1 }],
+    }).success).toBe(false);
   });
 });

--- a/__tests__/lib/utils/validation-gear.test.ts
+++ b/__tests__/lib/utils/validation-gear.test.ts
@@ -46,6 +46,8 @@ describe("gear validation schemas", () => {
       leagueId: LEAGUE_ID,
       pledgeId: ITEM_ID,
       quantity: 1,
+      expectedVersion: 0,
+      idempotencyKey: "receipt-command-1",
     };
 
     expect(receiveGearPledgeSchema.safeParse({ ...base, poolStockId: STOCK_ID }).success).toBe(true);

--- a/app/(dashboard)/league/[leagueId]/gear/needs/[needId]/page.tsx
+++ b/app/(dashboard)/league/[leagueId]/gear/needs/[needId]/page.tsx
@@ -9,8 +9,8 @@ import { getGearNeedDetail, getGearNeedsContext } from "@/lib/actions/gear-needs
 
 export default async function GearNeedDetailPage({ params }: { params: Promise<{ leagueId: string; needId: string }> }) {
   const { leagueId, needId } = await params;
-  const [need, context] = await Promise.all([getGearNeedDetail(leagueId, needId), getGearNeedsContext(leagueId)]);
-  if (!need || !context) notFound();
+  const need = await getGearNeedDetail(leagueId, needId);
+  if (!need) notFound();
 
   return (
     <PageContainer maxWidth="md">
@@ -27,7 +27,13 @@ export default async function GearNeedDetailPage({ params }: { params: Promise<{
               <Chip label={need.status} />
             </Stack>
             {need.notes && <Typography variant="body2">{need.notes}</Typography>}
-            <GearNeedActions leagueId={leagueId} needId={need.id} expectedVersion={need.version} status={need.status} canManageAll={context.canManageAll} />
+            <GearNeedActions
+              leagueId={leagueId}
+              needId={need.id}
+              expectedVersion={need.version}
+              status={need.status}
+              capabilities={need.capabilities}
+            />
           </Stack>
         </Card>
         <Card variant="outlined" sx={{ p: 2 }}>

--- a/app/(dashboard)/league/[leagueId]/gear/needs/[needId]/page.tsx
+++ b/app/(dashboard)/league/[leagueId]/gear/needs/[needId]/page.tsx
@@ -1,0 +1,50 @@
+import Link from "next/link";
+import { ArrowBackOutlined } from "@mui/icons-material";
+import { Alert, Button, Card, Chip, Divider, Stack, Typography } from "@mui/material";
+import { notFound } from "next/navigation";
+import { GearNeedActions } from "@/components/features/gear/GearNeedActions";
+import { PageContainer } from "@/components/ui/PageContainer";
+import { PageHeader } from "@/components/ui/PageHeader";
+import { getGearNeedDetail, getGearNeedsContext } from "@/lib/actions/gear-needs";
+
+export default async function GearNeedDetailPage({ params }: { params: Promise<{ leagueId: string; needId: string }> }) {
+  const { leagueId, needId } = await params;
+  const [need, context] = await Promise.all([getGearNeedDetail(leagueId, needId), getGearNeedsContext(leagueId)]);
+  if (!need || !context) notFound();
+
+  return (
+    <PageContainer maxWidth="md">
+      <Button component={Link} href={`/league/${leagueId}/gear/needs`} startIcon={<ArrowBackOutlined />} sx={{ minHeight: 44, mb: 1 }}>
+        All needs
+      </Button>
+      <PageHeader title={need.title} subtitle={`${need.teamName} gear need`} />
+      <Stack spacing={2}>
+        <Alert severity="info">This is a demand request, not a reservation. Inventory remains available until a separate reservation is approved and allocated.</Alert>
+        <Card variant="outlined" sx={{ p: 2 }}>
+          <Stack spacing={1}>
+            <Stack direction="row" justifyContent="space-between" alignItems="center">
+              <Typography variant="h6">Review status</Typography>
+              <Chip label={need.status} />
+            </Stack>
+            {need.notes && <Typography variant="body2">{need.notes}</Typography>}
+            <GearNeedActions leagueId={leagueId} needId={need.id} expectedVersion={need.version} status={need.status} canManageAll={context.canManageAll} />
+          </Stack>
+        </Card>
+        <Card variant="outlined" sx={{ p: 2 }}>
+          <Typography variant="h6" gutterBottom>Requested items</Typography>
+          <Stack divider={<Divider flexItem />}>
+            {need.lines.map((line) => (
+              <Stack key={line.id} direction="row" justifyContent="space-between" gap={2} py={1}>
+                <Stack>
+                  <Typography>{line.nameSnapshot}</Typography>
+                  <Typography variant="body2" color="text.secondary">{[line.categorySnapshot, line.sizeSnapshot].filter(Boolean).join(" - ") || "Uncatalogued request"}</Typography>
+                </Stack>
+                <Typography>{line.fulfilledQty} / {line.requestedQty}</Typography>
+              </Stack>
+            ))}
+          </Stack>
+        </Card>
+      </Stack>
+    </PageContainer>
+  );
+}

--- a/app/(dashboard)/league/[leagueId]/gear/needs/[needId]/page.tsx
+++ b/app/(dashboard)/league/[leagueId]/gear/needs/[needId]/page.tsx
@@ -1,11 +1,11 @@
-import Link from "next/link";
 import { ArrowBackOutlined } from "@mui/icons-material";
-import { Alert, Button, Card, Chip, Divider, Stack, Typography } from "@mui/material";
+import { Alert, Card, Chip, Divider, Stack, Typography } from "@mui/material";
 import { notFound } from "next/navigation";
 import { GearNeedActions } from "@/components/features/gear/GearNeedActions";
+import { LinkButton } from "@/components/ui/NextLinkComposites";
 import { PageContainer } from "@/components/ui/PageContainer";
 import { PageHeader } from "@/components/ui/PageHeader";
-import { getGearNeedDetail, getGearNeedsContext } from "@/lib/actions/gear-needs";
+import { getGearNeedDetail } from "@/lib/actions/gear-needs";
 
 export default async function GearNeedDetailPage({ params }: { params: Promise<{ leagueId: string; needId: string }> }) {
   const { leagueId, needId } = await params;
@@ -14,9 +14,9 @@ export default async function GearNeedDetailPage({ params }: { params: Promise<{
 
   return (
     <PageContainer maxWidth="md">
-      <Button component={Link} href={`/league/${leagueId}/gear/needs`} startIcon={<ArrowBackOutlined />} sx={{ minHeight: 44, mb: 1 }}>
+      <LinkButton href={`/league/${leagueId}/gear/needs`} startIcon={<ArrowBackOutlined />} sx={{ minHeight: 44, mb: 1 }}>
         All needs
-      </Button>
+      </LinkButton>
       <PageHeader title={need.title} subtitle={`${need.teamName} gear need`} />
       <Stack spacing={2}>
         <Alert severity="info">This is a demand request, not a reservation. Inventory remains available until a separate reservation is approved and allocated.</Alert>

--- a/app/(dashboard)/league/[leagueId]/gear/needs/new/page.tsx
+++ b/app/(dashboard)/league/[leagueId]/gear/needs/new/page.tsx
@@ -10,7 +10,7 @@ import { getGearNeedsContext } from "@/lib/actions/gear-needs";
 export default async function NewGearNeedPage({ params }: { params: Promise<{ leagueId: string }> }) {
   const { leagueId } = await params;
   const context = await getGearNeedsContext(leagueId);
-  if (!context || context.teamIds.length === 0) notFound();
+  if (!context || context.teams.length === 0) notFound();
 
   return (
     <PageContainer maxWidth="md">
@@ -18,7 +18,7 @@ export default async function NewGearNeedPage({ params }: { params: Promise<{ le
         All needs
       </Button>
       <PageHeader title="New gear need" subtitle="Describe a team need for association review. This does not reserve equipment." />
-      <GearNeedCreateForm leagueId={leagueId} teamIds={context.teamIds} />
+      <GearNeedCreateForm leagueId={leagueId} teams={context.teams} />
     </PageContainer>
   );
 }

--- a/app/(dashboard)/league/[leagueId]/gear/needs/new/page.tsx
+++ b/app/(dashboard)/league/[leagueId]/gear/needs/new/page.tsx
@@ -1,8 +1,7 @@
-import Link from "next/link";
 import { ArrowBackOutlined } from "@mui/icons-material";
-import { Button } from "@mui/material";
 import { notFound } from "next/navigation";
 import { GearNeedCreateForm } from "@/components/features/gear/GearNeedCreateForm";
+import { LinkButton } from "@/components/ui/NextLinkComposites";
 import { PageContainer } from "@/components/ui/PageContainer";
 import { PageHeader } from "@/components/ui/PageHeader";
 import { getGearNeedsContext } from "@/lib/actions/gear-needs";
@@ -14,9 +13,9 @@ export default async function NewGearNeedPage({ params }: { params: Promise<{ le
 
   return (
     <PageContainer maxWidth="md">
-      <Button component={Link} href={`/league/${leagueId}/gear/needs`} startIcon={<ArrowBackOutlined />} sx={{ minHeight: 44, mb: 1 }}>
+      <LinkButton href={`/league/${leagueId}/gear/needs`} startIcon={<ArrowBackOutlined />} sx={{ minHeight: 44, mb: 1 }}>
         All needs
-      </Button>
+      </LinkButton>
       <PageHeader title="New gear need" subtitle="Describe a team need for association review. This does not reserve equipment." />
       <GearNeedCreateForm leagueId={leagueId} teams={context.teams} />
     </PageContainer>

--- a/app/(dashboard)/league/[leagueId]/gear/needs/new/page.tsx
+++ b/app/(dashboard)/league/[leagueId]/gear/needs/new/page.tsx
@@ -1,0 +1,24 @@
+import Link from "next/link";
+import { ArrowBackOutlined } from "@mui/icons-material";
+import { Button } from "@mui/material";
+import { notFound } from "next/navigation";
+import { GearNeedCreateForm } from "@/components/features/gear/GearNeedCreateForm";
+import { PageContainer } from "@/components/ui/PageContainer";
+import { PageHeader } from "@/components/ui/PageHeader";
+import { getGearNeedsContext } from "@/lib/actions/gear-needs";
+
+export default async function NewGearNeedPage({ params }: { params: Promise<{ leagueId: string }> }) {
+  const { leagueId } = await params;
+  const context = await getGearNeedsContext(leagueId);
+  if (!context || context.teamIds.length === 0) notFound();
+
+  return (
+    <PageContainer maxWidth="md">
+      <Button component={Link} href={`/league/${leagueId}/gear/needs`} startIcon={<ArrowBackOutlined />} sx={{ minHeight: 44, mb: 1 }}>
+        All needs
+      </Button>
+      <PageHeader title="New gear need" subtitle="Describe a team need for association review. This does not reserve equipment." />
+      <GearNeedCreateForm leagueId={leagueId} teamIds={context.teamIds} />
+    </PageContainer>
+  );
+}

--- a/app/(dashboard)/league/[leagueId]/gear/needs/page.tsx
+++ b/app/(dashboard)/league/[leagueId]/gear/needs/page.tsx
@@ -1,8 +1,8 @@
-import Link from "next/link";
 import { AddOutlined } from "@mui/icons-material";
 import { Button, MenuItem, Stack, TextField } from "@mui/material";
 import { notFound } from "next/navigation";
 import { GearNeedsList, type GearNeedListItem } from "@/components/features/gear/GearNeedsList";
+import { LinkButton } from "@/components/ui/NextLinkComposites";
 import { PageContainer } from "@/components/ui/PageContainer";
 import { PageHeader } from "@/components/ui/PageHeader";
 import { getGearNeedsContext } from "@/lib/actions/gear-needs";
@@ -40,7 +40,11 @@ export default async function GearNeedsPage({ params, searchParams }: GearNeedsP
       <PageHeader
         title="Gear needs"
         subtitle="Team demand requests. Approving a need never reserves inventory."
-        actions={<Button component={Link} href={`/league/${leagueId}/gear/needs/new`} startIcon={<AddOutlined />} variant="contained" sx={{ minHeight: 44 }}>New need</Button>}
+        actions={
+          <LinkButton href={`/league/${leagueId}/gear/needs/new`} startIcon={<AddOutlined />} variant="contained" sx={{ minHeight: 44 }}>
+            New need
+          </LinkButton>
+        }
       />
       <Stack component="form" direction={{ xs: "column", sm: "row" }} spacing={1} method="get" sx={{ mb: 2 }}>
         <TextField select name="team" label="Team" defaultValue={filters.team ?? ""} sx={{ minWidth: 180 }}>

--- a/app/(dashboard)/league/[leagueId]/gear/needs/page.tsx
+++ b/app/(dashboard)/league/[leagueId]/gear/needs/page.tsx
@@ -1,0 +1,66 @@
+import Link from "next/link";
+import { AddOutlined } from "@mui/icons-material";
+import { Button, MenuItem, Stack, TextField } from "@mui/material";
+import { notFound } from "next/navigation";
+import { GearNeedsList, type GearNeedListItem } from "@/components/features/gear/GearNeedsList";
+import { PageContainer } from "@/components/ui/PageContainer";
+import { PageHeader } from "@/components/ui/PageHeader";
+import { getGearNeedsContext } from "@/lib/actions/gear-needs";
+
+interface GearNeedsPageProps {
+  params: Promise<{ leagueId: string }>;
+  searchParams: Promise<{ status?: string; priority?: string; team?: string; from?: string }>;
+}
+
+export default async function GearNeedsPage({ params, searchParams }: GearNeedsPageProps) {
+  const [{ leagueId }, filters] = await Promise.all([params, searchParams]);
+  const context = await getGearNeedsContext(leagueId);
+  if (!context) notFound();
+  const needs = context.needs
+    .filter((need) => !filters.status || need.status === filters.status)
+    .filter((need) => !filters.priority || need.lines.some((line) => line.priority === filters.priority))
+    .filter((need) => !filters.team || need.teamId === filters.team)
+    .filter((need) => !filters.from || need.createdAt.slice(0, 10) >= filters.from)
+    .map((need): GearNeedListItem => ({
+      id: need.id,
+      title: need.title,
+      teamName: need.teamName,
+      status: need.status,
+      submittedAt: need.submittedAt,
+      createdAt: need.createdAt,
+      requestedQuantity: need.lines.reduce((total, line) => total + line.requestedQty, 0),
+      fulfilledQuantity: need.lines.reduce((total, line) => total + line.fulfilledQty, 0),
+      priority: need.lines.some((line) => line.priority === "URGENT") ? "URGENT"
+        : need.lines.some((line) => line.priority === "HIGH") ? "HIGH"
+          : need.lines.some((line) => line.priority === "NORMAL") ? "NORMAL" : "LOW",
+    }));
+
+  return (
+    <PageContainer maxWidth="xl">
+      <PageHeader
+        title="Gear needs"
+        subtitle="Team demand requests. Approving a need never reserves inventory."
+        actions={<Button component={Link} href={`/league/${leagueId}/gear/needs/new`} startIcon={<AddOutlined />} variant="contained" sx={{ minHeight: 44 }}>New need</Button>}
+      />
+      <Stack component="form" direction={{ xs: "column", sm: "row" }} spacing={1} method="get" sx={{ mb: 2 }}>
+        <TextField select name="team" label="Team" defaultValue={filters.team ?? ""} sx={{ minWidth: 180 }}>
+          <MenuItem value="">All teams</MenuItem>
+          {[...new Map(context.needs.map((need) => [need.teamId, need.teamName])).entries()].map(([teamId, teamName]) => (
+            <MenuItem key={teamId} value={teamId}>{teamName}</MenuItem>
+          ))}
+        </TextField>
+        <TextField select name="status" label="Status" defaultValue={filters.status ?? ""} sx={{ minWidth: 160 }}>
+          <MenuItem value="">All statuses</MenuItem>
+          {["DRAFT", "SUBMITTED", "APPROVED", "FULFILLED", "CANCELED"].map((status) => <MenuItem key={status} value={status}>{status}</MenuItem>)}
+        </TextField>
+        <TextField select name="priority" label="Priority" defaultValue={filters.priority ?? ""} sx={{ minWidth: 160 }}>
+          <MenuItem value="">All priorities</MenuItem>
+          {["LOW", "NORMAL", "HIGH", "URGENT"].map((priority) => <MenuItem key={priority} value={priority}>{priority}</MenuItem>)}
+        </TextField>
+        <TextField name="from" label="Created on or after" type="date" defaultValue={filters.from ?? ""} slotProps={{ inputLabel: { shrink: true } }} />
+        <Button type="submit" variant="outlined" sx={{ minHeight: 44 }}>Filter</Button>
+      </Stack>
+      <GearNeedsList leagueId={leagueId} needs={needs} />
+    </PageContainer>
+  );
+}

--- a/app/(dashboard)/league/[leagueId]/gear/page.tsx
+++ b/app/(dashboard)/league/[leagueId]/gear/page.tsx
@@ -37,6 +37,11 @@ export default async function GearInventoryPage({ params, searchParams }: GearIn
             <LinkButton href={`/league/${leagueId}/gear/reservations`} variant="outlined" sx={{ minHeight: 44 }}>
               Reservations
             </LinkButton>
+            {data.canManageInventory && (
+              <LinkButton href={`/league/${leagueId}/gear/wishlist`} variant="outlined" sx={{ minHeight: 44 }}>
+                Wishlist
+              </LinkButton>
+            )}
           </>
         }
       />

--- a/app/(dashboard)/league/[leagueId]/gear/page.tsx
+++ b/app/(dashboard)/league/[leagueId]/gear/page.tsx
@@ -30,13 +30,14 @@ export default async function GearInventoryPage({ params, searchParams }: GearIn
         title="Gear inventory"
         subtitle={`${data.league.name} equipment, locations, and current availability.`}
         actions={
-          <LinkButton
-            href={`/league/${leagueId}/gear/reservations`}
-            variant="outlined"
-            sx={{ minHeight: 44 }}
-          >
-            Reservations
-          </LinkButton>
+          <>
+            <LinkButton href={`/league/${leagueId}/gear/needs`} variant="outlined" sx={{ minHeight: 44 }}>
+              Needs
+            </LinkButton>
+            <LinkButton href={`/league/${leagueId}/gear/reservations`} variant="outlined" sx={{ minHeight: 44 }}>
+              Reservations
+            </LinkButton>
+          </>
         }
       />
       {hasInventory || data.canManageInventory ? (

--- a/app/(dashboard)/league/[leagueId]/gear/wishlist/page.tsx
+++ b/app/(dashboard)/league/[leagueId]/gear/wishlist/page.tsx
@@ -1,0 +1,58 @@
+import { Alert, Card, Chip, Divider, Stack, Typography } from "@mui/material";
+import { notFound } from "next/navigation";
+import { GearWishlistAdminActions } from "@/components/features/gear/GearWishlistAdminActions";
+import { PageContainer } from "@/components/ui/PageContainer";
+import { PageHeader } from "@/components/ui/PageHeader";
+import { getGearPledgeAdminContext } from "@/lib/actions/gear-pledges";
+import { getGearWishlistAdminContext } from "@/lib/actions/gear-wishlist";
+
+export default async function GearWishlistAdminPage({ params }: { params: Promise<{ leagueId: string }> }) {
+  const { leagueId } = await params;
+  const [wishlist, pledges] = await Promise.all([
+    getGearWishlistAdminContext(leagueId),
+    getGearPledgeAdminContext(leagueId),
+  ]);
+  if (!wishlist) notFound();
+
+  return (
+    <PageContainer maxWidth="lg">
+      <PageHeader title="Public gear wishlist" subtitle="Curated public donation requests and private pledge coordination." />
+      <Stack spacing={2}>
+        <Card variant="outlined" sx={{ p: 2 }}>
+          <Stack spacing={1}>
+            <Typography variant="h6">{wishlist.title}</Typography>
+            {wishlist.description && <Typography color="text.secondary">{wishlist.description}</Typography>}
+            <Chip label={wishlist.status} sx={{ alignSelf: "start" }} />
+            <GearWishlistAdminActions leagueId={leagueId} shareToken={wishlist.shareToken} status={wishlist.status} version={wishlist.version} />
+          </Stack>
+        </Card>
+        <Card variant="outlined" sx={{ p: 2 }}>
+          <Typography variant="h6" gutterBottom>Curated public items</Typography>
+          <Stack divider={<Divider flexItem />}>
+            {wishlist.items.filter((item) => item.isActive).map((item) => (
+              <Stack key={item.id} direction="row" justifyContent="space-between" gap={2} py={1}>
+                <Typography>{item.nameSnapshot}</Typography>
+                <Typography color="text.secondary">{item.receivedQty} received / {item.targetQty} target</Typography>
+              </Stack>
+            ))}
+          </Stack>
+        </Card>
+        <Card variant="outlined" sx={{ p: 2 }}>
+          <Typography variant="h6" gutterBottom>Private donor pledge queue</Typography>
+          <Alert severity="info" sx={{ mb: 1 }}>Donor contact information is visible only to league administrators.</Alert>
+          <Stack divider={<Divider flexItem />}>
+            {pledges.length === 0 ? <Typography color="text.secondary">No pledges yet.</Typography> : pledges.map((pledge) => (
+              <Stack key={pledge.id} spacing={0.5} py={1}>
+                <Stack direction="row" justifyContent="space-between" gap={2}>
+                  <Typography>{pledge.wishlistItem.nameSnapshot}: {pledge.quantity}</Typography>
+                  <Chip size="small" label={pledge.status} />
+                </Stack>
+                <Typography variant="body2">{pledge.donorName}{pledge.donorEmail ? ` · ${pledge.donorEmail}` : ""}{pledge.donorPhone ? ` · ${pledge.donorPhone}` : ""}</Typography>
+              </Stack>
+            ))}
+          </Stack>
+        </Card>
+      </Stack>
+    </PageContainer>
+  );
+}

--- a/app/(dashboard)/league/[leagueId]/gear/wishlist/page.tsx
+++ b/app/(dashboard)/league/[leagueId]/gear/wishlist/page.tsx
@@ -1,42 +1,68 @@
 import { Alert, Card, Chip, Divider, Stack, Typography } from "@mui/material";
-import { notFound } from "next/navigation";
 import { GearWishlistAdminActions } from "@/components/features/gear/GearWishlistAdminActions";
+import { GearWishlistEditor } from "@/components/features/gear/GearWishlistEditor";
+import { GearPledgeAdminActions } from "@/components/features/gear/GearPledgeAdminActions";
 import { PageContainer } from "@/components/ui/PageContainer";
 import { PageHeader } from "@/components/ui/PageHeader";
+import { getGearInventoryContext } from "@/lib/actions/gear-context";
 import { getGearPledgeAdminContext } from "@/lib/actions/gear-pledges";
 import { getGearWishlistAdminContext } from "@/lib/actions/gear-wishlist";
 
 export default async function GearWishlistAdminPage({ params }: { params: Promise<{ leagueId: string }> }) {
   const { leagueId } = await params;
-  const [wishlist, pledges] = await Promise.all([
+  const [wishlist, pledges, inventory] = await Promise.all([
     getGearWishlistAdminContext(leagueId),
     getGearPledgeAdminContext(leagueId),
+    getGearInventoryContext(leagueId),
   ]);
-  if (!wishlist) notFound();
+  if (!inventory) return null;
 
   return (
     <PageContainer maxWidth="lg">
       <PageHeader title="Public gear wishlist" subtitle="Curated public donation requests and private pledge coordination." />
       <Stack spacing={2}>
-        <Card variant="outlined" sx={{ p: 2 }}>
-          <Stack spacing={1}>
-            <Typography variant="h6">{wishlist.title}</Typography>
-            {wishlist.description && <Typography color="text.secondary">{wishlist.description}</Typography>}
-            <Chip label={wishlist.status} sx={{ alignSelf: "start" }} />
-            <GearWishlistAdminActions leagueId={leagueId} shareToken={wishlist.shareToken} status={wishlist.status} version={wishlist.version} />
-          </Stack>
-        </Card>
-        <Card variant="outlined" sx={{ p: 2 }}>
-          <Typography variant="h6" gutterBottom>Curated public items</Typography>
-          <Stack divider={<Divider flexItem />}>
-            {wishlist.items.filter((item) => item.isActive).map((item) => (
-              <Stack key={item.id} direction="row" justifyContent="space-between" gap={2} py={1}>
-                <Typography>{item.nameSnapshot}</Typography>
-                <Typography color="text.secondary">{item.receivedQty} received / {item.targetQty} target</Typography>
+        {wishlist ? (
+          <>
+            <Card variant="outlined" sx={{ p: 2 }}>
+              <Stack spacing={1}>
+                <Typography variant="h6">{wishlist.title}</Typography>
+                {wishlist.description && <Typography color="text.secondary">{wishlist.description}</Typography>}
+                <Chip label={wishlist.status} sx={{ alignSelf: "start" }} />
+                <GearWishlistAdminActions leagueId={leagueId} shareToken={wishlist.shareToken} status={wishlist.status} version={wishlist.version} />
               </Stack>
-            ))}
-          </Stack>
-        </Card>
+            </Card>
+            <Card variant="outlined" sx={{ p: 2 }}>
+              <Typography variant="h6" gutterBottom>Curated public items</Typography>
+              <Stack divider={<Divider flexItem />}>
+                {wishlist.items.filter((item) => item.isActive).map((item) => (
+                  <Stack key={item.id} direction="row" justifyContent="space-between" gap={2} py={1}>
+                    <Typography>{item.nameSnapshot}</Typography>
+                    <Typography color="text.secondary">{item.receivedQty} received / {item.targetQty} target</Typography>
+                  </Stack>
+                ))}
+              </Stack>
+            </Card>
+          </>
+        ) : (
+          <Alert severity="info">Create your first public donation campaign below. Only curated snapshots will be shared publicly.</Alert>
+        )}
+        <GearWishlistEditor
+          leagueId={leagueId}
+          catalogItems={inventory.catalogItems}
+          initial={wishlist ? {
+            title: wishlist.title,
+            description: wishlist.description,
+            version: wishlist.version,
+            items: wishlist.items.filter((item) => item.isActive).map((item) => ({
+              catalogItemId: item.catalogItemId ?? "",
+              nameSnapshot: item.nameSnapshot,
+              categorySnapshot: item.categorySnapshot ?? "",
+              sizeSnapshot: item.sizeSnapshot ?? "",
+              description: item.description ?? "",
+              targetQty: item.targetQty,
+            })),
+          } : undefined}
+        />
         <Card variant="outlined" sx={{ p: 2 }}>
           <Typography variant="h6" gutterBottom>Private donor pledge queue</Typography>
           <Alert severity="info" sx={{ mb: 1 }}>Donor contact information is visible only to league administrators.</Alert>
@@ -48,6 +74,21 @@ export default async function GearWishlistAdminPage({ params }: { params: Promis
                   <Chip size="small" label={pledge.status} />
                 </Stack>
                 <Typography variant="body2">{pledge.donorName}{pledge.donorEmail ? ` · ${pledge.donorEmail}` : ""}{pledge.donorPhone ? ` · ${pledge.donorPhone}` : ""}</Typography>
+                <GearPledgeAdminActions
+                  leagueId={leagueId}
+                  pledgeId={pledge.id}
+                  pledgeVersion={pledge.version}
+                  status={pledge.status}
+                  catalogItems={inventory.catalogItems
+                    .filter((item) => item.isActive && item.trackingMode === "INDIVIDUAL")
+                    .map((item) => ({ id: item.id, name: item.name }))}
+                  locations={inventory.locations
+                    .filter((location) => location.isActive)
+                    .map((location) => ({ id: location.id, name: location.name }))}
+                  poolStock={inventory.pooledStock
+                    .filter((stock) => stock.availableQuantity > 0)
+                    .map((stock) => ({ id: stock.id, catalogName: stock.catalogName, locationName: stock.locationName }))}
+                />
               </Stack>
             ))}
           </Stack>

--- a/app/(dashboard)/league/[leagueId]/gear/wishlist/page.tsx
+++ b/app/(dashboard)/league/[leagueId]/gear/wishlist/page.tsx
@@ -66,6 +66,7 @@ export default async function GearWishlistAdminPage({ params }: { params: Promis
         <Card variant="outlined" sx={{ p: 2 }}>
           <Typography variant="h6" gutterBottom>Private donor pledge queue</Typography>
           <Alert severity="info" sx={{ mb: 1 }}>Donor contact information is visible only to league administrators.</Alert>
+          <Alert severity="warning" sx={{ mb: 1 }}>Automatic pledge expiry is intentionally deferred. Review pledge age and use “Expire pledge” when a donor commitment is no longer active.</Alert>
           <Stack divider={<Divider flexItem />}>
             {pledges.length === 0 ? <Typography color="text.secondary">No pledges yet.</Typography> : pledges.map((pledge) => (
               <Stack key={pledge.id} spacing={0.5} py={1}>
@@ -73,7 +74,16 @@ export default async function GearWishlistAdminPage({ params }: { params: Promis
                   <Typography>{pledge.wishlistItem.nameSnapshot}: {pledge.quantity}</Typography>
                   <Chip size="small" label={pledge.status} />
                 </Stack>
-                <Typography variant="body2">{pledge.donorName}{pledge.donorEmail ? ` · ${pledge.donorEmail}` : ""}{pledge.donorPhone ? ` · ${pledge.donorPhone}` : ""}</Typography>
+                <Typography variant="body2">{pledge.donorName ?? "Donor details redacted"}{pledge.donorEmail ? ` · ${pledge.donorEmail}` : ""}{pledge.donorPhone ? ` · ${pledge.donorPhone}` : ""}</Typography>
+                {pledge.note && <Typography variant="body2" color="text.secondary">Donor note: {pledge.note}</Typography>}
+                <Typography variant="body2" color="text.secondary">
+                  Created {new Intl.DateTimeFormat("en", { dateStyle: "medium" }).format(new Date(pledge.createdAt))} · {pledge.receipts.reduce((total, receipt) => total + receipt.quantity, 0)} received · {Math.max(pledge.quantity - pledge.receipts.reduce((total, receipt) => total + receipt.quantity, 0), 0)} remaining
+                </Typography>
+                {pledge.receipts.map((receipt) => (
+                  <Typography key={receipt.id} variant="caption" color="text.secondary">
+                    Receipt {receipt.id} · {receipt.quantity} · {new Date(receipt.receivedAt).toLocaleString()} · {receipt.poolStockId ? `Pooled stock ${receipt.poolStockId}` : `Unit ${receipt.gearUnitId}`}
+                  </Typography>
+                ))}
                 <GearPledgeAdminActions
                   leagueId={leagueId}
                   pledgeId={pledge.id}
@@ -82,12 +92,16 @@ export default async function GearWishlistAdminPage({ params }: { params: Promis
                   catalogItems={inventory.catalogItems
                     .filter((item) => item.isActive && item.trackingMode === "INDIVIDUAL")
                     .map((item) => ({ id: item.id, name: item.name }))}
+                  pooledCatalogItems={inventory.catalogItems
+                    .filter((item) => item.isActive && item.trackingMode === "POOLED")
+                    .map((item) => ({ id: item.id, name: item.name }))}
                   locations={inventory.locations
                     .filter((location) => location.isActive)
                     .map((location) => ({ id: location.id, name: location.name }))}
                   poolStock={inventory.pooledStock
-                    .filter((stock) => stock.availableQuantity > 0)
                     .map((stock) => ({ id: stock.id, catalogName: stock.catalogName, locationName: stock.locationName }))}
+                  remainingQuantity={Math.max(pledge.quantity - pledge.receipts.reduce((total, receipt) => total + receipt.quantity, 0), 0)}
+                  receipts={pledge.receipts}
                 />
               </Stack>
             ))}

--- a/app/gear-wishlist/[token]/page.tsx
+++ b/app/gear-wishlist/[token]/page.tsx
@@ -1,0 +1,44 @@
+import { notFound } from "next/navigation";
+import { GearPledgeForm } from "@/components/features/gear/GearPledgeForm";
+import { PublicGearWishlist } from "@/components/features/gear/PublicGearWishlist";
+import { createPublicGearPledge } from "@/lib/actions/gear-pledges";
+import { getPublicGearWishlist } from "@/lib/actions/gear-wishlist";
+
+export default async function PublicGearWishlistPage({ params }: { params: Promise<{ token: string }> }) {
+  const { token } = await params;
+  const wishlist = await getPublicGearWishlist(token).catch(() => null);
+  if (!wishlist) notFound();
+
+  return (
+    <main>
+      <PublicGearWishlist
+        data={{
+          associationName: wishlist.associationName,
+          title: wishlist.title,
+          description: wishlist.description,
+          items: wishlist.items.map((item) => ({
+            id: item.id,
+            name: item.nameSnapshot,
+            category: item.categorySnapshot,
+            size: item.sizeSnapshot,
+            description: item.description,
+            targetQty: item.targetQty,
+            pledgedQty: item.pledgedQty,
+            receivedQty: item.receivedQty,
+          })),
+        }}
+      />
+      <GearPledgeForm
+        token={token}
+        items={wishlist.items.map((item) => ({
+          id: item.id,
+          name: item.nameSnapshot,
+          targetQty: item.targetQty,
+          pledgedQty: item.pledgedQty,
+          receivedQty: item.receivedQty,
+        }))}
+        submit={createPublicGearPledge}
+      />
+    </main>
+  );
+}

--- a/components/features/gear/GearNeedActions.tsx
+++ b/components/features/gear/GearNeedActions.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useState } from "react";
+import { Alert, Button, Stack } from "@mui/material";
+import {
+  approveTeamGearNeed,
+  cancelTeamGearNeed,
+  fulfillTeamGearNeed,
+  submitTeamGearNeed,
+} from "@/lib/actions/gear-needs";
+
+type NeedStatus = "DRAFT" | "SUBMITTED" | "APPROVED" | "FULFILLED" | "CANCELED";
+
+export function GearNeedActions({
+  leagueId,
+  needId,
+  expectedVersion,
+  status,
+  canManageAll,
+}: {
+  leagueId: string;
+  needId: string;
+  expectedVersion: number;
+  status: NeedStatus;
+  canManageAll: boolean;
+}) {
+  const [message, setMessage] = useState<string | null>(null);
+  const [pending, setPending] = useState(false);
+
+  async function transition(action: "submit" | "approve" | "fulfill" | "cancel") {
+    setPending(true);
+    setMessage(null);
+    const input = { leagueId, needId, expectedVersion };
+    const result = await ({
+      submit: submitTeamGearNeed,
+      approve: approveTeamGearNeed,
+      fulfill: fulfillTeamGearNeed,
+      cancel: cancelTeamGearNeed,
+    })[action](input);
+    setPending(false);
+    setMessage(result.success ? "Need updated. Refreshing the latest progress..." : result.error);
+  }
+
+  if (status === "FULFILLED" || status === "CANCELED") return null;
+
+  return (
+    <Stack spacing={1}>
+      {message && <Alert severity={message.startsWith("Need updated") ? "success" : "error"}>{message}</Alert>}
+      <Stack direction={{ xs: "column", sm: "row" }} spacing={1}>
+        {status === "DRAFT" && (
+          <Button variant="contained" disabled={pending} onClick={() => transition("submit")} sx={{ minHeight: 44 }}>
+            Submit need
+          </Button>
+        )}
+        {canManageAll && status === "SUBMITTED" && (
+          <Button variant="contained" disabled={pending} onClick={() => transition("approve")} sx={{ minHeight: 44 }}>
+            Approve need
+          </Button>
+        )}
+        {canManageAll && status === "APPROVED" && (
+          <Button variant="contained" disabled={pending} onClick={() => transition("fulfill")} sx={{ minHeight: 44 }}>
+            Mark fulfilled
+          </Button>
+        )}
+        <Button color="inherit" disabled={pending} onClick={() => transition("cancel")} sx={{ minHeight: 44 }}>
+          {canManageAll && status === "SUBMITTED" ? "Decline need" : "Cancel need"}
+        </Button>
+      </Stack>
+    </Stack>
+  );
+}

--- a/components/features/gear/GearNeedActions.tsx
+++ b/components/features/gear/GearNeedActions.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useRouter } from "next/navigation";
 import { Alert, Button, Stack } from "@mui/material";
 import {
   approveTeamGearNeed,
@@ -16,14 +17,20 @@ export function GearNeedActions({
   needId,
   expectedVersion,
   status,
-  canManageAll,
+  capabilities,
 }: {
   leagueId: string;
   needId: string;
   expectedVersion: number;
   status: NeedStatus;
-  canManageAll: boolean;
+  capabilities: {
+    canSubmit: boolean;
+    canCancel: boolean;
+    canApprove: boolean;
+    canFulfill: boolean;
+  };
 }) {
+  const router = useRouter();
   const [message, setMessage] = useState<string | null>(null);
   const [pending, setPending] = useState(false);
 
@@ -38,7 +45,12 @@ export function GearNeedActions({
       cancel: cancelTeamGearNeed,
     })[action](input);
     setPending(false);
-    setMessage(result.success ? "Need updated. Refreshing the latest progress..." : result.error);
+    if (result.success) {
+      setMessage("Need updated.");
+      router.refresh();
+    } else {
+      setMessage(result.error);
+    }
   }
 
   if (status === "FULFILLED" || status === "CANCELED") return null;
@@ -47,24 +59,26 @@ export function GearNeedActions({
     <Stack spacing={1}>
       {message && <Alert severity={message.startsWith("Need updated") ? "success" : "error"}>{message}</Alert>}
       <Stack direction={{ xs: "column", sm: "row" }} spacing={1}>
-        {status === "DRAFT" && (
+        {capabilities.canSubmit && (
           <Button variant="contained" disabled={pending} onClick={() => transition("submit")} sx={{ minHeight: 44 }}>
             Submit need
           </Button>
         )}
-        {canManageAll && status === "SUBMITTED" && (
+        {capabilities.canApprove && (
           <Button variant="contained" disabled={pending} onClick={() => transition("approve")} sx={{ minHeight: 44 }}>
             Approve need
           </Button>
         )}
-        {canManageAll && status === "APPROVED" && (
+        {capabilities.canFulfill && (
           <Button variant="contained" disabled={pending} onClick={() => transition("fulfill")} sx={{ minHeight: 44 }}>
             Mark fulfilled
           </Button>
         )}
-        <Button color="inherit" disabled={pending} onClick={() => transition("cancel")} sx={{ minHeight: 44 }}>
-          {canManageAll && status === "SUBMITTED" ? "Decline need" : "Cancel need"}
-        </Button>
+        {capabilities.canCancel && (
+          <Button color="inherit" disabled={pending} onClick={() => transition("cancel")} sx={{ minHeight: 44 }}>
+            Cancel need
+          </Button>
+        )}
       </Stack>
     </Stack>
   );

--- a/components/features/gear/GearNeedCreateForm.tsx
+++ b/components/features/gear/GearNeedCreateForm.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useState } from "react";
+import { AddOutlined, DeleteOutline } from "@mui/icons-material";
+import { Alert, Button, Card, IconButton, MenuItem, Stack, TextField, Typography } from "@mui/material";
+import { createTeamGearNeed } from "@/lib/actions/gear-needs";
+
+type NeedLine = { nameSnapshot: string; requestedQty: number; priority: "LOW" | "NORMAL" | "HIGH" | "URGENT" };
+
+export function GearNeedCreateForm({ leagueId, teamIds }: { leagueId: string; teamIds: string[] }) {
+  const [lines, setLines] = useState<NeedLine[]>([{ nameSnapshot: "", requestedQty: 1, priority: "NORMAL" }]);
+  const [message, setMessage] = useState<string | null>(null);
+
+  async function submit(formData: FormData) {
+    const result = await createTeamGearNeed({
+      leagueId,
+      teamId: String(formData.get("teamId") ?? ""),
+      title: String(formData.get("title") ?? ""),
+      notes: String(formData.get("notes") ?? ""),
+      lines,
+    });
+    setMessage(result.success ? "Draft need created. Submit it from the need details page when ready for association review." : result.error);
+  }
+
+  function updateLine(index: number, patch: Partial<NeedLine>) {
+    setLines((current) => current.map((line, lineIndex) => lineIndex === index ? { ...line, ...patch } : line));
+  }
+
+  return (
+    <Card component="form" action={submit} variant="outlined" sx={{ p: 2 }}>
+      <Stack spacing={2}>
+        {message && <Alert severity={message.startsWith("Draft") ? "success" : "error"}>{message}</Alert>}
+        <TextField name="teamId" select label="Team" required defaultValue={teamIds[0] ?? ""}>
+          {teamIds.map((teamId) => <MenuItem key={teamId} value={teamId}>{teamId}</MenuItem>)}
+        </TextField>
+        <TextField name="title" label="Need title" required />
+        <TextField name="notes" label="Team notes" multiline minRows={2} />
+        <Typography variant="h6">Requested items</Typography>
+        {lines.map((line, index) => (
+          <Stack key={index} direction={{ xs: "column", sm: "row" }} spacing={1} alignItems={{ sm: "center" }}>
+            <TextField
+              label="Item or description"
+              required
+              value={line.nameSnapshot}
+              onChange={(event) => updateLine(index, { nameSnapshot: event.target.value })}
+              fullWidth
+            />
+            <TextField
+              label="Quantity"
+              type="number"
+              required
+              inputProps={{ min: 1 }}
+              value={line.requestedQty}
+              onChange={(event) => updateLine(index, { requestedQty: Number(event.target.value) })}
+              sx={{ minWidth: { sm: 130 } }}
+            />
+            <TextField
+              select
+              label="Priority"
+              value={line.priority}
+              onChange={(event) => updateLine(index, { priority: event.target.value as NeedLine["priority"] })}
+              sx={{ minWidth: { sm: 140 } }}
+            >
+              {["LOW", "NORMAL", "HIGH", "URGENT"].map((priority) => <MenuItem key={priority} value={priority}>{priority}</MenuItem>)}
+            </TextField>
+            <IconButton aria-label="Remove item" disabled={lines.length === 1} onClick={() => setLines((current) => current.filter((_, lineIndex) => lineIndex !== index))}>
+              <DeleteOutline />
+            </IconButton>
+          </Stack>
+        ))}
+        <Button startIcon={<AddOutlined />} onClick={() => setLines((current) => [...current, { nameSnapshot: "", requestedQty: 1, priority: "NORMAL" }])} sx={{ alignSelf: "start", minHeight: 44 }}>
+          Add item
+        </Button>
+        <Alert severity="info">A need records demand only. It does not allocate, reserve, or check out gear.</Alert>
+        <Button type="submit" variant="contained" sx={{ minHeight: 44 }}>Save draft need</Button>
+      </Stack>
+    </Card>
+  );
+}

--- a/components/features/gear/GearNeedCreateForm.tsx
+++ b/components/features/gear/GearNeedCreateForm.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { AddOutlined, DeleteOutline } from "@mui/icons-material";
-import { Alert, Button, Card, IconButton, MenuItem, Stack, TextField, Typography } from "@mui/material";
+import { Alert, Box, Button, Card, IconButton, MenuItem, Stack, TextField, Typography } from "@mui/material";
 import { createTeamGearNeed } from "@/lib/actions/gear-needs";
 
 type NeedLine = { nameSnapshot: string; requestedQty: number; priority: "LOW" | "NORMAL" | "HIGH" | "URGENT" };
@@ -16,15 +16,22 @@ export function GearNeedCreateForm({
 }) {
   const [lines, setLines] = useState<NeedLine[]>([{ nameSnapshot: "", requestedQty: 1, priority: "NORMAL" }]);
   const [message, setMessage] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+  const [idempotencyKey, setIdempotencyKey] = useState(() => crypto.randomUUID());
 
   async function submit(formData: FormData) {
+    setIsSaving(true);
+    setMessage(null);
     const result = await createTeamGearNeed({
       leagueId,
       teamId: String(formData.get("teamId") ?? ""),
+      idempotencyKey,
       title: String(formData.get("title") ?? ""),
       notes: String(formData.get("notes") ?? ""),
       lines,
     });
+    setIsSaving(false);
+    if (result.success) setIdempotencyKey(crypto.randomUUID());
     setMessage(result.success ? "Draft need created. Submit it from the need details page when ready for association review." : result.error);
   }
 
@@ -36,49 +43,29 @@ export function GearNeedCreateForm({
     <Card component="form" action={submit} variant="outlined" sx={{ p: 2 }}>
       <Stack spacing={2}>
         {message && <Alert severity={message.startsWith("Draft") ? "success" : "error"}>{message}</Alert>}
-        <TextField name="teamId" select label="Team" required defaultValue={teams[0]?.id ?? ""}>
-          {teams.map((team) => <MenuItem key={team.id} value={team.id}>{team.name}</MenuItem>)}
-        </TextField>
-        <TextField name="title" label="Need title" required />
-        <TextField name="notes" label="Team notes" multiline minRows={2} />
-        <Typography variant="h6">Requested items</Typography>
-        {lines.map((line, index) => (
-          <Stack key={index} direction={{ xs: "column", sm: "row" }} spacing={1} alignItems={{ sm: "center" }}>
-            <TextField
-              label="Item or description"
-              required
-              value={line.nameSnapshot}
-              onChange={(event) => updateLine(index, { nameSnapshot: event.target.value })}
-              fullWidth
-            />
-            <TextField
-              label="Quantity"
-              type="number"
-              required
-              inputProps={{ min: 1 }}
-              value={line.requestedQty}
-              onChange={(event) => updateLine(index, { requestedQty: Number(event.target.value) })}
-              sx={{ minWidth: { sm: 130 } }}
-            />
-            <TextField
-              select
-              label="Priority"
-              value={line.priority}
-              onChange={(event) => updateLine(index, { priority: event.target.value as NeedLine["priority"] })}
-              sx={{ minWidth: { sm: 140 } }}
-            >
-              {["LOW", "NORMAL", "HIGH", "URGENT"].map((priority) => <MenuItem key={priority} value={priority}>{priority}</MenuItem>)}
+        <Box component="fieldset" disabled={isSaving} sx={{ border: 0, p: 0, m: 0 }}>
+          <Stack spacing={2}>
+            <TextField name="teamId" select label="Team" required defaultValue={teams[0]?.id ?? ""}>
+              {teams.map((team) => <MenuItem key={team.id} value={team.id}>{team.name}</MenuItem>)}
             </TextField>
-            <IconButton aria-label="Remove item" disabled={lines.length === 1} onClick={() => setLines((current) => current.filter((_, lineIndex) => lineIndex !== index))}>
-              <DeleteOutline />
-            </IconButton>
+            <TextField name="title" label="Need title" required />
+            <TextField name="notes" label="Team notes" multiline minRows={2} />
+            <Typography variant="h6">Requested items</Typography>
+            {lines.map((line, index) => (
+              <Stack key={index} direction={{ xs: "column", sm: "row" }} spacing={1} alignItems={{ sm: "center" }}>
+                <TextField label="Item or description" required value={line.nameSnapshot} onChange={(event) => updateLine(index, { nameSnapshot: event.target.value })} fullWidth />
+                <TextField label="Quantity" type="number" required inputProps={{ min: 1 }} value={line.requestedQty} onChange={(event) => updateLine(index, { requestedQty: Number(event.target.value) })} sx={{ minWidth: { sm: 130 } }} />
+                <TextField select label="Priority" value={line.priority} onChange={(event) => updateLine(index, { priority: event.target.value as NeedLine["priority"] })} sx={{ minWidth: { sm: 140 } }}>
+                  {["LOW", "NORMAL", "HIGH", "URGENT"].map((priority) => <MenuItem key={priority} value={priority}>{priority}</MenuItem>)}
+                </TextField>
+                <IconButton aria-label="Remove item" disabled={lines.length === 1} onClick={() => setLines((current) => current.filter((_, lineIndex) => lineIndex !== index))}><DeleteOutline /></IconButton>
+              </Stack>
+            ))}
+            <Button startIcon={<AddOutlined />} onClick={() => setLines((current) => [...current, { nameSnapshot: "", requestedQty: 1, priority: "NORMAL" }])} sx={{ alignSelf: "start", minHeight: 44 }}>Add item</Button>
           </Stack>
-        ))}
-        <Button startIcon={<AddOutlined />} onClick={() => setLines((current) => [...current, { nameSnapshot: "", requestedQty: 1, priority: "NORMAL" }])} sx={{ alignSelf: "start", minHeight: 44 }}>
-          Add item
-        </Button>
+        </Box>
         <Alert severity="info">A need records demand only. It does not allocate, reserve, or check out gear.</Alert>
-        <Button type="submit" variant="contained" sx={{ minHeight: 44 }}>Save draft need</Button>
+        <Button type="submit" variant="contained" disabled={isSaving} sx={{ minHeight: 44 }}>{isSaving ? "Saving..." : "Save draft need"}</Button>
       </Stack>
     </Card>
   );

--- a/components/features/gear/GearNeedCreateForm.tsx
+++ b/components/features/gear/GearNeedCreateForm.tsx
@@ -7,7 +7,13 @@ import { createTeamGearNeed } from "@/lib/actions/gear-needs";
 
 type NeedLine = { nameSnapshot: string; requestedQty: number; priority: "LOW" | "NORMAL" | "HIGH" | "URGENT" };
 
-export function GearNeedCreateForm({ leagueId, teamIds }: { leagueId: string; teamIds: string[] }) {
+export function GearNeedCreateForm({
+  leagueId,
+  teams,
+}: {
+  leagueId: string;
+  teams: Array<{ id: string; name: string }>;
+}) {
   const [lines, setLines] = useState<NeedLine[]>([{ nameSnapshot: "", requestedQty: 1, priority: "NORMAL" }]);
   const [message, setMessage] = useState<string | null>(null);
 
@@ -30,8 +36,8 @@ export function GearNeedCreateForm({ leagueId, teamIds }: { leagueId: string; te
     <Card component="form" action={submit} variant="outlined" sx={{ p: 2 }}>
       <Stack spacing={2}>
         {message && <Alert severity={message.startsWith("Draft") ? "success" : "error"}>{message}</Alert>}
-        <TextField name="teamId" select label="Team" required defaultValue={teamIds[0] ?? ""}>
-          {teamIds.map((teamId) => <MenuItem key={teamId} value={teamId}>{teamId}</MenuItem>)}
+        <TextField name="teamId" select label="Team" required defaultValue={teams[0]?.id ?? ""}>
+          {teams.map((team) => <MenuItem key={team.id} value={team.id}>{team.name}</MenuItem>)}
         </TextField>
         <TextField name="title" label="Need title" required />
         <TextField name="notes" label="Team notes" multiline minRows={2} />

--- a/components/features/gear/GearNeedsList.tsx
+++ b/components/features/gear/GearNeedsList.tsx
@@ -1,0 +1,98 @@
+import Link from "next/link";
+import { Alert, Box, Button, Card, Chip, Stack, Table, TableBody, TableCell, TableHead, TableRow, Typography } from "@mui/material";
+
+export type GearNeedListItem = {
+  id: string;
+  title: string;
+  teamName: string;
+  status: "DRAFT" | "SUBMITTED" | "APPROVED" | "FULFILLED" | "CANCELED";
+  submittedAt: string | null;
+  createdAt: string;
+  requestedQuantity: number;
+  fulfilledQuantity: number;
+  priority: "LOW" | "NORMAL" | "HIGH" | "URGENT";
+};
+
+const statusColor = {
+  DRAFT: "default",
+  SUBMITTED: "warning",
+  APPROVED: "info",
+  FULFILLED: "success",
+  CANCELED: "default",
+} as const;
+
+const priorityColor = {
+  LOW: "default",
+  NORMAL: "default",
+  HIGH: "warning",
+  URGENT: "error",
+} as const;
+
+export function GearNeedsList({
+  leagueId,
+  needs,
+}: {
+  leagueId: string;
+  needs: GearNeedListItem[];
+}) {
+  if (needs.length === 0) {
+    return <Alert severity="info">No gear needs match these filters. Needs describe future demand and never reserve inventory.</Alert>;
+  }
+
+  return (
+    <>
+      <Box sx={{ display: { xs: "block", md: "none" } }}>
+        <Stack spacing={2}>
+          {needs.map((need) => (
+            <Card key={need.id} variant="outlined" sx={{ p: 2 }}>
+              <Stack spacing={1}>
+                <Stack direction="row" justifyContent="space-between" alignItems="center" gap={1}>
+                  <Typography fontWeight={700}>{need.title}</Typography>
+                  <Chip size="small" label={need.status} color={statusColor[need.status]} />
+                </Stack>
+                <Typography variant="body2">{need.teamName}</Typography>
+                <Stack direction="row" spacing={1}>
+                  <Chip size="small" label={need.priority} color={priorityColor[need.priority]} variant="outlined" />
+                  <Typography variant="body2" color="text.secondary">
+                    {need.fulfilledQuantity} of {need.requestedQuantity} fulfilled
+                  </Typography>
+                </Stack>
+                <Button component={Link} href={`/league/${leagueId}/gear/needs/${need.id}`} variant="outlined" sx={{ minHeight: 44 }}>
+                  View need
+                </Button>
+              </Stack>
+            </Card>
+          ))}
+        </Stack>
+      </Box>
+      <Table size="small" sx={{ display: { xs: "none", md: "table" } }}>
+        <TableHead>
+          <TableRow>
+            <TableCell>Need</TableCell>
+            <TableCell>Team</TableCell>
+            <TableCell>Priority</TableCell>
+            <TableCell>Status</TableCell>
+            <TableCell>Progress</TableCell>
+            <TableCell align="right"> </TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {needs.map((need) => (
+            <TableRow key={need.id}>
+              <TableCell>{need.title}</TableCell>
+              <TableCell>{need.teamName}</TableCell>
+              <TableCell><Chip size="small" label={need.priority} color={priorityColor[need.priority]} variant="outlined" /></TableCell>
+              <TableCell><Chip size="small" label={need.status} color={statusColor[need.status]} /></TableCell>
+              <TableCell>{need.fulfilledQuantity} / {need.requestedQuantity}</TableCell>
+              <TableCell align="right">
+                <Button component={Link} href={`/league/${leagueId}/gear/needs/${need.id}`} sx={{ minHeight: 44 }}>
+                  Details
+                </Button>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </>
+  );
+}

--- a/components/features/gear/GearNeedsList.tsx
+++ b/components/features/gear/GearNeedsList.tsx
@@ -1,5 +1,5 @@
-import Link from "next/link";
-import { Alert, Box, Button, Card, Chip, Stack, Table, TableBody, TableCell, TableHead, TableRow, Typography } from "@mui/material";
+import { Alert, Box, Card, Chip, Stack, Table, TableBody, TableCell, TableHead, TableRow, Typography } from "@mui/material";
+import { LinkButton } from "@/components/ui/NextLinkComposites";
 
 export type GearNeedListItem = {
   id: string;
@@ -57,9 +57,9 @@ export function GearNeedsList({
                     {need.fulfilledQuantity} of {need.requestedQuantity} fulfilled
                   </Typography>
                 </Stack>
-                <Button component={Link} href={`/league/${leagueId}/gear/needs/${need.id}`} variant="outlined" sx={{ minHeight: 44 }}>
+                <LinkButton href={`/league/${leagueId}/gear/needs/${need.id}`} variant="outlined" sx={{ minHeight: 44 }}>
                   View need
-                </Button>
+                </LinkButton>
               </Stack>
             </Card>
           ))}
@@ -85,9 +85,9 @@ export function GearNeedsList({
               <TableCell><Chip size="small" label={need.status} color={statusColor[need.status]} /></TableCell>
               <TableCell>{need.fulfilledQuantity} / {need.requestedQuantity}</TableCell>
               <TableCell align="right">
-                <Button component={Link} href={`/league/${leagueId}/gear/needs/${need.id}`} sx={{ minHeight: 44 }}>
+                <LinkButton href={`/league/${leagueId}/gear/needs/${need.id}`} sx={{ minHeight: 44 }}>
                   Details
-                </Button>
+                </LinkButton>
               </TableCell>
             </TableRow>
           ))}

--- a/components/features/gear/GearPledgeAdminActions.tsx
+++ b/components/features/gear/GearPledgeAdminActions.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Alert, Button, MenuItem, Stack, TextField } from "@mui/material";
+import { declineGearPledge, receiveGearPledge } from "@/lib/actions/gear-pledges";
+
+type InventoryOption = { id: string; name: string };
+type PoolStockOption = { id: string; catalogName: string; locationName: string };
+
+export function GearPledgeAdminActions({
+  leagueId,
+  pledgeId,
+  pledgeVersion,
+  status,
+  catalogItems,
+  locations,
+  poolStock,
+}: {
+  leagueId: string;
+  pledgeId: string;
+  pledgeVersion: number;
+  status: "PLEDGED" | "RECEIVED" | "DECLINED" | "CANCELED" | "EXPIRED";
+  catalogItems: InventoryOption[];
+  locations: InventoryOption[];
+  poolStock: PoolStockOption[];
+}) {
+  const router = useRouter();
+  const [message, setMessage] = useState<string | null>(null);
+  const [pending, setPending] = useState(false);
+  const [mode, setMode] = useState<"pooled" | "tagged">("pooled");
+
+  async function receive(formData: FormData) {
+    setPending(true);
+    const assetTags = String(formData.get("assetTags") ?? "")
+      .split(",")
+      .map((tag) => tag.trim())
+      .filter(Boolean);
+    const result = await receiveGearPledge({
+      leagueId,
+      pledgeId,
+      expectedVersion: pledgeVersion,
+      idempotencyKey: crypto.randomUUID(),
+      poolStockId: mode === "pooled" ? String(formData.get("poolStockId") ?? "") : "",
+      catalogItemId: mode === "tagged" ? String(formData.get("catalogItemId") ?? "") : "",
+      locationId: mode === "tagged" ? String(formData.get("locationId") ?? "") : "",
+      condition: mode === "tagged" ? "GOOD" : undefined,
+      assetTags: mode === "tagged" ? assetTags : [],
+      quantity: Number(formData.get("quantity") ?? 0),
+      notes: String(formData.get("notes") ?? ""),
+    });
+    setPending(false);
+    if (result.success) {
+      setMessage("Receipt recorded.");
+      router.refresh();
+    } else {
+      setMessage(result.error);
+    }
+  }
+
+  async function decline() {
+    setPending(true);
+    const result = await declineGearPledge({ leagueId, pledgeId, expectedVersion: pledgeVersion });
+    setPending(false);
+    if (result.success) {
+      setMessage("Pledge declined.");
+      router.refresh();
+    } else {
+      setMessage(result.error);
+    }
+  }
+
+  if (status !== "PLEDGED") return null;
+  return (
+    <Stack component="form" action={receive} spacing={1} sx={{ pt: 1 }}>
+      {message && <Alert severity={message.endsWith(".") && !message.includes("error") ? "success" : "error"}>{message}</Alert>}
+      <TextField select label="Receipt type" value={mode} onChange={(event) => setMode(event.target.value as "pooled" | "tagged")}>
+        <MenuItem value="pooled">Pooled inventory</MenuItem>
+        <MenuItem value="tagged">Individually tagged units</MenuItem>
+      </TextField>
+      {mode === "pooled" ? (
+        <TextField select name="poolStockId" label="Pooled stock destination" required defaultValue="">
+          <MenuItem value="" disabled>Select stock</MenuItem>
+          {poolStock.map((stock) => <MenuItem key={stock.id} value={stock.id}>{stock.catalogName} - {stock.locationName}</MenuItem>)}
+        </TextField>
+      ) : (
+        <>
+          <TextField select name="catalogItemId" label="Catalog item" required defaultValue="">
+            <MenuItem value="" disabled>Select item</MenuItem>
+            {catalogItems.map((item) => <MenuItem key={item.id} value={item.id}>{item.name}</MenuItem>)}
+          </TextField>
+          <TextField select name="locationId" label="Storage location" required defaultValue="">
+            <MenuItem value="" disabled>Select location</MenuItem>
+            {locations.map((location) => <MenuItem key={location.id} value={location.id}>{location.name}</MenuItem>)}
+          </TextField>
+          <TextField name="assetTags" label="Asset tags" helperText="One unique tag per unit, separated by commas." required />
+        </>
+      )}
+      <TextField name="quantity" label="Received quantity" type="number" inputProps={{ min: 1 }} required />
+      <TextField name="notes" label="Receipt notes" multiline minRows={2} />
+      <Stack direction={{ xs: "column", sm: "row" }} spacing={1}>
+        <Button type="submit" variant="contained" disabled={pending} sx={{ minHeight: 44 }}>Record receipt</Button>
+        <Button type="button" color="inherit" disabled={pending} onClick={decline} sx={{ minHeight: 44 }}>Decline pledge</Button>
+      </Stack>
+    </Stack>
+  );
+}

--- a/components/features/gear/GearPledgeAdminActions.tsx
+++ b/components/features/gear/GearPledgeAdminActions.tsx
@@ -1,12 +1,15 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import { Alert, Button, MenuItem, Stack, TextField } from "@mui/material";
-import { declineGearPledge, receiveGearPledge } from "@/lib/actions/gear-pledges";
+import { Alert, Button, MenuItem, Stack, TextField, Typography } from "@mui/material";
+import { correctGearPledgeReceipt, declineGearPledge, expireGearPledge, receiveGearPledge } from "@/lib/actions/gear-pledges";
 
 type InventoryOption = { id: string; name: string };
 type PoolStockOption = { id: string; catalogName: string; locationName: string };
+type ReceiptOption = { id: string; quantity: number; receivedAt: string };
+const conditions = ["NEW", "EXCELLENT", "GOOD", "FAIR", "POOR", "DAMAGED"] as const;
+type Condition = (typeof conditions)[number];
 
 export function GearPledgeAdminActions({
   leagueId,
@@ -14,24 +17,42 @@ export function GearPledgeAdminActions({
   pledgeVersion,
   status,
   catalogItems,
+  pooledCatalogItems,
   locations,
   poolStock,
+  remainingQuantity,
+  receipts,
 }: {
   leagueId: string;
   pledgeId: string;
   pledgeVersion: number;
   status: "PLEDGED" | "RECEIVED" | "DECLINED" | "CANCELED" | "EXPIRED";
   catalogItems: InventoryOption[];
+  pooledCatalogItems: InventoryOption[];
   locations: InventoryOption[];
   poolStock: PoolStockOption[];
+  remainingQuantity: number;
+  receipts: ReceiptOption[];
 }) {
   const router = useRouter();
   const [message, setMessage] = useState<string | null>(null);
   const [pending, setPending] = useState(false);
   const [mode, setMode] = useState<"pooled" | "tagged">("pooled");
+  const [condition, setCondition] = useState<Condition | "">("");
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+  const [correctionReceiptId, setCorrectionReceiptId] = useState(receipts[0]?.id ?? "");
+  const [correctionReason, setCorrectionReason] = useState("");
+  const [operationKey, setOperationKey] = useState(() => {
+    const storageKey = `gear-pledge-receipt:${pledgeId}:${pledgeVersion}`;
+    return typeof window === "undefined" ? crypto.randomUUID() : sessionStorage.getItem(storageKey) ?? crypto.randomUUID();
+  });
+  useEffect(() => {
+    sessionStorage.setItem(`gear-pledge-receipt:${pledgeId}:${pledgeVersion}`, operationKey);
+  }, [operationKey, pledgeId, pledgeVersion]);
 
   async function receive(formData: FormData) {
     setPending(true);
+    setFieldErrors({});
     const assetTags = String(formData.get("assetTags") ?? "")
       .split(",")
       .map((tag) => tag.trim())
@@ -40,20 +61,23 @@ export function GearPledgeAdminActions({
       leagueId,
       pledgeId,
       expectedVersion: pledgeVersion,
-      idempotencyKey: crypto.randomUUID(),
+      idempotencyKey: operationKey,
       poolStockId: mode === "pooled" ? String(formData.get("poolStockId") ?? "") : "",
-      catalogItemId: mode === "tagged" ? String(formData.get("catalogItemId") ?? "") : "",
-      locationId: mode === "tagged" ? String(formData.get("locationId") ?? "") : "",
-      condition: mode === "tagged" ? "GOOD" : undefined,
+      catalogItemId: String(formData.get("catalogItemId") ?? ""),
+      locationId: String(formData.get("locationId") ?? ""),
+      condition: condition || undefined,
       assetTags: mode === "tagged" ? assetTags : [],
       quantity: Number(formData.get("quantity") ?? 0),
       notes: String(formData.get("notes") ?? ""),
     });
     setPending(false);
     if (result.success) {
+      sessionStorage.removeItem(`gear-pledge-receipt:${pledgeId}:${pledgeVersion}`);
+      setOperationKey(crypto.randomUUID());
       setMessage("Receipt recorded.");
       router.refresh();
     } else {
+      setFieldErrors(actionFieldErrors(result.details));
       setMessage(result.error);
     }
   }
@@ -70,38 +94,111 @@ export function GearPledgeAdminActions({
     }
   }
 
-  if (status !== "PLEDGED") return null;
+  async function expire() {
+    setPending(true);
+    const result = await expireGearPledge({ leagueId, pledgeId, expectedVersion: pledgeVersion });
+    setPending(false);
+    if (result.success) {
+      setMessage("Pledge expired.");
+      router.refresh();
+    } else {
+      setMessage(result.error);
+    }
+  }
+
+  async function correct() {
+    setPending(true);
+    setFieldErrors({});
+    const result = await correctGearPledgeReceipt({
+      leagueId,
+      pledgeId,
+      receiptId: correctionReceiptId,
+      expectedVersion: pledgeVersion,
+      reason: correctionReason,
+    });
+    setPending(false);
+    if (result.success) {
+      setMessage("Receipt correction recorded.");
+      router.refresh();
+    } else {
+      setFieldErrors(actionFieldErrors(result.details));
+      setMessage(result.error);
+    }
+  }
+
+  const canReceive = status === "PLEDGED" && remainingQuantity > 0;
+  const canCorrect = ["PLEDGED", "RECEIVED"].includes(status) && receipts.length > 0;
+  if (!canReceive && !canCorrect) return null;
   return (
-    <Stack component="form" action={receive} spacing={1} sx={{ pt: 1 }}>
+    <Stack spacing={1} sx={{ pt: 1 }}>
       {message && <Alert severity={message.endsWith(".") && !message.includes("error") ? "success" : "error"}>{message}</Alert>}
+      {canReceive && <Stack component="form" action={receive} spacing={1}>
       <TextField select label="Receipt type" value={mode} onChange={(event) => setMode(event.target.value as "pooled" | "tagged")}>
         <MenuItem value="pooled">Pooled inventory</MenuItem>
         <MenuItem value="tagged">Individually tagged units</MenuItem>
       </TextField>
       {mode === "pooled" ? (
-        <TextField select name="poolStockId" label="Pooled stock destination" required defaultValue="">
-          <MenuItem value="" disabled>Select stock</MenuItem>
+        <>
+          <TextField select name="poolStockId" label="Existing pooled stock destination" defaultValue="" error={Boolean(fieldErrors.poolStockId)} helperText={fieldErrors.poolStockId}>
+          <MenuItem value="">Create or select a destination below</MenuItem>
           {poolStock.map((stock) => <MenuItem key={stock.id} value={stock.id}>{stock.catalogName} - {stock.locationName}</MenuItem>)}
-        </TextField>
+          </TextField>
+          <TextField select name="catalogItemId" label="Pooled catalog item" defaultValue="" error={Boolean(fieldErrors.catalogItemId)} helperText={fieldErrors.catalogItemId}>
+          <MenuItem value="">Select when creating a new pooled destination</MenuItem>
+          {pooledCatalogItems.map((item) => <MenuItem key={item.id} value={item.id}>{item.name}</MenuItem>)}
+          </TextField>
+        </>
       ) : (
         <>
-          <TextField select name="catalogItemId" label="Catalog item" required defaultValue="">
+          <TextField select name="catalogItemId" label="Catalog item" required defaultValue="" error={Boolean(fieldErrors.catalogItemId)} helperText={fieldErrors.catalogItemId}>
             <MenuItem value="" disabled>Select item</MenuItem>
             {catalogItems.map((item) => <MenuItem key={item.id} value={item.id}>{item.name}</MenuItem>)}
           </TextField>
-          <TextField select name="locationId" label="Storage location" required defaultValue="">
-            <MenuItem value="" disabled>Select location</MenuItem>
-            {locations.map((location) => <MenuItem key={location.id} value={location.id}>{location.name}</MenuItem>)}
-          </TextField>
-          <TextField name="assetTags" label="Asset tags" helperText="One unique tag per unit, separated by commas." required />
+          <TextField name="assetTags" label="Asset tags" error={Boolean(fieldErrors.assetTags)} helperText={fieldErrors.assetTags ?? "One unique tag per unit, separated by commas."} required />
         </>
       )}
-      <TextField name="quantity" label="Received quantity" type="number" inputProps={{ min: 1 }} required />
+      <TextField select name="locationId" label="Storage location" required defaultValue="" error={Boolean(fieldErrors.locationId)} helperText={fieldErrors.locationId}>
+        <MenuItem value="" disabled>Select location</MenuItem>
+        {locations.map((location) => <MenuItem key={location.id} value={location.id}>{location.name}</MenuItem>)}
+      </TextField>
+      <TextField select label="Observed condition" value={condition} onChange={(event) => setCondition(event.target.value as Condition)} error={Boolean(fieldErrors.condition)} helperText={fieldErrors.condition} required>
+        <MenuItem value="" disabled>Select observed condition</MenuItem>
+        {conditions.map((value) => <MenuItem key={value} value={value}>{value}</MenuItem>)}
+      </TextField>
+      <TextField name="quantity" label="Received quantity" type="number" inputProps={{ min: 1, max: remainingQuantity }} error={Boolean(fieldErrors.quantity)} helperText={fieldErrors.quantity ?? `${remainingQuantity} remaining on this pledge`} required />
       <TextField name="notes" label="Receipt notes" multiline minRows={2} />
       <Stack direction={{ xs: "column", sm: "row" }} spacing={1}>
         <Button type="submit" variant="contained" disabled={pending} sx={{ minHeight: 44 }}>Record receipt</Button>
         <Button type="button" color="inherit" disabled={pending} onClick={decline} sx={{ minHeight: 44 }}>Decline pledge</Button>
+        <Button type="button" color="inherit" disabled={pending} onClick={expire} sx={{ minHeight: 44 }}>Expire pledge</Button>
       </Stack>
+      </Stack>}
+      {canCorrect && (
+        <Stack spacing={1} sx={{ pt: 1 }}>
+          <Typography variant="subtitle2">Correct a receipt</Typography>
+          <TextField select label="Receipt to correct" value={correctionReceiptId} onChange={(event) => setCorrectionReceiptId(event.target.value)}>
+            {receipts.map((receipt) => <MenuItem key={receipt.id} value={receipt.id}>{receipt.id} · {receipt.quantity} · {new Date(receipt.receivedAt).toLocaleDateString()}</MenuItem>)}
+          </TextField>
+          <TextField label="Correction reason" value={correctionReason} onChange={(event) => setCorrectionReason(event.target.value)} error={Boolean(fieldErrors.reason)} helperText={fieldErrors.reason} required />
+          <Button type="button" color="warning" disabled={pending || !correctionReceiptId || !correctionReason} onClick={correct} sx={{ alignSelf: "start", minHeight: 44 }}>Correct receipt</Button>
+        </Stack>
+      )}
     </Stack>
   );
+}
+
+function actionFieldErrors(details: unknown): Record<string, string> {
+  if (!Array.isArray(details)) return {};
+  return Object.fromEntries(details.flatMap((issue) => {
+    if (
+      typeof issue !== "object"
+      || issue === null
+      || !("message" in issue)
+      || !("path" in issue)
+      || typeof issue.message !== "string"
+      || !Array.isArray(issue.path)
+      || typeof issue.path[0] !== "string"
+    ) return [];
+    return [[issue.path[0], issue.message]];
+  }));
 }

--- a/components/features/gear/GearPledgeForm.tsx
+++ b/components/features/gear/GearPledgeForm.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { useState } from "react";
+import { Alert, Button, Card, Checkbox, FormControlLabel, MenuItem, Stack, TextField, Typography } from "@mui/material";
+
+type PledgeItem = {
+  id: string;
+  name: string;
+  targetQty: number;
+  pledgedQty: number;
+  receivedQty: number;
+};
+
+type PledgeInput = {
+  wishlistToken: string;
+  wishlistItemId: string;
+  donorName: string;
+  donorEmail: string;
+  donorPhone: string;
+  contactConsent: boolean;
+  quantity: number;
+  note: string;
+  idempotencyKey: string;
+  website: string;
+};
+
+type PledgeResult = { success: boolean; error?: string };
+
+export function GearPledgeForm({
+  token,
+  items,
+  submit,
+}: {
+  token: string;
+  items: PledgeItem[];
+  submit: (input: PledgeInput) => Promise<PledgeResult>;
+}) {
+  const [message, setMessage] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [key] = useState(() => crypto.randomUUID());
+
+  async function handleSubmit(formData: FormData) {
+    setIsSubmitting(true);
+    setMessage(null);
+    const result = await submit({
+      wishlistToken: token,
+      wishlistItemId: String(formData.get("wishlistItemId") ?? ""),
+      donorName: String(formData.get("donorName") ?? ""),
+      donorEmail: String(formData.get("donorEmail") ?? ""),
+      donorPhone: String(formData.get("donorPhone") ?? ""),
+      contactConsent: formData.get("contactConsent") === "on",
+      quantity: Number(formData.get("quantity") ?? 0),
+      note: String(formData.get("note") ?? ""),
+      idempotencyKey: key,
+      website: String(formData.get("website") ?? ""),
+    });
+    setIsSubmitting(false);
+    setMessage(result.success
+      ? "Thank you. The association will use your contact details only to coordinate this donation."
+      : result.error ?? "We could not record your pledge. Please try again.");
+  }
+
+  return (
+    <Card component="form" action={handleSubmit} variant="outlined" sx={{ p: 2 }}>
+      <Stack spacing={2}>
+        <Typography variant="h5">Pledge an item</Typography>
+        {message && <Alert severity={message.startsWith("Thank") ? "success" : "error"}>{message}</Alert>}
+        <TextField select name="wishlistItemId" label="Item" required defaultValue={items[0]?.id ?? ""}>
+          {items.map((item) => (
+            <MenuItem key={item.id} value={item.id}>
+              {item.name} ({item.receivedQty}/{item.targetQty} received)
+            </MenuItem>
+          ))}
+        </TextField>
+        <TextField name="quantity" label="Quantity" type="number" inputProps={{ min: 1 }} required />
+        <TextField name="donorName" label="Your name" required autoComplete="name" />
+        <TextField name="donorEmail" label="Email" type="email" autoComplete="email" />
+        <TextField name="donorPhone" label="Phone" type="tel" autoComplete="tel" />
+        <TextField name="note" label="Donation note" multiline minRows={2} />
+        <TextField
+          name="website"
+          label="Website"
+          tabIndex={-1}
+          autoComplete="off"
+          sx={{ position: "absolute", left: "-10000px", width: 1, height: 1, overflow: "hidden" }}
+        />
+        <FormControlLabel
+          control={<Checkbox name="contactConsent" required />}
+          label="I agree that the association may contact me only to coordinate this in-kind donation."
+        />
+        <Button type="submit" disabled={isSubmitting || items.length === 0} variant="contained" sx={{ minHeight: 44 }}>
+          {isSubmitting ? "Submitting..." : "Submit pledge"}
+        </Button>
+      </Stack>
+    </Card>
+  );
+}

--- a/components/features/gear/GearPledgeForm.tsx
+++ b/components/features/gear/GearPledgeForm.tsx
@@ -24,7 +24,7 @@ type PledgeInput = {
   website: string;
 };
 
-type PledgeResult = { success: boolean; error?: string };
+type PledgeResult = { success: boolean; error?: string; details?: unknown };
 
 export function GearPledgeForm({
   token,
@@ -37,12 +37,14 @@ export function GearPledgeForm({
 }) {
   const [message, setMessage] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
   const [idempotencyKey, setIdempotencyKey] = useState(() => crypto.randomUUID());
   const formRef = useRef<HTMLFormElement>(null);
 
   async function handleSubmit(formData: FormData) {
     setIsSubmitting(true);
     setMessage(null);
+    setFieldErrors({});
     const result = await submit({
       wishlistToken: token,
       wishlistItemId: String(formData.get("wishlistItemId") ?? ""),
@@ -61,6 +63,7 @@ export function GearPledgeForm({
       setIdempotencyKey(crypto.randomUUID());
       setMessage("Thank you. The association will use your contact details only to coordinate this donation.");
     } else {
+      setFieldErrors(actionFieldErrors(result.details));
       setMessage(result.error ?? "We could not record your pledge. Please try again.");
     }
   }
@@ -77,17 +80,19 @@ export function GearPledgeForm({
             </MenuItem>
           ))}
         </TextField>
-        <TextField name="quantity" label="Quantity" type="number" inputProps={{ min: 1 }} required />
+        <TextField name="quantity" label="Quantity" type="number" inputProps={{ min: 1 }} error={Boolean(fieldErrors.quantity)} helperText={fieldErrors.quantity} required />
         <TextField name="donorName" label="Your name" required autoComplete="name" />
-        <TextField name="donorEmail" label="Email" type="email" autoComplete="email" />
-        <TextField name="donorPhone" label="Phone" type="tel" autoComplete="tel" />
+        <TextField name="donorEmail" label="Email" type="email" autoComplete="email" error={Boolean(fieldErrors.donorEmail)} helperText={fieldErrors.donorEmail} />
+        <TextField name="donorPhone" label="Phone" type="tel" autoComplete="tel" error={Boolean(fieldErrors.donorPhone)} helperText={fieldErrors.donorPhone} />
+        <Typography variant="body2" color="text.secondary">Include at least one contact method: email or phone.</Typography>
         <TextField name="note" label="Donation note" multiline minRows={2} />
-        <TextField
+        <input
           name="website"
-          label="Website"
+          aria-hidden="true"
           tabIndex={-1}
-          autoComplete="off"
-          sx={{ position: "absolute", left: "-10000px", width: 1, height: 1, overflow: "hidden" }}
+          autoComplete="new-password"
+          inert
+          style={{ position: "absolute", left: "-10000px", width: 1, height: 1, overflow: "hidden" }}
         />
         <FormControlLabel
           control={<Checkbox name="contactConsent" required />}
@@ -99,4 +104,20 @@ export function GearPledgeForm({
       </Stack>
     </Card>
   );
+}
+
+function actionFieldErrors(details: unknown): Record<string, string> {
+  if (!Array.isArray(details)) return {};
+  return Object.fromEntries(details.flatMap((issue) => {
+    if (
+      typeof issue !== "object"
+      || issue === null
+      || !("message" in issue)
+      || !("path" in issue)
+      || typeof issue.message !== "string"
+      || !Array.isArray(issue.path)
+      || typeof issue.path[0] !== "string"
+    ) return [];
+    return [[issue.path[0], issue.message]];
+  }));
 }

--- a/components/features/gear/GearPledgeForm.tsx
+++ b/components/features/gear/GearPledgeForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { Alert, Button, Card, Checkbox, FormControlLabel, MenuItem, Stack, TextField, Typography } from "@mui/material";
 
 type PledgeItem = {
@@ -37,7 +37,8 @@ export function GearPledgeForm({
 }) {
   const [message, setMessage] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [key] = useState(() => crypto.randomUUID());
+  const [idempotencyKey, setIdempotencyKey] = useState(() => crypto.randomUUID());
+  const formRef = useRef<HTMLFormElement>(null);
 
   async function handleSubmit(formData: FormData) {
     setIsSubmitting(true);
@@ -51,17 +52,21 @@ export function GearPledgeForm({
       contactConsent: formData.get("contactConsent") === "on",
       quantity: Number(formData.get("quantity") ?? 0),
       note: String(formData.get("note") ?? ""),
-      idempotencyKey: key,
+      idempotencyKey,
       website: String(formData.get("website") ?? ""),
     });
     setIsSubmitting(false);
-    setMessage(result.success
-      ? "Thank you. The association will use your contact details only to coordinate this donation."
-      : result.error ?? "We could not record your pledge. Please try again.");
+    if (result.success) {
+      formRef.current?.reset();
+      setIdempotencyKey(crypto.randomUUID());
+      setMessage("Thank you. The association will use your contact details only to coordinate this donation.");
+    } else {
+      setMessage(result.error ?? "We could not record your pledge. Please try again.");
+    }
   }
 
   return (
-    <Card component="form" action={handleSubmit} variant="outlined" sx={{ p: 2 }}>
+    <Card ref={formRef} component="form" action={handleSubmit} variant="outlined" sx={{ p: 2 }}>
       <Stack spacing={2}>
         <Typography variant="h5">Pledge an item</Typography>
         {message && <Alert severity={message.startsWith("Thank") ? "success" : "error"}>{message}</Alert>}

--- a/components/features/gear/GearWishlistAdminActions.tsx
+++ b/components/features/gear/GearWishlistAdminActions.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { Alert, Button, Stack } from "@mui/material";
+import { archiveGearWishlist, rotateGearWishlistShareToken, setGearWishlistStatus } from "@/lib/actions/gear-wishlist";
+
+export function GearWishlistAdminActions({
+  leagueId,
+  shareToken,
+  status,
+  version,
+}: {
+  leagueId: string;
+  shareToken: string;
+  status: "DRAFT" | "PUBLISHED" | "ARCHIVED";
+  version: number;
+}) {
+  const [message, setMessage] = useState<string | null>(null);
+  const [pending, setPending] = useState(false);
+
+  async function run(action: "publish" | "rotate" | "archive") {
+    setPending(true);
+    const input = { leagueId, expectedVersion: version };
+    const result = action === "publish"
+      ? await setGearWishlistStatus({ ...input, status: "PUBLISHED" })
+      : action === "rotate"
+        ? await rotateGearWishlistShareToken(input)
+        : await archiveGearWishlist(input);
+    setPending(false);
+    setMessage(result.success ? "Wishlist updated. Refresh to see its current version." : result.error);
+  }
+
+  if (status === "ARCHIVED") return null;
+  return (
+    <Stack spacing={1}>
+      {message && <Alert severity={message.startsWith("Wishlist updated") ? "success" : "error"}>{message}</Alert>}
+      <Stack direction={{ xs: "column", sm: "row" }} spacing={1}>
+        {status === "DRAFT" && <Button variant="contained" disabled={pending} onClick={() => run("publish")} sx={{ minHeight: 44 }}>Publish</Button>}
+        {status === "PUBLISHED" && (
+          <Button component={Link} href={`/gear-wishlist/${shareToken}`} target="_blank" variant="outlined" sx={{ minHeight: 44 }}>
+            Open public wishlist
+          </Button>
+        )}
+        <Button disabled={pending} onClick={() => run("rotate")} sx={{ minHeight: 44 }}>Rotate link</Button>
+        <Button color="inherit" disabled={pending} onClick={() => run("archive")} sx={{ minHeight: 44 }}>Archive</Button>
+      </Stack>
+    </Stack>
+  );
+}

--- a/components/features/gear/GearWishlistEditor.tsx
+++ b/components/features/gear/GearWishlistEditor.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { AddOutlined, DeleteOutline } from "@mui/icons-material";
+import { Alert, Button, Card, IconButton, MenuItem, Stack, TextField, Typography } from "@mui/material";
+import { saveGearWishlist } from "@/lib/actions/gear-wishlist";
+
+type WishlistItem = {
+  catalogItemId: string;
+  nameSnapshot: string;
+  categorySnapshot: string;
+  sizeSnapshot: string;
+  description: string;
+  targetQty: number;
+};
+
+type CatalogItem = {
+  id: string;
+  name: string;
+  category: string;
+  size: string | null;
+};
+
+export function GearWishlistEditor({
+  leagueId,
+  catalogItems,
+  initial,
+}: {
+  leagueId: string;
+  catalogItems: CatalogItem[];
+  initial?: {
+    title: string;
+    description: string | null;
+    version: number;
+    items: WishlistItem[];
+  };
+}) {
+  const router = useRouter();
+  const [items, setItems] = useState<WishlistItem[]>(
+    initial?.items.length ? initial.items : [{ catalogItemId: "", nameSnapshot: "", categorySnapshot: "", sizeSnapshot: "", description: "", targetQty: 1 }],
+  );
+  const [message, setMessage] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  function updateItem(index: number, patch: Partial<WishlistItem>) {
+    setItems((current) => current.map((item, itemIndex) => itemIndex === index ? { ...item, ...patch } : item));
+  }
+
+  function chooseCatalog(index: number, id: string) {
+    const catalogItem = catalogItems.find((item) => item.id === id);
+    updateItem(index, catalogItem
+      ? { catalogItemId: id, nameSnapshot: catalogItem.name, categorySnapshot: catalogItem.category, sizeSnapshot: catalogItem.size ?? "" }
+      : { catalogItemId: "" });
+  }
+
+  async function save(formData: FormData) {
+    setSaving(true);
+    const result = await saveGearWishlist({
+      leagueId,
+      title: String(formData.get("title") ?? ""),
+      description: String(formData.get("description") ?? ""),
+      publish: formData.get("publish") === "true",
+      expectedVersion: initial?.version,
+      items,
+    });
+    setSaving(false);
+    if (result.success) {
+      setMessage("Wishlist saved.");
+      router.refresh();
+    } else {
+      setMessage(result.error);
+    }
+  }
+
+  return (
+    <Card component="form" action={save} variant="outlined" sx={{ p: 2 }}>
+      <Stack spacing={2}>
+        {message && <Alert severity={message === "Wishlist saved." ? "success" : "error"}>{message}</Alert>}
+        <TextField name="title" label="Public title" defaultValue={initial?.title ?? "Association gear wishlist"} required />
+        <TextField name="description" label="Public donation instructions" defaultValue={initial?.description ?? ""} multiline minRows={2} />
+        <Typography variant="h6">Curated public items</Typography>
+        {items.map((item, index) => (
+          <Stack key={index} direction={{ xs: "column", md: "row" }} spacing={1} alignItems={{ md: "center" }}>
+            <TextField select label="Catalog item (optional)" value={item.catalogItemId} onChange={(event) => chooseCatalog(index, event.target.value)} sx={{ minWidth: { md: 220 } }}>
+              <MenuItem value="">Custom snapshot</MenuItem>
+              {catalogItems.map((catalogItem) => <MenuItem key={catalogItem.id} value={catalogItem.id}>{catalogItem.name}</MenuItem>)}
+            </TextField>
+            <TextField label="Item name" required value={item.nameSnapshot} onChange={(event) => updateItem(index, { nameSnapshot: event.target.value })} fullWidth />
+            <TextField label="Target" type="number" inputProps={{ min: 1 }} value={item.targetQty} onChange={(event) => updateItem(index, { targetQty: Number(event.target.value) })} sx={{ minWidth: { md: 110 } }} />
+            <IconButton aria-label="Remove wishlist item" disabled={items.length === 1} onClick={() => setItems((current) => current.filter((_, itemIndex) => itemIndex !== index))}>
+              <DeleteOutline />
+            </IconButton>
+          </Stack>
+        ))}
+        <Button startIcon={<AddOutlined />} onClick={() => setItems((current) => [...current, { catalogItemId: "", nameSnapshot: "", categorySnapshot: "", sizeSnapshot: "", description: "", targetQty: 1 }])} sx={{ alignSelf: "start", minHeight: 44 }}>
+          Add item
+        </Button>
+        <Stack direction={{ xs: "column", sm: "row" }} spacing={1}>
+          <Button type="submit" name="publish" value="false" disabled={saving} variant="outlined" sx={{ minHeight: 44 }}>Save draft</Button>
+          <Button type="submit" name="publish" value="true" disabled={saving} variant="contained" sx={{ minHeight: 44 }}>Save and publish</Button>
+        </Stack>
+      </Stack>
+    </Card>
+  );
+}

--- a/components/features/gear/PublicGearWishlist.tsx
+++ b/components/features/gear/PublicGearWishlist.tsx
@@ -1,0 +1,54 @@
+import { Card, Chip, Divider, Stack, Typography } from "@mui/material";
+
+export type PublicGearWishlistData = {
+  associationName: string;
+  title: string;
+  description: string | null;
+  items: Array<{
+    id: string;
+    name: string;
+    category: string | null;
+    size: string | null;
+    description: string | null;
+    targetQty: number;
+    pledgedQty: number;
+    receivedQty: number;
+  }>;
+};
+
+export function PublicGearWishlist({ data }: { data: PublicGearWishlistData }) {
+  return (
+    <Stack spacing={2}>
+      <Stack spacing={0.5}>
+        <Typography variant="overline" color="primary.main">{data.associationName}</Typography>
+        <Typography variant="h3">{data.title}</Typography>
+        {data.description && <Typography color="text.secondary">{data.description}</Typography>}
+      </Stack>
+      <Typography color="text.secondary">
+        Donations are in-kind pledges. They do not reserve or purchase inventory; the association will coordinate receipt directly.
+      </Typography>
+      <Stack spacing={2}>
+        {data.items.map((item) => (
+          <Card key={item.id} variant="outlined" sx={{ p: 2 }}>
+            <Stack spacing={1}>
+              <Stack direction="row" justifyContent="space-between" gap={1} alignItems="center">
+                <Typography variant="h6">{item.name}</Typography>
+                <Chip label={`${item.receivedQty} received`} color="success" size="small" />
+              </Stack>
+              {(item.category || item.size) && (
+                <Typography variant="body2" color="text.secondary">
+                  {[item.category, item.size].filter(Boolean).join(" - ")}
+                </Typography>
+              )}
+              {item.description && <Typography variant="body2">{item.description}</Typography>}
+              <Divider />
+              <Typography variant="body2" color="text.secondary">
+                Target: {item.targetQty} · Promised: {item.pledgedQty} · Received: {item.receivedQty}
+              </Typography>
+            </Stack>
+          </Card>
+        ))}
+      </Stack>
+    </Stack>
+  );
+}

--- a/lib/actions/gear-needs.ts
+++ b/lib/actions/gear-needs.ts
@@ -27,6 +27,13 @@ const needCommandSchema = z.object({
 
 type Tx = Prisma.TransactionClient;
 
+export type GearNeedCapabilities = {
+  canSubmit: boolean;
+  canCancel: boolean;
+  canApprove: boolean;
+  canFulfill: boolean;
+};
+
 export type GearNeedDto = {
   id: string;
   teamId: string;
@@ -40,6 +47,11 @@ export type GearNeedDto = {
   fulfilledAt: string | null;
   canceledAt: string | null;
   createdAt: string;
+  canSubmit: boolean;
+  canCancel: boolean;
+  canApprove: boolean;
+  canFulfill: boolean;
+  capabilities: GearNeedCapabilities;
   lines: Array<{
     id: string;
     catalogItemId: string | null;
@@ -73,7 +85,23 @@ type NeedRecord = {
   lines: GearNeedDto["lines"];
 };
 
-function serializeNeed(need: NeedRecord): GearNeedDto {
+function needCapabilities(
+  need: Pick<NeedRecord, "status">,
+  isLeagueAdmin: boolean,
+  isTeamAdminForNeed: boolean,
+): GearNeedCapabilities {
+  return {
+    canSubmit: isTeamAdminForNeed && need.status === "DRAFT",
+    canCancel: isTeamAdminForNeed && ["DRAFT", "SUBMITTED", "APPROVED"].includes(need.status),
+    canApprove: isLeagueAdmin && need.status === "SUBMITTED",
+    canFulfill: isLeagueAdmin && need.status === "APPROVED",
+  };
+}
+
+function serializeNeed(
+  need: NeedRecord,
+  capabilities: ReturnType<typeof needCapabilities>,
+): GearNeedDto {
   return {
     id: need.id,
     teamId: need.teamId,
@@ -87,6 +115,8 @@ function serializeNeed(need: NeedRecord): GearNeedDto {
     fulfilledAt: need.fulfilledAt?.toISOString() ?? null,
     canceledAt: need.canceledAt?.toISOString() ?? null,
     createdAt: need.createdAt.toISOString(),
+    ...capabilities,
+    capabilities,
     lines: need.lines,
   };
 }
@@ -228,6 +258,7 @@ async function transitionNeed(
       const event = {
         leagueId: validated.leagueId,
         eventType: `gear.need.${target.toLowerCase()}`,
+        occurrenceKey: `v${need.version + 1}`,
         aggregateType: "NEED" as const,
         aggregateId: need.id,
         payload: { needId: need.id, teamId: need.teamId, status: target },
@@ -351,6 +382,7 @@ export async function decideTeamGearNeed(input: unknown) {
 export async function getGearNeedsContext(leagueId: string): Promise<{
   canManageAll: boolean;
   teamIds: string[];
+  teams: Array<{ id: string; name: string }>;
   needs: GearNeedDto[];
 } | null> {
   const userId = await requireUserId();
@@ -358,17 +390,23 @@ export async function getGearNeedsContext(leagueId: string): Promise<{
   if (!leagueRole) return null;
 
   const canManageAll = leagueRole === "LEAGUE_ADMIN";
-  const teamIds = canManageAll
-    ? (await prisma.team.findMany({
+  const [allTeams, teamAdminMemberships] = await Promise.all([
+    canManageAll
+      ? prisma.team.findMany({
         where: { leagueId, isActive: true },
-        select: { id: true },
-      })).map((team) => team.id)
-    : (await prisma.teamMember.findMany({
-        where: { userId, role: "ADMIN", team: { leagueId, isActive: true } },
-        select: { teamId: true },
-      })).map((membership) => membership.teamId);
+        select: { id: true, name: true },
+      })
+      : Promise.resolve([]),
+    prisma.teamMember.findMany({
+      where: { userId, role: "ADMIN", team: { leagueId, isActive: true } },
+      select: { team: { select: { id: true, name: true } } },
+    }),
+  ]);
+  const teamAdminIds = new Set(teamAdminMemberships.map((membership) => membership.team.id));
+  const teams = canManageAll ? allTeams : teamAdminMemberships.map((membership) => membership.team);
+  const teamIds = teams.map((team) => team.id);
 
-  if (teamIds.length === 0) return { canManageAll, teamIds, needs: [] };
+  if (teamIds.length === 0) return { canManageAll, teamIds, teams, needs: [] };
   const needs = await prisma.teamGearNeed.findMany({
     where: { leagueId, teamId: { in: teamIds } },
     select: {
@@ -385,7 +423,15 @@ export async function getGearNeedsContext(leagueId: string): Promise<{
     },
     orderBy: { createdAt: "desc" },
   });
-  return { canManageAll, teamIds, needs: needs.map(serializeNeed) };
+  return {
+    canManageAll,
+    teamIds,
+    teams,
+    needs: needs.map((need) => serializeNeed(
+      need,
+      needCapabilities(need, canManageAll, teamAdminIds.has(need.teamId)),
+    )),
+  };
 }
 
 export async function getGearNeedDetail(leagueId: string, needId: string): Promise<GearNeedDto | null> {
@@ -406,8 +452,14 @@ export async function getGearNeedDetail(leagueId: string, needId: string): Promi
     },
   });
   if (!need) return null;
-  await assertNeedAccess(leagueId, need.teamId, userId);
-  return serializeNeed(need);
+  const [leagueRole, teamAdmin] = await Promise.all([
+    getUserLeagueRole(userId, leagueId),
+    isTeamAdmin(userId, need.teamId),
+  ]);
+  if (leagueRole !== "LEAGUE_ADMIN" && !teamAdmin) {
+    throw new Error("Unauthorized: team admin access is required.");
+  }
+  return serializeNeed(need, needCapabilities(need, leagueRole === "LEAGUE_ADMIN", teamAdmin));
 }
 
 export async function getTeamGearNeeds(leagueId: string, teamId: string): Promise<GearNeedDto[]> {

--- a/lib/actions/gear-needs.ts
+++ b/lib/actions/gear-needs.ts
@@ -6,6 +6,7 @@ import { z } from "zod";
 import { getUserLeagueRole, isTeamAdmin, requireLeagueRole, requireUserId } from "@/lib/auth/session";
 import { prisma } from "@/lib/db/prisma";
 import { recordGearActivity } from "@/lib/services/gear-ledger";
+import { reportGearActionFailure } from "@/lib/services/gear-observability";
 import {
   type GearOutboxEvent,
   queueGearOutboxForLeagueAdmins,
@@ -133,6 +134,7 @@ function invalid(message: string): never {
 }
 
 function actionError(error: unknown): ActionResult<never> {
+  reportGearActionFailure({ action: "need", error });
   if (error instanceof GearConflictError) return { success: false, error: error.message };
   if (error instanceof z.ZodError) {
     return { success: false, error: "Please correct the highlighted gear need fields.", details: error.issues };
@@ -296,6 +298,18 @@ export async function createTeamGearNeed(
     await assertNeedAccess(validated.leagueId, validated.teamId, userId);
 
     const created = await withGearSerializableRetry(() => prisma.$transaction(async (tx) => {
+      const priorCommand = await tx.teamGearNeedCommand.findUnique({
+        where: {
+          leagueId_teamId_idempotencyKey: {
+            leagueId: validated.leagueId,
+            teamId: validated.teamId,
+            idempotencyKey: validated.idempotencyKey,
+          },
+        },
+        select: { need: { select: { id: true, version: true } } },
+      });
+      if (priorCommand) return priorCommand.need;
+
       const catalogIds = validated.lines
         .map((line) => line.catalogItemId)
         .filter((id): id is string => Boolean(id));
@@ -335,6 +349,14 @@ export async function createTeamGearNeed(
         },
         select: { id: true, version: true },
       });
+      await tx.teamGearNeedCommand.create({
+        data: {
+          leagueId: validated.leagueId,
+          teamId: validated.teamId,
+          idempotencyKey: validated.idempotencyKey,
+          needId: need.id,
+        },
+      });
       await recordGearActivity(tx, {
         leagueId: validated.leagueId,
         entityType: "NEED",
@@ -350,6 +372,22 @@ export async function createTeamGearNeed(
     revalidatePath(needsPath(validated.leagueId, validated.teamId));
     return { success: true, data: created };
   } catch (error) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002") {
+      const parsed = createTeamGearNeedSchema.safeParse(input);
+      if (parsed.success) {
+        const priorCommand = await prisma.teamGearNeedCommand.findUnique({
+          where: {
+            leagueId_teamId_idempotencyKey: {
+              leagueId: parsed.data.leagueId,
+              teamId: parsed.data.teamId,
+              idempotencyKey: parsed.data.idempotencyKey,
+            },
+          },
+          select: { need: { select: { id: true, version: true } } },
+        });
+        if (priorCommand) return { success: true, data: priorCommand.need };
+      }
+    }
     return actionError(error);
   }
 }

--- a/lib/actions/gear-needs.ts
+++ b/lib/actions/gear-needs.ts
@@ -1,0 +1,417 @@
+"use server";
+
+import { Prisma } from "@prisma/client";
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+import { getUserLeagueRole, isTeamAdmin, requireLeagueRole, requireUserId } from "@/lib/auth/session";
+import { prisma } from "@/lib/db/prisma";
+import { recordGearActivity } from "@/lib/services/gear-ledger";
+import {
+  queueGearOutboxForLeagueAdmins,
+  queueGearOutboxForRecipients,
+} from "@/lib/services/gear-outbox";
+import {
+  GearConflictError,
+  gearTransactionOptions,
+  withGearSerializableRetry,
+} from "@/lib/services/gear-transaction";
+import { createTeamGearNeedSchema } from "@/lib/utils/validation";
+import type { ActionResult } from "@/lib/actions/gear-inventory";
+
+const gearId = z.string().cuid("Invalid gear identifier");
+const needCommandSchema = z.object({
+  leagueId: gearId,
+  needId: gearId,
+  expectedVersion: z.coerce.number().int().min(0),
+});
+
+type Tx = Prisma.TransactionClient;
+
+export type GearNeedDto = {
+  id: string;
+  teamId: string;
+  teamName: string;
+  title: string;
+  notes: string | null;
+  status: "DRAFT" | "SUBMITTED" | "APPROVED" | "FULFILLED" | "CANCELED";
+  version: number;
+  submittedAt: string | null;
+  approvedAt: string | null;
+  fulfilledAt: string | null;
+  canceledAt: string | null;
+  createdAt: string;
+  lines: Array<{
+    id: string;
+    catalogItemId: string | null;
+    nameSnapshot: string;
+    categorySnapshot: string | null;
+    sizeSnapshot: string | null;
+    trackingMode: "POOLED" | "INDIVIDUAL" | null;
+    requestedQty: number;
+    fulfilledQty: number;
+    canceledQty: number;
+    priority: "LOW" | "NORMAL" | "HIGH" | "URGENT";
+    status: "OPEN" | "PARTIALLY_FULFILLED" | "FULFILLED" | "CANCELED";
+    notes: string | null;
+    version: number;
+  }>;
+};
+
+type NeedRecord = {
+  id: string;
+  teamId: string;
+  title: string;
+  notes: string | null;
+  status: GearNeedDto["status"];
+  version: number;
+  submittedAt: Date | null;
+  approvedAt: Date | null;
+  fulfilledAt: Date | null;
+  canceledAt: Date | null;
+  createdAt: Date;
+  team: { name: string };
+  lines: GearNeedDto["lines"];
+};
+
+function serializeNeed(need: NeedRecord): GearNeedDto {
+  return {
+    id: need.id,
+    teamId: need.teamId,
+    teamName: need.team.name,
+    title: need.title,
+    notes: need.notes,
+    status: need.status,
+    version: need.version,
+    submittedAt: need.submittedAt?.toISOString() ?? null,
+    approvedAt: need.approvedAt?.toISOString() ?? null,
+    fulfilledAt: need.fulfilledAt?.toISOString() ?? null,
+    canceledAt: need.canceledAt?.toISOString() ?? null,
+    createdAt: need.createdAt.toISOString(),
+    lines: need.lines,
+  };
+}
+
+function needsPath(leagueId: string, teamId?: string) {
+  return teamId
+    ? `/league/${leagueId}/gear/needs/${teamId}`
+    : `/league/${leagueId}/gear/needs`;
+}
+
+function invalid(message: string): never {
+  throw new Error(`Gear validation: ${message}`);
+}
+
+function actionError(error: unknown): ActionResult<never> {
+  if (error instanceof GearConflictError) return { success: false, error: error.message };
+  if (error instanceof z.ZodError) {
+    return { success: false, error: "Please correct the highlighted gear need fields.", details: error.issues };
+  }
+  if (error instanceof Error) {
+    if (error.message.startsWith("Unauthorized")) {
+      return { success: false, error: "You do not have permission to manage this gear need." };
+    }
+    if (error.message.startsWith("Gear validation:")) {
+      return { success: false, error: error.message.slice(17) };
+    }
+  }
+  return { success: false, error: "Unable to update the gear need. Please try again." };
+}
+
+async function assertNeedAccess(leagueId: string, teamId: string, userId: string): Promise<boolean> {
+  const role = await getUserLeagueRole(userId, leagueId);
+  if (role === "LEAGUE_ADMIN") return true;
+
+  const [team, teamAdmin] = await Promise.all([
+    prisma.team.findFirst({
+      where: { id: teamId, leagueId, isActive: true },
+      select: { id: true },
+    }),
+    isTeamAdmin(userId, teamId),
+  ]);
+  if (!team || !teamAdmin) {
+    throw new Error("Unauthorized: team admin access is required.");
+  }
+  return false;
+}
+
+async function assertTeamAdminNeedAccess(leagueId: string, teamId: string, userId: string): Promise<void> {
+  const [team, teamAdmin] = await Promise.all([
+    prisma.team.findFirst({
+      where: { id: teamId, leagueId, isActive: true },
+      select: { id: true },
+    }),
+    isTeamAdmin(userId, teamId),
+  ]);
+  if (!team || !teamAdmin) {
+    throw new Error("Unauthorized: team admin access is required.");
+  }
+}
+
+async function getNeedForMutation(tx: Tx, leagueId: string, needId: string) {
+  const need = await tx.teamGearNeed.findFirst({
+    where: { id: needId, leagueId, league: { isActive: true }, team: { leagueId, isActive: true } },
+    include: { lines: true },
+  });
+  if (!need) invalid("Gear need not found in this league.");
+  return need;
+}
+
+async function transitionNeed(
+  input: unknown,
+  target: "SUBMITTED" | "APPROVED" | "FULFILLED" | "CANCELED",
+): Promise<ActionResult<{ id: string; status: string; version: number }>> {
+  try {
+    const validated = needCommandSchema.parse(input);
+    const userId = target === "APPROVED" || target === "FULFILLED"
+      ? await requireLeagueRole(validated.leagueId, "LEAGUE_ADMIN")
+      : await requireUserId();
+
+    const result = await withGearSerializableRetry(() => prisma.$transaction(async (tx) => {
+      const need = await getNeedForMutation(tx, validated.leagueId, validated.needId);
+      if (target === "SUBMITTED" || target === "CANCELED") {
+        await assertTeamAdminNeedAccess(validated.leagueId, need.teamId, userId);
+      }
+      if (need.version !== validated.expectedVersion) throw new GearConflictError();
+
+      const permitted: Record<typeof target, readonly string[]> = {
+        SUBMITTED: ["DRAFT"],
+        APPROVED: ["SUBMITTED"],
+        FULFILLED: ["APPROVED"],
+        CANCELED: ["DRAFT", "SUBMITTED", "APPROVED"],
+      };
+      if (!permitted[target].includes(need.status)) {
+        invalid(`This gear need cannot transition from ${need.status.toLowerCase()} to ${target.toLowerCase()}.`);
+      }
+
+      const now = new Date();
+      const update = await tx.teamGearNeed.updateMany({
+        where: { id: need.id, version: need.version, status: need.status },
+        data: {
+          status: target,
+          version: { increment: 1 },
+          ...(target === "SUBMITTED" ? { submittedAt: now } : {}),
+          ...(target === "APPROVED" ? { approvedAt: now } : {}),
+          ...(target === "FULFILLED" ? { fulfilledAt: now } : {}),
+          ...(target === "CANCELED" ? { canceledAt: now } : {}),
+        },
+      });
+      if (update.count !== 1) throw new GearConflictError();
+
+      if (target === "FULFILLED") {
+        await Promise.all(
+          need.lines
+            .filter((line) => line.status !== "CANCELED")
+            .map((line) => tx.teamGearNeedLine.update({
+              where: { id: line.id },
+              data: {
+                fulfilledQty: line.requestedQty,
+                status: "FULFILLED",
+                version: { increment: 1 },
+              },
+            })),
+        );
+      } else if (target === "CANCELED") {
+        await tx.teamGearNeedLine.updateMany({
+          where: { needId: need.id, status: { not: "FULFILLED" } },
+          data: { status: "CANCELED", version: { increment: 1 } },
+        });
+      }
+
+      await recordGearActivity(tx, {
+        leagueId: validated.leagueId,
+        entityType: "NEED",
+        entityId: need.id,
+        action: target.toLowerCase(),
+        actorUserId: userId,
+        details: { teamId: need.teamId },
+      });
+      const event = {
+        leagueId: validated.leagueId,
+        eventType: `gear.need.${target.toLowerCase()}`,
+        aggregateType: "NEED" as const,
+        aggregateId: need.id,
+        payload: { needId: need.id, teamId: need.teamId, status: target },
+      };
+      if (target === "SUBMITTED") {
+        await queueGearOutboxForLeagueAdmins(tx, event);
+      } else {
+        const teamAdmins = await tx.teamMember.findMany({
+          where: { teamId: need.teamId, role: "ADMIN" },
+          select: { userId: true },
+        });
+        await queueGearOutboxForRecipients(tx, event, [
+          ...teamAdmins.map((membership) => membership.userId),
+          ...(need.createdById ? [need.createdById] : []),
+        ]);
+      }
+      return { id: need.id, status: target, version: need.version + 1, teamId: need.teamId };
+    }, gearTransactionOptions));
+
+    revalidatePath(needsPath(validated.leagueId));
+    revalidatePath(needsPath(validated.leagueId, result.teamId));
+    return { success: true, data: result };
+  } catch (error) {
+    return actionError(error);
+  }
+}
+
+export async function createTeamGearNeed(
+  input: z.input<typeof createTeamGearNeedSchema>,
+): Promise<ActionResult<{ id: string; version: number }>> {
+  try {
+    const validated = createTeamGearNeedSchema.parse(input);
+    const userId = await requireUserId();
+    await assertNeedAccess(validated.leagueId, validated.teamId, userId);
+
+    const created = await withGearSerializableRetry(() => prisma.$transaction(async (tx) => {
+      const catalogIds = validated.lines
+        .map((line) => line.catalogItemId)
+        .filter((id): id is string => Boolean(id));
+      const catalogItems = catalogIds.length === 0
+        ? []
+        : await tx.gearCatalogItem.findMany({
+            where: { leagueId: validated.leagueId, id: { in: catalogIds }, isActive: true },
+            select: { id: true, name: true, category: true, size: true, trackingMode: true },
+          });
+      const catalogById = new Map(catalogItems.map((item) => [item.id, item]));
+      if (catalogById.size !== new Set(catalogIds).size) {
+        invalid("A selected catalog item is not active in this league.");
+      }
+
+      const need = await tx.teamGearNeed.create({
+        data: {
+          leagueId: validated.leagueId,
+          teamId: validated.teamId,
+          title: validated.title,
+          notes: validated.notes || null,
+          createdById: userId,
+          lines: {
+            create: validated.lines.map((line) => {
+              const catalog = line.catalogItemId ? catalogById.get(line.catalogItemId) : undefined;
+              return {
+                catalogItemId: catalog?.id ?? null,
+                nameSnapshot: catalog?.name ?? line.nameSnapshot,
+                categorySnapshot: (catalog?.category ?? line.categorySnapshot) || null,
+                sizeSnapshot: (catalog?.size ?? line.sizeSnapshot) || null,
+                trackingMode: catalog?.trackingMode ?? line.trackingMode,
+                requestedQty: line.requestedQty,
+                priority: line.priority,
+                notes: line.notes || null,
+              };
+            }),
+          },
+        },
+        select: { id: true, version: true },
+      });
+      await recordGearActivity(tx, {
+        leagueId: validated.leagueId,
+        entityType: "NEED",
+        entityId: need.id,
+        action: "created",
+        actorUserId: userId,
+        details: { teamId: validated.teamId, lineCount: validated.lines.length },
+      });
+      return need;
+    }, gearTransactionOptions));
+
+    revalidatePath(needsPath(validated.leagueId));
+    revalidatePath(needsPath(validated.leagueId, validated.teamId));
+    return { success: true, data: created };
+  } catch (error) {
+    return actionError(error);
+  }
+}
+
+export async function submitTeamGearNeed(input: unknown) {
+  return transitionNeed(input, "SUBMITTED");
+}
+
+export async function approveTeamGearNeed(input: unknown) {
+  return transitionNeed(input, "APPROVED");
+}
+
+export async function fulfillTeamGearNeed(input: unknown) {
+  return transitionNeed(input, "FULFILLED");
+}
+
+export async function cancelTeamGearNeed(input: unknown) {
+  return transitionNeed(input, "CANCELED");
+}
+
+export async function decideTeamGearNeed(input: unknown) {
+  const parsed = z.object({
+    leagueId: gearId,
+    needId: gearId,
+    expectedVersion: z.coerce.number().int().min(0),
+    status: z.enum(["APPROVED", "CANCELED"]),
+  }).parse(input);
+  return transitionNeed(parsed, parsed.status);
+}
+
+export async function getGearNeedsContext(leagueId: string): Promise<{
+  canManageAll: boolean;
+  teamIds: string[];
+  needs: GearNeedDto[];
+} | null> {
+  const userId = await requireUserId();
+  const leagueRole = await getUserLeagueRole(userId, leagueId);
+  if (!leagueRole) return null;
+
+  const canManageAll = leagueRole === "LEAGUE_ADMIN";
+  const teamIds = canManageAll
+    ? (await prisma.team.findMany({
+        where: { leagueId, isActive: true },
+        select: { id: true },
+      })).map((team) => team.id)
+    : (await prisma.teamMember.findMany({
+        where: { userId, role: "ADMIN", team: { leagueId, isActive: true } },
+        select: { teamId: true },
+      })).map((membership) => membership.teamId);
+
+  if (teamIds.length === 0) return { canManageAll, teamIds, needs: [] };
+  const needs = await prisma.teamGearNeed.findMany({
+    where: { leagueId, teamId: { in: teamIds } },
+    select: {
+      id: true, teamId: true, title: true, notes: true, status: true, version: true,
+      submittedAt: true, approvedAt: true, fulfilledAt: true, canceledAt: true, createdAt: true,
+      team: { select: { name: true } },
+      lines: {
+        select: {
+          id: true, catalogItemId: true, nameSnapshot: true, categorySnapshot: true, sizeSnapshot: true,
+          trackingMode: true, requestedQty: true, fulfilledQty: true, canceledQty: true,
+          priority: true, status: true, notes: true, version: true,
+        },
+      },
+    },
+    orderBy: { createdAt: "desc" },
+  });
+  return { canManageAll, teamIds, needs: needs.map(serializeNeed) };
+}
+
+export async function getGearNeedDetail(leagueId: string, needId: string): Promise<GearNeedDto | null> {
+  const userId = await requireUserId();
+  const need = await prisma.teamGearNeed.findFirst({
+    where: { id: needId, leagueId, league: { isActive: true }, team: { leagueId, isActive: true } },
+    select: {
+      id: true, teamId: true, title: true, notes: true, status: true, version: true,
+      submittedAt: true, approvedAt: true, fulfilledAt: true, canceledAt: true, createdAt: true,
+      team: { select: { name: true } },
+      lines: {
+        select: {
+          id: true, catalogItemId: true, nameSnapshot: true, categorySnapshot: true, sizeSnapshot: true,
+          trackingMode: true, requestedQty: true, fulfilledQty: true, canceledQty: true,
+          priority: true, status: true, notes: true, version: true,
+        },
+      },
+    },
+  });
+  if (!need) return null;
+  await assertNeedAccess(leagueId, need.teamId, userId);
+  return serializeNeed(need);
+}
+
+export async function getTeamGearNeeds(leagueId: string, teamId: string): Promise<GearNeedDto[]> {
+  const context = await getGearNeedsContext(leagueId);
+  if (!context || !context.teamIds.includes(teamId)) return [];
+  return context.needs.filter((need) => need.teamId === teamId);
+}

--- a/lib/actions/gear-needs.ts
+++ b/lib/actions/gear-needs.ts
@@ -7,6 +7,7 @@ import { getUserLeagueRole, isTeamAdmin, requireLeagueRole, requireUserId } from
 import { prisma } from "@/lib/db/prisma";
 import { recordGearActivity } from "@/lib/services/gear-ledger";
 import {
+  type GearOutboxEvent,
   queueGearOutboxForLeagueAdmins,
   queueGearOutboxForRecipients,
 } from "@/lib/services/gear-outbox";
@@ -253,15 +254,15 @@ async function transitionNeed(
         entityId: need.id,
         action: target.toLowerCase(),
         actorUserId: userId,
-        details: { teamId: need.teamId },
+        details: { metadata: { teamId: need.teamId } },
       });
-      const event = {
+      const event: GearOutboxEvent = {
         leagueId: validated.leagueId,
         eventType: `gear.need.${target.toLowerCase()}`,
         occurrenceKey: `v${need.version + 1}`,
         aggregateType: "NEED" as const,
         aggregateId: need.id,
-        payload: { needId: need.id, teamId: need.teamId, status: target },
+        payload: { kind: "GEAR_NEED", data: { needId: need.id, teamId: need.teamId, status: target } },
       };
       if (target === "SUBMITTED") {
         await queueGearOutboxForLeagueAdmins(tx, event);
@@ -340,7 +341,7 @@ export async function createTeamGearNeed(
         entityId: need.id,
         action: "created",
         actorUserId: userId,
-        details: { teamId: validated.teamId, lineCount: validated.lines.length },
+        details: { metadata: { teamId: validated.teamId, lineCount: validated.lines.length } },
       });
       return need;
     }, gearTransactionOptions));

--- a/lib/actions/gear-pledges.ts
+++ b/lib/actions/gear-pledges.ts
@@ -1,12 +1,15 @@
 "use server";
 
+import { createHash } from "node:crypto";
 import { Prisma } from "@prisma/client";
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
 import { requireLeagueRole } from "@/lib/auth/session";
 import { prisma } from "@/lib/db/prisma";
 import { recordGearActivity, recordGearInventoryMovement } from "@/lib/services/gear-ledger";
+import { reportGearActionFailure } from "@/lib/services/gear-observability";
 import { queueGearOutboxForLeagueAdmins } from "@/lib/services/gear-outbox";
+import { redactTerminalGearPledgePii } from "@/lib/services/gear-pledge-retention";
 import {
   GearConflictError,
   gearTransactionOptions,
@@ -19,7 +22,11 @@ import {
   rateLimitMessage,
 } from "@/lib/utils/durable-rate-limit";
 import { normalizeGearAssetTag } from "@/lib/utils/gear";
-import { createGearPledgeSchema, receiveGearPledgeSchema } from "@/lib/utils/validation";
+import {
+  correctGearPledgeReceiptSchema,
+  createGearPledgeSchema,
+  receiveGearPledgeSchema,
+} from "@/lib/utils/validation";
 import type { ActionResult } from "@/lib/actions/gear-inventory";
 
 const gearId = z.string().cuid("Invalid gear identifier");
@@ -40,6 +47,7 @@ function invalid(message: string): never {
 }
 
 function actionError(error: unknown): ActionResult<never> {
+  reportGearActionFailure({ action: "pledge", error });
   if (error instanceof GearConflictError) return { success: false, error: error.message };
   if (error instanceof z.ZodError) {
     return { success: false, error: "Please correct the highlighted pledge fields.", details: error.issues };
@@ -49,6 +57,26 @@ function actionError(error: unknown): ActionResult<never> {
     if (error.message.startsWith("Gear validation:")) return { success: false, error: error.message.slice(17) };
   }
   return { success: false, error: "Unable to update the gear pledge. Please try again." };
+}
+
+function hashPledgeRateLimitScope(wishlistToken: string, wishlistItemId: string): string {
+  return createHash("sha256").update(`${wishlistToken}:${wishlistItemId}`).digest("hex").slice(0, 32);
+}
+
+function receiptPayloadHash(input: z.output<typeof receiveGearPledgeSchema>): string {
+  const payload = {
+    leagueId: input.leagueId,
+    pledgeId: input.pledgeId,
+    expectedVersion: input.expectedVersion,
+    poolStockId: input.poolStockId || null,
+    catalogItemId: input.catalogItemId || null,
+    locationId: input.locationId || null,
+    condition: input.condition ?? null,
+    quantity: input.quantity,
+    notes: input.notes || null,
+    assetTags: (input.assetTags ?? []).map(normalizeGearAssetTag).sort(),
+  };
+  return createHash("sha256").update(JSON.stringify(payload)).digest("hex");
 }
 
 async function publicPledgeByIdempotency(
@@ -70,11 +98,11 @@ export async function createGearPledge(
   input: z.input<typeof createGearPledgeSchema>,
 ): Promise<ActionResult<{ id: string | null; status: string }>> {
   try {
-    // Check the honeypot before normal validation so bots always receive the
-    // same generic response, even when they omit consent or other fields.
+    // Do not simulate success: callers need a retryable failure rather than a
+    // silently dropped donation, while still revealing no anti-bot detail.
     if (typeof input === "object" && input !== null && "website" in input
       && typeof input.website === "string" && input.website.trim()) {
-      return { success: true, data: { id: null, status: "PLEDGED" } };
+      return { success: false, error: "Unable to submit the pledge. Please try again." };
     }
     const validated = createGearPledgeSchema.parse(input);
     if (!validated.contactConsent) invalid("Contact consent is required to submit a pledge.");
@@ -87,11 +115,16 @@ export async function createGearPledge(
     if (existing) return { success: true, data: existing };
 
     const ip = await getClientIp();
-    if (ip) {
-      const rateLimit = await checkRateLimit(`gear-pledge:ip:${ip}`, RATE_LIMITS.GEAR_PLEDGE_PER_IP);
-      if (!rateLimit.allowed) {
-        return { success: false, error: rateLimitMessage(rateLimit.retryAfterSec) };
-      }
+    if (!ip) {
+      return { success: false, error: "Unable to submit the pledge. Please try again." };
+    }
+    const rateLimit = await checkRateLimit(
+      `gear-pledge:ip:${ip}:scope:${hashPledgeRateLimitScope(validated.wishlistToken, validated.wishlistItemId)}`,
+      RATE_LIMITS.GEAR_PLEDGE_PER_IP,
+      { failOpen: false },
+    );
+    if (!rateLimit.allowed) {
+      return { success: false, error: rateLimitMessage(rateLimit.retryAfterSec) };
     }
 
     const pledge = await withGearSerializableRetry(() => prisma.$transaction(async (tx) => {
@@ -108,16 +141,29 @@ export async function createGearPledge(
         select: { id: true, wishlistId: true, pledgedQty: true, receivedQty: true, targetQty: true, wishlist: { select: { leagueId: true } } },
       });
       if (!item) invalid("This wishlist item is no longer accepting pledges.");
+      // Take a row lock before deriving the remaining capacity. Serializable
+      // retries alone protect this in PostgreSQL, but the lock makes the cap
+      // explicit and keeps same-item pledge writers from both passing a stale
+      // projection check.
+      const lockedItem = await tx.gearWishlistItem.update({
+        where: { id: item.id },
+        data: { pledgedQty: { increment: 0 } },
+        select: { id: true, targetQty: true, pledgedQty: true, receivedQty: true, wishlist: { select: { leagueId: true } } },
+      });
+      const remaining = lockedItem.targetQty - lockedItem.pledgedQty - lockedItem.receivedQty;
+      if (validated.quantity > remaining) {
+        invalid("Pledge quantity exceeds the remaining wishlist target.");
+      }
       const duplicate = await tx.gearPledge.findUnique({
-        where: { leagueId_idempotencyKey: { leagueId: item.wishlist.leagueId, idempotencyKey: validated.idempotencyKey } },
+        where: { leagueId_idempotencyKey: { leagueId: lockedItem.wishlist.leagueId, idempotencyKey: validated.idempotencyKey } },
         select: { id: true, status: true },
       });
       if (duplicate) return duplicate;
 
       const created = await tx.gearPledge.create({
         data: {
-          leagueId: item.wishlist.leagueId,
-          wishlistItemId: item.id,
+          leagueId: lockedItem.wishlist.leagueId,
+          wishlistItemId: lockedItem.id,
           donorName: validated.donorName,
           donorEmail: validated.donorEmail || null,
           donorPhone: validated.donorPhone || null,
@@ -129,24 +175,24 @@ export async function createGearPledge(
         select: { id: true, status: true },
       });
       await tx.gearWishlistItem.update({
-        where: { id: item.id },
+        where: { id: lockedItem.id },
         data: { pledgedQty: { increment: validated.quantity } },
       });
       await recordGearActivity(tx, {
-        leagueId: item.wishlist.leagueId,
+        leagueId: lockedItem.wishlist.leagueId,
         entityType: "PLEDGE",
         entityId: created.id,
         action: "pledged",
         actorKind: "PUBLIC_DONOR",
-        details: { metadata: { wishlistItemId: item.id, quantity: validated.quantity } },
+        details: { metadata: { wishlistItemId: lockedItem.id, quantity: validated.quantity } },
       });
       await queueGearOutboxForLeagueAdmins(tx, {
-        leagueId: item.wishlist.leagueId,
+        leagueId: lockedItem.wishlist.leagueId,
         eventType: "gear.pledge.created",
         occurrenceKey: created.id,
         aggregateType: "PLEDGE",
         aggregateId: created.id,
-        payload: { kind: "GEAR_PLEDGE", data: { pledgeId: created.id, wishlistItemId: item.id, quantity: validated.quantity } },
+        payload: { kind: "GEAR_PLEDGE", data: { pledgeId: created.id, wishlistItemId: lockedItem.id, quantity: validated.quantity } },
       });
       return created;
     }, gearTransactionOptions));
@@ -180,6 +226,7 @@ export async function receiveGearPledge(
   try {
     const validated = receiveGearPledgeSchema.parse(input);
     const userId = await requireLeagueRole(validated.leagueId, "LEAGUE_ADMIN");
+    const payloadHash = receiptPayloadHash(validated);
     const result = await withGearSerializableRetry(() => prisma.$transaction(async (tx) => {
       const priorCommand = await tx.gearPledgeReceiptCommand.findUnique({
         where: {
@@ -190,12 +237,16 @@ export async function receiveGearPledge(
           },
         },
         select: {
+          payloadHash: true,
           resultingStatus: true,
           resultingVersion: true,
           receipts: { select: { id: true } },
         },
       });
       if (priorCommand) {
+        if (priorCommand.payloadHash !== payloadHash) {
+          invalid("This receipt operation key was already used with different details.");
+        }
         const receiptIds = priorCommand.receipts.map((receipt) => receipt.id);
         if (receiptIds.length === 0) invalid("The saved receipt command has no receipts.");
         return {
@@ -213,7 +264,7 @@ export async function receiveGearPledge(
       if (pledge.version !== validated.expectedVersion) throw new GearConflictError();
 
       const received = await tx.gearPledgeReceipt.aggregate({
-        where: { pledgeId: pledge.id },
+        where: { pledgeId: pledge.id, correctionOfReceiptId: null, correction: { is: null } },
         _sum: { quantity: true },
       });
       const alreadyReceived = received._sum.quantity ?? 0;
@@ -228,6 +279,7 @@ export async function receiveGearPledge(
           leagueId: validated.leagueId,
           pledgeId: pledge.id,
           idempotencyKey: validated.idempotencyKey,
+          payloadHash,
           expectedVersion: validated.expectedVersion,
           resultingVersion: pledge.version + 1,
           resultingStatus: pledgeStatus,
@@ -236,26 +288,68 @@ export async function receiveGearPledge(
       });
       const receiptIds: string[] = [];
 
-      if (validated.poolStockId) {
-        const stock = await tx.gearPoolStock.findFirst({
-          where: {
-            id: validated.poolStockId,
-            leagueId: validated.leagueId,
-            catalogItem: { trackingMode: "POOLED", isActive: true },
-          },
-          select: { id: true, catalogItemId: true, locationId: true, condition: true },
-        });
-        if (!stock) invalid("The selected pooled inventory row is not active in this league.");
-        if (validated.catalogItemId && validated.catalogItemId !== stock.catalogItemId) {
-          invalid("The selected pooled inventory does not match the supplied catalog item.");
+      const isPooledReceipt = Boolean(validated.poolStockId) || (validated.assetTags?.length ?? 0) === 0;
+      if (isPooledReceipt) {
+        let stock = validated.poolStockId
+          ? await tx.gearPoolStock.findFirst({
+              where: {
+                id: validated.poolStockId,
+                leagueId: validated.leagueId,
+                catalogItem: { trackingMode: "POOLED" },
+              },
+              select: { id: true, catalogItemId: true, locationId: true, condition: true },
+            })
+          : null;
+        if (validated.poolStockId) {
+          if (!stock) invalid("The selected pooled inventory row was not found in this league.");
+          if (validated.catalogItemId && validated.catalogItemId !== stock.catalogItemId) {
+            invalid("The selected pooled inventory does not match the supplied catalog item.");
+          }
+        } else {
+          if (!validated.catalogItemId || !validated.locationId || !validated.condition) {
+            invalid("A new pooled stock row requires catalog, storage location, and condition.");
+          }
+          const [catalogItem, location] = await Promise.all([
+            tx.gearCatalogItem.findFirst({
+              where: { id: validated.catalogItemId, leagueId: validated.leagueId, trackingMode: "POOLED" },
+              select: { id: true },
+            }),
+            tx.gearStorageLocation.findFirst({
+              where: { id: validated.locationId, leagueId: validated.leagueId },
+              select: { id: true },
+            }),
+          ]);
+          if (!catalogItem || !location) invalid("The selected pooled catalog item or storage location was not found.");
+          stock = await tx.gearPoolStock.upsert({
+            where: {
+              leagueId_catalogItemId_locationId_condition: {
+                leagueId: validated.leagueId,
+                catalogItemId: catalogItem.id,
+                locationId: location.id,
+                condition: validated.condition,
+              },
+            },
+            create: {
+              leagueId: validated.leagueId,
+              catalogItemId: catalogItem.id,
+              locationId: location.id,
+              condition: validated.condition,
+              quantityOnHand: validated.quantity,
+            },
+            update: { quantityOnHand: { increment: validated.quantity }, version: { increment: 1 } },
+            select: { id: true, catalogItemId: true, locationId: true, condition: true },
+          });
         }
+        if (!stock) invalid("The selected pooled inventory row was not found in this league.");
         if (pledge.wishlistItem.catalogItemId && pledge.wishlistItem.catalogItemId !== stock.catalogItemId) {
           invalid("Received inventory does not match the pledged catalog item.");
         }
-        await tx.gearPoolStock.update({
-          where: { id: stock.id },
-          data: { quantityOnHand: { increment: validated.quantity }, version: { increment: 1 } },
-        });
+        if (validated.poolStockId) {
+          await tx.gearPoolStock.update({
+            where: { id: stock.id },
+            data: { quantityOnHand: { increment: validated.quantity }, version: { increment: 1 } },
+          });
+        }
         const receipt = await tx.gearPledgeReceipt.create({
           data: {
             leagueId: validated.leagueId,
@@ -387,7 +481,7 @@ export async function receiveGearPledge(
           metadata: {
             receiptCount: receiptIds.length,
             quantity: validated.quantity,
-            inventoryKind: validated.poolStockId ? "POOLED" : "INDIVIDUAL",
+            inventoryKind: isPooledReceipt ? "POOLED" : "INDIVIDUAL",
           },
         },
       });
@@ -427,12 +521,17 @@ export async function receiveGearPledge(
             },
           },
           select: {
+            payloadHash: true,
             resultingStatus: true,
             resultingVersion: true,
             receipts: { select: { id: true } },
           },
         });
         if (priorCommand?.receipts.length) {
+          const payloadHash = receiptPayloadHash(parsed.data);
+          if (priorCommand.payloadHash !== payloadHash) {
+            return { success: false, error: "This receipt operation key was already used with different details." };
+          }
           const receiptIds = priorCommand.receipts.map((receipt) => receipt.id);
           return {
             success: true,
@@ -450,6 +549,186 @@ export async function receiveGearPledge(
   }
 }
 
+export async function correctGearPledgeReceipt(
+  input: z.input<typeof correctGearPledgeReceiptSchema>,
+): Promise<ActionResult<{ receiptId: string; correctionReceiptId: string; pledgeStatus: string; pledgeVersion: number }>> {
+  try {
+    const validated = correctGearPledgeReceiptSchema.parse(input);
+    const userId = await requireLeagueRole(validated.leagueId, "LEAGUE_ADMIN");
+    const result = await withGearSerializableRetry(() => prisma.$transaction(async (tx) => {
+      const receipt = await tx.gearPledgeReceipt.findFirst({
+        where: {
+          id: validated.receiptId,
+          leagueId: validated.leagueId,
+          pledgeId: validated.pledgeId,
+          correctionOfReceiptId: null,
+        },
+        include: {
+          correction: { select: { id: true } },
+          pledge: { include: { wishlistItem: { select: { id: true, receivedQty: true } } } },
+        },
+      });
+      if (!receipt) invalid("The original receipt was not found.");
+      if (receipt.pledge.version !== validated.expectedVersion) throw new GearConflictError();
+      if (receipt.correction) {
+        return {
+          receiptId: receipt.id,
+          correctionReceiptId: receipt.correction.id,
+          pledgeStatus: receipt.pledge.status,
+          pledgeVersion: receipt.pledge.version,
+        };
+      }
+      if (!["PLEDGED", "RECEIVED"].includes(receipt.pledge.status)) {
+        invalid("Only active or received pledge receipts can be corrected.");
+      }
+      if (receipt.pledge.wishlistItem.receivedQty < receipt.quantity) {
+        invalid("Wishlist receipt projections are inconsistent.");
+      }
+
+      if (receipt.poolStockId) {
+        const stock = await tx.gearPoolStock.updateMany({
+          where: {
+            id: receipt.poolStockId,
+            leagueId: validated.leagueId,
+            quantityOnHand: { gte: receipt.quantity },
+          },
+          data: {
+            quantityOnHand: { decrement: receipt.quantity },
+            version: { increment: 1 },
+          },
+        });
+        if (stock.count !== 1) invalid("Pooled inventory is no longer available for this correction.");
+      } else if (receipt.gearUnitId) {
+        const unit = await tx.gearUnit.updateMany({
+          where: {
+            id: receipt.gearUnitId,
+            leagueId: validated.leagueId,
+            status: "AVAILABLE",
+          },
+          data: {
+            status: "RETIRED",
+            retiredAt: new Date(),
+            version: { increment: 1 },
+          },
+        });
+        if (unit.count !== 1) invalid("The tagged item is no longer available for this correction.");
+      } else {
+        invalid("The original receipt has no inventory link.");
+      }
+
+      const correction = await tx.gearPledgeReceipt.create({
+        data: {
+          leagueId: validated.leagueId,
+          pledgeId: receipt.pledgeId,
+          catalogItemId: receipt.catalogItemId,
+          poolStockId: receipt.poolStockId,
+          gearUnitId: receipt.gearUnitId,
+          quantity: receipt.quantity,
+          correctionOfReceiptId: receipt.id,
+          correctionReason: validated.reason,
+        },
+        select: { id: true },
+      });
+      await recordGearInventoryMovement(tx, {
+        leagueId: validated.leagueId,
+        type: "ADJUSTMENT",
+        direction: "DECREASE",
+        quantity: receipt.quantity,
+        poolStockId: receipt.poolStockId,
+        gearUnitId: receipt.gearUnitId,
+        pledgeReceiptId: correction.id,
+        recordedById: userId,
+        notes: validated.reason,
+      });
+      const pledgeUpdate = await tx.gearPledge.updateMany({
+        where: {
+          id: receipt.pledgeId,
+          leagueId: validated.leagueId,
+          version: receipt.pledge.version,
+          status: receipt.pledge.status,
+        },
+        data: {
+          status: "PLEDGED",
+          receivedAt: null,
+          version: { increment: 1 },
+        },
+      });
+      if (pledgeUpdate.count !== 1) throw new GearConflictError();
+      await tx.gearWishlistItem.update({
+        where: { id: receipt.pledge.wishlistItem.id },
+        data: {
+          pledgedQty: { increment: receipt.quantity },
+          receivedQty: { decrement: receipt.quantity },
+        },
+      });
+      await recordGearActivity(tx, {
+        leagueId: validated.leagueId,
+        entityType: "PLEDGE",
+        entityId: receipt.pledgeId,
+        action: "receipt_corrected",
+        actorUserId: userId,
+        details: { metadata: { receiptId: receipt.id, correctionReceiptId: correction.id, quantity: receipt.quantity } },
+      });
+      await queueGearOutboxForLeagueAdmins(tx, {
+        leagueId: validated.leagueId,
+        eventType: "gear.pledge.receipt_corrected",
+        occurrenceKey: correction.id,
+        aggregateType: "PLEDGE",
+        aggregateId: receipt.pledgeId,
+        payload: {
+          kind: "GEAR_PLEDGE",
+          data: {
+            pledgeId: receipt.pledgeId,
+            receiptId: receipt.id,
+            correctionReceiptId: correction.id,
+            wishlistItemId: receipt.pledge.wishlistItem.id,
+            quantity: receipt.quantity,
+            status: "PLEDGED",
+          },
+        },
+      });
+      return {
+        receiptId: receipt.id,
+        correctionReceiptId: correction.id,
+        pledgeStatus: "PLEDGED",
+        pledgeVersion: receipt.pledge.version + 1,
+      };
+    }, gearTransactionOptions));
+    revalidatePath(wishlistPath(validated.leagueId));
+    revalidatePath(`/league/${validated.leagueId}/gear`);
+    return { success: true, data: result };
+  } catch (error) {
+    return actionError(error);
+  }
+}
+
+export async function redactGearPledgePii(
+  input: unknown,
+): Promise<ActionResult<{ id: string; version: number }>> {
+  try {
+    const validated = pledgeCommandSchema.parse(input);
+    const userId = await requireLeagueRole(validated.leagueId, "LEAGUE_ADMIN");
+    const result = await withGearSerializableRetry(() => prisma.$transaction(async (tx) => {
+      const pledge = await tx.gearPledge.findFirst({
+        where: { id: validated.pledgeId, leagueId: validated.leagueId },
+        select: { id: true, leagueId: true, wishlistItemId: true, status: true, version: true, piiRedactionStatus: true },
+      });
+      if (!pledge || !["RECEIVED", "DECLINED", "CANCELED", "EXPIRED"].includes(pledge.status)) {
+        invalid("Only terminal pledges can be redacted.");
+      }
+      if (pledge.version !== validated.expectedVersion) throw new GearConflictError();
+      return redactTerminalGearPledgePii(tx, {
+        ...pledge,
+        status: pledge.status as "RECEIVED" | "DECLINED" | "CANCELED" | "EXPIRED",
+      }, userId);
+    }, gearTransactionOptions));
+    revalidatePath(wishlistPath(validated.leagueId));
+    return { success: true, data: result };
+  } catch (error) {
+    return actionError(error);
+  }
+}
+
 async function transitionPledge(
   input: unknown,
   target: "DECLINED" | "CANCELED" | "EXPIRED",
@@ -462,7 +741,10 @@ async function transitionPledge(
         where: { id: validated.pledgeId, leagueId: validated.leagueId, status: "PLEDGED" },
         select: {
           id: true, quantity: true, wishlistItemId: true, version: true,
-          receipts: { select: { quantity: true } },
+          receipts: {
+            where: { correctionOfReceiptId: null, correction: { is: null } },
+            select: { quantity: true },
+          },
         },
       });
       if (!pledge) invalid("Only active pledges can be updated.");
@@ -529,7 +811,7 @@ export type GearPledgeAdminContext = Array<{
   id: string;
   version: number;
   wishlistItemId: string;
-  donorName: string;
+  donorName: string | null;
   donorEmail: string | null;
   donorPhone: string | null;
   contactConsentAt: string | null;
@@ -538,6 +820,8 @@ export type GearPledgeAdminContext = Array<{
   note: string | null;
   expiresAt: string | null;
   receivedAt: string | null;
+  piiRedactionStatus: "PENDING" | "REDACTED";
+  piiRedactedAt: string | null;
   createdAt: string;
   wishlistItem: { nameSnapshot: string; categorySnapshot: string | null; sizeSnapshot: string | null };
   receipts: Array<{
@@ -557,6 +841,7 @@ export async function getGearPledgeAdminContext(leagueId: string): Promise<GearP
     select: {
       id: true, version: true, wishlistItemId: true, donorName: true, donorEmail: true, donorPhone: true, contactConsentAt: true,
       status: true, quantity: true, note: true, expiresAt: true, receivedAt: true, createdAt: true,
+      piiRedactionStatus: true, piiRedactedAt: true,
       wishlistItem: { select: { nameSnapshot: true, categorySnapshot: true, sizeSnapshot: true } },
       receipts: {
         select: { id: true, quantity: true, receivedAt: true, notes: true, poolStockId: true, gearUnitId: true },
@@ -565,17 +850,25 @@ export async function getGearPledgeAdminContext(leagueId: string): Promise<GearP
     },
     orderBy: { createdAt: "desc" },
   });
-  return pledges.map((pledge) => ({
-    ...pledge,
-    contactConsentAt: pledge.contactConsentAt?.toISOString() ?? null,
-    expiresAt: pledge.expiresAt?.toISOString() ?? null,
-    receivedAt: pledge.receivedAt?.toISOString() ?? null,
-    createdAt: pledge.createdAt.toISOString(),
-    receipts: pledge.receipts.map((receipt) => ({
-      ...receipt,
-      receivedAt: receipt.receivedAt.toISOString(),
-    })),
-  }));
+  return pledges.map((pledge) => {
+    const redacted = pledge.piiRedactionStatus === "REDACTED";
+    return {
+      ...pledge,
+      donorName: redacted ? null : pledge.donorName,
+      donorEmail: redacted ? null : pledge.donorEmail,
+      donorPhone: redacted ? null : pledge.donorPhone,
+      contactConsentAt: redacted ? null : pledge.contactConsentAt?.toISOString() ?? null,
+      note: redacted ? null : pledge.note,
+      piiRedactedAt: pledge.piiRedactedAt?.toISOString() ?? null,
+      expiresAt: pledge.expiresAt?.toISOString() ?? null,
+      receivedAt: pledge.receivedAt?.toISOString() ?? null,
+      createdAt: pledge.createdAt.toISOString(),
+      receipts: pledge.receipts.map((receipt) => ({
+        ...receipt,
+        receivedAt: receipt.receivedAt.toISOString(),
+      })),
+    };
+  });
 }
 
 export async function getGearPledgesForAdmin(leagueId: string) {

--- a/lib/actions/gear-pledges.ts
+++ b/lib/actions/gear-pledges.ts
@@ -1,0 +1,502 @@
+"use server";
+
+import { Prisma } from "@prisma/client";
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+import { requireLeagueRole } from "@/lib/auth/session";
+import { prisma } from "@/lib/db/prisma";
+import { recordGearActivity, recordGearInventoryMovement } from "@/lib/services/gear-ledger";
+import { queueGearOutboxForLeagueAdmins } from "@/lib/services/gear-outbox";
+import {
+  GearConflictError,
+  gearTransactionOptions,
+  withGearSerializableRetry,
+} from "@/lib/services/gear-transaction";
+import {
+  checkRateLimit,
+  getClientIp,
+  RATE_LIMITS,
+  rateLimitMessage,
+} from "@/lib/utils/durable-rate-limit";
+import { normalizeGearAssetTag } from "@/lib/utils/gear";
+import { createGearPledgeSchema, receiveGearPledgeSchema } from "@/lib/utils/validation";
+import type { ActionResult } from "@/lib/actions/gear-inventory";
+
+const gearId = z.string().cuid("Invalid gear identifier");
+const pledgeCommandSchema = z.object({
+  leagueId: gearId,
+  pledgeId: gearId,
+});
+
+type Tx = Prisma.TransactionClient;
+
+function wishlistPath(leagueId: string) {
+  return `/league/${leagueId}/gear/wishlist`;
+}
+
+function invalid(message: string): never {
+  throw new Error(`Gear validation: ${message}`);
+}
+
+function actionError(error: unknown): ActionResult<never> {
+  if (error instanceof GearConflictError) return { success: false, error: error.message };
+  if (error instanceof z.ZodError) {
+    return { success: false, error: "Please correct the highlighted pledge fields.", details: error.issues };
+  }
+  if (error instanceof Error) {
+    if (error.message.startsWith("Unauthorized")) return { success: false, error: "League admin access is required." };
+    if (error.message.startsWith("Gear validation:")) return { success: false, error: error.message.slice(17) };
+  }
+  return { success: false, error: "Unable to update the gear pledge. Please try again." };
+}
+
+async function publicPledgeByIdempotency(
+  wishlistToken: string,
+  wishlistItemId: string,
+  idempotencyKey: string,
+) {
+  return prisma.gearPledge.findFirst({
+    where: {
+      idempotencyKey,
+      wishlistItemId,
+      wishlistItem: { wishlist: { shareToken: wishlistToken } },
+    },
+    select: { id: true, status: true },
+  });
+}
+
+export async function createGearPledge(
+  input: z.input<typeof createGearPledgeSchema>,
+): Promise<ActionResult<{ id: string | null; status: string }>> {
+  try {
+    // Check the honeypot before normal validation so bots always receive the
+    // same generic response, even when they omit consent or other fields.
+    if (typeof input === "object" && input !== null && "website" in input
+      && typeof input.website === "string" && input.website.trim()) {
+      return { success: true, data: { id: null, status: "PLEDGED" } };
+    }
+    const validated = createGearPledgeSchema.parse(input);
+    if (!validated.contactConsent) invalid("Contact consent is required to submit a pledge.");
+
+    const existing = await publicPledgeByIdempotency(
+      validated.wishlistToken,
+      validated.wishlistItemId,
+      validated.idempotencyKey,
+    );
+    if (existing) return { success: true, data: existing };
+
+    const ip = await getClientIp();
+    if (ip) {
+      const rateLimit = await checkRateLimit(`gear-pledge:ip:${ip}`, RATE_LIMITS.GEAR_PLEDGE_PER_IP);
+      if (!rateLimit.allowed) {
+        return { success: false, error: rateLimitMessage(rateLimit.retryAfterSec) };
+      }
+    }
+
+    const pledge = await withGearSerializableRetry(() => prisma.$transaction(async (tx) => {
+      const item = await tx.gearWishlistItem.findFirst({
+        where: {
+          id: validated.wishlistItemId,
+          isActive: true,
+          wishlist: {
+            shareToken: validated.wishlistToken,
+            status: "PUBLISHED",
+            league: { isActive: true },
+          },
+        },
+        select: { id: true, wishlistId: true, pledgedQty: true, receivedQty: true, targetQty: true, wishlist: { select: { leagueId: true } } },
+      });
+      if (!item) invalid("This wishlist item is no longer accepting pledges.");
+      const duplicate = await tx.gearPledge.findUnique({
+        where: { leagueId_idempotencyKey: { leagueId: item.wishlist.leagueId, idempotencyKey: validated.idempotencyKey } },
+        select: { id: true, status: true },
+      });
+      if (duplicate) return duplicate;
+
+      const created = await tx.gearPledge.create({
+        data: {
+          leagueId: item.wishlist.leagueId,
+          wishlistItemId: item.id,
+          donorName: validated.donorName,
+          donorEmail: validated.donorEmail || null,
+          donorPhone: validated.donorPhone || null,
+          contactConsentAt: validated.contactConsent ? new Date() : null,
+          quantity: validated.quantity,
+          note: validated.note || null,
+          idempotencyKey: validated.idempotencyKey,
+        },
+        select: { id: true, status: true },
+      });
+      await tx.gearWishlistItem.update({
+        where: { id: item.id },
+        data: { pledgedQty: { increment: validated.quantity } },
+      });
+      await recordGearActivity(tx, {
+        leagueId: item.wishlist.leagueId,
+        entityType: "PLEDGE",
+        entityId: created.id,
+        action: "pledged",
+        actorKind: "PUBLIC_DONOR",
+        details: { wishlistItemId: item.id, quantity: validated.quantity },
+      });
+      await queueGearOutboxForLeagueAdmins(tx, {
+        leagueId: item.wishlist.leagueId,
+        eventType: "gear.pledge.created",
+        aggregateType: "PLEDGE",
+        aggregateId: created.id,
+        payload: { pledgeId: created.id, wishlistItemId: item.id, quantity: validated.quantity },
+      });
+      return created;
+    }, gearTransactionOptions));
+
+    return { success: true, data: pledge };
+  } catch (error) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002") {
+      const parsed = createGearPledgeSchema.safeParse(input);
+      if (parsed.success) {
+        const existing = await publicPledgeByIdempotency(
+          parsed.data.wishlistToken,
+          parsed.data.wishlistItemId,
+          parsed.data.idempotencyKey,
+        );
+        if (existing) return { success: true, data: existing };
+      }
+    }
+    return actionError(error);
+  }
+}
+
+export async function createPublicGearPledge(
+  input: z.input<typeof createGearPledgeSchema>,
+): Promise<ActionResult<{ id: string | null; status: string }>> {
+  return createGearPledge(input);
+}
+
+export async function receiveGearPledge(
+  input: z.input<typeof receiveGearPledgeSchema>,
+): Promise<ActionResult<{ receiptId: string; receiptIds: string[]; pledgeStatus: string }>> {
+  try {
+    const validated = receiveGearPledgeSchema.parse(input);
+    const userId = await requireLeagueRole(validated.leagueId, "LEAGUE_ADMIN");
+    const result = await withGearSerializableRetry(() => prisma.$transaction(async (tx) => {
+      const pledge = await tx.gearPledge.findFirst({
+        where: { id: validated.pledgeId, leagueId: validated.leagueId, status: "PLEDGED" },
+        include: { wishlistItem: { select: { id: true, catalogItemId: true } } },
+      });
+      if (!pledge) invalid("An active pledge was not found.");
+
+      const received = await tx.gearPledgeReceipt.aggregate({
+        where: { pledgeId: pledge.id },
+        _sum: { quantity: true },
+      });
+      const alreadyReceived = received._sum.quantity ?? 0;
+      if (alreadyReceived + validated.quantity > pledge.quantity) {
+        invalid("Receipt quantity exceeds the remaining pledged quantity.");
+      }
+
+      const receiptIds: string[] = [];
+
+      if (validated.poolStockId) {
+        const stock = await tx.gearPoolStock.findFirst({
+          where: {
+            id: validated.poolStockId,
+            leagueId: validated.leagueId,
+            catalogItem: { trackingMode: "POOLED", isActive: true },
+          },
+          select: { id: true, catalogItemId: true, locationId: true, condition: true },
+        });
+        if (!stock) invalid("The selected pooled inventory row is not active in this league.");
+        if (validated.catalogItemId && validated.catalogItemId !== stock.catalogItemId) {
+          invalid("The selected pooled inventory does not match the supplied catalog item.");
+        }
+        if (pledge.wishlistItem.catalogItemId && pledge.wishlistItem.catalogItemId !== stock.catalogItemId) {
+          invalid("Received inventory does not match the pledged catalog item.");
+        }
+        await tx.gearPoolStock.update({
+          where: { id: stock.id },
+          data: { quantityOnHand: { increment: validated.quantity }, version: { increment: 1 } },
+        });
+        const receipt = await tx.gearPledgeReceipt.create({
+          data: {
+            leagueId: validated.leagueId,
+            pledgeId: pledge.id,
+            catalogItemId: stock.catalogItemId,
+            poolStockId: stock.id,
+            quantity: validated.quantity,
+            notes: validated.notes || null,
+          },
+          select: { id: true },
+        });
+        receiptIds.push(receipt.id);
+        await recordGearInventoryMovement(tx, {
+          leagueId: validated.leagueId,
+          type: "RECEIPT",
+          quantity: validated.quantity,
+          poolStockId: stock.id,
+          pledgeReceiptId: receipt.id,
+          afterLocationId: stock.locationId,
+          afterCondition: stock.condition,
+          recordedById: userId,
+          notes: validated.notes || null,
+        });
+      } else {
+        const assetTags = (validated.assetTags ?? []).map(normalizeGearAssetTag);
+        if (!validated.catalogItemId || !validated.locationId || !validated.condition || assetTags.length === 0) {
+          invalid("Tagged receipts require catalog, location, condition, and asset tags.");
+        }
+        if (new Set(assetTags).size !== assetTags.length) invalid("Each received asset tag must be unique.");
+        const [catalogItem, location, existingUnits] = await Promise.all([
+          tx.gearCatalogItem.findFirst({
+            where: {
+              id: validated.catalogItemId,
+              leagueId: validated.leagueId,
+              isActive: true,
+              trackingMode: "INDIVIDUAL",
+            },
+            select: { id: true },
+          }),
+          tx.gearStorageLocation.findFirst({
+            where: { id: validated.locationId, leagueId: validated.leagueId, isActive: true },
+            select: { id: true },
+          }),
+          tx.gearUnit.findMany({
+            where: { leagueId: validated.leagueId, assetTag: { in: assetTags } },
+            select: { assetTag: true },
+          }),
+        ]);
+        if (!catalogItem) invalid("The selected catalog item is not active for individually tracked inventory.");
+        if (!location) invalid("The selected storage location is not active in this league.");
+        if (existingUnits.length > 0) invalid("One or more received asset tags already exist in this league.");
+        if (pledge.wishlistItem.catalogItemId && pledge.wishlistItem.catalogItemId !== catalogItem.id) {
+          invalid("Received inventory does not match the pledged catalog item.");
+        }
+
+        for (const assetTag of assetTags) {
+          const unit = await tx.gearUnit.create({
+            data: {
+              leagueId: validated.leagueId,
+              catalogItemId: catalogItem.id,
+              assetTag,
+              status: "AVAILABLE",
+              currentCondition: validated.condition,
+              currentLocationId: location.id,
+              acquiredAt: new Date(),
+            },
+            select: { id: true },
+          });
+          const receipt = await tx.gearPledgeReceipt.create({
+            data: {
+              leagueId: validated.leagueId,
+              pledgeId: pledge.id,
+              catalogItemId: catalogItem.id,
+              gearUnitId: unit.id,
+              quantity: 1,
+              notes: validated.notes || null,
+            },
+            select: { id: true },
+          });
+          receiptIds.push(receipt.id);
+          await recordGearInventoryMovement(tx, {
+            leagueId: validated.leagueId,
+            type: "RECEIPT",
+            quantity: 1,
+            gearUnitId: unit.id,
+            pledgeReceiptId: receipt.id,
+            afterLocationId: location.id,
+            afterCondition: validated.condition,
+            recordedById: userId,
+            notes: validated.notes || null,
+          });
+          await recordGearActivity(tx, {
+            leagueId: validated.leagueId,
+            entityType: "UNIT",
+            entityId: unit.id,
+            action: "received_from_pledge",
+            actorUserId: userId,
+            details: { pledgeId: pledge.id, receiptId: receipt.id, assetTag },
+          });
+        }
+      }
+
+      const remainingAfterReceipt = pledge.quantity - alreadyReceived - validated.quantity;
+      const pledgeStatus = remainingAfterReceipt === 0 ? "RECEIVED" : "PLEDGED";
+      const pledgeUpdate = await tx.gearPledge.updateMany({
+        where: { id: pledge.id, status: "PLEDGED" },
+        data: {
+          ...(pledgeStatus === "RECEIVED" ? { status: "RECEIVED", receivedAt: new Date() } : {}),
+        },
+      });
+      if (pledgeUpdate.count !== 1) throw new GearConflictError();
+      await tx.gearWishlistItem.update({
+        where: { id: pledge.wishlistItem.id },
+        data: {
+          pledgedQty: { decrement: validated.quantity },
+          receivedQty: { increment: validated.quantity },
+        },
+      });
+      await recordGearActivity(tx, {
+        leagueId: validated.leagueId,
+        entityType: "PLEDGE",
+        entityId: pledge.id,
+        action: pledgeStatus === "RECEIVED" ? "received" : "partially_received",
+        actorUserId: userId,
+        details: {
+          receiptIds,
+          quantity: validated.quantity,
+          inventoryKind: validated.poolStockId ? "POOLED" : "INDIVIDUAL",
+        },
+      });
+      await queueGearOutboxForLeagueAdmins(tx, {
+        leagueId: validated.leagueId,
+        eventType: "gear.pledge.received",
+        aggregateType: "PLEDGE",
+        aggregateId: pledge.id,
+        payload: {
+          pledgeId: pledge.id,
+          receiptIds,
+          wishlistItemId: pledge.wishlistItem.id,
+          quantity: validated.quantity,
+          status: pledgeStatus,
+        },
+      });
+      return { receiptId: receiptIds[0], receiptIds, pledgeStatus };
+    }, gearTransactionOptions));
+
+    revalidatePath(wishlistPath(validated.leagueId));
+    revalidatePath(`/league/${validated.leagueId}/gear`);
+    return { success: true, data: result };
+  } catch (error) {
+    return actionError(error);
+  }
+}
+
+async function transitionPledge(
+  input: unknown,
+  target: "DECLINED" | "CANCELED" | "EXPIRED",
+): Promise<ActionResult<{ id: string; status: string }>> {
+  try {
+    const validated = pledgeCommandSchema.parse(input);
+    const userId = await requireLeagueRole(validated.leagueId, "LEAGUE_ADMIN");
+    const result = await withGearSerializableRetry(() => prisma.$transaction(async (tx) => {
+      const pledge = await tx.gearPledge.findFirst({
+        where: { id: validated.pledgeId, leagueId: validated.leagueId, status: "PLEDGED" },
+        select: {
+          id: true, quantity: true, wishlistItemId: true,
+          receipts: { select: { quantity: true } },
+        },
+      });
+      if (!pledge) invalid("Only active pledges can be updated.");
+      const receivedQty = pledge.receipts.reduce((total, receipt) => total + receipt.quantity, 0);
+      const outstandingQty = pledge.quantity - receivedQty;
+      if (outstandingQty < 0) invalid("Pledge receipt history is inconsistent.");
+      const update = await tx.gearPledge.updateMany({
+        where: { id: pledge.id, status: "PLEDGED" },
+        data: { status: target },
+      });
+      if (update.count !== 1) throw new GearConflictError();
+      if (outstandingQty > 0) {
+        await tx.gearWishlistItem.update({
+          where: { id: pledge.wishlistItemId },
+          data: { pledgedQty: { decrement: outstandingQty } },
+        });
+      }
+      await recordGearActivity(tx, {
+        leagueId: validated.leagueId,
+        entityType: "PLEDGE",
+        entityId: pledge.id,
+        action: target.toLowerCase(),
+        actorUserId: userId,
+        details: { wishlistItemId: pledge.wishlistItemId, outstandingQty },
+      });
+      await queueGearOutboxForLeagueAdmins(tx, {
+        leagueId: validated.leagueId,
+        eventType: `gear.pledge.${target.toLowerCase()}`,
+        aggregateType: "PLEDGE",
+        aggregateId: pledge.id,
+        payload: { pledgeId: pledge.id, wishlistItemId: pledge.wishlistItemId, status: target },
+      });
+      return { id: pledge.id, status: target };
+    }, gearTransactionOptions));
+    revalidatePath(wishlistPath(validated.leagueId));
+    return { success: true, data: result };
+  } catch (error) {
+    return actionError(error);
+  }
+}
+
+export async function declineGearPledge(input: unknown) {
+  return transitionPledge(input, "DECLINED");
+}
+
+export async function cancelGearPledge(input: unknown) {
+  return transitionPledge(input, "CANCELED");
+}
+
+export async function expireGearPledge(input: unknown) {
+  return transitionPledge(input, "EXPIRED");
+}
+
+export async function updateGearPledgeStatus(input: unknown) {
+  const parsed = z.object({
+    leagueId: gearId,
+    pledgeId: gearId,
+    status: z.enum(["DECLINED", "CANCELED", "EXPIRED"]),
+  }).parse(input);
+  return transitionPledge(parsed, parsed.status);
+}
+
+export type GearPledgeAdminContext = Array<{
+  id: string;
+  wishlistItemId: string;
+  donorName: string;
+  donorEmail: string | null;
+  donorPhone: string | null;
+  contactConsentAt: string | null;
+  status: "PLEDGED" | "RECEIVED" | "DECLINED" | "CANCELED" | "EXPIRED";
+  quantity: number;
+  note: string | null;
+  expiresAt: string | null;
+  receivedAt: string | null;
+  createdAt: string;
+  wishlistItem: { nameSnapshot: string; categorySnapshot: string | null; sizeSnapshot: string | null };
+  receipts: Array<{
+    id: string;
+    quantity: number;
+    receivedAt: string;
+    notes: string | null;
+    poolStockId: string | null;
+    gearUnitId: string | null;
+  }>;
+}>;
+
+export async function getGearPledgeAdminContext(leagueId: string): Promise<GearPledgeAdminContext> {
+  await requireLeagueRole(leagueId, "LEAGUE_ADMIN");
+  const pledges = await prisma.gearPledge.findMany({
+    where: { leagueId },
+    select: {
+      id: true, wishlistItemId: true, donorName: true, donorEmail: true, donorPhone: true, contactConsentAt: true,
+      status: true, quantity: true, note: true, expiresAt: true, receivedAt: true, createdAt: true,
+      wishlistItem: { select: { nameSnapshot: true, categorySnapshot: true, sizeSnapshot: true } },
+      receipts: {
+        select: { id: true, quantity: true, receivedAt: true, notes: true, poolStockId: true, gearUnitId: true },
+        orderBy: { receivedAt: "asc" },
+      },
+    },
+    orderBy: { createdAt: "desc" },
+  });
+  return pledges.map((pledge) => ({
+    ...pledge,
+    contactConsentAt: pledge.contactConsentAt?.toISOString() ?? null,
+    expiresAt: pledge.expiresAt?.toISOString() ?? null,
+    receivedAt: pledge.receivedAt?.toISOString() ?? null,
+    createdAt: pledge.createdAt.toISOString(),
+    receipts: pledge.receipts.map((receipt) => ({
+      ...receipt,
+      receivedAt: receipt.receivedAt.toISOString(),
+    })),
+  }));
+}
+
+export async function getGearPledgesForAdmin(leagueId: string) {
+  return getGearPledgeAdminContext(leagueId);
+}

--- a/lib/actions/gear-pledges.ts
+++ b/lib/actions/gear-pledges.ts
@@ -26,6 +26,7 @@ const gearId = z.string().cuid("Invalid gear identifier");
 const pledgeCommandSchema = z.object({
   leagueId: gearId,
   pledgeId: gearId,
+  expectedVersion: z.coerce.number().int().min(0),
 });
 
 type Tx = Prisma.TransactionClient;
@@ -142,6 +143,7 @@ export async function createGearPledge(
       await queueGearOutboxForLeagueAdmins(tx, {
         leagueId: item.wishlist.leagueId,
         eventType: "gear.pledge.created",
+        occurrenceKey: created.id,
         aggregateType: "PLEDGE",
         aggregateId: created.id,
         payload: { pledgeId: created.id, wishlistItemId: item.id, quantity: validated.quantity },
@@ -174,16 +176,41 @@ export async function createPublicGearPledge(
 
 export async function receiveGearPledge(
   input: z.input<typeof receiveGearPledgeSchema>,
-): Promise<ActionResult<{ receiptId: string; receiptIds: string[]; pledgeStatus: string }>> {
+): Promise<ActionResult<{ receiptId: string; receiptIds: string[]; pledgeStatus: string; pledgeVersion: number }>> {
   try {
     const validated = receiveGearPledgeSchema.parse(input);
     const userId = await requireLeagueRole(validated.leagueId, "LEAGUE_ADMIN");
     const result = await withGearSerializableRetry(() => prisma.$transaction(async (tx) => {
+      const priorCommand = await tx.gearPledgeReceiptCommand.findUnique({
+        where: {
+          leagueId_pledgeId_idempotencyKey: {
+            leagueId: validated.leagueId,
+            pledgeId: validated.pledgeId,
+            idempotencyKey: validated.idempotencyKey,
+          },
+        },
+        select: {
+          resultingStatus: true,
+          resultingVersion: true,
+          receipts: { select: { id: true } },
+        },
+      });
+      if (priorCommand) {
+        const receiptIds = priorCommand.receipts.map((receipt) => receipt.id);
+        if (receiptIds.length === 0) invalid("The saved receipt command has no receipts.");
+        return {
+          receiptId: receiptIds[0],
+          receiptIds,
+          pledgeStatus: priorCommand.resultingStatus,
+          pledgeVersion: priorCommand.resultingVersion,
+        };
+      }
       const pledge = await tx.gearPledge.findFirst({
         where: { id: validated.pledgeId, leagueId: validated.leagueId, status: "PLEDGED" },
         include: { wishlistItem: { select: { id: true, catalogItemId: true } } },
       });
       if (!pledge) invalid("An active pledge was not found.");
+      if (pledge.version !== validated.expectedVersion) throw new GearConflictError();
 
       const received = await tx.gearPledgeReceipt.aggregate({
         where: { pledgeId: pledge.id },
@@ -194,6 +221,19 @@ export async function receiveGearPledge(
         invalid("Receipt quantity exceeds the remaining pledged quantity.");
       }
 
+      const remainingAfterReceipt = pledge.quantity - alreadyReceived - validated.quantity;
+      const pledgeStatus = remainingAfterReceipt === 0 ? "RECEIVED" : "PLEDGED";
+      const command = await tx.gearPledgeReceiptCommand.create({
+        data: {
+          leagueId: validated.leagueId,
+          pledgeId: pledge.id,
+          idempotencyKey: validated.idempotencyKey,
+          expectedVersion: validated.expectedVersion,
+          resultingVersion: pledge.version + 1,
+          resultingStatus: pledgeStatus,
+        },
+        select: { id: true },
+      });
       const receiptIds: string[] = [];
 
       if (validated.poolStockId) {
@@ -220,6 +260,7 @@ export async function receiveGearPledge(
           data: {
             leagueId: validated.leagueId,
             pledgeId: pledge.id,
+            receiptCommandId: command.id,
             catalogItemId: stock.catalogItemId,
             poolStockId: stock.id,
             quantity: validated.quantity,
@@ -288,6 +329,7 @@ export async function receiveGearPledge(
             data: {
               leagueId: validated.leagueId,
               pledgeId: pledge.id,
+              receiptCommandId: command.id,
               catalogItemId: catalogItem.id,
               gearUnitId: unit.id,
               quantity: 1,
@@ -318,12 +360,11 @@ export async function receiveGearPledge(
         }
       }
 
-      const remainingAfterReceipt = pledge.quantity - alreadyReceived - validated.quantity;
-      const pledgeStatus = remainingAfterReceipt === 0 ? "RECEIVED" : "PLEDGED";
       const pledgeUpdate = await tx.gearPledge.updateMany({
-        where: { id: pledge.id, status: "PLEDGED" },
+        where: { id: pledge.id, leagueId: validated.leagueId, status: "PLEDGED", version: pledge.version },
         data: {
           ...(pledgeStatus === "RECEIVED" ? { status: "RECEIVED", receivedAt: new Date() } : {}),
+          version: { increment: 1 },
         },
       });
       if (pledgeUpdate.count !== 1) throw new GearConflictError();
@@ -349,6 +390,7 @@ export async function receiveGearPledge(
       await queueGearOutboxForLeagueAdmins(tx, {
         leagueId: validated.leagueId,
         eventType: "gear.pledge.received",
+        occurrenceKey: command.id,
         aggregateType: "PLEDGE",
         aggregateId: pledge.id,
         payload: {
@@ -359,13 +401,44 @@ export async function receiveGearPledge(
           status: pledgeStatus,
         },
       });
-      return { receiptId: receiptIds[0], receiptIds, pledgeStatus };
+      return { receiptId: receiptIds[0], receiptIds, pledgeStatus, pledgeVersion: pledge.version + 1 };
     }, gearTransactionOptions));
 
     revalidatePath(wishlistPath(validated.leagueId));
     revalidatePath(`/league/${validated.leagueId}/gear`);
     return { success: true, data: result };
   } catch (error) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002") {
+      const parsed = receiveGearPledgeSchema.safeParse(input);
+      if (parsed.success) {
+        const priorCommand = await prisma.gearPledgeReceiptCommand.findUnique({
+          where: {
+            leagueId_pledgeId_idempotencyKey: {
+              leagueId: parsed.data.leagueId,
+              pledgeId: parsed.data.pledgeId,
+              idempotencyKey: parsed.data.idempotencyKey,
+            },
+          },
+          select: {
+            resultingStatus: true,
+            resultingVersion: true,
+            receipts: { select: { id: true } },
+          },
+        });
+        if (priorCommand?.receipts.length) {
+          const receiptIds = priorCommand.receipts.map((receipt) => receipt.id);
+          return {
+            success: true,
+            data: {
+              receiptId: receiptIds[0],
+              receiptIds,
+              pledgeStatus: priorCommand.resultingStatus,
+              pledgeVersion: priorCommand.resultingVersion,
+            },
+          };
+        }
+      }
+    }
     return actionError(error);
   }
 }
@@ -373,7 +446,7 @@ export async function receiveGearPledge(
 async function transitionPledge(
   input: unknown,
   target: "DECLINED" | "CANCELED" | "EXPIRED",
-): Promise<ActionResult<{ id: string; status: string }>> {
+): Promise<ActionResult<{ id: string; status: string; version: number }>> {
   try {
     const validated = pledgeCommandSchema.parse(input);
     const userId = await requireLeagueRole(validated.leagueId, "LEAGUE_ADMIN");
@@ -381,17 +454,18 @@ async function transitionPledge(
       const pledge = await tx.gearPledge.findFirst({
         where: { id: validated.pledgeId, leagueId: validated.leagueId, status: "PLEDGED" },
         select: {
-          id: true, quantity: true, wishlistItemId: true,
+          id: true, quantity: true, wishlistItemId: true, version: true,
           receipts: { select: { quantity: true } },
         },
       });
       if (!pledge) invalid("Only active pledges can be updated.");
+      if (pledge.version !== validated.expectedVersion) throw new GearConflictError();
       const receivedQty = pledge.receipts.reduce((total, receipt) => total + receipt.quantity, 0);
       const outstandingQty = pledge.quantity - receivedQty;
       if (outstandingQty < 0) invalid("Pledge receipt history is inconsistent.");
       const update = await tx.gearPledge.updateMany({
-        where: { id: pledge.id, status: "PLEDGED" },
-        data: { status: target },
+        where: { id: pledge.id, leagueId: validated.leagueId, status: "PLEDGED", version: pledge.version },
+        data: { status: target, version: { increment: 1 } },
       });
       if (update.count !== 1) throw new GearConflictError();
       if (outstandingQty > 0) {
@@ -411,11 +485,12 @@ async function transitionPledge(
       await queueGearOutboxForLeagueAdmins(tx, {
         leagueId: validated.leagueId,
         eventType: `gear.pledge.${target.toLowerCase()}`,
+        occurrenceKey: `v${pledge.version + 1}`,
         aggregateType: "PLEDGE",
         aggregateId: pledge.id,
         payload: { pledgeId: pledge.id, wishlistItemId: pledge.wishlistItemId, status: target },
       });
-      return { id: pledge.id, status: target };
+      return { id: pledge.id, status: target, version: pledge.version + 1 };
     }, gearTransactionOptions));
     revalidatePath(wishlistPath(validated.leagueId));
     return { success: true, data: result };
@@ -437,9 +512,7 @@ export async function expireGearPledge(input: unknown) {
 }
 
 export async function updateGearPledgeStatus(input: unknown) {
-  const parsed = z.object({
-    leagueId: gearId,
-    pledgeId: gearId,
+  const parsed = pledgeCommandSchema.extend({
     status: z.enum(["DECLINED", "CANCELED", "EXPIRED"]),
   }).parse(input);
   return transitionPledge(parsed, parsed.status);
@@ -447,6 +520,7 @@ export async function updateGearPledgeStatus(input: unknown) {
 
 export type GearPledgeAdminContext = Array<{
   id: string;
+  version: number;
   wishlistItemId: string;
   donorName: string;
   donorEmail: string | null;
@@ -474,7 +548,7 @@ export async function getGearPledgeAdminContext(leagueId: string): Promise<GearP
   const pledges = await prisma.gearPledge.findMany({
     where: { leagueId },
     select: {
-      id: true, wishlistItemId: true, donorName: true, donorEmail: true, donorPhone: true, contactConsentAt: true,
+      id: true, version: true, wishlistItemId: true, donorName: true, donorEmail: true, donorPhone: true, contactConsentAt: true,
       status: true, quantity: true, note: true, expiresAt: true, receivedAt: true, createdAt: true,
       wishlistItem: { select: { nameSnapshot: true, categorySnapshot: true, sizeSnapshot: true } },
       receipts: {

--- a/lib/actions/gear-pledges.ts
+++ b/lib/actions/gear-pledges.ts
@@ -138,7 +138,7 @@ export async function createGearPledge(
         entityId: created.id,
         action: "pledged",
         actorKind: "PUBLIC_DONOR",
-        details: { wishlistItemId: item.id, quantity: validated.quantity },
+        details: { metadata: { wishlistItemId: item.id, quantity: validated.quantity } },
       });
       await queueGearOutboxForLeagueAdmins(tx, {
         leagueId: item.wishlist.leagueId,
@@ -146,7 +146,7 @@ export async function createGearPledge(
         occurrenceKey: created.id,
         aggregateType: "PLEDGE",
         aggregateId: created.id,
-        payload: { pledgeId: created.id, wishlistItemId: item.id, quantity: validated.quantity },
+        payload: { kind: "GEAR_PLEDGE", data: { pledgeId: created.id, wishlistItemId: item.id, quantity: validated.quantity } },
       });
       return created;
     }, gearTransactionOptions));
@@ -272,6 +272,7 @@ export async function receiveGearPledge(
         await recordGearInventoryMovement(tx, {
           leagueId: validated.leagueId,
           type: "RECEIPT",
+          direction: "INCREASE",
           quantity: validated.quantity,
           poolStockId: stock.id,
           pledgeReceiptId: receipt.id,
@@ -341,6 +342,7 @@ export async function receiveGearPledge(
           await recordGearInventoryMovement(tx, {
             leagueId: validated.leagueId,
             type: "RECEIPT",
+            direction: "INCREASE",
             quantity: 1,
             gearUnitId: unit.id,
             pledgeReceiptId: receipt.id,
@@ -355,7 +357,7 @@ export async function receiveGearPledge(
             entityId: unit.id,
             action: "received_from_pledge",
             actorUserId: userId,
-            details: { pledgeId: pledge.id, receiptId: receipt.id, assetTag },
+            details: { metadata: { pledgeId: pledge.id, receiptId: receipt.id, assetTag } },
           });
         }
       }
@@ -382,9 +384,11 @@ export async function receiveGearPledge(
         action: pledgeStatus === "RECEIVED" ? "received" : "partially_received",
         actorUserId: userId,
         details: {
-          receiptIds,
-          quantity: validated.quantity,
-          inventoryKind: validated.poolStockId ? "POOLED" : "INDIVIDUAL",
+          metadata: {
+            receiptCount: receiptIds.length,
+            quantity: validated.quantity,
+            inventoryKind: validated.poolStockId ? "POOLED" : "INDIVIDUAL",
+          },
         },
       });
       await queueGearOutboxForLeagueAdmins(tx, {
@@ -394,11 +398,14 @@ export async function receiveGearPledge(
         aggregateType: "PLEDGE",
         aggregateId: pledge.id,
         payload: {
-          pledgeId: pledge.id,
-          receiptIds,
-          wishlistItemId: pledge.wishlistItem.id,
-          quantity: validated.quantity,
-          status: pledgeStatus,
+          kind: "GEAR_PLEDGE",
+          data: {
+            pledgeId: pledge.id,
+            receiptCount: receiptIds.length,
+            wishlistItemId: pledge.wishlistItem.id,
+            quantity: validated.quantity,
+            status: pledgeStatus,
+          },
         },
       });
       return { receiptId: receiptIds[0], receiptIds, pledgeStatus, pledgeVersion: pledge.version + 1 };
@@ -480,7 +487,7 @@ async function transitionPledge(
         entityId: pledge.id,
         action: target.toLowerCase(),
         actorUserId: userId,
-        details: { wishlistItemId: pledge.wishlistItemId, outstandingQty },
+        details: { metadata: { wishlistItemId: pledge.wishlistItemId, outstandingQty } },
       });
       await queueGearOutboxForLeagueAdmins(tx, {
         leagueId: validated.leagueId,
@@ -488,7 +495,7 @@ async function transitionPledge(
         occurrenceKey: `v${pledge.version + 1}`,
         aggregateType: "PLEDGE",
         aggregateId: pledge.id,
-        payload: { pledgeId: pledge.id, wishlistItemId: pledge.wishlistItemId, status: target },
+        payload: { kind: "GEAR_PLEDGE", data: { pledgeId: pledge.id, wishlistItemId: pledge.wishlistItemId, status: target } },
       });
       return { id: pledge.id, status: target, version: pledge.version + 1 };
     }, gearTransactionOptions));

--- a/lib/actions/gear-wishlist.ts
+++ b/lib/actions/gear-wishlist.ts
@@ -7,6 +7,7 @@ import { z } from "zod";
 import { requireLeagueRole, requireUserId } from "@/lib/auth/session";
 import { prisma } from "@/lib/db/prisma";
 import { recordGearActivity } from "@/lib/services/gear-ledger";
+import { reportGearActionFailure } from "@/lib/services/gear-observability";
 import { queueGearOutboxForLeagueAdmins } from "@/lib/services/gear-outbox";
 import {
   GearConflictError,
@@ -34,6 +35,7 @@ function invalid(message: string): never {
 }
 
 function actionError(error: unknown): ActionResult<never> {
+  reportGearActionFailure({ action: "wishlist", error });
   if (error instanceof GearConflictError) return { success: false, error: error.message };
   if (error instanceof z.ZodError) {
     return { success: false, error: "Please correct the highlighted wishlist fields.", details: error.issues };

--- a/lib/actions/gear-wishlist.ts
+++ b/lib/actions/gear-wishlist.ts
@@ -137,7 +137,7 @@ export async function saveGearWishlist(
           entityId: created.id,
           action: validated.publish ? "created_and_published" : "created",
           actorUserId: userId,
-          details: { itemCount: items.length },
+          details: { metadata: { itemCount: items.length } },
         });
         await queueGearOutboxForLeagueAdmins(tx, {
           leagueId: validated.leagueId,
@@ -145,7 +145,7 @@ export async function saveGearWishlist(
           occurrenceKey: `v${created.version}`,
           aggregateType: "WISHLIST",
           aggregateId: created.id,
-          payload: { wishlistId: created.id, status: created.status, itemCount: items.length },
+          payload: { kind: "GEAR_WISHLIST", data: { wishlistId: created.id, status: created.status, itemCount: items.length } },
         });
         return created;
       }
@@ -185,7 +185,7 @@ export async function saveGearWishlist(
           entityId: existing.id,
           action: "recycled",
           actorUserId: userId,
-          details: { itemCount: items.length, status },
+          details: { metadata: { itemCount: items.length, status } },
         });
         await queueGearOutboxForLeagueAdmins(tx, {
           leagueId: validated.leagueId,
@@ -193,7 +193,7 @@ export async function saveGearWishlist(
           occurrenceKey: `v${existing.version + 1}`,
           aggregateType: "WISHLIST",
           aggregateId: existing.id,
-          payload: { wishlistId: existing.id, status, itemCount: items.length },
+          payload: { kind: "GEAR_WISHLIST", data: { wishlistId: existing.id, status, itemCount: items.length } },
         });
         return {
           id: existing.id,
@@ -259,7 +259,7 @@ export async function saveGearWishlist(
         entityId: existing.id,
         action: nextStatus === "PUBLISHED" && existing.status === "DRAFT" ? "published" : "updated",
         actorUserId: userId,
-        details: { itemCount: items.length },
+        details: { metadata: { itemCount: items.length } },
       });
       if (nextStatus === "PUBLISHED" && existing.status === "DRAFT") {
         await queueGearOutboxForLeagueAdmins(tx, {
@@ -268,7 +268,7 @@ export async function saveGearWishlist(
           occurrenceKey: `v${existing.version + 1}`,
           aggregateType: "WISHLIST",
           aggregateId: existing.id,
-          payload: { wishlistId: existing.id, status: nextStatus, itemCount: items.length },
+          payload: { kind: "GEAR_WISHLIST", data: { wishlistId: existing.id, status: nextStatus, itemCount: items.length } },
         });
       }
       return {
@@ -310,7 +310,7 @@ export async function archiveGearWishlist(input: unknown): Promise<ActionResult<
         occurrenceKey: `v${wishlist.version + 1}`,
         aggregateType: "WISHLIST",
         aggregateId: wishlist.id,
-        payload: { wishlistId: wishlist.id, status: "ARCHIVED" },
+        payload: { kind: "GEAR_WISHLIST", data: { wishlistId: wishlist.id, status: "ARCHIVED" } },
       });
       return { id: wishlist.id, version: wishlist.version + 1 };
     }, gearTransactionOptions));
@@ -351,7 +351,7 @@ export async function rotateGearWishlistShareToken(
         occurrenceKey: `v${wishlist.version + 1}`,
         aggregateType: "WISHLIST",
         aggregateId: wishlist.id,
-        payload: { wishlistId: wishlist.id },
+        payload: { kind: "GEAR_WISHLIST", data: { wishlistId: wishlist.id } },
       });
       return { id: wishlist.id, shareToken: token, version: wishlist.version + 1 };
     }, gearTransactionOptions));
@@ -402,7 +402,7 @@ export async function setGearWishlistStatus(input: unknown): Promise<ActionResul
         occurrenceKey: `v${wishlist.version + 1}`,
         aggregateType: "WISHLIST",
         aggregateId: wishlist.id,
-        payload: { wishlistId: wishlist.id, status: "PUBLISHED", itemCount: wishlist.items.length },
+        payload: { kind: "GEAR_WISHLIST", data: { wishlistId: wishlist.id, status: "PUBLISHED", itemCount: wishlist.items.length } },
       });
       return { id: wishlist.id, status: "PUBLISHED", version: wishlist.version + 1 };
     }, gearTransactionOptions));

--- a/lib/actions/gear-wishlist.ts
+++ b/lib/actions/gear-wishlist.ts
@@ -1,0 +1,452 @@
+"use server";
+
+import { randomBytes } from "node:crypto";
+import { Prisma } from "@prisma/client";
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+import { requireLeagueRole, requireUserId } from "@/lib/auth/session";
+import { prisma } from "@/lib/db/prisma";
+import { recordGearActivity } from "@/lib/services/gear-ledger";
+import { queueGearOutboxForLeagueAdmins } from "@/lib/services/gear-outbox";
+import {
+  GearConflictError,
+  gearTransactionOptions,
+  withGearSerializableRetry,
+} from "@/lib/services/gear-transaction";
+import { normalizeGearKey } from "@/lib/utils/gear";
+import { saveGearWishlistSchema } from "@/lib/utils/validation";
+import type { ActionResult } from "@/lib/actions/gear-inventory";
+
+const gearId = z.string().cuid("Invalid gear identifier");
+const wishlistCommandSchema = z.object({
+  leagueId: gearId,
+  expectedVersion: z.coerce.number().int().min(0),
+});
+
+type Tx = Prisma.TransactionClient;
+
+function wishlistPath(leagueId: string) {
+  return `/league/${leagueId}/gear/wishlist`;
+}
+
+function invalid(message: string): never {
+  throw new Error(`Gear validation: ${message}`);
+}
+
+function actionError(error: unknown): ActionResult<never> {
+  if (error instanceof GearConflictError) return { success: false, error: error.message };
+  if (error instanceof z.ZodError) {
+    return { success: false, error: "Please correct the highlighted wishlist fields.", details: error.issues };
+  }
+  if (error instanceof Error) {
+    if (error.message.startsWith("Unauthorized")) return { success: false, error: "League admin access is required." };
+    if (error.message.startsWith("Gear validation:")) return { success: false, error: error.message.slice(17) };
+  }
+  return { success: false, error: "Unable to update the gear wishlist. Please try again." };
+}
+
+function newShareToken() {
+  return randomBytes(32).toString("base64url");
+}
+
+async function curatedItems(
+  tx: Tx,
+  leagueId: string,
+  items: z.output<typeof saveGearWishlistSchema>["items"],
+) {
+  const catalogIds = items
+    .map((item) => item.catalogItemId)
+    .filter((id): id is string => Boolean(id));
+  const catalogItems = catalogIds.length === 0
+    ? []
+    : await tx.gearCatalogItem.findMany({
+        where: { leagueId, id: { in: catalogIds }, isActive: true },
+        select: { id: true, name: true, category: true, size: true },
+      });
+  const catalogById = new Map(catalogItems.map((item) => [item.id, item]));
+  if (catalogById.size !== new Set(catalogIds).size) {
+    invalid("A selected catalog item is not active in this league.");
+  }
+
+  const curated = items.map((item) => {
+    const catalog = item.catalogItemId ? catalogById.get(item.catalogItemId) : undefined;
+    const nameSnapshot = catalog?.name ?? item.nameSnapshot;
+    const categorySnapshot = (catalog?.category ?? item.categorySnapshot) || null;
+    const sizeSnapshot = (catalog?.size ?? item.sizeSnapshot) || null;
+    return {
+      catalogItemId: catalog?.id ?? null,
+      nameSnapshot,
+      categorySnapshot,
+      sizeSnapshot,
+      description: item.description || null,
+      targetQty: item.targetQty,
+      normalizedKey: normalizeGearKey([
+        catalog?.id ?? "",
+        nameSnapshot,
+        categorySnapshot ?? "",
+        sizeSnapshot ?? "",
+      ].join(" ")),
+    };
+  });
+  if (new Set(curated.map((item) => item.normalizedKey)).size !== curated.length) {
+    invalid("Each wishlist item must be distinct.");
+  }
+  return curated;
+}
+
+export async function saveGearWishlist(
+  input: z.input<typeof saveGearWishlistSchema>,
+): Promise<ActionResult<{ id: string; shareToken: string; status: string; version: number }>> {
+  try {
+    const validated = saveGearWishlistSchema.parse(input);
+    const userId = await requireLeagueRole(validated.leagueId, "LEAGUE_ADMIN");
+
+    const result = await withGearSerializableRetry(() => prisma.$transaction(async (tx) => {
+      const existing = await tx.gearWishlist.findUnique({
+        where: { leagueId: validated.leagueId },
+        include: {
+          items: {
+            select: {
+              id: true, normalizedKey: true, targetQty: true, pledgedQty: true, receivedQty: true, isActive: true,
+            },
+          },
+        },
+      });
+      const items = await curatedItems(tx, validated.leagueId, validated.items);
+      if (validated.publish && items.length === 0) invalid("Add at least one item before publishing the wishlist.");
+
+      if (!existing) {
+        if (validated.expectedVersion !== undefined && validated.expectedVersion !== 0) {
+          throw new GearConflictError();
+        }
+        const created = await tx.gearWishlist.create({
+          data: {
+            leagueId: validated.leagueId,
+            shareToken: newShareToken(),
+            status: validated.publish ? "PUBLISHED" : "DRAFT",
+            title: validated.title,
+            description: validated.description || null,
+            publishedAt: validated.publish ? new Date() : null,
+            items: { create: items },
+          },
+          select: { id: true, shareToken: true, status: true, version: true },
+        });
+        await recordGearActivity(tx, {
+          leagueId: validated.leagueId,
+          entityType: "WISHLIST",
+          entityId: created.id,
+          action: validated.publish ? "created_and_published" : "created",
+          actorUserId: userId,
+          details: { itemCount: items.length },
+        });
+        await queueGearOutboxForLeagueAdmins(tx, {
+          leagueId: validated.leagueId,
+          eventType: validated.publish ? "gear.wishlist.created_and_published" : "gear.wishlist.created",
+          aggregateType: "WISHLIST",
+          aggregateId: created.id,
+          payload: { wishlistId: created.id, status: created.status, itemCount: items.length },
+        });
+        return created;
+      }
+
+      if (existing.status === "ARCHIVED") {
+        invalid("An archived wishlist cannot be edited. Create a new association wishlist instead.");
+      }
+      if (validated.expectedVersion === undefined || existing.version !== validated.expectedVersion) {
+        throw new GearConflictError();
+      }
+
+      const existingByKey = new Map(existing.items.map((item) => [item.normalizedKey, item]));
+      const submittedKeys = new Set(items.map((item) => item.normalizedKey));
+      for (const oldItem of existing.items) {
+        if (!submittedKeys.has(oldItem.normalizedKey) && oldItem.pledgedQty > 0) {
+          invalid("A wishlist item with outstanding pledges cannot be removed.");
+        }
+      }
+      for (const item of items) {
+        const oldItem = existingByKey.get(item.normalizedKey);
+        if (oldItem && item.targetQty < oldItem.pledgedQty + oldItem.receivedQty) {
+          invalid("A wishlist target cannot be below the currently pledged and received quantity.");
+        }
+      }
+
+      const now = new Date();
+      const nextStatus = existing.status === "PUBLISHED" || validated.publish ? "PUBLISHED" : "DRAFT";
+      const update = await tx.gearWishlist.updateMany({
+        where: { id: existing.id, version: existing.version, status: existing.status },
+        data: {
+          title: validated.title,
+          description: validated.description || null,
+          status: nextStatus,
+          publishedAt: nextStatus === "PUBLISHED" ? (existing.publishedAt ?? now) : null,
+          version: { increment: 1 },
+        },
+      });
+      if (update.count !== 1) throw new GearConflictError();
+
+      for (const item of items) {
+        const oldItem = existingByKey.get(item.normalizedKey);
+        if (oldItem) {
+          await tx.gearWishlistItem.update({
+            where: { id: oldItem.id },
+            data: { ...item, isActive: true },
+          });
+        } else {
+          await tx.gearWishlistItem.create({ data: { wishlistId: existing.id, ...item } });
+        }
+      }
+      await tx.gearWishlistItem.updateMany({
+        where: {
+          wishlistId: existing.id,
+          normalizedKey: { notIn: [...submittedKeys] },
+          pledgedQty: 0,
+        },
+        data: { isActive: false },
+      });
+
+      await recordGearActivity(tx, {
+        leagueId: validated.leagueId,
+        entityType: "WISHLIST",
+        entityId: existing.id,
+        action: nextStatus === "PUBLISHED" && existing.status === "DRAFT" ? "published" : "updated",
+        actorUserId: userId,
+        details: { itemCount: items.length },
+      });
+      if (nextStatus === "PUBLISHED" && existing.status === "DRAFT") {
+        await queueGearOutboxForLeagueAdmins(tx, {
+          leagueId: validated.leagueId,
+          eventType: "gear.wishlist.published",
+          aggregateType: "WISHLIST",
+          aggregateId: existing.id,
+          payload: { wishlistId: existing.id, status: nextStatus, itemCount: items.length },
+        });
+      }
+      return {
+        id: existing.id,
+        shareToken: existing.shareToken,
+        status: nextStatus,
+        version: existing.version + 1,
+      };
+    }, gearTransactionOptions));
+
+    revalidatePath(wishlistPath(validated.leagueId));
+    return { success: true, data: result };
+  } catch (error) {
+    return actionError(error);
+  }
+}
+
+export async function archiveGearWishlist(input: unknown): Promise<ActionResult<{ id: string; version: number }>> {
+  try {
+    const validated = wishlistCommandSchema.parse(input);
+    const userId = await requireLeagueRole(validated.leagueId, "LEAGUE_ADMIN");
+    const result = await withGearSerializableRetry(() => prisma.$transaction(async (tx) => {
+      const wishlist = await tx.gearWishlist.findUnique({ where: { leagueId: validated.leagueId } });
+      if (!wishlist) invalid("Wishlist not found.");
+      if (wishlist.status === "ARCHIVED") invalid("Wishlist is already archived.");
+      if (wishlist.version !== validated.expectedVersion) throw new GearConflictError();
+      const update = await tx.gearWishlist.updateMany({
+        where: { id: wishlist.id, version: wishlist.version, status: wishlist.status },
+        data: { status: "ARCHIVED", archivedAt: new Date(), version: { increment: 1 } },
+      });
+      if (update.count !== 1) throw new GearConflictError();
+      await recordGearActivity(tx, {
+        leagueId: validated.leagueId, entityType: "WISHLIST", entityId: wishlist.id,
+        action: "archived", actorUserId: userId,
+      });
+      await queueGearOutboxForLeagueAdmins(tx, {
+        leagueId: validated.leagueId,
+        eventType: "gear.wishlist.archived",
+        aggregateType: "WISHLIST",
+        aggregateId: wishlist.id,
+        payload: { wishlistId: wishlist.id, status: "ARCHIVED" },
+      });
+      return { id: wishlist.id, version: wishlist.version + 1 };
+    }, gearTransactionOptions));
+    revalidatePath(wishlistPath(validated.leagueId));
+    return { success: true, data: result };
+  } catch (error) {
+    return actionError(error);
+  }
+}
+
+export async function rotateGearWishlistShareToken(
+  input: unknown,
+): Promise<ActionResult<{ id: string; shareToken: string; version: number }>> {
+  try {
+    const validated = wishlistCommandSchema.parse(input);
+    const userId = await requireLeagueRole(validated.leagueId, "LEAGUE_ADMIN");
+    const result = await withGearSerializableRetry(() => prisma.$transaction(async (tx) => {
+      const wishlist = await tx.gearWishlist.findUnique({ where: { leagueId: validated.leagueId } });
+      if (!wishlist) invalid("Wishlist not found.");
+      if (wishlist.status === "ARCHIVED") invalid("An archived wishlist cannot receive a new share link.");
+      if (wishlist.version !== validated.expectedVersion) throw new GearConflictError();
+      const token = newShareToken();
+      const update = await tx.gearWishlist.updateMany({
+        where: { id: wishlist.id, version: wishlist.version, status: wishlist.status },
+        data: { shareToken: token, version: { increment: 1 } },
+      });
+      if (update.count !== 1) throw new GearConflictError();
+      await recordGearActivity(tx, {
+        leagueId: validated.leagueId,
+        entityType: "WISHLIST",
+        entityId: wishlist.id,
+        action: "share_token_rotated",
+        actorUserId: userId,
+      });
+      await queueGearOutboxForLeagueAdmins(tx, {
+        leagueId: validated.leagueId,
+        eventType: "gear.wishlist.share_token_rotated",
+        aggregateType: "WISHLIST",
+        aggregateId: wishlist.id,
+        payload: { wishlistId: wishlist.id },
+      });
+      return { id: wishlist.id, shareToken: token, version: wishlist.version + 1 };
+    }, gearTransactionOptions));
+    revalidatePath(wishlistPath(validated.leagueId));
+    return { success: true, data: result };
+  } catch (error) {
+    return actionError(error);
+  }
+}
+
+export async function setGearWishlistStatus(input: unknown): Promise<ActionResult<{ id: string; status: string; version: number }>> {
+  try {
+    const validated = wishlistCommandSchema.extend({
+      status: z.enum(["PUBLISHED", "ARCHIVED"]),
+    }).parse(input);
+    if (validated.status === "ARCHIVED") {
+      const archived = await archiveGearWishlist(validated);
+      return archived.success
+        ? { success: true, data: { ...archived.data, status: "ARCHIVED" } }
+        : archived;
+    }
+
+    const userId = await requireLeagueRole(validated.leagueId, "LEAGUE_ADMIN");
+    const result = await withGearSerializableRetry(() => prisma.$transaction(async (tx) => {
+      const wishlist = await tx.gearWishlist.findUnique({
+        where: { leagueId: validated.leagueId },
+        select: { id: true, status: true, version: true, publishedAt: true, items: { select: { id: true } } },
+      });
+      if (!wishlist) invalid("Wishlist not found.");
+      if (wishlist.status !== "DRAFT") invalid("Only draft wishlists can be published.");
+      if (wishlist.items.length === 0) invalid("Add at least one item before publishing the wishlist.");
+      if (wishlist.version !== validated.expectedVersion) throw new GearConflictError();
+      const update = await tx.gearWishlist.updateMany({
+        where: { id: wishlist.id, version: wishlist.version, status: "DRAFT" },
+        data: { status: "PUBLISHED", publishedAt: new Date(), version: { increment: 1 } },
+      });
+      if (update.count !== 1) throw new GearConflictError();
+      await recordGearActivity(tx, {
+        leagueId: validated.leagueId,
+        entityType: "WISHLIST",
+        entityId: wishlist.id,
+        action: "published",
+        actorUserId: userId,
+      });
+      await queueGearOutboxForLeagueAdmins(tx, {
+        leagueId: validated.leagueId,
+        eventType: "gear.wishlist.published",
+        aggregateType: "WISHLIST",
+        aggregateId: wishlist.id,
+        payload: { wishlistId: wishlist.id, status: "PUBLISHED", itemCount: wishlist.items.length },
+      });
+      return { id: wishlist.id, status: "PUBLISHED", version: wishlist.version + 1 };
+    }, gearTransactionOptions));
+    revalidatePath(wishlistPath(validated.leagueId));
+    return { success: true, data: result };
+  } catch (error) {
+    return actionError(error);
+  }
+}
+
+export type GearWishlistAdminContext = {
+  id: string;
+  shareToken: string;
+  status: "DRAFT" | "PUBLISHED" | "ARCHIVED";
+  title: string;
+  description: string | null;
+  version: number;
+  publishedAt: string | null;
+  archivedAt: string | null;
+  items: Array<{
+    id: string;
+    catalogItemId: string | null;
+    normalizedKey: string;
+    nameSnapshot: string;
+    categorySnapshot: string | null;
+    sizeSnapshot: string | null;
+    description: string | null;
+    targetQty: number;
+    pledgedQty: number;
+    receivedQty: number;
+    isActive: boolean;
+  }>;
+};
+
+export async function getGearWishlistAdminContext(leagueId: string): Promise<GearWishlistAdminContext | null> {
+  await requireLeagueRole(leagueId, "LEAGUE_ADMIN");
+  const wishlist = await prisma.gearWishlist.findUnique({
+    where: { leagueId },
+    select: {
+      id: true, shareToken: true, status: true, title: true, description: true, version: true,
+      publishedAt: true, archivedAt: true,
+      items: {
+        select: {
+          id: true, catalogItemId: true, normalizedKey: true, nameSnapshot: true, categorySnapshot: true,
+          sizeSnapshot: true, description: true, targetQty: true, pledgedQty: true, receivedQty: true, isActive: true,
+        },
+        orderBy: { createdAt: "asc" },
+      },
+    },
+  });
+  if (!wishlist) return null;
+  return {
+    ...wishlist,
+    publishedAt: wishlist.publishedAt?.toISOString() ?? null,
+    archivedAt: wishlist.archivedAt?.toISOString() ?? null,
+  };
+}
+
+export async function getGearWishlistForAdmin(leagueId: string) {
+  return getGearWishlistAdminContext(leagueId);
+}
+
+/** The share-token projection intentionally omits league identity and all donor records. */
+export async function getPublicGearWishlist(wishlistToken: string) {
+  const token = z.string().trim().min(16).max(255).parse(wishlistToken);
+  const wishlist = await prisma.gearWishlist.findFirst({
+    where: { shareToken: token, status: "PUBLISHED", league: { isActive: true } },
+    select: {
+      league: { select: { name: true } },
+      title: true,
+      description: true,
+      items: {
+        where: { isActive: true },
+        select: {
+          id: true, nameSnapshot: true, categorySnapshot: true, sizeSnapshot: true, description: true,
+          targetQty: true, pledgedQty: true, receivedQty: true,
+        },
+        orderBy: { createdAt: "asc" },
+      },
+    },
+  });
+  if (!wishlist) return null;
+  return {
+    associationName: wishlist.league.name,
+    title: wishlist.title,
+    description: wishlist.description,
+    items: wishlist.items.map((item) => ({
+      ...item,
+      remainingQty: Math.max(0, item.targetQty - item.pledgedQty - item.receivedQty),
+    })),
+  };
+}
+
+export async function canViewGearWishlist(leagueId: string): Promise<boolean> {
+  const userId = await requireUserId();
+  return Boolean(await prisma.leagueUser.findFirst({
+    where: { leagueId, userId, league: { isActive: true } },
+    select: { id: true },
+  }));
+}

--- a/lib/actions/gear-wishlist.ts
+++ b/lib/actions/gear-wishlist.ts
@@ -142,6 +142,7 @@ export async function saveGearWishlist(
         await queueGearOutboxForLeagueAdmins(tx, {
           leagueId: validated.leagueId,
           eventType: validated.publish ? "gear.wishlist.created_and_published" : "gear.wishlist.created",
+          occurrenceKey: `v${created.version}`,
           aggregateType: "WISHLIST",
           aggregateId: created.id,
           payload: { wishlistId: created.id, status: created.status, itemCount: items.length },
@@ -149,11 +150,57 @@ export async function saveGearWishlist(
         return created;
       }
 
-      if (existing.status === "ARCHIVED") {
-        invalid("An archived wishlist cannot be edited. Create a new association wishlist instead.");
-      }
       if (validated.expectedVersion === undefined || existing.version !== validated.expectedVersion) {
         throw new GearConflictError();
+      }
+      if (existing.status === "ARCHIVED") {
+        const now = new Date();
+        const shareToken = newShareToken();
+        const status = validated.publish ? "PUBLISHED" : "DRAFT";
+        const update = await tx.gearWishlist.updateMany({
+          where: { id: existing.id, version: existing.version, status: "ARCHIVED" },
+          data: {
+            shareToken,
+            title: validated.title,
+            description: validated.description || null,
+            status,
+            publishedAt: validated.publish ? now : null,
+            archivedAt: null,
+            version: { increment: 1 },
+          },
+        });
+        if (update.count !== 1) throw new GearConflictError();
+        await tx.gearWishlistItem.updateMany({
+          where: { leagueId: validated.leagueId, wishlistId: existing.id },
+          data: { isActive: false },
+        });
+        for (const item of items) {
+          await tx.gearWishlistItem.create({
+            data: { leagueId: validated.leagueId, wishlistId: existing.id, ...item },
+          });
+        }
+        await recordGearActivity(tx, {
+          leagueId: validated.leagueId,
+          entityType: "WISHLIST",
+          entityId: existing.id,
+          action: "recycled",
+          actorUserId: userId,
+          details: { itemCount: items.length, status },
+        });
+        await queueGearOutboxForLeagueAdmins(tx, {
+          leagueId: validated.leagueId,
+          eventType: "gear.wishlist.recycled",
+          occurrenceKey: `v${existing.version + 1}`,
+          aggregateType: "WISHLIST",
+          aggregateId: existing.id,
+          payload: { wishlistId: existing.id, status, itemCount: items.length },
+        });
+        return {
+          id: existing.id,
+          shareToken,
+          status,
+          version: existing.version + 1,
+        };
       }
 
       const existingByKey = new Map(existing.items.map((item) => [item.normalizedKey, item]));
@@ -192,7 +239,9 @@ export async function saveGearWishlist(
             data: { ...item, isActive: true },
           });
         } else {
-          await tx.gearWishlistItem.create({ data: { wishlistId: existing.id, ...item } });
+          await tx.gearWishlistItem.create({
+            data: { leagueId: validated.leagueId, wishlistId: existing.id, ...item },
+          });
         }
       }
       await tx.gearWishlistItem.updateMany({
@@ -216,6 +265,7 @@ export async function saveGearWishlist(
         await queueGearOutboxForLeagueAdmins(tx, {
           leagueId: validated.leagueId,
           eventType: "gear.wishlist.published",
+          occurrenceKey: `v${existing.version + 1}`,
           aggregateType: "WISHLIST",
           aggregateId: existing.id,
           payload: { wishlistId: existing.id, status: nextStatus, itemCount: items.length },
@@ -257,6 +307,7 @@ export async function archiveGearWishlist(input: unknown): Promise<ActionResult<
       await queueGearOutboxForLeagueAdmins(tx, {
         leagueId: validated.leagueId,
         eventType: "gear.wishlist.archived",
+        occurrenceKey: `v${wishlist.version + 1}`,
         aggregateType: "WISHLIST",
         aggregateId: wishlist.id,
         payload: { wishlistId: wishlist.id, status: "ARCHIVED" },
@@ -297,6 +348,7 @@ export async function rotateGearWishlistShareToken(
       await queueGearOutboxForLeagueAdmins(tx, {
         leagueId: validated.leagueId,
         eventType: "gear.wishlist.share_token_rotated",
+        occurrenceKey: `v${wishlist.version + 1}`,
         aggregateType: "WISHLIST",
         aggregateId: wishlist.id,
         payload: { wishlistId: wishlist.id },
@@ -347,6 +399,7 @@ export async function setGearWishlistStatus(input: unknown): Promise<ActionResul
       await queueGearOutboxForLeagueAdmins(tx, {
         leagueId: validated.leagueId,
         eventType: "gear.wishlist.published",
+        occurrenceKey: `v${wishlist.version + 1}`,
         aggregateType: "WISHLIST",
         aggregateId: wishlist.id,
         payload: { wishlistId: wishlist.id, status: "PUBLISHED", itemCount: wishlist.items.length },

--- a/lib/services/gear-ledger.ts
+++ b/lib/services/gear-ledger.ts
@@ -1,4 +1,5 @@
 import type {
+  GearActivityActorKind,
   GearActivityEntityType,
   GearInventoryDirection,
   GearInventoryMovementType,
@@ -17,7 +18,8 @@ export type GearActivityInput = {
   entityType: GearActivityEntityType;
   entityId: string;
   action: string;
-  actorUserId: string;
+  actorUserId?: string | null;
+  actorKind?: GearActivityActorKind;
   details?: Omit<GearActivityDetails, "action">;
 };
 
@@ -31,6 +33,7 @@ export type GearMovementInput = {
   gearUnitId?: string | null;
   allocationId?: string | null;
   handoffId?: string | null;
+  pledgeReceiptId?: string | null;
   beforeLocationId?: string | null;
   afterLocationId?: string | null;
   beforeCondition?: "NEW" | "EXCELLENT" | "GOOD" | "FAIR" | "POOR" | "DAMAGED" | null;
@@ -43,6 +46,10 @@ export async function recordGearActivity(
   tx: GearTransaction,
   input: GearActivityInput,
 ): Promise<void> {
+  const actorKind = input.actorKind ?? "USER";
+  if (actorKind === "USER" && !input.actorUserId) {
+    throw new Error("User activity requires an actor.");
+  }
   const details = gearActivityDetailsSchema.parse({
     action: input.action,
     ...input.details,
@@ -51,7 +58,7 @@ export async function recordGearActivity(
     data: {
       ...input,
       details,
-      actorKind: "USER",
+      actorKind,
     },
   });
 }

--- a/lib/services/gear-ledger.ts
+++ b/lib/services/gear-ledger.ts
@@ -1,6 +1,7 @@
 import type {
   GearActivityActorKind,
   GearActivityEntityType,
+  GearCondition,
   GearInventoryDirection,
   GearInventoryMovementType,
   Prisma,
@@ -36,8 +37,8 @@ export type GearMovementInput = {
   pledgeReceiptId?: string | null;
   beforeLocationId?: string | null;
   afterLocationId?: string | null;
-  beforeCondition?: "NEW" | "EXCELLENT" | "GOOD" | "FAIR" | "POOR" | "DAMAGED" | null;
-  afterCondition?: "NEW" | "EXCELLENT" | "GOOD" | "FAIR" | "POOR" | "DAMAGED" | null;
+  beforeCondition?: GearCondition | null;
+  afterCondition?: GearCondition | null;
   notes?: string | null;
 };
 

--- a/lib/services/gear-observability.ts
+++ b/lib/services/gear-observability.ts
@@ -1,0 +1,29 @@
+import { Prisma } from "@prisma/client";
+import { z } from "zod";
+import { GearConflictError } from "@/lib/services/gear-transaction";
+
+type GearFailure = {
+  action: "need" | "wishlist" | "pledge";
+  error: unknown;
+};
+
+/**
+ * Emits only structured operational classifications. Inputs, tokens, and donor
+ * fields are deliberately excluded so this remains safe at public boundaries.
+ */
+export function reportGearActionFailure({ action, error }: GearFailure): void {
+  if (error instanceof z.ZodError) return;
+  if (error instanceof GearConflictError) {
+    if (error.retryExhausted) {
+      console.error({ event: "gear.retry_exhausted", action, errorType: error.name });
+    }
+    return;
+  }
+  if (error instanceof Prisma.PrismaClientKnownRequestError) {
+    console.error({ event: "gear.action_failed", action, category: "prisma", code: error.code });
+    return;
+  }
+  if (error instanceof Error && !error.message.startsWith("Gear validation:") && !error.message.startsWith("Unauthorized")) {
+    console.error({ event: "gear.action_failed", action, category: "unexpected", errorType: error.name });
+  }
+}

--- a/lib/services/gear-outbox.ts
+++ b/lib/services/gear-outbox.ts
@@ -5,6 +5,8 @@ type GearTransaction = Prisma.TransactionClient;
 export type GearOutboxEvent = {
   leagueId: string;
   eventType: string;
+  /** Stable identifier for this specific occurrence, not merely its aggregate. */
+  occurrenceKey: string;
   aggregateType: "NEED" | "PLEDGE" | "WISHLIST";
   aggregateId: string;
   payload: Prisma.InputJsonValue;
@@ -26,7 +28,7 @@ export async function queueGearOutboxForRecipients(
       aggregateType: event.aggregateType,
       aggregateId: event.aggregateId,
       payload: event.payload,
-      dedupeKey: `${event.eventType}:${event.aggregateId}:${recipientUserId}`,
+      dedupeKey: `${event.eventType}:${event.aggregateId}:${event.occurrenceKey}:${recipientUserId}`,
     })),
     skipDuplicates: true,
   });

--- a/lib/services/gear-outbox.ts
+++ b/lib/services/gear-outbox.ts
@@ -1,4 +1,6 @@
 import type { Prisma } from "@prisma/client";
+import type { GearNotificationPayload } from "@/types/gear";
+import { gearNotificationPayloadSchema } from "@/lib/utils/validation";
 
 type GearTransaction = Prisma.TransactionClient;
 
@@ -9,7 +11,7 @@ export type GearOutboxEvent = {
   occurrenceKey: string;
   aggregateType: "NEED" | "PLEDGE" | "WISHLIST";
   aggregateId: string;
-  payload: Prisma.InputJsonValue;
+  payload: GearNotificationPayload;
 };
 
 export async function queueGearOutboxForRecipients(
@@ -20,15 +22,21 @@ export async function queueGearOutboxForRecipients(
   const recipientIds = [...new Set(recipientUserIds)];
   if (recipientIds.length === 0) return;
 
+  const recipients = await tx.user.findMany({
+    where: { id: { in: recipientIds } },
+    select: { id: true, email: true },
+  });
+  const payload = gearNotificationPayloadSchema.parse(event.payload);
   await tx.notificationOutbox.createMany({
-    data: recipientIds.map((recipientUserId) => ({
+    data: recipients.map((recipient) => ({
       leagueId: event.leagueId,
-      recipientUserId,
+      recipientUserId: recipient.id,
+      recipientEmail: recipient.email,
       eventType: event.eventType,
       aggregateType: event.aggregateType,
       aggregateId: event.aggregateId,
-      payload: event.payload,
-      dedupeKey: `${event.eventType}:${event.aggregateId}:${event.occurrenceKey}:${recipientUserId}`,
+      payload,
+      dedupeKey: `${event.eventType}:${event.aggregateId}:${event.occurrenceKey}:${recipient.id}`,
     })),
     skipDuplicates: true,
   });

--- a/lib/services/gear-outbox.ts
+++ b/lib/services/gear-outbox.ts
@@ -1,0 +1,50 @@
+import type { Prisma } from "@prisma/client";
+
+type GearTransaction = Prisma.TransactionClient;
+
+export type GearOutboxEvent = {
+  leagueId: string;
+  eventType: string;
+  aggregateType: "NEED" | "PLEDGE" | "WISHLIST";
+  aggregateId: string;
+  payload: Prisma.InputJsonValue;
+};
+
+export async function queueGearOutboxForRecipients(
+  tx: GearTransaction,
+  event: GearOutboxEvent,
+  recipientUserIds: readonly string[],
+): Promise<void> {
+  const recipientIds = [...new Set(recipientUserIds)];
+  if (recipientIds.length === 0) return;
+
+  await tx.notificationOutbox.createMany({
+    data: recipientIds.map((recipientUserId) => ({
+      leagueId: event.leagueId,
+      recipientUserId,
+      eventType: event.eventType,
+      aggregateType: event.aggregateType,
+      aggregateId: event.aggregateId,
+      payload: event.payload,
+      dedupeKey: `${event.eventType}:${event.aggregateId}:${recipientUserId}`,
+    })),
+    skipDuplicates: true,
+  });
+}
+
+/**
+ * Queue an internal gear event for every league administrator while the
+ * originating mutation is still transactional. Callers must provide a payload
+ * that contains operational IDs and quantities only—never donor contact data.
+ */
+export async function queueGearOutboxForLeagueAdmins(
+  tx: GearTransaction,
+  event: GearOutboxEvent,
+): Promise<void> {
+  const administrators = await tx.leagueUser.findMany({
+    where: { leagueId: event.leagueId, role: "LEAGUE_ADMIN" },
+    select: { userId: true },
+  });
+
+  await queueGearOutboxForRecipients(tx, event, administrators.map(({ userId }) => userId));
+}

--- a/lib/services/gear-pledge-retention.ts
+++ b/lib/services/gear-pledge-retention.ts
@@ -1,0 +1,71 @@
+import type { Prisma } from "@prisma/client";
+import { recordGearActivity } from "@/lib/services/gear-ledger";
+import { queueGearOutboxForLeagueAdmins } from "@/lib/services/gear-outbox";
+import { GearConflictError } from "@/lib/services/gear-transaction";
+
+type GearTransaction = Prisma.TransactionClient;
+
+type TerminalPledge = {
+  id: string;
+  leagueId: string;
+  wishlistItemId: string;
+  status: "RECEIVED" | "DECLINED" | "CANCELED" | "EXPIRED";
+  version: number;
+  piiRedactionStatus: "PENDING" | "REDACTED";
+};
+
+/**
+ * Shared by the administrator action and future retention scheduling. This
+ * deliberately changes only mutable PII projections; the custody ledger stays
+ * immutable and carries no donor data.
+ */
+export async function redactTerminalGearPledgePii(
+  tx: GearTransaction,
+  pledge: TerminalPledge,
+  actorUserId?: string,
+): Promise<{ id: string; version: number }> {
+  if (pledge.piiRedactionStatus === "REDACTED") {
+    return { id: pledge.id, version: pledge.version };
+  }
+  const update = await tx.gearPledge.updateMany({
+    where: {
+      id: pledge.id,
+      leagueId: pledge.leagueId,
+      version: pledge.version,
+      piiRedactionStatus: "PENDING",
+    },
+    data: {
+      donorName: null,
+      donorEmail: null,
+      donorPhone: null,
+      contactConsentAt: null,
+      note: null,
+      piiRedactionStatus: "REDACTED",
+      piiRedactedAt: new Date(),
+      version: { increment: 1 },
+    },
+  });
+  if (update.count !== 1) throw new GearConflictError();
+
+  await recordGearActivity(tx, {
+    leagueId: pledge.leagueId,
+    entityType: "PLEDGE",
+    entityId: pledge.id,
+    action: "pii_redacted",
+    actorKind: actorUserId ? "USER" : "SYSTEM",
+    actorUserId,
+    details: { metadata: { wishlistItemId: pledge.wishlistItemId, terminalStatus: pledge.status } },
+  });
+  await queueGearOutboxForLeagueAdmins(tx, {
+    leagueId: pledge.leagueId,
+    eventType: "gear.pledge.pii_redacted",
+    occurrenceKey: `v${pledge.version + 1}`,
+    aggregateType: "PLEDGE",
+    aggregateId: pledge.id,
+    payload: {
+      kind: "GEAR_PLEDGE",
+      data: { pledgeId: pledge.id, wishlistItemId: pledge.wishlistItemId, status: pledge.status },
+    },
+  });
+  return { id: pledge.id, version: pledge.version + 1 };
+}

--- a/lib/utils/durable-rate-limit.ts
+++ b/lib/utils/durable-rate-limit.ts
@@ -24,6 +24,11 @@ export interface RateLimitResult {
   retryAfterSec?: number;
 }
 
+export interface RateLimitCheckOptions {
+  /** Public, anonymous operations must not proceed when the limiter is down. */
+  failOpen?: boolean;
+}
+
 /** Every Server Action rate-limit policy, defined in one place. */
 export const RATE_LIMITS = {
   /** Signup burns a bcrypt hash (cost 12) + a verification email per account. */
@@ -73,7 +78,8 @@ const CLEANUP_PROBABILITY = 0.01;
  */
 export async function checkRateLimit(
   key: string,
-  opts: RateLimitOptions
+  opts: RateLimitOptions,
+  { failOpen = true }: RateLimitCheckOptions = {},
 ): Promise<RateLimitResult> {
   try {
     const now = Date.now();
@@ -105,8 +111,8 @@ export async function checkRateLimit(
     }
     return { allowed: true };
   } catch (error) {
-    console.error(`Rate-limit check failed for "${key}" (failing open):`, error);
-    return { allowed: true };
+    console.error({ event: "rate_limit_check_failed", failOpen, errorType: error instanceof Error ? error.name : "unknown" });
+    return { allowed: failOpen };
   }
 }
 
@@ -117,18 +123,16 @@ export function rateLimitMessage(retryAfterSec?: number): string {
 }
 
 /**
- * Client IP for keying unauthenticated actions, read from proxy-set headers
- * (same trust model as getClientIp in lib/utils/rate-limit.ts). Returns null
- * when no IP is available — callers should SKIP their per-IP check in that
- * case rather than throttle all IP-less traffic in one shared bucket.
+ * Client IP for keying unauthenticated actions. We use Vercel's platform-set
+ * header only when Vercel confirms the deployment context; every other proxy
+ * header, including `x-forwarded-for`, is client-controlled at this boundary.
+ * Returning null makes public actions fail closed rather than bypass limiting.
  */
 export async function getClientIp(): Promise<string | null> {
   try {
     const headerList = await headers();
-    const forwarded = headerList.get("x-forwarded-for");
-    const realIp = headerList.get("x-real-ip");
-    const cfConnectingIp = headerList.get("cf-connecting-ip"); // Cloudflare
-    return forwarded?.split(",")[0]?.trim() || realIp || cfConnectingIp || null;
+    if (process.env.VERCEL !== "1") return null;
+    return headerList.get("x-vercel-forwarded-for") || null;
   } catch {
     // headers() throws outside a request scope (e.g. unit tests).
     return null;

--- a/lib/utils/durable-rate-limit.ts
+++ b/lib/utils/durable-rate-limit.ts
@@ -51,6 +51,8 @@ export const RATE_LIMITS = {
   INVITATION_SEND_PER_USER: { limit: 30, windowSec: 60 * 60 },
   /** League/team message fan-out per sender. */
   MESSAGE_SEND_PER_USER: { limit: 20, windowSec: 60 * 60 },
+  /** Public wishlist pledges are anonymous and therefore throttled per IP. */
+  GEAR_PLEDGE_PER_IP: { limit: 10, windowSec: 60 * 60 },
 } as const satisfies Record<string, RateLimitOptions>;
 
 /** Fraction of checks that piggyback a delete of expired buckets. */

--- a/lib/utils/validation.ts
+++ b/lib/utils/validation.ts
@@ -2341,7 +2341,7 @@ export const gearActivityDetailsSchema = z
 
 export const gearNotificationPayloadSchema = z
   .object({
-    kind: z.enum(["GEAR_RESERVATION", "GEAR_ALLOCATION", "GEAR_PLEDGE", "GEAR_WISHLIST"]),
+    kind: z.enum(["GEAR_RESERVATION", "GEAR_ALLOCATION", "GEAR_NEED", "GEAR_PLEDGE", "GEAR_WISHLIST"]),
     data: z.record(z.string().max(80), z.union([z.string().max(500), z.number(), z.boolean(), z.null()])),
   })
   .superRefine((value, context) => {

--- a/lib/utils/validation.ts
+++ b/lib/utils/validation.ts
@@ -2126,6 +2126,7 @@ export const createGearUnitSchema = z.object({
 export const createTeamGearNeedSchema = z.object({
   leagueId: gearCuidSchema,
   teamId: gearCuidSchema,
+  idempotencyKey: z.string().trim().min(16).max(255),
   title: sanitizedStringWithMin(1, 160),
   notes: optionalSanitizedString(2_000),
   lines: z
@@ -2202,9 +2203,12 @@ export const createGearPledgeSchema = z.object({
   donorEmail: optionalEmailSchema,
   donorPhone: optionalSanitizedString(40),
   contactConsent: z.boolean().default(false),
-  quantity: gearQuantitySchema,
+  quantity: gearQuantitySchema.max(100, "A pledge cannot exceed 100 items"),
   note: optionalSanitizedString(1_000),
   idempotencyKey: z.string().trim().min(16).max(255),
+}).refine((value) => Boolean(value.donorEmail || value.donorPhone), {
+  message: "Provide an email address or phone number so we can contact you.",
+  path: ["donorEmail"],
 });
 
 export const receiveGearPledgeSchema = z.object({
@@ -2238,14 +2242,15 @@ export const receiveGearPledgeSchema = z.object({
       path: ["assetTags"],
     });
   }
-  if (!isPoolReceipt && assetTags.length === 0) {
+  const isTaggedReceipt = assetTags.length > 0;
+  if (!isPoolReceipt && !isTaggedReceipt && (!value.catalogItemId || !value.locationId || !value.condition)) {
     context.addIssue({
       code: z.ZodIssueCode.custom,
-      message: "A tagged receipt requires at least one asset tag",
-      path: ["assetTags"],
+      message: "A pooled receipt needs catalog, storage location, and condition when no stock row is selected",
+      path: ["catalogItemId"],
     });
   }
-  if (!isPoolReceipt) {
+  if (!isPoolReceipt && isTaggedReceipt) {
     if (!value.catalogItemId) {
       context.addIssue({
         code: z.ZodIssueCode.custom,
@@ -2275,6 +2280,14 @@ export const receiveGearPledgeSchema = z.object({
       });
     }
   }
+});
+
+export const correctGearPledgeReceiptSchema = z.object({
+  leagueId: gearCuidSchema,
+  pledgeId: gearCuidSchema,
+  receiptId: gearCuidSchema,
+  expectedVersion: z.coerce.number().int().min(0),
+  reason: sanitizedStringWithMin(1, 1_000),
 });
 
 export const recordGearInventoryMovementSchema = z
@@ -2376,5 +2389,6 @@ export type CreateGearReservationInput = z.input<typeof createGearReservationSch
 export type SaveGearWishlistInput = z.input<typeof saveGearWishlistSchema>;
 export type CreateGearPledgeInput = z.input<typeof createGearPledgeSchema>;
 export type ReceiveGearPledgeInput = z.input<typeof receiveGearPledgeSchema>;
+export type CorrectGearPledgeReceiptInput = z.input<typeof correctGearPledgeReceiptSchema>;
 export type RecordGearInventoryMovementInput = z.input<typeof recordGearInventoryMovementSchema>;
 export type RecordGearHandoffInput = z.input<typeof recordGearHandoffSchema>;

--- a/lib/utils/validation.ts
+++ b/lib/utils/validation.ts
@@ -2195,6 +2195,9 @@ export const saveGearWishlistSchema = z.object({
 export const createGearPledgeSchema = z.object({
   wishlistToken: z.string().trim().min(16).max(255),
   wishlistItemId: gearCuidSchema,
+  // Kept empty by real clients; spam bots that populate it receive a generic
+  // success response without creating a pledge.
+  website: optionalSanitizedString(255),
   donorName: sanitizedStringWithMin(1, 160),
   donorEmail: optionalEmailSchema,
   donorPhone: optionalSanitizedString(40),
@@ -2209,24 +2212,66 @@ export const receiveGearPledgeSchema = z.object({
   pledgeId: gearCuidSchema,
   catalogItemId: gearCuidSchema.optional().or(z.literal("")),
   poolStockId: gearCuidSchema.optional().or(z.literal("")),
+  /** @deprecated Tagged pledge receipts create new units from assetTags. */
   gearUnitId: gearCuidSchema.optional().or(z.literal("")),
+  assetTags: z.array(sanitizedStringWithMin(1, 80)).max(100).optional(),
+  locationId: gearCuidSchema.optional().or(z.literal("")),
+  condition: z.enum(GEAR_CONDITIONS).optional(),
   quantity: gearQuantitySchema,
   notes: optionalSanitizedString(1_000),
 }).superRefine((value, context) => {
-  const inventoryLinks = [value.poolStockId, value.gearUnitId].filter(Boolean);
-  if (inventoryLinks.length !== 1) {
+  const isPoolReceipt = Boolean(value.poolStockId);
+  const assetTags = value.assetTags ?? [];
+  if (value.gearUnitId) {
     context.addIssue({
       code: z.ZodIssueCode.custom,
-      message: "A receipt must link to exactly one pool stock row or tagged unit",
-      path: ["poolStockId"],
+      message: "Tagged receipts use new asset tags rather than a pre-existing unit",
+      path: ["gearUnitId"],
     });
   }
-  if (value.gearUnitId && value.quantity !== 1) {
+  if (isPoolReceipt && assetTags.length > 0) {
     context.addIssue({
       code: z.ZodIssueCode.custom,
-      message: "A tagged-unit receipt quantity must be exactly 1",
-      path: ["quantity"],
+      message: "A receipt may use pooled stock or asset tags, not both",
+      path: ["assetTags"],
     });
+  }
+  if (!isPoolReceipt && assetTags.length === 0) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "A tagged receipt requires at least one asset tag",
+      path: ["assetTags"],
+    });
+  }
+  if (!isPoolReceipt) {
+    if (!value.catalogItemId) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Tagged receipts require a catalog item",
+        path: ["catalogItemId"],
+      });
+    }
+    if (!value.locationId) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Tagged receipts require a storage location",
+        path: ["locationId"],
+      });
+    }
+    if (!value.condition) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Tagged receipts require an item condition",
+        path: ["condition"],
+      });
+    }
+    if (assetTags.length !== value.quantity) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Tagged receipt quantity must equal the number of asset tags",
+        path: ["quantity"],
+      });
+    }
   }
 });
 

--- a/lib/utils/validation.ts
+++ b/lib/utils/validation.ts
@@ -2210,6 +2210,8 @@ export const createGearPledgeSchema = z.object({
 export const receiveGearPledgeSchema = z.object({
   leagueId: gearCuidSchema,
   pledgeId: gearCuidSchema,
+  expectedVersion: z.coerce.number().int().min(0),
+  idempotencyKey: z.string().trim().min(16).max(255),
   catalogItemId: gearCuidSchema.optional().or(z.literal("")),
   poolStockId: gearCuidSchema.optional().or(z.literal("")),
   /** @deprecated Tagged pledge receipts create new units from assetTags. */

--- a/prisma/migrations/20260816190000_gear_layer_four_receipt_commands/migration.sql
+++ b/prisma/migrations/20260816190000_gear_layer_four_receipt_commands/migration.sql
@@ -1,22 +1,42 @@
 -- Durable idempotency and optimistic-concurrency journal for Layer-4 pledge
 -- receipt commands. A command may produce multiple tagged-unit receipts.
 
+BEGIN;
+
+CREATE TYPE "GearPledgePiiRedactionStatus" AS ENUM ('PENDING', 'REDACTED');
+
 ALTER TABLE "gear_pledges"
-  ADD COLUMN "version" INTEGER NOT NULL DEFAULT 0;
+  ADD COLUMN "version" INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN "piiRedactionStatus" "GearPledgePiiRedactionStatus" NOT NULL DEFAULT 'PENDING',
+  ADD COLUMN "piiRedactedAt" TIMESTAMP(3),
+  ALTER COLUMN "donorName" DROP NOT NULL;
 
 ALTER TABLE "gear_pledge_receipts"
-  ADD COLUMN "receiptCommandId" TEXT;
+  ADD COLUMN "receiptCommandId" TEXT,
+  ADD COLUMN "correctionOfReceiptId" TEXT,
+  ADD COLUMN "correctionReason" TEXT;
 
 CREATE TABLE "gear_pledge_receipt_commands" (
   "id" TEXT NOT NULL,
   "leagueId" TEXT NOT NULL,
   "pledgeId" TEXT NOT NULL,
   "idempotencyKey" TEXT NOT NULL,
+  "payloadHash" TEXT NOT NULL,
   "expectedVersion" INTEGER NOT NULL,
   "resultingVersion" INTEGER NOT NULL,
   "resultingStatus" "GearPledgeStatus" NOT NULL,
   "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
   CONSTRAINT "gear_pledge_receipt_commands_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "team_gear_need_commands" (
+  "id" TEXT NOT NULL,
+  "leagueId" TEXT NOT NULL,
+  "teamId" TEXT NOT NULL,
+  "idempotencyKey" TEXT NOT NULL,
+  "needId" TEXT NOT NULL,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "team_gear_need_commands_pkey" PRIMARY KEY ("id")
 );
 
 CREATE UNIQUE INDEX "gear_pledge_receipt_commands_leagueId_id_key"
@@ -25,6 +45,16 @@ CREATE UNIQUE INDEX "gear_pledge_receipt_commands_leagueId_pledgeId_idempotencyK
   ON "gear_pledge_receipt_commands"("leagueId", "pledgeId", "idempotencyKey");
 CREATE INDEX "gear_pledge_receipt_commands_leagueId_pledgeId_createdAt_idx"
   ON "gear_pledge_receipt_commands"("leagueId", "pledgeId", "createdAt");
+CREATE UNIQUE INDEX "gear_pledge_receipts_leagueId_correctionOfReceiptId_key"
+  ON "gear_pledge_receipts"("leagueId", "correctionOfReceiptId");
+CREATE UNIQUE INDEX "team_gear_need_commands_leagueId_id_key"
+  ON "team_gear_need_commands"("leagueId", "id");
+CREATE UNIQUE INDEX "team_gear_need_commands_leagueId_teamId_idempotencyKey_key"
+  ON "team_gear_need_commands"("leagueId", "teamId", "idempotencyKey");
+CREATE UNIQUE INDEX "team_gear_need_commands_leagueId_needId_key"
+  ON "team_gear_need_commands"("leagueId", "needId");
+CREATE INDEX "team_gear_need_commands_leagueId_teamId_createdAt_idx"
+  ON "team_gear_need_commands"("leagueId", "teamId", "createdAt");
 
 ALTER TABLE "gear_pledge_receipt_commands"
   ADD CONSTRAINT "gear_pledge_receipt_commands_leagueId_fkey"
@@ -35,3 +65,23 @@ ALTER TABLE "gear_pledge_receipt_commands"
 ALTER TABLE "gear_pledge_receipts"
   ADD CONSTRAINT "gear_pledge_receipts_leagueId_receiptCommandId_fkey"
   FOREIGN KEY ("leagueId", "receiptCommandId") REFERENCES "gear_pledge_receipt_commands"("leagueId", "id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "gear_pledge_receipts"
+  ADD CONSTRAINT "gear_pledge_receipts_correctionOfReceiptId_fkey"
+  FOREIGN KEY ("leagueId", "correctionOfReceiptId") REFERENCES "gear_pledge_receipts"("leagueId", "id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "gear_pledge_receipts"
+  ADD CONSTRAINT "gear_pledge_receipts_correction_fields_valid"
+  CHECK (
+    ("correctionOfReceiptId" IS NULL AND "correctionReason" IS NULL)
+    OR ("correctionOfReceiptId" IS NOT NULL AND "correctionReason" IS NOT NULL)
+  );
+ALTER TABLE "team_gear_need_commands"
+  ADD CONSTRAINT "team_gear_need_commands_leagueId_fkey"
+  FOREIGN KEY ("leagueId") REFERENCES "leagues"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "team_gear_need_commands"
+  ADD CONSTRAINT "team_gear_need_commands_leagueId_teamId_fkey"
+  FOREIGN KEY ("leagueId", "teamId") REFERENCES "Team"("leagueId", "id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "team_gear_need_commands"
+  ADD CONSTRAINT "team_gear_need_commands_leagueId_needId_fkey"
+  FOREIGN KEY ("leagueId", "needId") REFERENCES "team_gear_needs"("leagueId", "id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+COMMIT;

--- a/prisma/migrations/20260816190000_gear_layer_four_receipt_commands/migration.sql
+++ b/prisma/migrations/20260816190000_gear_layer_four_receipt_commands/migration.sql
@@ -1,0 +1,37 @@
+-- Durable idempotency and optimistic-concurrency journal for Layer-4 pledge
+-- receipt commands. A command may produce multiple tagged-unit receipts.
+
+ALTER TABLE "gear_pledges"
+  ADD COLUMN "version" INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE "gear_pledge_receipts"
+  ADD COLUMN "receiptCommandId" TEXT;
+
+CREATE TABLE "gear_pledge_receipt_commands" (
+  "id" TEXT NOT NULL,
+  "leagueId" TEXT NOT NULL,
+  "pledgeId" TEXT NOT NULL,
+  "idempotencyKey" TEXT NOT NULL,
+  "expectedVersion" INTEGER NOT NULL,
+  "resultingVersion" INTEGER NOT NULL,
+  "resultingStatus" "GearPledgeStatus" NOT NULL,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "gear_pledge_receipt_commands_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "gear_pledge_receipt_commands_leagueId_id_key"
+  ON "gear_pledge_receipt_commands"("leagueId", "id");
+CREATE UNIQUE INDEX "gear_pledge_receipt_commands_leagueId_pledgeId_idempotencyKey_key"
+  ON "gear_pledge_receipt_commands"("leagueId", "pledgeId", "idempotencyKey");
+CREATE INDEX "gear_pledge_receipt_commands_leagueId_pledgeId_createdAt_idx"
+  ON "gear_pledge_receipt_commands"("leagueId", "pledgeId", "createdAt");
+
+ALTER TABLE "gear_pledge_receipt_commands"
+  ADD CONSTRAINT "gear_pledge_receipt_commands_leagueId_fkey"
+  FOREIGN KEY ("leagueId") REFERENCES "leagues"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "gear_pledge_receipt_commands"
+  ADD CONSTRAINT "gear_pledge_receipt_commands_leagueId_pledgeId_fkey"
+  FOREIGN KEY ("leagueId", "pledgeId") REFERENCES "gear_pledges"("leagueId", "id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "gear_pledge_receipts"
+  ADD CONSTRAINT "gear_pledge_receipts_leagueId_receiptCommandId_fkey"
+  FOREIGN KEY ("leagueId", "receiptCommandId") REFERENCES "gear_pledge_receipt_commands"("leagueId", "id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -559,6 +559,7 @@ model League {
   gearWishlist            GearWishlist?
   gearPledges             GearPledge[]
   gearPledgeReceipts      GearPledgeReceipt[]
+  gearPledgeReceiptCommands GearPledgeReceiptCommand[]
   gearActivity            GearActivity[]
   notificationOutbox      NotificationOutbox[]
 
@@ -1099,6 +1100,7 @@ model GearPledge {
   quantity         Int
   note             String?
   idempotencyKey   String
+  version          Int              @default(0)
   expiresAt        DateTime?
   receivedAt       DateTime?
   createdAt        DateTime         @default(now())
@@ -1107,6 +1109,7 @@ model GearPledge {
   league       League              @relation(fields: [leagueId], references: [id], onDelete: Restrict)
   wishlistItem GearWishlistItem    @relation(fields: [leagueId, wishlistItemId], references: [leagueId, id], onDelete: Restrict)
   receipts     GearPledgeReceipt[]
+  receiptCommands GearPledgeReceiptCommand[]
 
   @@unique([leagueId, idempotencyKey])
   @@unique([leagueId, id])
@@ -1121,6 +1124,7 @@ model GearPledgeReceipt {
   catalogItemId String?
   poolStockId   String?
   gearUnitId    String?
+  receiptCommandId String?
   quantity      Int
   receivedAt    DateTime @default(now())
   notes         String?
@@ -1131,12 +1135,35 @@ model GearPledgeReceipt {
   catalogItem        GearCatalogItem?        @relation(fields: [leagueId, catalogItemId], references: [leagueId, id], onDelete: Restrict)
   poolStock          GearPoolStock?          @relation(fields: [leagueId, poolStockId], references: [leagueId, id], onDelete: Restrict)
   gearUnit           GearUnit?               @relation(fields: [leagueId, gearUnitId], references: [leagueId, id], onDelete: Restrict)
+  receiptCommand     GearPledgeReceiptCommand? @relation(fields: [leagueId, receiptCommandId], references: [leagueId, id], onDelete: Restrict)
   inventoryMovements GearInventoryMovement[]
 
   @@unique([leagueId, id])
   @@index([leagueId, receivedAt])
   @@index([pledgeId])
   @@map("gear_pledge_receipts")
+}
+
+// A durable receipt-command journal makes receipt retries idempotent even when
+// a command creates multiple tagged-unit receipts.
+model GearPledgeReceiptCommand {
+  id               String           @id @default(cuid())
+  leagueId         String
+  pledgeId         String
+  idempotencyKey   String
+  expectedVersion  Int
+  resultingVersion Int
+  resultingStatus  GearPledgeStatus
+  createdAt        DateTime         @default(now())
+
+  league   League             @relation(fields: [leagueId], references: [id], onDelete: Restrict)
+  pledge   GearPledge         @relation(fields: [leagueId, pledgeId], references: [leagueId, id], onDelete: Restrict)
+  receipts GearPledgeReceipt[]
+
+  @@unique([leagueId, id])
+  @@unique([leagueId, pledgeId, idempotencyKey])
+  @@index([leagueId, pledgeId, createdAt])
+  @@map("gear_pledge_receipt_commands")
 }
 
 // Immutable operational ledger. `details` deliberately excludes public donor

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -209,6 +209,7 @@ model Team {
   hostedSignupEvents SignupEvent[]
   signupPhases       EventRegistrationPhase[] @relation("PhaseTeams")
   gearNeeds          TeamGearNeed[]
+  gearNeedCommands   TeamGearNeedCommand[]
   gearReservations   GearReservation[]
 
   @@unique([leagueId, id])
@@ -529,39 +530,40 @@ model League {
   updatedAt DateTime @updatedAt
 
   // Essential relationships only
-  divisions               Division[]
-  teams                   Team[]
-  events                  Event[]
-  players                 Player[]
-  users                   LeagueUser[]
-  invitations             Invitation[]
-  playerTransfers         PlayerTransfer[]
-  messages                LeagueMessage[]
-  notificationPreferences NotificationPreference[]
-  notificationBatches     NotificationBatch[]
-  auditLogs               AuditLog[]
-  venues                  Venue[]
-  seasons                 Season[]
-  gameProposals           GameProposal[]
-  venueRelationships      VenueRelationship[]
-  iceTimeRequests         IceTimeRequest[]
-  hostedSignupEvents      SignupEvent[]
-  payments                Payment[]
-  gearCatalogItems        GearCatalogItem[]
-  gearStorageLocations    GearStorageLocation[]
-  gearPoolStocks          GearPoolStock[]
-  gearUnits               GearUnit[]
-  gearNeeds               TeamGearNeed[]
-  gearReservations        GearReservation[]
-  gearAllocations         GearAllocation[]
-  gearHandoffs            GearHandoff[]
-  gearInventoryMovements  GearInventoryMovement[]
-  gearWishlist            GearWishlist?
-  gearPledges             GearPledge[]
-  gearPledgeReceipts      GearPledgeReceipt[]
+  divisions                 Division[]
+  teams                     Team[]
+  events                    Event[]
+  players                   Player[]
+  users                     LeagueUser[]
+  invitations               Invitation[]
+  playerTransfers           PlayerTransfer[]
+  messages                  LeagueMessage[]
+  notificationPreferences   NotificationPreference[]
+  notificationBatches       NotificationBatch[]
+  auditLogs                 AuditLog[]
+  venues                    Venue[]
+  seasons                   Season[]
+  gameProposals             GameProposal[]
+  venueRelationships        VenueRelationship[]
+  iceTimeRequests           IceTimeRequest[]
+  hostedSignupEvents        SignupEvent[]
+  payments                  Payment[]
+  gearCatalogItems          GearCatalogItem[]
+  gearStorageLocations      GearStorageLocation[]
+  gearPoolStocks            GearPoolStock[]
+  gearUnits                 GearUnit[]
+  gearNeeds                 TeamGearNeed[]
+  gearNeedCommands          TeamGearNeedCommand[]
+  gearReservations          GearReservation[]
+  gearAllocations           GearAllocation[]
+  gearHandoffs              GearHandoff[]
+  gearInventoryMovements    GearInventoryMovement[]
+  gearWishlist              GearWishlist?
+  gearPledges               GearPledge[]
+  gearPledgeReceipts        GearPledgeReceipt[]
   gearPledgeReceiptCommands GearPledgeReceiptCommand[]
-  gearActivity            GearActivity[]
-  notificationOutbox      NotificationOutbox[]
+  gearActivity              GearActivity[]
+  notificationOutbox        NotificationOutbox[]
 
   @@map("leagues")
 }
@@ -717,6 +719,11 @@ enum GearPledgeStatus {
   DECLINED
   CANCELED
   EXPIRED
+}
+
+enum GearPledgePiiRedactionStatus {
+  PENDING
+  REDACTED
 }
 
 enum GearActivityEntityType {
@@ -875,14 +882,36 @@ model TeamGearNeed {
   updatedAt   DateTime       @updatedAt
   createdById String?
 
-  league    League             @relation(fields: [leagueId], references: [id], onDelete: Restrict)
-  team      Team               @relation(fields: [leagueId, teamId], references: [leagueId, id], onDelete: Restrict)
-  createdBy User?              @relation("GearNeedCreator", fields: [createdById], references: [id], onDelete: SetNull)
-  lines     TeamGearNeedLine[]
+  league        League               @relation(fields: [leagueId], references: [id], onDelete: Restrict)
+  team          Team                 @relation(fields: [leagueId, teamId], references: [leagueId, id], onDelete: Restrict)
+  createdBy     User?                @relation("GearNeedCreator", fields: [createdById], references: [id], onDelete: SetNull)
+  lines         TeamGearNeedLine[]
+  createCommand TeamGearNeedCommand?
 
   @@unique([leagueId, id])
   @@index([leagueId, teamId, status])
   @@map("team_gear_needs")
+}
+
+// Durable idempotency journal for draft-need creation. Its tenant/team scoped
+// key makes retries return the original need instead of creating another draft.
+model TeamGearNeedCommand {
+  id             String   @id @default(cuid())
+  leagueId       String
+  teamId         String
+  idempotencyKey String
+  needId         String
+  createdAt      DateTime @default(now())
+
+  league League       @relation(fields: [leagueId], references: [id], onDelete: Restrict)
+  team   Team         @relation(fields: [leagueId, teamId], references: [leagueId, id], onDelete: Restrict)
+  need   TeamGearNeed @relation(fields: [leagueId, needId], references: [leagueId, id], onDelete: Restrict)
+
+  @@unique([leagueId, id])
+  @@unique([leagueId, teamId, idempotencyKey])
+  @@unique([leagueId, needId])
+  @@index([leagueId, teamId, createdAt])
+  @@map("team_gear_need_commands")
 }
 
 model TeamGearNeedLine {
@@ -1089,26 +1118,28 @@ model GearWishlistItem {
 }
 
 model GearPledge {
-  id               String           @id @default(cuid())
-  leagueId         String
-  wishlistItemId   String
-  donorName        String
-  donorEmail       String?
-  donorPhone       String?
-  contactConsentAt DateTime?
-  status           GearPledgeStatus @default(PLEDGED)
-  quantity         Int
-  note             String?
-  idempotencyKey   String
-  version          Int              @default(0)
-  expiresAt        DateTime?
-  receivedAt       DateTime?
-  createdAt        DateTime         @default(now())
-  updatedAt        DateTime         @updatedAt
+  id                 String                       @id @default(cuid())
+  leagueId           String
+  wishlistItemId     String
+  donorName          String?
+  donorEmail         String?
+  donorPhone         String?
+  contactConsentAt   DateTime?
+  status             GearPledgeStatus             @default(PLEDGED)
+  quantity           Int
+  note               String?
+  idempotencyKey     String
+  version            Int                          @default(0)
+  expiresAt          DateTime?
+  receivedAt         DateTime?
+  piiRedactionStatus GearPledgePiiRedactionStatus @default(PENDING)
+  piiRedactedAt      DateTime?
+  createdAt          DateTime                     @default(now())
+  updatedAt          DateTime                     @updatedAt
 
-  league       League              @relation(fields: [leagueId], references: [id], onDelete: Restrict)
-  wishlistItem GearWishlistItem    @relation(fields: [leagueId, wishlistItemId], references: [leagueId, id], onDelete: Restrict)
-  receipts     GearPledgeReceipt[]
+  league          League                     @relation(fields: [leagueId], references: [id], onDelete: Restrict)
+  wishlistItem    GearWishlistItem           @relation(fields: [leagueId, wishlistItemId], references: [leagueId, id], onDelete: Restrict)
+  receipts        GearPledgeReceipt[]
   receiptCommands GearPledgeReceiptCommand[]
 
   @@unique([leagueId, idempotencyKey])
@@ -1118,27 +1149,32 @@ model GearPledge {
 }
 
 model GearPledgeReceipt {
-  id            String   @id @default(cuid())
-  leagueId      String
-  pledgeId      String
-  catalogItemId String?
-  poolStockId   String?
-  gearUnitId    String?
-  receiptCommandId String?
-  quantity      Int
-  receivedAt    DateTime @default(now())
-  notes         String?
-  createdAt     DateTime @default(now())
+  id                    String   @id @default(cuid())
+  leagueId              String
+  pledgeId              String
+  catalogItemId         String?
+  poolStockId           String?
+  gearUnitId            String?
+  receiptCommandId      String?
+  correctionOfReceiptId String?
+  correctionReason      String?
+  quantity              Int
+  receivedAt            DateTime @default(now())
+  notes                 String?
+  createdAt             DateTime @default(now())
 
-  league             League                  @relation(fields: [leagueId], references: [id], onDelete: Restrict)
-  pledge             GearPledge              @relation(fields: [leagueId, pledgeId], references: [leagueId, id], onDelete: Restrict)
-  catalogItem        GearCatalogItem?        @relation(fields: [leagueId, catalogItemId], references: [leagueId, id], onDelete: Restrict)
-  poolStock          GearPoolStock?          @relation(fields: [leagueId, poolStockId], references: [leagueId, id], onDelete: Restrict)
-  gearUnit           GearUnit?               @relation(fields: [leagueId, gearUnitId], references: [leagueId, id], onDelete: Restrict)
+  league             League                    @relation(fields: [leagueId], references: [id], onDelete: Restrict)
+  pledge             GearPledge                @relation(fields: [leagueId, pledgeId], references: [leagueId, id], onDelete: Restrict)
+  catalogItem        GearCatalogItem?          @relation(fields: [leagueId, catalogItemId], references: [leagueId, id], onDelete: Restrict)
+  poolStock          GearPoolStock?            @relation(fields: [leagueId, poolStockId], references: [leagueId, id], onDelete: Restrict)
+  gearUnit           GearUnit?                 @relation(fields: [leagueId, gearUnitId], references: [leagueId, id], onDelete: Restrict)
   receiptCommand     GearPledgeReceiptCommand? @relation(fields: [leagueId, receiptCommandId], references: [leagueId, id], onDelete: Restrict)
+  correctionOf       GearPledgeReceipt?        @relation("GearReceiptCorrection", fields: [leagueId, correctionOfReceiptId], references: [leagueId, id], onDelete: Restrict)
+  correction         GearPledgeReceipt?        @relation("GearReceiptCorrection")
   inventoryMovements GearInventoryMovement[]
 
   @@unique([leagueId, id])
+  @@unique([leagueId, correctionOfReceiptId])
   @@index([leagueId, receivedAt])
   @@index([pledgeId])
   @@map("gear_pledge_receipts")
@@ -1151,13 +1187,14 @@ model GearPledgeReceiptCommand {
   leagueId         String
   pledgeId         String
   idempotencyKey   String
+  payloadHash      String
   expectedVersion  Int
   resultingVersion Int
   resultingStatus  GearPledgeStatus
   createdAt        DateTime         @default(now())
 
-  league   League             @relation(fields: [leagueId], references: [id], onDelete: Restrict)
-  pledge   GearPledge         @relation(fields: [leagueId, pledgeId], references: [leagueId, id], onDelete: Restrict)
+  league   League              @relation(fields: [leagueId], references: [id], onDelete: Restrict)
+  pledge   GearPledge          @relation(fields: [leagueId, pledgeId], references: [leagueId, id], onDelete: Restrict)
   receipts GearPledgeReceipt[]
 
   @@unique([leagueId, id])

--- a/types/gear.ts
+++ b/types/gear.ts
@@ -75,7 +75,7 @@ export type GearActivityDetails = {
 };
 
 export type GearNotificationPayload = {
-  kind: "GEAR_RESERVATION" | "GEAR_ALLOCATION" | "GEAR_PLEDGE" | "GEAR_WISHLIST";
+  kind: "GEAR_RESERVATION" | "GEAR_ALLOCATION" | "GEAR_NEED" | "GEAR_PLEDGE" | "GEAR_WISHLIST";
   data: Record<string, string | number | boolean | null>;
 };
 


### PR DESCRIPTION
## Summary
- add tenant-safe team gear needs with versioned workflow transitions and responsive need surfaces
- add a revocable public wishlist plus privacy-safe in-kind pledge submission
- add serializable pledge receipt handling for pooled stock and tagged units, with immutable activity/movement records and transactional outbox events

## Validation
- `bun run test __tests__/lib/actions/gear-layer-four.test.ts __tests__/components/features/gear/GearNeedsList.test.tsx __tests__/components/features/gear/PublicGearWishlist.test.tsx`
- `bun run type-check`
- changed-file ESLint
- `bun run check:raw-sql`
- `bun run adr:check ...`