### PR TITLE
feat(scheduling): cut over season operations

### DIFF
--- a/__tests__/api/league-schedule-ics.test.ts
+++ b/__tests__/api/league-schedule-ics.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockAuth, mockPrisma, mockSchedule } = vi.hoisted(() => ({
+  mockAuth: { getCurrentUserId: vi.fn() },
+  mockPrisma: { leagueUser: { findFirst: vi.fn() } },
+  mockSchedule: {
+    getLeagueScheduleItems: vi.fn(),
+    buildScheduleIcs: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/auth/session", () => mockAuth);
+vi.mock("@/lib/db/prisma", () => ({ prisma: mockPrisma }));
+vi.mock("@/lib/data/schedule-items", () => mockSchedule);
+
+import { GET } from "@/app/api/leagues/[leagueId]/schedule.ics/route";
+
+describe("private league schedule ICS", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuth.getCurrentUserId.mockResolvedValue("member-1");
+    mockPrisma.leagueUser.findFirst.mockResolvedValue({
+      role: "MEMBER",
+      league: { id: "league-1", name: "Test League" },
+    });
+    mockSchedule.getLeagueScheduleItems.mockResolvedValue([]);
+    mockSchedule.buildScheduleIcs.mockReturnValue("BEGIN:VCALENDAR\r\nEND:VCALENDAR\r\n");
+  });
+
+  it("forwards the authenticated viewer and exact league role", async () => {
+    const response = await GET(
+      new Request("https://example.test/api/leagues/league-1/schedule.ics") as never,
+      { params: Promise.resolve({ leagueId: "league-1" }) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockSchedule.getLeagueScheduleItems).toHaveBeenCalledWith("league-1", {
+      userId: "member-1",
+      leagueRole: "MEMBER",
+    });
+  });
+
+  it("does not invoke the reader for a non-member", async () => {
+    mockPrisma.leagueUser.findFirst.mockResolvedValue(null);
+
+    const response = await GET(
+      new Request("https://example.test/api/leagues/league-1/schedule.ics") as never,
+      { params: Promise.resolve({ leagueId: "league-1" }) },
+    );
+
+    expect(response.status).toBe(404);
+    expect(mockSchedule.getLeagueScheduleItems).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/api/public-association-ics.test.ts
+++ b/__tests__/api/public-association-ics.test.ts
@@ -1,0 +1,153 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const { mockGetCurrentUserId, mockPrisma } = vi.hoisted(() => ({
+  mockGetCurrentUserId: vi.fn(),
+  mockPrisma: {
+    league: { findFirst: vi.fn(), findUnique: vi.fn() },
+    event: { findMany: vi.fn() },
+    seasonGame: { findMany: vi.fn() },
+    eventGame: { findMany: vi.fn() },
+    practiceSession: { findMany: vi.fn() },
+    signupEvent: { findMany: vi.fn() },
+    venueScheduleBlock: { findMany: vi.fn() },
+    team: { findMany: vi.fn() },
+    venueReservation: { findMany: vi.fn() },
+  },
+}));
+
+vi.mock("@/lib/auth/session", () => ({
+  getCurrentUserId: (...args: unknown[]) => mockGetCurrentUserId(...args),
+}));
+
+vi.mock("@/lib/db/prisma", () => ({ prisma: mockPrisma }));
+
+import { GET } from "@/app/api/associations/[slug]/schedule.ics/route";
+
+const SLUG = "north-stars";
+const LEAGUE_NAME = "North Stars";
+
+function request() {
+  return new NextRequest(`http://localhost/api/associations/${SLUG}/schedule.ics`);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetCurrentUserId.mockResolvedValue(null);
+  mockPrisma.league.findFirst.mockResolvedValue({
+    id: "clleague0000000000000001",
+    name: LEAGUE_NAME,
+    slug: SLUG,
+    timezone: "America/New_York",
+    publicDescription: "A public association",
+    mission: "Grow the game",
+    brandPrimaryColor: "#123456",
+    brandSecondaryColor: "#654321",
+  });
+  mockPrisma.event.findMany.mockResolvedValue([
+    {
+      id: "clevent0000000000000001",
+      type: "GAME",
+      title: "Arrows vs Blizzards",
+      startAt: new Date("2026-09-05T22:00:00.000Z"),
+      endAt: new Date("2026-09-05T23:30:00.000Z"),
+      location: "North Rink",
+      opponent: "Blizzards",
+      updatedAt: new Date("2026-08-17T00:00:00.000Z"),
+      homeTeam: { name: "Arrows" },
+      awayTeam: { name: "Blizzards" },
+    },
+  ]);
+  mockPrisma.seasonGame.findMany.mockResolvedValue([
+    {
+      id: "clseason-game-000000000000001",
+      status: "SCHEDULED",
+      startAt: new Date("2026-09-05T22:00:00.000Z"),
+      endAt: new Date("2026-09-05T23:30:00.000Z"),
+      timezone: "America/New_York",
+      venueId: null,
+      surfaceId: null,
+      segmentId: null,
+      updatedAt: new Date("2026-08-17T00:00:00.000Z"),
+      homeTeam: { id: "team-arrows", name: "Arrows" },
+      awayTeam: { id: "team-blizzards", name: "Blizzards" },
+      venue: null,
+      venueReservationId: null,
+      venueReservation: null,
+      event: { id: "clevent0000000000000001" },
+    },
+  ]);
+  mockPrisma.eventGame.findMany.mockResolvedValue([]);
+  mockPrisma.practiceSession.findMany.mockResolvedValue([]);
+  mockPrisma.signupEvent.findMany.mockResolvedValue([]);
+  mockPrisma.venueScheduleBlock.findMany.mockResolvedValue([]);
+  mockPrisma.team.findMany.mockResolvedValue([
+    { id: "team-arrows" },
+    { id: "team-blizzards" },
+  ]);
+  mockPrisma.venueReservation.findMany.mockImplementation(
+    async ({ where }: { where: unknown }) => {
+      const serialized = JSON.stringify(where);
+      // A real database returns these private rows only when the selector
+      // accidentally admits bare owner inventory or non-public blocks.
+      if (
+        serialized.includes("ownerLeagueId")
+        || !serialized.includes('"visibility":"PUBLIC"')
+      ) {
+        return [{
+          id: "private-reservation",
+          startsAt: new Date("2026-09-06T22:00:00.000Z"),
+          endsAt: new Date("2026-09-06T23:30:00.000Z"),
+          timezone: "America/New_York",
+          venueId: "private-venue",
+          surfaceId: null,
+          segmentId: null,
+          venue: { name: "Private rink", timezone: "America/New_York" },
+        }];
+      }
+      return [];
+    },
+  );
+});
+
+describe("public association ICS", () => {
+  it("serves canonical public schedule contents for a slug without requiring sign-in", async () => {
+    const response = await GET(request(), { params: Promise.resolve({ slug: SLUG }) });
+
+    expect(mockGetCurrentUserId).not.toHaveBeenCalled();
+    expect(mockPrisma.league.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          slug: SLUG,
+          isActive: true,
+        }),
+        select: { id: true, name: true, slug: true },
+      }),
+    );
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("text/calendar");
+
+    const body = await response.text();
+    expect(body).toContain("BEGIN:VCALENDAR");
+    expect(body).toContain(`X-WR-CALNAME:${LEAGUE_NAME} Schedule`);
+    expect(body).toContain("SUMMARY:Arrows vs Blizzards");
+    expect(body).not.toContain("publicDescription");
+    expect(body).not.toContain("mission");
+    expect(body).not.toContain("gearReservation");
+    expect(body).not.toContain("donor");
+    expect(body).not.toContain("Reserved venue time");
+    expect(body).not.toContain("Private rink");
+    const reservationWhere =
+      mockPrisma.venueReservation.findMany.mock.calls[0][0].where;
+    expect(JSON.stringify(reservationWhere)).not.toContain("ownerLeagueId");
+    expect(JSON.stringify(reservationWhere)).toContain('"visibility":"PUBLIC"');
+  });
+
+  it("returns not found for an unpublished association slug", async () => {
+    mockPrisma.league.findFirst.mockResolvedValue(null);
+
+    const response = await GET(request(), { params: Promise.resolve({ slug: SLUG }) });
+
+    expect(response.status).toBe(404);
+  });
+});

--- a/__tests__/components/features/events/EventForm.test.tsx
+++ b/__tests__/components/features/events/EventForm.test.tsx
@@ -1,0 +1,200 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import EventForm from "@/components/features/events/EventForm";
+import { createEvent, updateEvent } from "@/lib/actions/events";
+
+const mockPush = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+vi.mock("@/lib/actions/events", () => ({
+  createEvent: vi.fn(),
+  updateEvent: vi.fn(),
+}));
+
+vi.mock("@/components/features/venues/VenueSelector", () => ({
+  default: ({ onChange }: { onChange: (id: string, name: string, timezone: string) => void }) => (
+    <button
+      type="button"
+      onClick={() => onChange(
+        "cvenue0000000000000000001",
+        "North Rink",
+        "America/New_York",
+      )}
+    >
+      Select North Rink
+    </button>
+  ),
+}));
+
+vi.mock("@/components/ui/date", () => ({
+  DateTimeField: ({
+    label,
+    name,
+    value,
+    onChange,
+    required,
+    helperText,
+  }: {
+    label: string;
+    name: string;
+    value: string;
+    onChange: (value: string) => void;
+    required?: boolean;
+    helperText?: string;
+  }) => (
+    <label>
+      {label}
+      <input
+        aria-label={label}
+        name={name}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        required={required}
+      />
+      <span>{helperText}</span>
+    </label>
+  ),
+}));
+
+describe("EventForm venue end time", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("marks end time required and shows field validation for a selected venue", async () => {
+    const user = userEvent.setup();
+    render(
+      <EventForm
+        teamId="cteam00000000000000000001"
+        initialData={{
+          type: "PRACTICE",
+          title: "Practice",
+          startAt: new Date("2099-08-01T18:00:00.000Z"),
+          location: "North Rink",
+          opponent: "",
+          notes: "",
+        }}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Select North Rink" }));
+
+    const endAt = screen.getByLabelText("End Date & Time");
+    expect(endAt).toBeRequired();
+    expect(screen.getByText(/required for venue events/i)).toBeInTheDocument();
+
+    fireEvent.submit(endAt.closest("form")!);
+
+    expect(await screen.findByText("End date and time is required when a venue is selected"))
+      .toBeInTheDocument();
+    expect(createEvent).not.toHaveBeenCalled();
+  });
+
+  it("submits the selected confirmed reservation and its venue-local interval", async () => {
+    vi.mocked(createEvent).mockResolvedValue({
+      success: true,
+      data: {
+        id: "cevent0000000000000000001",
+        type: "PRACTICE",
+        title: "Practice",
+        startAt: new Date("2099-08-01T22:00:00.000Z"),
+        location: "North Rink",
+        opponent: null,
+        notes: null,
+      },
+    });
+    const user = userEvent.setup();
+    render(
+      <EventForm
+        teamId="cteam00000000000000000001"
+        initialData={{
+          type: "PRACTICE",
+          title: "Practice",
+          startAt: new Date("2099-08-01T22:00:00.000Z"),
+          location: "North Rink",
+          opponent: "",
+          notes: "",
+        }}
+        reservations={[{
+          id: "cres000000000000000000001",
+          startsAt: "2099-08-01T22:00:00.000Z",
+          endsAt: "2099-08-01T23:00:00.000Z",
+          timezone: "America/New_York",
+          venueId: "cvenue0000000000000000001",
+          venueName: "North Rink",
+          surfaceName: "Rink 1",
+          segmentName: null,
+        }]}
+      />,
+    );
+
+    await user.click(screen.getByLabelText("Confirmed reservation"));
+    await user.click(screen.getByRole("option", { name: /North Rink/ }));
+    await user.click(screen.getByRole("button", { name: "Create Event" }));
+
+    expect(createEvent).toHaveBeenCalledWith(expect.objectContaining({
+      reservationId: "cres000000000000000000001",
+      venueId: "cvenue0000000000000000001",
+      startAt: new Date("2099-08-01T22:00:00.000Z"),
+      endAt: new Date("2099-08-01T23:00:00.000Z"),
+    }));
+  });
+
+  it("preserves the currently assigned reservation while editing other fields", async () => {
+    vi.mocked(updateEvent).mockResolvedValue({
+      success: true,
+      data: {
+        id: "cevent0000000000000000001",
+        type: "PRACTICE",
+        title: "Updated practice",
+        startAt: new Date("2099-08-01T22:00:00.000Z"),
+        location: "North Rink",
+        opponent: null,
+        notes: null,
+      },
+    });
+    const user = userEvent.setup();
+    const reservation = {
+      id: "cres000000000000000000001",
+      startsAt: "2099-08-01T22:00:00.000Z",
+      endsAt: "2099-08-01T23:00:00.000Z",
+      timezone: "America/New_York",
+      venueId: "cvenue0000000000000000001",
+      venueName: "North Rink",
+      surfaceName: "Rink 1",
+      segmentName: null,
+    };
+    render(
+      <EventForm
+        teamId="cteam00000000000000000001"
+        eventId="cevent0000000000000000001"
+        reservations={[reservation]}
+        initialData={{
+          type: "PRACTICE",
+          title: "Practice",
+          startAt: new Date(reservation.startsAt),
+          endAt: new Date(reservation.endsAt),
+          timezone: reservation.timezone,
+          location: reservation.venueName,
+          venueId: reservation.venueId,
+          reservationId: reservation.id,
+          opponent: "",
+          notes: "",
+        }}
+      />,
+    );
+
+    await user.clear(screen.getByRole("textbox", { name: /Title/ }));
+    await user.type(screen.getByRole("textbox", { name: /Title/ }), "Updated practice");
+    await user.click(screen.getByRole("button", { name: "Update Event" }));
+
+    expect(updateEvent).toHaveBeenCalledWith(expect.objectContaining({
+      id: "cevent0000000000000000001",
+      reservationId: reservation.id,
+    }));
+  });
+});

--- a/__tests__/components/features/navigation/LeagueNavigation.test.tsx
+++ b/__tests__/components/features/navigation/LeagueNavigation.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ThemeProvider } from "@mui/material/styles";
+import { describe, expect, it, vi } from "vitest";
+import DashboardNav from "@/components/features/dashboard/DashboardNav";
+import MobileNavigation from "@/components/features/navigation/MobileNavigation";
+import theme from "@/lib/theme";
+
+const mocks = vi.hoisted(() => ({
+  pathname: "/",
+  currentLeague: { id: "league-1" },
+  logout: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ href, children, ...props }: any) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => mocks.pathname,
+}));
+
+vi.mock("@/components/providers/LeagueProvider", () => ({
+  useLeague: () => ({ currentLeague: mocks.currentLeague }),
+}));
+
+vi.mock("@/lib/actions/logout", () => ({
+  logout: mocks.logout,
+}));
+
+const renderWithTheme = (component: React.ReactElement) =>
+  render(<ThemeProvider theme={theme}>{component}</ThemeProvider>);
+
+describe("league navigation", () => {
+  it.each([
+    {
+      pathname: "/league/league-123/operations/review",
+      selected: "Operations",
+    },
+    {
+      pathname: "/league/league-123/venue-reservations/review",
+      selected: "Venue Reservations",
+    },
+  ])("keeps $selected active and league-scoped on desktop", ({ pathname, selected }) => {
+    mocks.pathname = pathname;
+    mocks.currentLeague = { id: "league-123" };
+
+    renderWithTheme(<DashboardNav isLeagueMode />);
+
+    expect(screen.getByRole("link", { name: "Operations" })).toHaveAttribute(
+      "href",
+      "/league/league-123/operations",
+    );
+    expect(screen.getByRole("link", { name: "Venue Reservations" })).toHaveAttribute(
+      "href",
+      "/league/league-123/venue-reservations",
+    );
+    expect(screen.getByRole("link", { name: "Gear" })).toHaveAttribute(
+      "href",
+      "/league/league-123/gear",
+    );
+    expect(screen.getByRole("link", { name: selected })).toHaveClass("Mui-selected");
+  });
+
+  it("surfaces Operations and Venue Reservations in the mobile more menu", () => {
+    mocks.pathname = "/league/league-123/dashboard";
+    mocks.currentLeague = { id: "league-123" };
+
+    renderWithTheme(<MobileNavigation isLeagueMode />);
+
+    fireEvent.click(screen.getByRole("button", { name: /more/i }));
+
+    expect(screen.getByRole("menuitem", { name: "Gear" })).toHaveAttribute(
+      "href",
+      "/league/league-123/gear",
+    );
+    expect(screen.getByRole("menuitem", { name: "Operations" })).toHaveAttribute(
+      "href",
+      "/league/league-123/operations",
+    );
+    expect(screen.getByRole("menuitem", { name: "Venue Reservations" })).toHaveAttribute(
+      "href",
+      "/league/league-123/venue-reservations",
+    );
+  });
+});

--- a/__tests__/components/features/seasons/GenerationWizard.test.tsx
+++ b/__tests__/components/features/seasons/GenerationWizard.test.tsx
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { GenerationWizard } from "@/components/features/seasons/GenerationWizard";
+import { previewRoundRobin } from "@/lib/actions/season-generation";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: vi.fn() }),
+}));
+
+vi.mock("@/lib/actions/season-generation", () => ({
+  previewRoundRobin: vi.fn(),
+  generateRoundRobin: vi.fn(),
+}));
+
+vi.mock("@/lib/actions/seasons", () => ({
+  updateSeason: vi.fn(),
+  updateSeasonPhase: vi.fn(),
+}));
+
+describe("GenerationWizard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("preselects projected division teams and gives reservation-specific guidance", async () => {
+    const user = userEvent.setup();
+    vi.mocked(previewRoundRobin).mockResolvedValue({
+      success: true,
+      data: {
+        games: [],
+        totalPairings: 1,
+        unslottedCount: 1,
+        unslottedPairings: [{
+          homeTeamId: "clteam00000000000000001",
+          awayTeamId: "clteam00000000000000002",
+          round: 1,
+          reason: "NO_RESERVATION",
+        }],
+      },
+    });
+
+    render(
+      <GenerationWizard
+        seasonId="clseason000000000000001"
+        seasonStartDate={new Date("2099-09-01T00:00:00.000Z")}
+        seasonEndDate={new Date("2099-09-30T00:00:00.000Z")}
+        phases={[]}
+        teams={[
+          { id: "clteam00000000000000001", name: "Arrows", divisionId: "cldivision00000000000001" },
+          { id: "clteam00000000000000002", name: "Blizzards", divisionId: "cldivision00000000000001" },
+          { id: "clteam00000000000000003", name: "Comets", divisionId: null },
+        ]}
+        divisions={[{ id: "cldivision00000000000001", name: "A Division" }]}
+        venues={[{
+          id: "clvenue00000000000000001",
+          name: "North Rink",
+          timezone: "America/New_York",
+        }]}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Generate games" }));
+    await user.click(screen.getByLabelText("Format"));
+    await user.click(within(await screen.findByRole("listbox")).getByRole("option", {
+      name: "Round robin",
+    }));
+    await user.click(screen.getByRole("button", { name: "Next" }));
+
+    await user.click(screen.getByLabelText("Division (optional)"));
+    await user.click(within(await screen.findByRole("listbox")).getByRole("option", {
+      name: "A Division",
+    }));
+    expect(screen.getByRole("checkbox", { name: "Arrows" })).toBeChecked();
+    expect(screen.getByRole("checkbox", { name: "Blizzards" })).toBeChecked();
+    expect(screen.getByRole("checkbox", { name: "Comets" })).not.toBeChecked();
+
+    await user.click(screen.getByLabelText("Default venue (optional)"));
+    await user.click(within(await screen.findByRole("listbox")).getByRole("option", {
+      name: "North Rink",
+    }));
+    await user.click(screen.getByRole("button", { name: "Preview games" }));
+
+    expect(await screen.findByText(/no confirmed reservation inventory was available/i))
+      .toBeInTheDocument();
+    expect(screen.queryByText(/did not fit in the selected date range/i)).not.toBeInTheDocument();
+  });
+});

--- a/__tests__/components/features/seasons/ProposalThread.test.tsx
+++ b/__tests__/components/features/seasons/ProposalThread.test.tsx
@@ -1,0 +1,181 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockAcceptGameProposal, mockRefresh } = vi.hoisted(() => ({
+  mockAcceptGameProposal: vi.fn(),
+  mockRefresh: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: mockRefresh }),
+}));
+vi.mock("@/lib/actions/game-proposals", () => ({
+  acceptGameProposal: (...args: unknown[]) => mockAcceptGameProposal(...args),
+  counterGameProposal: vi.fn(),
+  declineGameProposal: vi.fn(),
+  withdrawGameProposal: vi.fn(),
+}));
+
+import { ProposalThread } from "@/components/features/seasons/ProposalThread";
+
+const startAt = new Date("2027-01-10T18:00:00.000Z");
+const endAt = new Date("2027-01-10T19:30:00.000Z");
+
+const proposal = {
+  id: "clproposal000000000001",
+  status: "PENDING" as const,
+  leagueId: "clleague0000000000000001",
+  proposingTeam: { id: "clteam00000000000000001", name: "Arrows" },
+  receivingTeam: { id: "clteam00000000000000002", name: "Blizzards" },
+  seasonId: "clseason000000000000001",
+  createdAt: new Date("2026-12-01T00:00:00.000Z"),
+  resolvedAt: null,
+  entries: [{
+    id: "clentry00000000000000001",
+    kind: "PROPOSE" as const,
+    startAt,
+    endAt,
+    venue: { id: "clvenue00000000000000001", name: "North Rink" },
+    venueReservationId: null,
+    note: null,
+    actorTeamId: "clteam00000000000000001",
+    createdAt: new Date("2026-12-01T00:00:00.000Z"),
+  }],
+  resultingGameId: null,
+  isExpired: false,
+};
+
+const reservations = [{
+  id: "clreservation0000000001",
+  venueId: "clvenue00000000000000001",
+  startsAt: startAt,
+  endsAt: endAt,
+  venueName: "North Rink",
+  surfaceName: "Main",
+  segmentName: null,
+  proposalId: null,
+  ownerLeagueId: proposal.leagueId,
+  ownerTeamId: null,
+}];
+
+describe("ProposalThread reservation assignment", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAcceptGameProposal.mockResolvedValue({
+      success: true,
+      data: { gameId: "clgame000000000000000001" },
+    });
+  });
+
+  it("requires and submits confirmed matching inventory for normal acceptance", async () => {
+    const user = userEvent.setup();
+    render(
+      <ProposalThread
+        proposal={proposal}
+        canAct
+        canWithdraw
+        venues={[{ id: reservations[0].venueId, name: "North Rink", timezone: "UTC" }]}
+        reservations={reservations}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Accept" })).toBeDisabled();
+    await user.click(screen.getByRole("combobox", { name: "Confirmed venue reservation" }));
+    await user.click(screen.getByRole("option", { name: /North Rink · Main/ }));
+    await user.click(screen.getByRole("button", { name: "Accept" }));
+
+    await waitFor(() => expect(mockAcceptGameProposal).toHaveBeenCalledWith({
+      proposalId: proposal.id,
+      reservationId: reservations[0].id,
+      overrideConflicts: false,
+      overrideReason: undefined,
+    }));
+  });
+
+  it("keeps conflict override explicit and reasoned", async () => {
+    const user = userEvent.setup();
+    mockAcceptGameProposal
+      .mockResolvedValueOnce({
+        success: false,
+        error: "Conflict",
+        details: {
+          conflicts: [{
+            source: "seasonGame",
+            title: "Existing game",
+            startAt,
+            endAt,
+            surfaceId: null,
+            segmentId: null,
+            segmentName: null,
+          }],
+        },
+      })
+      .mockResolvedValueOnce({ success: true, data: { gameId: "game-1" } });
+    render(
+      <ProposalThread
+        proposal={proposal}
+        canAct
+        canWithdraw
+        venues={[{ id: reservations[0].venueId, name: "North Rink", timezone: "UTC" }]}
+        reservations={reservations}
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox", { name: "Confirmed venue reservation" }));
+    await user.click(screen.getByRole("option", { name: /North Rink · Main/ }));
+    await user.click(screen.getByRole("button", { name: "Accept" }));
+    const overrideButton = await screen.findByRole("button", { name: "Accept anyway" });
+    expect(overrideButton).toBeDisabled();
+    await user.type(screen.getByRole("textbox", { name: "Override reason" }), "Venue approved");
+    await user.click(overrideButton);
+
+    await waitFor(() => expect(mockAcceptGameProposal).toHaveBeenLastCalledWith({
+      proposalId: proposal.id,
+      reservationId: reservations[0].id,
+      overrideConflicts: true,
+      overrideReason: "Venue approved",
+    }));
+  });
+
+  it("does not offer inventory owned outside the two proposal teams", () => {
+    render(
+      <ProposalThread
+        proposal={proposal}
+        canAct
+        canWithdraw
+        venues={[{ id: reservations[0].venueId, name: "North Rink", timezone: "UTC" }]}
+        reservations={[{
+          ...reservations[0],
+          ownerLeagueId: null,
+          ownerTeamId: "clteam00000000000000003",
+        }]}
+      />,
+    );
+
+    expect(screen.getByText(
+      "No confirmed unassigned reservation matches these terms.",
+    )).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Accept" })).toBeDisabled();
+  });
+
+  it("does not trust a held reservation omitted by the scoped inventory query", () => {
+    render(
+      <ProposalThread
+        proposal={{
+          ...proposal,
+          entries: [{
+            ...proposal.entries[0],
+            venueReservationId: "clreservation0000000009",
+          }],
+        }}
+        canAct
+        canWithdraw
+        venues={[{ id: reservations[0].venueId, name: "North Rink", timezone: "UTC" }]}
+        reservations={[]}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Accept" })).toBeDisabled();
+  });
+});

--- a/__tests__/components/features/seasons/SeasonForm.test.tsx
+++ b/__tests__/components/features/seasons/SeasonForm.test.tsx
@@ -22,6 +22,7 @@ const editValues = {
   startDate: new Date("2026-09-01T00:00:00.000Z"),
   endDate: new Date("2026-12-01T00:00:00.000Z"),
   format: null,
+  scheduleVisibility: "PRIVATE" as const,
 };
 
 describe("SeasonForm", () => {
@@ -39,6 +40,7 @@ describe("SeasonForm", () => {
       expect(screen.getByRole("group", { name: /starts/i })).toBeInTheDocument();
       expect(screen.getByRole("group", { name: /ends/i })).toBeInTheDocument();
       expect(screen.getByRole("button", { name: /create season/i })).toBeInTheDocument();
+      expect(screen.getByLabelText(/schedule visibility/i)).toBeInTheDocument();
     });
 
     it("presents NO format control on the create path", () => {
@@ -94,6 +96,7 @@ describe("SeasonForm", () => {
       expect(input.name).toBe("Fall 2026");
       expect(input.leagueId).toBe(LEAGUE_ID);
       expect(input.teamId).toBeUndefined();
+      expect(input.scheduleVisibility).toBe("PRIVATE");
       expect(input).not.toHaveProperty("format");
     });
   });

--- a/__tests__/integration/reservation-writer-matrix.test.ts
+++ b/__tests__/integration/reservation-writer-matrix.test.ts
@@ -1,0 +1,865 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockAuth,
+  mockPrisma,
+} = vi.hoisted(() => {
+  const delegate = () => ({
+    create: vi.fn(),
+    createMany: vi.fn(),
+    delete: vi.fn(),
+    deleteMany: vi.fn(),
+    findFirst: vi.fn(),
+    findMany: vi.fn(),
+    findUnique: vi.fn(),
+    findUniqueOrThrow: vi.fn(),
+    update: vi.fn(),
+    updateMany: vi.fn(),
+  });
+  return {
+    mockAuth: {
+      requireUserId: vi.fn(),
+      requireSeasonManager: vi.fn(),
+      requireTeamAdmin: vi.fn(),
+      requireTeamMember: vi.fn(),
+      requireLeagueRole: vi.fn(),
+      requireEventManager: vi.fn(),
+      requireSignupEventHostAdmin: vi.fn(),
+      requireVenueScheduleManager: vi.fn(),
+      requireVenueContentManager: vi.fn(),
+    },
+    mockPrisma: {
+      league: delegate(),
+      season: delegate(),
+      seasonPhase: delegate(),
+      seasonGame: delegate(),
+      team: delegate(),
+      teamMember: delegate(),
+      leagueUser: delegate(),
+      venue: delegate(),
+      venueOrganization: delegate(),
+      venueRelationship: delegate(),
+      venueStaff: delegate(),
+      iceSurface: delegate(),
+      surfaceSegment: delegate(),
+      segmentCoexistence: delegate(),
+      iceTimeRequest: delegate(),
+      venueReservation: delegate(),
+      event: delegate(),
+      rSVP: delegate(),
+      eventTeam: delegate(),
+      eventGame: delegate(),
+      signupEvent: delegate(),
+      signupSlot: delegate(),
+      eventRegistrationPhase: delegate(),
+      eventRegistration: delegate(),
+      gameProposal: delegate(),
+      gameProposalEntry: delegate(),
+      venueScheduleBlock: delegate(),
+      practiceSession: delegate(),
+      practiceSessionPlay: delegate(),
+      play: delegate(),
+      auditLog: delegate(),
+      notificationOutbox: delegate(),
+      $transaction: vi.fn(),
+    },
+  };
+});
+
+vi.mock("@/lib/auth/session", () => ({
+  VENUE_SCHEDULE_ROLES: ["OWNER", "MANAGER", "SCHEDULER"],
+  requireUserId: (...args: unknown[]) => mockAuth.requireUserId(...args),
+  requireTeamAdmin: (...args: unknown[]) => mockAuth.requireTeamAdmin(...args),
+  requireTeamMember: (...args: unknown[]) => mockAuth.requireTeamMember(...args),
+  requireLeagueRole: (...args: unknown[]) => mockAuth.requireLeagueRole(...args),
+  requireEventManager: (...args: unknown[]) => mockAuth.requireEventManager(...args),
+  requireSignupEventHostAdmin: (...args: unknown[]) =>
+    mockAuth.requireSignupEventHostAdmin(...args),
+  requireVenueScheduleManager: (...args: unknown[]) =>
+    mockAuth.requireVenueScheduleManager(...args),
+  requireVenueContentManager: (...args: unknown[]) =>
+    mockAuth.requireVenueContentManager(...args),
+  getCurrentUserId: vi.fn(),
+  isEventManager: vi.fn(),
+}));
+vi.mock("@/lib/actions/seasons", () => ({
+  requireSeasonManager: (...args: unknown[]) =>
+    mockAuth.requireSeasonManager(...args),
+}));
+vi.mock("@/lib/actions/venues", () => ({
+  canUserAccessVenue: vi.fn().mockResolvedValue(true),
+}));
+vi.mock("@/lib/db/prisma", () => ({ prisma: mockPrisma }));
+vi.mock("@/lib/email/templates", () => ({
+  sendEventNotifications: vi.fn().mockResolvedValue(undefined),
+  sendGameProposalNotifications: vi.fn().mockResolvedValue(undefined),
+  sendSignupEventCanceledEmail: vi.fn().mockResolvedValue(undefined),
+  sendSignupEventUpdatedEmail: vi.fn().mockResolvedValue(undefined),
+  sendPracticePlanNotifications: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("@/lib/services/venue-activity", () => ({
+  logVenueActivity: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("@/lib/actions/venue-organizations", async (importOriginal) => {
+  const original = await importOriginal<Record<string, unknown>>();
+  return { ...original, logVenueActivity: vi.fn().mockResolvedValue(undefined) };
+});
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+
+import { createEvent, updateEvent } from "@/lib/actions/events";
+import {
+  createSeasonGame,
+  publishSeasonGames,
+  updateSeasonGame,
+} from "@/lib/actions/season-games";
+import { acceptGameProposal } from "@/lib/actions/game-proposals";
+import { upsertEventGame } from "@/lib/actions/event-teams";
+import {
+  publishSignupEvent,
+  updateSignupEvent,
+} from "@/lib/actions/signup-events";
+import {
+  archiveIceSurface,
+  createScheduleBlock,
+  publishScheduleBlock,
+  updateScheduleBlock,
+} from "@/lib/actions/venue-schedules";
+import { publishSpecialtyEvent } from "@/lib/actions/venue-content";
+import {
+  createPracticeSession,
+  updatePracticeSession,
+} from "@/lib/actions/practice-sessions";
+import { setSegmentActive } from "@/lib/actions/venue-surfaces";
+
+const USER_ID = "cluser000000000000000001";
+const LEAGUE_ID = "clleague0000000000000001";
+const TEAM_A = "clteam00000000000000001";
+const TEAM_B = "clteam00000000000000002";
+const SEASON_ID = "clseason000000000000001";
+const SEASON_GAME_ID = "clgame0000000000000001";
+const EVENT_ID = "clevent0000000000000001";
+const EVENT_GAME_ID = "cleventgame00000000001";
+const PROPOSAL_ID = "clproposal000000000001";
+const ORGANIZATION_ID = "clorg000000000000000001";
+const VENUE_ID = "clvenue00000000000000001";
+const SURFACE_ID = "clsurface000000000000001";
+const SEGMENT_ID = "clsegment000000000000001";
+const RESERVATION_ID = "clreservation0000000001";
+const BLOCK_ID = "clblock000000000000001";
+const PRACTICE_ID = "clpractice0000000000001";
+const START = new Date("2099-09-05T22:00:00.000Z");
+const END = new Date("2099-09-05T23:30:00.000Z");
+
+const conflictSources = [
+  "seasonGame",
+  "eventGame",
+  "event",
+  "practice",
+  "scheduleBlock",
+  "venueReservation",
+  "iceTimeRequest",
+] as const;
+type ConflictSource = (typeof conflictSources)[number];
+
+const reservationRecord = () => ({
+  id: RESERVATION_ID,
+  status: "CONFIRMED",
+  startsAt: START,
+  endsAt: END,
+  timezone: "America/New_York",
+  heldUntil: null,
+  confirmedAt: START,
+  venueId: VENUE_ID,
+  surfaceId: SURFACE_ID,
+  segmentId: SEGMENT_ID,
+  ownerLeagueId: LEAGUE_ID,
+  ownerTeamId: null,
+  ownerVenueOrganizationId: null,
+  sourceRequestId: null,
+  venue: {
+    id: VENUE_ID,
+    isActive: true,
+    timezone: "America/New_York",
+    organizationId: ORGANIZATION_ID,
+    leagueId: LEAGUE_ID,
+    teamId: TEAM_A,
+  },
+  events: [],
+  seasonGames: [],
+  eventGames: [],
+  signupEvents: [],
+  practiceSessions: [],
+  proposalEntries: [],
+});
+
+const seasonGameRecord = (status = "SCHEDULED") => ({
+  id: SEASON_GAME_ID,
+  seasonId: SEASON_ID,
+  phaseId: null,
+  status,
+  startAt: START,
+  endAt: END,
+  timezone: "America/New_York",
+  venueId: VENUE_ID,
+  surfaceId: SURFACE_ID,
+  segmentId: SEGMENT_ID,
+  locationText: null,
+  notes: null,
+  homeTeamId: TEAM_A,
+  awayTeamId: TEAM_B,
+  eventId: null,
+  venueReservationId: null,
+  season: { id: SEASON_ID, leagueId: LEAGUE_ID, teamId: null },
+  homeTeam: { leagueId: LEAGUE_ID },
+  awayTeam: { leagueId: LEAGUE_ID },
+});
+
+const teamEventRecord = () => ({
+  id: EVENT_ID,
+  type: "GAME",
+  title: "Arrows vs Blizzards",
+  startAt: START,
+  endAt: END,
+  timezone: "America/New_York",
+  location: "North Rink",
+  venueId: VENUE_ID,
+  opponent: "Blizzards",
+  notes: null,
+  teamId: TEAM_A,
+  homeTeamId: null,
+  awayTeamId: null,
+  leagueId: LEAGUE_ID,
+  venueReservationId: null,
+  team: { leagueId: LEAGUE_ID },
+  homeTeam: null,
+  awayTeam: null,
+  seasonGame: null,
+});
+
+const signupEventRecord = (status: "DRAFT" | "PUBLISHED") => ({
+  id: EVENT_ID,
+  status,
+  visibility: "PUBLIC",
+  linkToken: null,
+  title: "Mite Night",
+  category: "SCRIMMAGE",
+  ageClassification: "U8",
+  acceptsOnlinePayment: false,
+  acceptsManualPayment: true,
+  galleryEnabled: true,
+  galleryVisibility: "PARTICIPANTS",
+  publicRoster: false,
+  hostOrganizationId: null,
+  hostLeagueId: LEAGUE_ID,
+  hostTeamId: null,
+  venueId: VENUE_ID,
+  startAt: START,
+  endAt: END,
+  timezone: "America/New_York",
+  locationText: null,
+  venueReservationId: null,
+  venueReservation: null,
+  venue: { slug: "north-rink" },
+  hostOrganization: null,
+  hostLeague: {
+    id: LEAGUE_ID,
+    name: "OpenLeague Association",
+    slug: "openleague",
+    stripeAccountId: null,
+    stripeChargesEnabled: false,
+  },
+  hostTeam: null,
+  slots: [{ id: "clslot00000000000000001", capacity: 40, priceAmount: null, _count: { registrations: 0 } }],
+  surfaces: [{ id: SURFACE_ID }],
+});
+
+const eventGameRecord = () => ({
+  id: EVENT_GAME_ID,
+  eventId: EVENT_ID,
+  name: "Game 1",
+  status: "SCHEDULED",
+  homeTeamId: TEAM_A,
+  awayTeamId: TEAM_B,
+  startAt: START,
+  endAt: END,
+  surfaceId: SURFACE_ID,
+  segmentId: SEGMENT_ID,
+  venueReservationId: null,
+  venueReservation: null,
+  event: {
+    id: EVENT_ID,
+    hostOrganizationId: null,
+    hostLeagueId: LEAGUE_ID,
+    hostTeamId: null,
+  },
+});
+
+const blockRecord = (status: "DRAFT" | "PUBLISHED" = "PUBLISHED") => ({
+  id: BLOCK_ID,
+  venueId: VENUE_ID,
+  surfaceId: SURFACE_ID,
+  segmentId: SEGMENT_ID,
+  title: "Open skate",
+  startsAt: START,
+  endsAt: END,
+  status,
+  intent: "VENUE_ACTIVITY",
+  activityType: "OPEN_SKATE",
+  recurrenceRule: null,
+  recurrenceEndDate: null,
+  reservationOccurrences: [],
+  venue: {
+    organizationId: ORGANIZATION_ID,
+    slug: "north-rink",
+    timezone: "America/New_York",
+  },
+});
+
+const practiceRecord = () => ({
+  id: PRACTICE_ID,
+  title: "Practice",
+  date: START,
+  startAt: START,
+  duration: 90,
+  isShared: false,
+  teamId: TEAM_A,
+  venueId: VENUE_ID,
+  surfaceId: SURFACE_ID,
+  segmentId: SEGMENT_ID,
+  venueReservationId: null,
+  team: { leagueId: LEAGUE_ID },
+});
+
+function configureConflict(source: ConflictSource): void {
+  mockPrisma.venueReservation.findMany.mockImplementation(
+    async ({ where }: { where: Record<string, unknown> }) => {
+      if (where.sourceScheduleBlockId) return [];
+      if (source !== "venueReservation") return [];
+      return [{
+        ...reservationRecord(),
+        id: "conflicting-reservation",
+        proposalEntries: [],
+      }];
+    },
+  );
+  mockPrisma.event.findMany.mockResolvedValue(
+    source === "event"
+      ? [{ id: "legacy-event", title: "Legacy event", startAt: START, endAt: END }]
+      : [],
+  );
+  mockPrisma.seasonGame.findMany.mockImplementation(
+    async ({ where }: { where: Record<string, unknown> }) => {
+      if (where.seasonId === SEASON_ID && where.status === "DRAFT") {
+        return [seasonGameRecord("DRAFT")];
+      }
+      return source === "seasonGame"
+        ? [{
+            ...seasonGameRecord(),
+            id: "legacy-season-game",
+            segment: { name: "North" },
+            homeTeam: { name: "A" },
+            awayTeam: { name: "B" },
+          }]
+        : [];
+    },
+  );
+  mockPrisma.eventGame.findMany.mockImplementation(
+    async ({ where }: { where: Record<string, unknown> }) => {
+      if (where.eventId === EVENT_ID) return [];
+      return source === "eventGame"
+        ? [{
+            ...eventGameRecord(),
+            id: "legacy-event-game",
+            segment: { name: "North" },
+            event: { title: "Signup" },
+          }]
+        : [];
+    },
+  );
+  mockPrisma.practiceSession.findMany.mockResolvedValue(
+    source === "practice"
+      ? [{ ...practiceRecord(), id: "legacy-practice", segment: { name: "North" } }]
+      : [],
+  );
+  mockPrisma.venueScheduleBlock.findMany.mockResolvedValue(
+    source === "scheduleBlock"
+      ? [{
+          ...blockRecord(),
+          id: "legacy-block",
+          segment: { name: "North" },
+          reservationOccurrences: [],
+        }]
+      : [],
+  );
+  mockPrisma.iceTimeRequest.findMany.mockResolvedValue(
+    source === "iceTimeRequest"
+      ? [{
+          id: "legacy-request",
+          requestedStartAt: START,
+          requestedEndAt: END,
+          approvedStartAt: START,
+          approvedEndAt: END,
+          approvedSurfaceId: SURFACE_ID,
+          approvedSegmentId: SEGMENT_ID,
+          scheduleBlock: {
+            title: "Public ice",
+            surfaceId: SURFACE_ID,
+            segmentId: SEGMENT_ID,
+          },
+        }]
+      : [],
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  for (const mock of Object.values(mockAuth)) mock.mockResolvedValue(USER_ID);
+  mockAuth.requireSeasonManager.mockResolvedValue({
+    season: { id: SEASON_ID, leagueId: LEAGUE_ID, teamId: null },
+    userId: USER_ID,
+  });
+  mockPrisma.$transaction.mockImplementation(
+    async (callback: (tx: typeof mockPrisma) => unknown) => callback(mockPrisma),
+  );
+  mockPrisma.league.findUnique.mockResolvedValue({ id: LEAGUE_ID });
+  mockPrisma.season.findUnique.mockResolvedValue({
+    id: SEASON_ID,
+    leagueId: LEAGUE_ID,
+    teamId: null,
+  });
+  mockPrisma.season.findFirst.mockResolvedValue({
+    id: SEASON_ID,
+    leagueId: LEAGUE_ID,
+    teamId: null,
+  });
+  mockPrisma.seasonPhase.findFirst.mockResolvedValue({ id: "clphase0000000000000001" });
+  mockPrisma.team.findMany.mockResolvedValue([
+    { id: TEAM_A, leagueId: LEAGUE_ID },
+    { id: TEAM_B, leagueId: LEAGUE_ID },
+  ]);
+  mockPrisma.team.findUnique.mockImplementation(
+    async ({ where }: { where: { id: string } }) => ({
+      id: where.id,
+      leagueId: LEAGUE_ID,
+    }),
+  );
+  mockPrisma.team.findUniqueOrThrow.mockImplementation(
+    async ({ where }: { where: { id: string } }) => ({
+      id: where.id,
+      name: where.id === TEAM_A ? "Arrows" : "Blizzards",
+      leagueId: LEAGUE_ID,
+    }),
+  );
+  mockPrisma.teamMember.findMany.mockResolvedValue([
+    { teamId: TEAM_A, userId: "clmember000000000000001" },
+    { teamId: TEAM_B, userId: "clmember000000000000002" },
+  ]);
+  mockPrisma.teamMember.findFirst.mockResolvedValue({ id: "membership-1" });
+  mockPrisma.leagueUser.findFirst.mockResolvedValue({ id: "league-user-1" });
+  mockPrisma.venue.findUnique.mockResolvedValue({
+    id: VENUE_ID,
+    name: "North Rink",
+    isActive: true,
+    visibility: "PUBLIC",
+    timezone: "America/New_York",
+    organizationId: ORGANIZATION_ID,
+    leagueId: LEAGUE_ID,
+    teamId: TEAM_A,
+  });
+  mockPrisma.venue.findFirst.mockResolvedValue({
+    id: VENUE_ID,
+    organizationId: ORGANIZATION_ID,
+    slug: "north-rink",
+    timezone: "America/New_York",
+  });
+  mockPrisma.venueOrganization.findUnique.mockResolvedValue({ id: ORGANIZATION_ID });
+  mockPrisma.venueRelationship.findFirst.mockResolvedValue({ id: "relationship-1" });
+  mockPrisma.venueStaff.findFirst.mockResolvedValue({ id: "staff-1" });
+  mockPrisma.iceSurface.findFirst.mockResolvedValue({ id: SURFACE_ID });
+  mockPrisma.iceSurface.update.mockResolvedValue({ id: SURFACE_ID, venueId: VENUE_ID });
+  mockPrisma.surfaceSegment.findFirst.mockResolvedValue({
+    id: SEGMENT_ID,
+    isActive: true,
+  });
+  mockPrisma.surfaceSegment.findUnique.mockResolvedValue({
+    id: SEGMENT_ID,
+    name: "North",
+    isActive: true,
+    surfaceId: SURFACE_ID,
+    surface: {
+      name: "Main",
+      venueId: VENUE_ID,
+      venue: { organizationId: ORGANIZATION_ID, slug: "north-rink" },
+    },
+  });
+  mockPrisma.segmentCoexistence.findMany.mockResolvedValue([]);
+  mockPrisma.iceTimeRequest.findUnique.mockResolvedValue(null);
+  mockPrisma.iceTimeRequest.findMany.mockResolvedValue([]);
+  mockPrisma.venueReservation.findUnique.mockResolvedValue(reservationRecord());
+  mockPrisma.venueReservation.findFirst.mockResolvedValue(null);
+  mockPrisma.venueReservation.findMany.mockResolvedValue([]);
+  mockPrisma.event.findUnique.mockImplementation(
+    async ({ where }: { where: Record<string, unknown> }) =>
+      where.venueReservationId ? null : teamEventRecord(),
+  );
+  mockPrisma.event.create.mockResolvedValue(teamEventRecord());
+  mockPrisma.event.update.mockResolvedValue(teamEventRecord());
+  mockPrisma.event.findMany.mockResolvedValue([]);
+  mockPrisma.rSVP.createMany.mockResolvedValue({ count: 2 });
+  mockPrisma.eventTeam.findMany.mockResolvedValue([
+    { id: TEAM_A, eventId: EVENT_ID },
+    { id: TEAM_B, eventId: EVENT_ID },
+  ]);
+  mockPrisma.eventGame.findFirst.mockResolvedValue(eventGameRecord());
+  mockPrisma.eventGame.findUnique.mockResolvedValue(eventGameRecord());
+  mockPrisma.eventGame.findMany.mockResolvedValue([]);
+  mockPrisma.eventGame.create.mockResolvedValue(eventGameRecord());
+  mockPrisma.eventGame.update.mockResolvedValue(eventGameRecord());
+  mockPrisma.signupEvent.findUnique.mockResolvedValue(signupEventRecord("PUBLISHED"));
+  mockPrisma.signupEvent.update.mockResolvedValue(signupEventRecord("PUBLISHED"));
+  mockPrisma.signupEvent.updateMany.mockResolvedValue({ count: 1 });
+  mockPrisma.signupSlot.deleteMany.mockResolvedValue({ count: 0 });
+  mockPrisma.eventRegistrationPhase.deleteMany.mockResolvedValue({ count: 0 });
+  mockPrisma.eventRegistration.findMany.mockResolvedValue([]);
+  mockPrisma.gameProposal.findUnique.mockResolvedValue({
+    id: PROPOSAL_ID,
+    status: "PENDING",
+    leagueId: LEAGUE_ID,
+    proposingTeamId: TEAM_A,
+    receivingTeamId: TEAM_B,
+    seasonId: SEASON_ID,
+    entries: [{
+      id: "entry-1",
+      kind: "PROPOSE",
+      startAt: START,
+      endAt: END,
+      venueId: VENUE_ID,
+      venueReservationId: null,
+      note: null,
+      actorTeamId: TEAM_A,
+      createdAt: new Date("2099-08-17T00:00:00.000Z"),
+    }],
+  });
+  mockPrisma.gameProposal.updateMany.mockResolvedValue({ count: 1 });
+  mockPrisma.gameProposalEntry.updateMany.mockResolvedValue({ count: 1 });
+  mockPrisma.seasonGame.findUnique.mockResolvedValue(seasonGameRecord());
+  mockPrisma.seasonGame.findMany.mockResolvedValue([]);
+  mockPrisma.seasonGame.create.mockResolvedValue(seasonGameRecord());
+  mockPrisma.seasonGame.update.mockResolvedValue(seasonGameRecord());
+  mockPrisma.venueScheduleBlock.findFirst.mockResolvedValue(blockRecord());
+  mockPrisma.venueScheduleBlock.findMany.mockResolvedValue([]);
+  mockPrisma.venueScheduleBlock.create.mockResolvedValue(blockRecord());
+  mockPrisma.venueScheduleBlock.update.mockResolvedValue(blockRecord());
+  mockPrisma.practiceSession.findUnique.mockResolvedValue(practiceRecord());
+  mockPrisma.practiceSession.findMany.mockResolvedValue([]);
+  mockPrisma.practiceSession.create.mockResolvedValue(practiceRecord());
+  mockPrisma.practiceSession.update.mockResolvedValue(practiceRecord());
+  mockPrisma.practiceSessionPlay.deleteMany.mockResolvedValue({ count: 0 });
+  mockPrisma.play.findMany.mockResolvedValue([]);
+  mockPrisma.auditLog.create.mockResolvedValue({ id: "audit-1" });
+  mockPrisma.notificationOutbox.createMany.mockResolvedValue({ count: 0 });
+});
+
+type WriterResult =
+  | { success: boolean; details?: unknown }
+  | { success: boolean; data?: unknown; details?: unknown };
+type Writer = {
+  name: string;
+  run: () => Promise<WriterResult>;
+  conflicts: (result: WriterResult) => unknown[];
+};
+const failureConflicts = (result: WriterResult) =>
+  ((result.details as { conflicts?: unknown[] } | undefined)?.conflicts ?? []);
+const publicationConflicts = (result: WriterResult) =>
+  ((result.details as { outcomes?: Array<{ conflicts?: unknown[] }> } | undefined)
+    ?.outcomes?.flatMap((outcome) => outcome.conflicts ?? []) ?? []);
+
+const scheduleInput = {
+  organizationId: ORGANIZATION_ID,
+  venueId: VENUE_ID,
+  surfaceId: SURFACE_ID,
+  segmentId: SEGMENT_ID,
+  title: "Open skate",
+  activityType: "OPEN_SKATE" as const,
+  startsAt: START,
+  endsAt: END,
+  status: "PUBLISHED" as const,
+};
+const signupInput = {
+  title: "Mite Night",
+  category: "SCRIMMAGE" as const,
+  ageClassification: "U8" as const,
+  visibility: "PUBLIC" as const,
+  startAt: START,
+  endAt: END,
+  acceptsOnlinePayment: false,
+  acceptsManualPayment: true,
+  galleryEnabled: true,
+  galleryVisibility: "PARTICIPANTS" as const,
+  publicRoster: false,
+  hostLeagueId: LEAGUE_ID,
+  venueId: VENUE_ID,
+  slots: [{
+    id: "clslot00000000000000001",
+    name: "Skater",
+    capacity: 40,
+    waitlistEnabled: true,
+    sortOrder: 0,
+  }],
+  phases: [],
+};
+
+const writers: Writer[] = [
+  {
+    name: "Team Event create",
+    run: () => createEvent({
+      type: "GAME",
+      title: "Arrows vs Blizzards",
+      startAt: START,
+      endAt: END,
+      location: "North Rink",
+      opponent: "Blizzards",
+      teamId: TEAM_A,
+      venueId: VENUE_ID,
+      reservationId: RESERVATION_ID,
+      overrideConflicts: false,
+    }),
+    conflicts: failureConflicts,
+  },
+  {
+    name: "Team Event update",
+    run: () => updateEvent({
+      id: EVENT_ID,
+      type: "GAME",
+      title: "Arrows vs Blizzards",
+      startAt: START,
+      endAt: END,
+      location: "North Rink",
+      opponent: "Blizzards",
+      teamId: TEAM_A,
+      venueId: VENUE_ID,
+      reservationId: RESERVATION_ID,
+      overrideConflicts: false,
+    }),
+    conflicts: failureConflicts,
+  },
+  {
+    name: "SeasonGame create",
+    run: () => createSeasonGame({
+      seasonId: SEASON_ID,
+      homeTeamId: TEAM_A,
+      awayTeamId: TEAM_B,
+      startAt: START,
+      endAt: END,
+      venueId: VENUE_ID,
+      surfaceId: SURFACE_ID,
+      segmentId: SEGMENT_ID,
+      publish: true,
+    }),
+    conflicts: failureConflicts,
+  },
+  {
+    name: "SeasonGame update",
+    run: () => updateSeasonGame({
+      gameId: SEASON_GAME_ID,
+      startAt: START,
+      endAt: END,
+      venueId: VENUE_ID,
+      surfaceId: SURFACE_ID,
+      segmentId: SEGMENT_ID,
+      reservationId: null,
+      overrideReason: "Create replacement inventory",
+    }),
+    conflicts: failureConflicts,
+  },
+  {
+    name: "SeasonGame publish",
+    run: () => {
+      mockPrisma.seasonGame.findUnique.mockResolvedValue(seasonGameRecord("DRAFT"));
+      return publishSeasonGames({
+        seasonId: SEASON_ID,
+        overrideReason: "Create publication inventory",
+      });
+    },
+    conflicts: publicationConflicts,
+  },
+  {
+    name: "proposal acceptance",
+    run: () => acceptGameProposal({
+      proposalId: PROPOSAL_ID,
+      reservationId: RESERVATION_ID,
+    }),
+    conflicts: failureConflicts,
+  },
+  {
+    name: "EventGame create",
+    run: () => upsertEventGame({
+      eventId: EVENT_ID,
+      homeTeamId: TEAM_A,
+      awayTeamId: TEAM_B,
+      startAt: START,
+      endAt: END,
+      venueId: VENUE_ID,
+      surfaceId: SURFACE_ID,
+      segmentId: SEGMENT_ID,
+    }),
+    conflicts: failureConflicts,
+  },
+  {
+    name: "EventGame update",
+    run: () => upsertEventGame({
+      gameId: EVENT_GAME_ID,
+      eventId: EVENT_ID,
+      homeTeamId: TEAM_A,
+      awayTeamId: TEAM_B,
+      startAt: START,
+      endAt: END,
+      venueId: VENUE_ID,
+      surfaceId: SURFACE_ID,
+      segmentId: SEGMENT_ID,
+    }),
+    conflicts: failureConflicts,
+  },
+  {
+    name: "parent SignupEvent publication",
+    run: () => {
+      mockPrisma.signupEvent.findUnique.mockResolvedValue(signupEventRecord("DRAFT"));
+      return publishSignupEvent({ eventId: EVENT_ID });
+    },
+    conflicts: failureConflicts,
+  },
+  {
+    name: "SignupEvent published update",
+    run: () => updateSignupEvent({
+      ...signupInput,
+      eventId: EVENT_ID,
+      startAt: new Date(START.getTime() + 60_000),
+      endAt: new Date(END.getTime() + 60_000),
+    }),
+    conflicts: failureConflicts,
+  },
+  {
+    name: "VenueScheduleBlock create",
+    run: () => createScheduleBlock(scheduleInput),
+    conflicts: failureConflicts,
+  },
+  {
+    name: "VenueScheduleBlock update",
+    run: () => updateScheduleBlock({
+      ...scheduleInput,
+      scheduleBlockId: BLOCK_ID,
+    }),
+    conflicts: failureConflicts,
+  },
+  {
+    name: "VenueScheduleBlock publish",
+    run: () => {
+      mockPrisma.venueScheduleBlock.findFirst.mockResolvedValue(blockRecord("DRAFT"));
+      return publishScheduleBlock({
+        organizationId: ORGANIZATION_ID,
+        venueId: VENUE_ID,
+        scheduleBlockId: BLOCK_ID,
+      });
+    },
+    conflicts: failureConflicts,
+  },
+  {
+    name: "specialty event publication",
+    run: () => publishSpecialtyEvent({
+      ...scheduleInput,
+      activityType: "SPECIALTY_EVENT",
+    }),
+    conflicts: failureConflicts,
+  },
+  {
+    name: "practice create",
+    run: () => createPracticeSession({
+      title: "Practice",
+      date: START,
+      duration: 90,
+      teamId: TEAM_A,
+      plays: [],
+      venueId: VENUE_ID,
+      surfaceId: SURFACE_ID,
+      segmentId: SEGMENT_ID,
+      startAt: START,
+    }),
+    conflicts: failureConflicts,
+  },
+  {
+    name: "practice update",
+    run: () => updatePracticeSession({
+      id: PRACTICE_ID,
+      title: "Practice",
+      date: START,
+      duration: 90,
+      teamId: TEAM_A,
+      plays: [],
+      venueId: VENUE_ID,
+      surfaceId: SURFACE_ID,
+      segmentId: SEGMENT_ID,
+      startAt: START,
+    }),
+    conflicts: failureConflicts,
+  },
+];
+
+describe("writer-by-conflicting-source matrix", () => {
+  it.each(
+    writers.flatMap((writer) =>
+      conflictSources.map((source) => ({ writer, source })),
+    ),
+  )("$writer.name blocks $source occupancy", async ({ writer, source }) => {
+    configureConflict(source);
+
+    const result = await writer.run();
+
+    expect(writer.conflicts(result), JSON.stringify(result)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ source }),
+      ]),
+    );
+  });
+});
+
+const archivalSources = [
+  "seasonGame",
+  "eventGame",
+  "practice",
+  "scheduleBlock",
+  "venueReservation",
+  "iceTimeRequest",
+] as const;
+
+describe("surface and segment archival dual-read guards", () => {
+  it.each(archivalSources)("surface archival blocks %s occupancy", async (source) => {
+    configureConflict(source);
+
+    const result = await archiveIceSurface({
+      organizationId: ORGANIZATION_ID,
+      venueId: VENUE_ID,
+      surfaceId: SURFACE_ID,
+    });
+
+    expect(result.success).toBe(false);
+    expect(
+      (result as { details?: { futureBookings?: Array<{ source: string }> } })
+        .details?.futureBookings,
+    ).toEqual(expect.arrayContaining([expect.objectContaining({ source })]));
+  });
+
+  it.each(archivalSources)("segment deactivation blocks %s occupancy", async (source) => {
+    configureConflict(source);
+
+    const result = await setSegmentActive({
+      segmentId: SEGMENT_ID,
+      isActive: false,
+    });
+
+    expect(result.success).toBe(false);
+    expect(
+      (result as { details?: { futureBookings?: Array<{ source: string }> } })
+        .details?.futureBookings,
+    ).toEqual(expect.arrayContaining([expect.objectContaining({ source })]));
+  });
+});

--- a/__tests__/lib/actions/event-teams.test.ts
+++ b/__tests__/lib/actions/event-teams.test.ts
@@ -2,12 +2,26 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
 
-const { mockRequireEventManager, mockGetCurrentUserId, mockTeamsEmail, mockPrisma } = vi.hoisted(() => ({
+const {
+  mockRequireEventManager,
+  mockGetCurrentUserId,
+  mockCanViewSignupEvent,
+  mockTeamsEmail,
+  mockCreateVenueReservation,
+  mockAssignVenueReservation,
+  mockTransitionVenueReservation,
+  mockPrisma,
+} = vi.hoisted(() => ({
   mockRequireEventManager: vi.fn(),
   mockGetCurrentUserId: vi.fn(),
+  mockCanViewSignupEvent: vi.fn(),
   mockTeamsEmail: vi.fn(),
+  mockCreateVenueReservation: vi.fn(),
+  mockAssignVenueReservation: vi.fn(),
+  mockTransitionVenueReservation: vi.fn(),
   mockPrisma: {
-    $transaction: vi.fn(async (ops: unknown[]) => Promise.all(ops as Promise<unknown>[])),
+    $transaction: vi.fn(async (ops: unknown) =>
+      typeof ops === "function" ? ops(mockPrisma) : Promise.all(ops as Promise<unknown>[])),
     signupEvent: { findUnique: vi.fn(), update: vi.fn() },
     eventTeam: { findUnique: vi.fn(), findFirst: vi.fn(), findMany: vi.fn(), create: vi.fn(), update: vi.fn(), delete: vi.fn() },
     eventTeamAssignment: { upsert: vi.fn(), deleteMany: vi.fn(), createMany: vi.fn(), findUnique: vi.fn(), findMany: vi.fn(), delete: vi.fn() },
@@ -16,6 +30,7 @@ const { mockRequireEventManager, mockGetCurrentUserId, mockTeamsEmail, mockPrism
     eventGameParticipant: { deleteMany: vi.fn(), createMany: vi.fn() },
     iceSurface: { findFirst: vi.fn() },
     auditLog: { create: vi.fn() },
+    venueReservation: undefined as unknown as Record<string, ReturnType<typeof vi.fn>>,
   },
 }));
 
@@ -31,12 +46,33 @@ vi.mock("@/lib/email/templates", () => ({
   sendEventTeamsUpdateEmail: (...args: unknown[]) => mockTeamsEmail(...args),
 }));
 
+vi.mock("@/lib/utils/event-access", () => ({
+  canViewSignupEvent: (...args: unknown[]) => mockCanViewSignupEvent(...args),
+}));
+
 vi.mock("@/lib/actions/venue-organizations", () => ({}));
+vi.mock("@/lib/services/venue-reservations", () => ({
+  assignVenueReservation: (...args: unknown[]) => mockAssignVenueReservation(...args),
+  createVenueReservation: (...args: unknown[]) => mockCreateVenueReservation(...args),
+  transitionVenueReservation: (...args: unknown[]) => mockTransitionVenueReservation(...args),
+  VenueReservationConflictError: class extends Error {
+    conflicts: unknown[];
+    constructor(conflicts: unknown[]) {
+      super("conflict");
+      this.conflicts = conflicts;
+    }
+  },
+  VenueReservationLifecycleError: class extends Error {},
+}));
 
 import {
   assignToEventTeam,
   publishEventTeams,
   setGameRotation,
+  upsertEventGame,
+  deleteEventGame,
+  getPublicEventGames,
+  getMyEventAssignments,
 } from "@/lib/actions/event-teams";
 
 const EVENT_ID = "cldevent0000000000000001";
@@ -50,6 +86,7 @@ const gameEnd = new Date(gameStart.getTime() + hour);
 describe("assignToEventTeam", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockPrisma.venueReservation = undefined as unknown as Record<string, ReturnType<typeof vi.fn>>;
     mockRequireEventManager.mockResolvedValue("admin-1");
     mockPrisma.eventTeam.findUnique.mockResolvedValue({
       id: TEAM_RED,
@@ -123,6 +160,7 @@ describe("assignToEventTeam", () => {
 describe("setGameRotation", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockPrisma.venueReservation = undefined as unknown as Record<string, ReturnType<typeof vi.fn>>;
     mockRequireEventManager.mockResolvedValue("admin-1");
     mockPrisma.eventGame.findUnique.mockResolvedValue({
       id: GAME_ID,
@@ -259,5 +297,321 @@ describe("publishEventTeams", () => {
 
     expect(result).toEqual({ success: false, error: "Assign participants to teams before posting." });
     expect(mockPrisma.signupEvent.update).not.toHaveBeenCalled();
+  });
+});
+
+describe("EventGame / parent-signup publication", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPrisma.venueReservation = undefined as unknown as Record<string, ReturnType<typeof vi.fn>>;
+    mockRequireEventManager.mockResolvedValue("admin-1");
+    mockGetCurrentUserId.mockResolvedValue(null);
+    mockCanViewSignupEvent.mockResolvedValue(true);
+    mockPrisma.signupEvent.findUnique.mockResolvedValue({
+      id: EVENT_ID,
+      status: "PUBLISHED",
+      visibility: "PUBLIC",
+      linkToken: null,
+      teamsPublishedAt: new Date(),
+      ageClassification: "U8",
+    });
+    mockPrisma.eventGame.findMany.mockResolvedValue([]);
+  });
+
+  it("threads a single reservation through a published EventGame and its parent signup event", async () => {
+    mockPrisma.eventTeam.findMany.mockResolvedValue([
+      { id: TEAM_RED, eventId: EVENT_ID },
+      { id: TEAM_WHITE, eventId: EVENT_ID },
+    ]);
+    mockPrisma.eventGame.create.mockResolvedValue({ id: GAME_ID });
+
+    await upsertEventGame({
+      eventId: EVENT_ID,
+      name: "Championship",
+      homeTeamId: TEAM_RED,
+      awayTeamId: TEAM_WHITE,
+      startAt: gameStart,
+      endAt: gameEnd,
+      venueId: "clvenue0000000000000001",
+      reservationId: "clreservation0000000001",
+    });
+
+    expect(mockPrisma.eventGame.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          venueReservationId: "clreservation0000000001",
+        }),
+      }),
+    );
+  });
+
+  it("rejects a cross-event update before mutating the foreign game", async () => {
+    mockPrisma.eventTeam.findMany.mockResolvedValue([
+      { id: TEAM_RED, eventId: EVENT_ID },
+      { id: TEAM_WHITE, eventId: EVENT_ID },
+    ]);
+    mockPrisma.eventGame.findFirst.mockResolvedValue(null);
+
+    const result = await upsertEventGame({
+      eventId: EVENT_ID,
+      gameId: GAME_ID,
+      homeTeamId: TEAM_RED,
+      awayTeamId: TEAM_WHITE,
+      startAt: gameStart,
+      endAt: gameEnd,
+    });
+
+    expect(result).toEqual({ success: false, error: "Game not found for this event" });
+    expect(mockPrisma.eventGame.update).not.toHaveBeenCalled();
+  });
+
+  it("gives a partial-window child game its own reservation and excludes the parent claim", async () => {
+    mockPrisma.venueReservation = { findUnique: vi.fn(), findFirst: vi.fn() };
+    const parentReservation = {
+      id: "clparentreservation0000001",
+      venueId: "clvenue0000000000000001",
+      surfaceId: null,
+      segmentId: null,
+      startsAt: gameStart,
+      endsAt: gameEnd,
+    };
+    mockPrisma.signupEvent.findUnique.mockResolvedValue({
+      id: EVENT_ID,
+      status: "PUBLISHED",
+      venueId: parentReservation.venueId,
+      startAt: gameStart,
+      endAt: gameEnd,
+      timezone: "America/New_York",
+      hostOrganizationId: "clorg000000000000000001",
+      hostLeagueId: null,
+      hostTeamId: null,
+      venueReservation: parentReservation,
+    });
+    mockPrisma.eventTeam.findMany.mockResolvedValue([
+      { id: TEAM_RED, eventId: EVENT_ID },
+      { id: TEAM_WHITE, eventId: EVENT_ID },
+    ]);
+    mockPrisma.eventGame.create.mockResolvedValue({ id: GAME_ID });
+    mockCreateVenueReservation.mockResolvedValue({ id: "clchildreservation000001" });
+
+    const result = await upsertEventGame({
+      eventId: EVENT_ID,
+      homeTeamId: TEAM_RED,
+      awayTeamId: TEAM_WHITE,
+      startAt: new Date(gameStart.getTime() + 15 * 60 * 1000),
+      endAt: new Date(gameEnd.getTime() - 15 * 60 * 1000),
+      venueId: parentReservation.venueId,
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockCreateVenueReservation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ excludeReservationIds: [parentReservation.id] }),
+    );
+    expect(mockAssignVenueReservation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        targetType: "EVENT_GAME",
+        targetId: GAME_ID,
+        excludeReservationIds: [parentReservation.id],
+      }),
+    );
+    expect(mockAssignVenueReservation).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ targetType: "SIGNUP_EVENT" }),
+    );
+  });
+
+  it("keeps draft games non-occupying after rechecking the parent in the transaction", async () => {
+    mockPrisma.venueReservation = { findUnique: vi.fn(), findFirst: vi.fn() };
+    mockPrisma.signupEvent.findUnique.mockResolvedValue({
+      id: EVENT_ID,
+      status: "DRAFT",
+      venueId: "clvenue0000000000000001",
+      startAt: gameStart,
+      endAt: gameEnd,
+      timezone: "America/New_York",
+      hostOrganizationId: "clorg000000000000000001",
+      hostLeagueId: null,
+      hostTeamId: null,
+      venueReservation: null,
+    });
+    mockPrisma.eventTeam.findMany.mockResolvedValue([
+      { id: TEAM_RED, eventId: EVENT_ID },
+      { id: TEAM_WHITE, eventId: EVENT_ID },
+    ]);
+    mockPrisma.eventGame.create.mockResolvedValue({ id: GAME_ID });
+
+    const result = await upsertEventGame({
+      eventId: EVENT_ID,
+      homeTeamId: TEAM_RED,
+      awayTeamId: TEAM_WHITE,
+      startAt: gameStart,
+      endAt: gameEnd,
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockPrisma.eventGame.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ venueReservationId: null }),
+      }),
+    );
+    expect(mockCreateVenueReservation).not.toHaveBeenCalled();
+    expect(mockAssignVenueReservation).not.toHaveBeenCalled();
+  });
+
+  it("loses the save race when the parent is canceled before the transaction reads it", async () => {
+    mockPrisma.venueReservation = { findUnique: vi.fn(), findFirst: vi.fn() };
+    const parent = {
+      id: EVENT_ID,
+      status: "DRAFT",
+      venueId: "clvenue0000000000000001",
+      startAt: gameStart,
+      endAt: gameEnd,
+      timezone: "America/New_York",
+      hostOrganizationId: "clorg000000000000000001",
+      hostLeagueId: null,
+      hostTeamId: null,
+      venueReservation: null,
+    };
+    mockPrisma.signupEvent.findUnique
+      .mockResolvedValueOnce(parent)
+      .mockResolvedValueOnce({ ...parent, status: "CANCELED" });
+    mockPrisma.eventTeam.findMany.mockResolvedValue([
+      { id: TEAM_RED, eventId: EVENT_ID },
+      { id: TEAM_WHITE, eventId: EVENT_ID },
+    ]);
+
+    const result = await upsertEventGame({
+      eventId: EVENT_ID,
+      homeTeamId: TEAM_RED,
+      awayTeamId: TEAM_WHITE,
+      startAt: gameStart,
+      endAt: gameEnd,
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error: "Games cannot be saved for a canceled event.",
+    });
+    expect(mockPrisma.eventGame.create).not.toHaveBeenCalled();
+    expect(mockCreateVenueReservation).not.toHaveBeenCalled();
+  });
+
+  it("detaches confirmed inventory before deleting its game", async () => {
+    mockPrisma.venueReservation = { findUnique: vi.fn(), findFirst: vi.fn() };
+    mockPrisma.eventGame.findUnique.mockResolvedValue({
+      id: GAME_ID,
+      eventId: EVENT_ID,
+      venueReservationId: "clreservation0000000001",
+    });
+    mockPrisma.eventGame.findFirst.mockResolvedValue({
+      id: GAME_ID,
+      eventId: EVENT_ID,
+      venueReservationId: "clreservation0000000001",
+      event: {
+        id: EVENT_ID,
+        hostOrganizationId: "clorg000000000000000001",
+        hostLeagueId: null,
+        hostTeamId: null,
+      },
+    });
+    mockPrisma.venueReservation.findUnique.mockResolvedValue({
+      id: "clreservation0000000001",
+      status: "CONFIRMED",
+      signupEvents: [],
+      eventGames: [{ id: GAME_ID }],
+    });
+
+    const result = await deleteEventGame({ gameId: GAME_ID });
+
+    expect(result.success).toBe(true);
+    expect(mockTransitionVenueReservation).not.toHaveBeenCalled();
+    expect(mockPrisma.eventGame.delete).toHaveBeenCalledWith({ where: { id: GAME_ID } });
+  });
+
+  it("keeps the public selector published-only and privacy-safe", async () => {
+    mockPrisma.eventGame.findMany.mockResolvedValue([
+      {
+        id: GAME_ID,
+        name: "Final",
+        status: "SCHEDULED",
+        startAt: gameStart,
+        endAt: gameEnd,
+        homeScore: 4,
+        awayScore: 2,
+        surface: { name: "Rink A" },
+        segment: { id: "clsegment0000000000001", name: "Half" },
+        homeTeam: { name: "Arrows", colorHex: "#fff" },
+        awayTeam: { name: "Blizzards", colorHex: "#000" },
+      },
+    ]);
+
+    const result = await getPublicEventGames(EVENT_ID);
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        id: GAME_ID,
+        homeScore: null,
+        awayScore: null,
+      }),
+    ]);
+    expect(JSON.stringify(result)).not.toMatch(/registrant|guardian|payment|invitation|audit/i);
+  });
+
+  it("does not duplicate a participant's primary game when the rotation list references the same booking", async () => {
+    mockGetCurrentUserId.mockResolvedValue("user-1");
+    mockPrisma.signupEvent.findUnique.mockResolvedValue({
+      id: EVENT_ID,
+      teamsPublishedAt: new Date(),
+    });
+    mockPrisma.eventRegistration.findMany.mockResolvedValue([
+      {
+        id: "creg00000000000000001",
+        participantName: "Skater One",
+        isFloater: false,
+        teamAssignment: {
+          eventTeam: { id: TEAM_RED, name: "Red", colorHex: "#f00" },
+        },
+        gameParticipations: [
+          {
+            eventTeam: { name: "Red" },
+            game: {
+              id: GAME_ID,
+              name: "Red vs White",
+              startAt: gameStart,
+              endAt: gameEnd,
+              segment: null,
+              homeTeam: { name: "Red" },
+              awayTeam: { name: "White" },
+            },
+          },
+        ],
+      },
+    ]);
+    mockPrisma.eventGame.findMany.mockResolvedValue([
+      {
+        id: GAME_ID,
+        name: "Red vs White",
+        startAt: gameStart,
+        endAt: gameEnd,
+        segment: null,
+        homeTeamId: TEAM_RED,
+        awayTeamId: TEAM_WHITE,
+        homeTeam: { name: "Red" },
+        awayTeam: { name: "White" },
+      },
+    ]);
+
+    const result = await getMyEventAssignments(EVENT_ID);
+
+    expect(result).toHaveLength(1);
+    expect(result?.[0].games).toHaveLength(1);
+    expect(result?.[0].games[0]).toEqual(
+      expect.objectContaining({
+        id: GAME_ID,
+        name: "Red vs White",
+      }),
+    );
   });
 });

--- a/__tests__/lib/actions/events.test.ts
+++ b/__tests__/lib/actions/events.test.ts
@@ -3,21 +3,37 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 const {
   mockPrismaEvent,
   mockPrismaTeamMember,
+  mockPrismaVenue,
   mockPrismaLeagueUser,
   mockRequireUserId,
+  mockRequireTeamAdmin,
   mockGetViewableTeamIds,
+  mockAssignVenueReservation,
+  mockCreateVenueReservation,
+  mockSendEventNotifications,
+  mockCanUserAccessVenue,
 } = vi.hoisted(() => ({
   mockPrismaEvent: {
     findUnique: vi.fn(),
+    findMany: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
   },
+  mockPrismaVenue: { findUnique: vi.fn() },
   mockPrismaTeamMember: {
     findUnique: vi.fn(),
+    findMany: vi.fn(),
   },
   mockPrismaLeagueUser: {
     findFirst: vi.fn(),
   },
   mockRequireUserId: vi.fn(),
+  mockRequireTeamAdmin: vi.fn(),
   mockGetViewableTeamIds: vi.fn(),
+  mockAssignVenueReservation: vi.fn(),
+  mockCreateVenueReservation: vi.fn(),
+  mockSendEventNotifications: vi.fn().mockResolvedValue(undefined),
+  mockCanUserAccessVenue: vi.fn(),
 }));
 
 vi.mock("next/cache", () => ({
@@ -26,31 +42,48 @@ vi.mock("next/cache", () => ({
 
 vi.mock("@/lib/auth/session", () => ({
   requireUserId: (...args: unknown[]) => mockRequireUserId(...args),
-  requireTeamAdmin: vi.fn(),
+  requireTeamAdmin: (...args: unknown[]) => mockRequireTeamAdmin(...args),
   requireTeamMember: vi.fn(),
   getViewableTeamIds: (...args: unknown[]) => mockGetViewableTeamIds(...args),
 }));
 
 vi.mock("@/lib/db/prisma", () => ({
   prisma: {
+    $transaction: vi.fn(async (work: (tx: unknown) => unknown) =>
+      work({ event: mockPrismaEvent }),
+    ),
     event: mockPrismaEvent,
     teamMember: mockPrismaTeamMember,
     leagueUser: mockPrismaLeagueUser,
+    venue: mockPrismaVenue,
+    venueReservation: {},
   },
 }));
 
 // Side-effecting / heavy modules pulled in by events.ts at import time.
 vi.mock("@/lib/email/templates", () => ({
-  sendEventNotifications: vi.fn().mockResolvedValue(undefined),
+  sendEventNotifications: (...args: unknown[]) => mockSendEventNotifications(...args),
 }));
 vi.mock("@/lib/actions/venues", () => ({
-  canUserAccessVenue: vi.fn(),
+  canUserAccessVenue: (...args: unknown[]) => mockCanUserAccessVenue(...args),
 }));
 vi.mock("@/lib/utils/availability", () => ({
   findBookingConflicts: vi.fn(),
 }));
+vi.mock("@/lib/services/venue-reservations", () => ({
+  assignVenueReservation: (...args: unknown[]) => mockAssignVenueReservation(...args),
+  createVenueReservation: (...args: unknown[]) => mockCreateVenueReservation(...args),
+  transitionVenueReservation: vi.fn(),
+  VenueReservationConflictError: class extends Error {
+    conflicts: unknown[];
+    constructor(conflicts: unknown[]) {
+      super("conflict");
+      this.conflicts = conflicts;
+    }
+  },
+}));
 
-import { getEvent } from "@/lib/actions/events";
+import { createEvent, getEvent, updateEvent } from "@/lib/actions/events";
 
 const GUARDIAN_USER_ID = "user-guardian";
 const MEMBER_USER_ID = "user-member";
@@ -131,5 +164,180 @@ describe("getEvent — guardian-aware view access", () => {
     const result = await getEvent(EVENT_ID);
 
     expect(result).toBeNull();
+  });
+});
+
+describe("venue-backed team events", () => {
+  const venueId = "cvenue0000000000000000001";
+  const reservationId = "cres000000000000000000001";
+  const event = {
+    id: EVENT_ID,
+    type: "GAME",
+    title: "vs Wolves",
+    startAt: new Date("2099-08-01T18:00:00Z"),
+    endAt: new Date("2099-08-01T19:00:00Z"),
+    location: "North Rink",
+    opponent: "Wolves",
+    notes: null,
+  };
+
+  beforeEach(() => {
+    mockRequireTeamAdmin.mockResolvedValue(GUARDIAN_USER_ID);
+    mockCanUserAccessVenue.mockResolvedValue(true);
+    mockPrismaTeamMember.findMany.mockResolvedValue([]);
+    mockPrismaVenue.findUnique
+      .mockResolvedValueOnce({
+        id: venueId,
+        name: "North Rink",
+        timezone: "America/New_York",
+        isActive: true,
+        visibility: "PUBLIC",
+        teamId: TEAM_ID,
+        leagueId: null,
+      })
+      .mockResolvedValueOnce({ name: "North Rink", timezone: "America/New_York" });
+    mockPrismaEvent.create.mockResolvedValue(event);
+    mockAssignVenueReservation.mockResolvedValue({ id: reservationId });
+  });
+
+  it("rejects create before authorization when a venue event has no end time", async () => {
+    const result = await createEvent({
+      type: "PRACTICE",
+      title: "Practice",
+      startAt: event.startAt,
+      location: "North Rink",
+      teamId: TEAM_ID,
+      venueId,
+      overrideConflicts: false,
+    });
+
+    expect(result).toMatchObject({
+      success: false,
+      error: expect.stringContaining("End date and time is required"),
+    });
+    expect(mockRequireTeamAdmin).not.toHaveBeenCalled();
+    expect(mockPrismaEvent.create).not.toHaveBeenCalled();
+  });
+
+  it("rejects update before lookup when a venue event has no end time", async () => {
+    const result = await updateEvent({
+      id: EVENT_ID,
+      type: "PRACTICE",
+      title: "Practice",
+      startAt: event.startAt,
+      location: "North Rink",
+      teamId: TEAM_ID,
+      venueId,
+      overrideConflicts: false,
+    });
+
+    expect(result).toMatchObject({
+      success: false,
+      error: expect.stringContaining("End date and time is required"),
+    });
+    expect(mockPrismaEvent.findUnique).not.toHaveBeenCalled();
+    expect(mockPrismaEvent.update).not.toHaveBeenCalled();
+  });
+
+  it("assigns exact existing inventory without minting venue-wide occupancy", async () => {
+    const result = await createEvent({
+      type: "GAME",
+      title: "vs Wolves",
+      startAt: event.startAt,
+      endAt: event.endAt,
+      location: "North Rink",
+      opponent: "Wolves",
+      teamId: TEAM_ID,
+      venueId,
+      reservationId,
+      overrideConflicts: false,
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockCreateVenueReservation).not.toHaveBeenCalled();
+    expect(mockAssignVenueReservation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        reservationId,
+        targetType: "EVENT",
+        actorId: GUARDIAN_USER_ID,
+      }),
+    );
+  });
+
+  it("rejects a timed venue event without explicit reservation inventory", async () => {
+    const result = await createEvent({
+      type: "GAME",
+      title: "vs Wolves",
+      startAt: event.startAt,
+      endAt: event.endAt,
+      location: "North Rink",
+      opponent: "Wolves",
+      teamId: TEAM_ID,
+      venueId,
+      overrideConflicts: false,
+    });
+
+    expect(result).toEqual(expect.objectContaining({
+      success: false,
+      error: expect.stringContaining("confirmed reservation"),
+    }));
+    expect(mockPrismaEvent.create).not.toHaveBeenCalled();
+  });
+
+  it("rejects a timed venue update when the reservation is omitted", async () => {
+    mockPrismaEvent.findUnique.mockResolvedValue({
+      teamId: TEAM_ID,
+      venueReservationId: reservationId,
+    });
+
+    const result = await updateEvent({
+      id: EVENT_ID,
+      type: "PRACTICE",
+      title: "Practice",
+      startAt: event.startAt,
+      endAt: event.endAt,
+      location: "North Rink",
+      teamId: TEAM_ID,
+      venueId,
+      overrideConflicts: false,
+    });
+
+    expect(result).toEqual(expect.objectContaining({
+      success: false,
+      error: expect.stringContaining("confirmed reservation"),
+    }));
+    expect(mockPrismaEvent.update).not.toHaveBeenCalled();
+  });
+
+  it("notifies only after the canonical transaction commits", async () => {
+    const order: string[] = [];
+    mockPrismaEvent.create.mockImplementation(async () => {
+      order.push("create");
+      return event;
+    });
+    mockAssignVenueReservation.mockImplementation(async () => {
+      order.push("assign");
+      return { id: reservationId };
+    });
+    mockSendEventNotifications.mockImplementation(async () => {
+      order.push("notify");
+    });
+
+    const result = await createEvent({
+      type: "GAME",
+      title: "vs Wolves",
+      startAt: event.startAt,
+      endAt: event.endAt,
+      location: "North Rink",
+      opponent: "Wolves",
+      teamId: TEAM_ID,
+      venueId,
+      reservationId,
+      overrideConflicts: false,
+    });
+
+    expect(result.success).toBe(true);
+    expect(order).toEqual(["create", "assign", "notify"]);
   });
 });

--- a/__tests__/lib/actions/game-proposals.test.ts
+++ b/__tests__/lib/actions/game-proposals.test.ts
@@ -1,0 +1,415 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockRequireTeamAdmin,
+  mockRequireLeagueRole,
+  mockFindBookingConflicts,
+  mockFindReservationConflicts,
+  mockPrisma,
+} = vi.hoisted(() => {
+  const tx = {
+    gameProposal: { findUnique: vi.fn(), updateMany: vi.fn() },
+    gameProposalEntry: { create: vi.fn(), updateMany: vi.fn() },
+    season: { findUnique: vi.fn(), findFirst: vi.fn() },
+    seasonPhase: { findFirst: vi.fn() },
+    seasonGame: { create: vi.fn(), updateMany: vi.fn() },
+    event: { create: vi.fn(), updateMany: vi.fn() },
+    team: { findUnique: vi.fn(), findUniqueOrThrow: vi.fn(), findMany: vi.fn() },
+    teamMember: { findMany: vi.fn(), findFirst: vi.fn() },
+    venue: { findUnique: vi.fn() },
+    venueRelationship: { findFirst: vi.fn() },
+    venueStaff: { findFirst: vi.fn() },
+    auditLog: { create: vi.fn() },
+    venueReservation: undefined as
+      | undefined
+      | {
+          findUnique: ReturnType<typeof vi.fn>;
+          update: ReturnType<typeof vi.fn>;
+        },
+  };
+  return {
+    mockRequireTeamAdmin: vi.fn(),
+    mockRequireLeagueRole: vi.fn(),
+    mockFindBookingConflicts: vi.fn(),
+    mockFindReservationConflicts: vi.fn(),
+    mockPrisma: {
+      gameProposal: { findUnique: vi.fn(), create: vi.fn(), updateMany: vi.fn(), findMany: vi.fn() },
+      gameProposalEntry: { create: vi.fn(), updateMany: vi.fn() },
+      season: { findUnique: vi.fn(), findFirst: vi.fn() },
+      seasonPhase: { findFirst: vi.fn() },
+      seasonGame: tx.seasonGame,
+      event: tx.event,
+      team: tx.team,
+      teamMember: tx.teamMember,
+      venue: tx.venue,
+      venueRelationship: tx.venueRelationship,
+      venueStaff: tx.venueStaff,
+      auditLog: tx.auditLog,
+      venueReservation: tx.venueReservation,
+      $transaction: vi.fn(
+        async (callback: (transaction: typeof tx) => unknown) =>
+          callback(mockPrisma),
+      ),
+    },
+  };
+});
+
+vi.mock("@/lib/auth/session", () => ({
+  requireTeamAdmin: (...args: unknown[]) => mockRequireTeamAdmin(...args),
+  requireLeagueRole: (...args: unknown[]) => mockRequireLeagueRole(...args),
+  requireUserId: vi.fn(),
+}));
+
+vi.mock("@/lib/db/prisma", () => ({ prisma: mockPrisma }));
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("@/lib/utils/availability", () => ({
+  findBookingConflicts: (...args: unknown[]) => mockFindBookingConflicts(...args),
+}));
+vi.mock("@/lib/services/venue-reservation-availability", () => ({
+  findVenueReservationWriteConflicts: (...args: unknown[]) =>
+    mockFindReservationConflicts(...args),
+}));
+vi.mock("@/lib/email/templates", () => ({
+  sendEventNotifications: vi.fn(() => Promise.resolve()),
+  sendGameProposalNotifications: vi.fn(() => Promise.resolve()),
+}));
+vi.mock("@/lib/actions/season-games", () => ({
+  createGameEventWithRsvps: vi.fn(),
+}));
+
+import { acceptGameProposal } from "@/lib/actions/game-proposals";
+
+const PROPOSAL_ID = "clproposal000000000001";
+const LEAGUE_ID = "clleague0000000000000001";
+const SEASON_ID = "clseason000000000000001";
+const VENUE_ID = "clvenue00000000000000001";
+const TEAM_A = "clteam00000000000000001";
+const TEAM_B = "clteam00000000000000002";
+const RESERVATION_ID = "clreservation0000000001";
+const USER_ID = "cluser000000000000000001";
+const EVENT_ID = "clevent0000000000000001";
+const GAME_ID = "clgame000000000000000001";
+
+let activeReservationAliases: string[];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockPrisma.venueReservation = undefined;
+  activeReservationAliases = ["proposal-entry"];
+  mockRequireTeamAdmin.mockResolvedValue(USER_ID);
+  mockRequireLeagueRole.mockResolvedValue(USER_ID);
+  mockFindBookingConflicts.mockResolvedValue([]);
+  mockFindReservationConflicts.mockResolvedValue([]);
+  mockPrisma.gameProposal.findUnique.mockResolvedValue({
+    id: PROPOSAL_ID,
+    status: "PENDING",
+    leagueId: LEAGUE_ID,
+    proposingTeamId: TEAM_A,
+    receivingTeamId: TEAM_B,
+    seasonId: SEASON_ID,
+    entries: [
+      {
+        id: "entry-1",
+        kind: "PROPOSE",
+        startAt: new Date("2026-09-05T22:00:00.000Z"),
+        endAt: new Date("2026-09-05T23:30:00.000Z"),
+        venueId: VENUE_ID,
+        note: null,
+        actorTeamId: TEAM_A,
+        createdAt: new Date("2026-08-17T00:00:00.000Z"),
+        venueReservationId: RESERVATION_ID,
+      },
+    ],
+  });
+  mockPrisma.gameProposal.updateMany.mockResolvedValue({ count: 1 });
+  mockPrisma.gameProposalEntry.updateMany.mockImplementation(async () => {
+    activeReservationAliases = activeReservationAliases.filter(
+      (alias) => alias !== "proposal-entry",
+    );
+    return { count: 1 };
+  });
+  mockPrisma.season.findUnique.mockResolvedValue({ id: SEASON_ID });
+  mockPrisma.season.findFirst.mockResolvedValue({ id: SEASON_ID });
+  mockPrisma.seasonPhase.findFirst.mockResolvedValue({ id: "clphase000000000000001" });
+  mockPrisma.venue.findUnique.mockResolvedValue({ name: "North Rink", timezone: "America/New_York" });
+  mockPrisma.team.findUniqueOrThrow.mockImplementation(async ({ where }: { where: { id: string } }) => ({
+    name: where.id === TEAM_A ? "Arrows" : "Blizzards",
+  }));
+  mockPrisma.teamMember.findMany.mockResolvedValue([{ userId: "p1" }, { userId: "p2" }]);
+  mockPrisma.teamMember.findFirst.mockResolvedValue({ id: "membership-1" });
+  mockPrisma.seasonGame.create.mockImplementation(async () => {
+    activeReservationAliases.push("season-game");
+    return { id: GAME_ID };
+  });
+  mockPrisma.event.create.mockImplementation(async () => {
+    activeReservationAliases.push("event");
+    return { id: EVENT_ID };
+  });
+});
+
+describe("reservation-backed proposal acceptance", () => {
+  it("threads one reservation into the accepted game and its participant Event", async () => {
+    const result = await acceptGameProposal({
+      proposalId: PROPOSAL_ID,
+      reservationId: RESERVATION_ID,
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockPrisma.gameProposalEntry.updateMany).toHaveBeenCalledWith({
+      where: {
+        proposalId: PROPOSAL_ID,
+        venueReservationId: RESERVATION_ID,
+      },
+      data: { venueReservationId: null },
+    });
+    expect(mockPrisma.gameProposalEntry.create).toHaveBeenCalledWith({
+      data: expect.not.objectContaining({
+        venueReservationId: expect.anything(),
+      }),
+    });
+    expect(mockPrisma.seasonGame.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          venueReservationId: RESERVATION_ID,
+        }),
+      }),
+    );
+    expect(mockPrisma.event.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          venueReservationId: RESERVATION_ID,
+          rsvps: {
+            create: [
+              { userId: "p1", status: "NO_RESPONSE" },
+              { userId: "p2", status: "NO_RESPONSE" },
+            ],
+          },
+        }),
+      }),
+    );
+    expect(activeReservationAliases).toEqual(["season-game", "event"]);
+  });
+
+  it("atomically assigns proposer-owned inventory when both exact teams consent", async () => {
+    const reservation = {
+      id: RESERVATION_ID,
+      status: "CONFIRMED",
+      usageStatus: "PENDING",
+      venueId: VENUE_ID,
+      surfaceId: null,
+      segmentId: null,
+      startsAt: new Date("2026-09-05T22:00:00.000Z"),
+      endsAt: new Date("2026-09-05T23:30:00.000Z"),
+      ownerLeagueId: null,
+      ownerTeamId: TEAM_A,
+      ownerVenueOrganizationId: null,
+      ownerTeam: { leagueId: LEAGUE_ID },
+      venue: {
+        id: VENUE_ID,
+        isActive: true,
+        timezone: "America/New_York",
+        organizationId: null,
+        leagueId: null,
+        teamId: TEAM_A,
+      },
+      events: [],
+      seasonGames: [],
+      eventGames: [],
+      signupEvents: [],
+      practiceSessions: [],
+      proposalEntries: [],
+    };
+    mockPrisma.venueReservation = {
+      findUnique: vi.fn().mockResolvedValue(reservation),
+      update: vi.fn().mockResolvedValue(reservation),
+    };
+    mockPrisma.team.findMany.mockResolvedValue([
+      { id: TEAM_A, leagueId: LEAGUE_ID },
+      { id: TEAM_B, leagueId: LEAGUE_ID },
+    ]);
+    mockPrisma.team.findUnique.mockResolvedValue({
+      id: TEAM_A,
+      leagueId: LEAGUE_ID,
+    });
+    mockPrisma.team.findUniqueOrThrow.mockImplementation(
+      async ({ where }: { where: { id: string } }) => ({
+        name: where.id === TEAM_A ? "Arrows" : "Blizzards",
+      }),
+    );
+    mockPrisma.seasonGame.updateMany.mockResolvedValue({ count: 1 });
+    mockPrisma.event.updateMany.mockResolvedValue({ count: 1 });
+
+    const result = await acceptGameProposal({
+      proposalId: PROPOSAL_ID,
+      reservationId: RESERVATION_ID,
+    });
+
+    expect(result).toEqual({ success: true, data: { gameId: GAME_ID } });
+    expect(mockPrisma.$transaction).toHaveBeenCalledTimes(1);
+    expect(mockPrisma.seasonGame.updateMany).toHaveBeenCalledWith({
+      where: expect.objectContaining({
+        id: GAME_ID,
+        proposalId: PROPOSAL_ID,
+        homeTeamId: TEAM_A,
+        awayTeamId: TEAM_B,
+        venueReservationId: null,
+      }),
+      data: { venueReservationId: RESERVATION_ID },
+    });
+    expect(mockPrisma.event.updateMany).toHaveBeenCalledWith({
+      where: expect.objectContaining({
+        id: EVENT_ID,
+        teamId: TEAM_A,
+        homeTeamId: TEAM_A,
+        awayTeamId: TEAM_B,
+        leagueId: LEAGUE_ID,
+        venueReservationId: null,
+      }),
+      data: { venueReservationId: RESERVATION_ID },
+    });
+    expect(mockPrisma.venueReservation.update).toHaveBeenCalledWith({
+      where: { id: RESERVATION_ID },
+      data: { assignedById: USER_ID },
+    });
+    expect(mockPrisma.auditLog.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        action: "VENUE_RESERVATION_ASSIGNED",
+        userId: USER_ID,
+        leagueId: LEAGUE_ID,
+        teamId: TEAM_A,
+        details: expect.objectContaining({
+          proposalId: PROPOSAL_ID,
+          consentTeamIds: [TEAM_A, TEAM_B],
+        }),
+      }),
+    });
+  });
+
+  it("rejects inventory owned by a team outside the exact proposal", async () => {
+    const outsideTeamId = "clteam00000000000000003";
+    mockPrisma.venueReservation = {
+      findUnique: vi.fn().mockResolvedValue({
+        id: RESERVATION_ID,
+        status: "CONFIRMED",
+        venueId: VENUE_ID,
+        surfaceId: null,
+        segmentId: null,
+        startsAt: new Date("2026-09-05T22:00:00.000Z"),
+        endsAt: new Date("2026-09-05T23:30:00.000Z"),
+        ownerLeagueId: null,
+        ownerTeamId: outsideTeamId,
+        ownerVenueOrganizationId: null,
+        ownerTeam: { leagueId: LEAGUE_ID },
+        venue: {
+          id: VENUE_ID,
+          isActive: true,
+          timezone: "America/New_York",
+          organizationId: null,
+          leagueId: null,
+          teamId: outsideTeamId,
+        },
+        events: [],
+        seasonGames: [],
+        eventGames: [],
+        signupEvents: [],
+        practiceSessions: [],
+        proposalEntries: [],
+      }),
+      update: vi.fn(),
+    };
+    mockPrisma.team.findUnique.mockResolvedValue({
+      id: outsideTeamId,
+      leagueId: LEAGUE_ID,
+    });
+
+    const result = await acceptGameProposal({
+      proposalId: PROPOSAL_ID,
+      reservationId: RESERVATION_ID,
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error: "The selected venue reservation is outside the proposal's league/team scope or does not match its slot.",
+    });
+    expect(mockPrisma.seasonGame.create).not.toHaveBeenCalled();
+    expect(mockPrisma.event.create).not.toHaveBeenCalled();
+  });
+
+  it("rejects a proposal owner that is no longer eligible for the venue", async () => {
+    mockPrisma.venueReservation = {
+      findUnique: vi.fn().mockResolvedValue({
+        id: RESERVATION_ID,
+        status: "CONFIRMED",
+        venueId: VENUE_ID,
+        surfaceId: null,
+        segmentId: null,
+        startsAt: new Date("2026-09-05T22:00:00.000Z"),
+        endsAt: new Date("2026-09-05T23:30:00.000Z"),
+        ownerLeagueId: null,
+        ownerTeamId: TEAM_A,
+        ownerVenueOrganizationId: null,
+        ownerTeam: { leagueId: LEAGUE_ID },
+        venue: {
+          id: VENUE_ID,
+          isActive: true,
+          timezone: "America/New_York",
+          organizationId: null,
+          leagueId: null,
+          teamId: null,
+        },
+        events: [],
+        seasonGames: [],
+        eventGames: [],
+        signupEvents: [],
+        practiceSessions: [],
+        proposalEntries: [],
+      }),
+      update: vi.fn(),
+    };
+    mockPrisma.team.findUnique.mockResolvedValue({
+      id: TEAM_A,
+      leagueId: LEAGUE_ID,
+    });
+    mockPrisma.venueRelationship.findFirst.mockResolvedValue(null);
+
+    const result = await acceptGameProposal({
+      proposalId: PROPOSAL_ID,
+      reservationId: RESERVATION_ID,
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error: "The selected venue reservation is outside the proposal's league/team scope or does not match its slot.",
+    });
+    expect(mockPrisma.seasonGame.create).not.toHaveBeenCalled();
+  });
+
+  it("rejects assignment unless the terms and acceptance come from the two proposal teams", async () => {
+    mockPrisma.gameProposal.findUnique.mockResolvedValue({
+      ...(await mockPrisma.gameProposal.findUnique()),
+      entries: [{
+        id: "entry-1",
+        kind: "PROPOSE",
+        startAt: new Date("2026-09-05T22:00:00.000Z"),
+        endAt: new Date("2026-09-05T23:30:00.000Z"),
+        venueId: VENUE_ID,
+        note: null,
+        actorTeamId: "clteam00000000000000003",
+        createdAt: new Date("2026-08-17T00:00:00.000Z"),
+        venueReservationId: RESERVATION_ID,
+      }],
+    });
+
+    const result = await acceptGameProposal({
+      proposalId: PROPOSAL_ID,
+      reservationId: RESERVATION_ID,
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error: "Reservation assignment requires verified consent from both proposal teams.",
+    });
+    expect(mockPrisma.$transaction).toHaveBeenCalledTimes(1);
+    expect(mockPrisma.gameProposal.updateMany).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/lib/actions/placements.test.ts
+++ b/__tests__/lib/actions/placements.test.ts
@@ -1,0 +1,161 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockRequireLeagueRole,
+  mockPrisma,
+} = vi.hoisted(() => ({
+  mockRequireLeagueRole: vi.fn(),
+  mockPrisma: {
+    season: { findUnique: vi.fn() },
+    team: { findMany: vi.fn(), findFirst: vi.fn(), update: vi.fn() },
+    division: { findFirst: vi.fn() },
+    seasonGame: { findMany: vi.fn() },
+    placementDecision: { findMany: vi.fn(), create: vi.fn() },
+    seasonTeamPlacement: { findMany: vi.fn(), upsert: vi.fn() },
+    $transaction: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/auth/session", () => ({
+  requireLeagueRole: (...args: unknown[]) => mockRequireLeagueRole(...args),
+}));
+
+vi.mock("@/lib/db/prisma", () => ({ prisma: mockPrisma }));
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+
+import { getPlacementBoard, recordPlacement } from "@/lib/actions/placements";
+
+const SEASON_ID = "clseason000000000000001";
+const TEAM_ID = "clteam000000000000000001";
+const DIVISION_ID = "cldivision00000000000001";
+const LEAGUE_ID = "clleague0000000000000001";
+const USER_ID = "cluser000000000000000001";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockRequireLeagueRole.mockResolvedValue(USER_ID);
+  mockPrisma.season.findUnique.mockResolvedValue({ id: SEASON_ID, leagueId: LEAGUE_ID });
+  mockPrisma.team.findMany.mockResolvedValue([
+    {
+      id: TEAM_ID,
+      name: "North Stars",
+      division: { id: "clcurrent000000000000001", name: "Current division", ageClassification: "U18" },
+    },
+  ]);
+  mockPrisma.team.findFirst.mockResolvedValue({ id: TEAM_ID });
+  mockPrisma.division.findFirst.mockResolvedValue({ id: DIVISION_ID });
+  mockPrisma.seasonGame.findMany.mockResolvedValue([]);
+  mockPrisma.placementDecision.findMany.mockResolvedValue([]);
+  mockPrisma.placementDecision.create.mockResolvedValue({ id: "cldecision000000000001" });
+  mockPrisma.seasonTeamPlacement.findMany.mockResolvedValue([]);
+  mockPrisma.seasonTeamPlacement.upsert.mockResolvedValue({ id: "clplacement000000000001" });
+  mockPrisma.team.update.mockResolvedValue({ id: TEAM_ID });
+  mockPrisma.$transaction.mockImplementation(async (callback: (tx: typeof mockPrisma) => unknown) =>
+    callback(mockPrisma)
+  );
+});
+
+describe("placement history", () => {
+  it("reads the season-specific placement instead of the team's current division default", async () => {
+    mockPrisma.seasonTeamPlacement.findMany.mockResolvedValue([
+      {
+        seasonId: SEASON_ID,
+        teamId: TEAM_ID,
+        divisionId: DIVISION_ID,
+        divisionName: "2026 Peewee",
+        teamNameSnapshot: "North Stars",
+        rank: 1,
+        privateNote: "Placed here for this season only",
+      },
+    ]);
+
+    const result = await getPlacementBoard({ seasonId: SEASON_ID });
+
+    expect(mockPrisma.seasonTeamPlacement.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ seasonId: SEASON_ID }),
+      }),
+    );
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data[0]).toEqual(
+        expect.objectContaining({
+          divisionId: DIVISION_ID,
+          divisionName: "2026 Peewee",
+          rank: 1,
+          privateNote: "Placed here for this season only",
+        }),
+      );
+    }
+  });
+
+  it("appends history for one season without mutating the team's global division default", async () => {
+    mockPrisma.placementDecision.findMany.mockResolvedValue([{ teamId: TEAM_ID, rank: 3, privateNote: "Old note" }]);
+
+    const result = await recordPlacement({
+      seasonId: SEASON_ID,
+      teamId: TEAM_ID,
+      divisionId: DIVISION_ID,
+      rank: 2,
+      privateNote: "New season placement",
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockPrisma.seasonTeamPlacement.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ seasonId_teamId: { seasonId: SEASON_ID, teamId: TEAM_ID } }),
+        create: expect.objectContaining({ seasonId: SEASON_ID, teamId: TEAM_ID, divisionId: DIVISION_ID }),
+        update: expect.objectContaining({ divisionId: DIVISION_ID }),
+      }),
+    );
+    expect(mockPrisma.team.update).not.toHaveBeenCalled();
+  });
+
+  it("keeps an explicit unassigned placement from falling back to the current division", async () => {
+    mockPrisma.seasonTeamPlacement.findMany.mockResolvedValue([{
+      seasonId: SEASON_ID,
+      teamId: TEAM_ID,
+      divisionId: null,
+      divisionNameSnapshot: null,
+      teamNameSnapshot: "North Stars",
+      rank: null,
+      privateNote: null,
+      division: null,
+    }]);
+
+    const result = await getPlacementBoard({ seasonId: SEASON_ID });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data[0]).toEqual(expect.objectContaining({
+        divisionId: null,
+        divisionName: null,
+        scoresGated: false,
+      }));
+    }
+  });
+
+  it("uses the season's moved division classification for score display", async () => {
+    mockPrisma.seasonTeamPlacement.findMany.mockResolvedValue([{
+      seasonId: SEASON_ID,
+      teamId: TEAM_ID,
+      divisionId: DIVISION_ID,
+      divisionNameSnapshot: "Mite",
+      teamNameSnapshot: "North Stars",
+      rank: null,
+      privateNote: null,
+      division: { name: "Mite", ageClassification: "U8" },
+    }]);
+
+    const result = await getPlacementBoard({ seasonId: SEASON_ID });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data[0]).toEqual(expect.objectContaining({
+        divisionId: DIVISION_ID,
+        divisionName: "Mite",
+        scoresGated: true,
+      }));
+    }
+  });
+});

--- a/__tests__/lib/actions/season-games.test.ts
+++ b/__tests__/lib/actions/season-games.test.ts
@@ -1,0 +1,571 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockRequireUserId,
+  mockRequireSeasonManager,
+  mockFindBookingConflicts,
+  mockAssignVenueReservation,
+  mockCreateVenueReservation,
+  mockPrisma,
+} = vi.hoisted(() => {
+  const tx = {
+    season: { findUnique: vi.fn() },
+    seasonGame: { create: vi.fn(), findUnique: vi.fn(), findMany: vi.fn(), update: vi.fn(), delete: vi.fn() },
+    seasonTeamPlacement: { findMany: vi.fn() },
+    team: { findMany: vi.fn(), findUniqueOrThrow: vi.fn(), findUnique: vi.fn() },
+    teamMember: { findMany: vi.fn() },
+    leagueUser: { findFirst: vi.fn() },
+    venue: { findUnique: vi.fn() },
+    event: { create: vi.fn(), findUnique: vi.fn(), update: vi.fn(), delete: vi.fn() },
+    venueReservation: { findUnique: vi.fn() },
+  };
+  return {
+    mockRequireUserId: vi.fn(),
+    mockRequireSeasonManager: vi.fn(),
+    mockFindBookingConflicts: vi.fn(),
+    mockAssignVenueReservation: vi.fn(),
+    mockCreateVenueReservation: vi.fn(),
+    mockPrisma: {
+      season: { ...tx.season, update: vi.fn() },
+      seasonPhase: { findUnique: vi.fn(), update: vi.fn() },
+      seasonGame: tx.seasonGame,
+      seasonTeamPlacement: tx.seasonTeamPlacement,
+      team: tx.team,
+      teamMember: tx.teamMember,
+      leagueUser: tx.leagueUser,
+      venue: tx.venue,
+      event: tx.event,
+      venueReservation: tx.venueReservation,
+      $transaction: vi.fn(
+        async (callback: (transaction: typeof tx) => unknown) => callback(tx),
+      ),
+    },
+  };
+});
+
+vi.mock("@/lib/auth/session", () => ({
+  requireUserId: (...args: unknown[]) => mockRequireUserId(...args),
+}));
+
+vi.mock("@/lib/actions/seasons", () => ({
+  requireSeasonManager: (...args: unknown[]) => mockRequireSeasonManager(...args),
+}));
+
+vi.mock("@/lib/db/prisma", () => ({ prisma: mockPrisma }));
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("@/lib/utils/availability", () => ({
+  findBookingConflicts: (...args: unknown[]) => mockFindBookingConflicts(...args),
+}));
+vi.mock("@/lib/services/venue-reservations", () => ({
+  assignVenueReservation: (...args: unknown[]) => mockAssignVenueReservation(...args),
+  createVenueReservation: (...args: unknown[]) => mockCreateVenueReservation(...args),
+  transitionVenueReservation: vi.fn(),
+  VenueReservationConflictError: class extends Error {
+    conflicts: unknown[];
+    constructor(conflicts: unknown[]) {
+      super("conflict");
+      this.conflicts = conflicts;
+    }
+  },
+  VenueReservationLifecycleError: class extends Error {},
+}));
+vi.mock("@/lib/email/templates", () => ({
+  sendEventNotifications: vi.fn(() => Promise.resolve()),
+}));
+
+import {
+  createSeasonGame,
+  deleteDraftGame,
+  publishSeasonGames,
+  recordSeasonGameScore,
+  updateSeasonGame,
+} from "@/lib/actions/season-games";
+
+const SEASON_ID = "clseason000000000000001";
+const LEAGUE_ID = "clleague0000000000000001";
+const TEAM_A = "clteam00000000000000001";
+const TEAM_B = "clteam00000000000000002";
+const USER_ID = "cluser000000000000000001";
+const VENUE_ID = "clvenue00000000000000001";
+const RESERVATION_ID = "clreservation0000000001";
+const GAME_ID = "clgame000000000000000001";
+const EVENT_ID = "clevent0000000000000001";
+
+const baseGame = {
+  seasonId: SEASON_ID,
+  homeTeamId: TEAM_A,
+  awayTeamId: TEAM_B,
+  startAt: "2026-09-05T22:00:00.000Z",
+  endAt: "2026-09-05T23:30:00.000Z",
+  venueId: VENUE_ID,
+  publish: true,
+  overrideConflicts: false,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockRequireUserId.mockResolvedValue(USER_ID);
+  mockRequireSeasonManager.mockResolvedValue({
+    season: { id: SEASON_ID, leagueId: LEAGUE_ID, teamId: null },
+    userId: USER_ID,
+  });
+  mockFindBookingConflicts.mockResolvedValue([]);
+  mockAssignVenueReservation.mockResolvedValue({ conflictsOverridden: false });
+  mockCreateVenueReservation.mockResolvedValue({ id: RESERVATION_ID });
+  mockPrisma.seasonGame.findUnique.mockResolvedValue(undefined);
+  if (!mockPrisma.venueReservation.findUnique) {
+    mockPrisma.venueReservation.findUnique = vi.fn();
+  }
+  mockPrisma.venueReservation.findUnique.mockResolvedValue(undefined);
+  mockPrisma.season.findUnique.mockResolvedValue({ id: SEASON_ID, leagueId: LEAGUE_ID, teamId: null });
+  mockPrisma.team.findMany.mockResolvedValue([{ id: TEAM_A }, { id: TEAM_B }]);
+  mockPrisma.leagueUser.findFirst.mockResolvedValue({ id: "cleagueuser000000000001" });
+  mockPrisma.venue.findUnique.mockResolvedValue({ timezone: "America/New_York" });
+  mockPrisma.team.findUniqueOrThrow.mockImplementation(async ({ where }: { where: { id: string } }) => ({
+    name: where.id === TEAM_A ? "Arrows" : "Blizzards",
+  }));
+  mockPrisma.teamMember.findMany.mockResolvedValue([
+    { userId: "p1" },
+    { userId: "p1" },
+    { userId: "p2" },
+  ]);
+  mockPrisma.seasonGame.create.mockResolvedValue({
+    id: GAME_ID,
+    seasonId: SEASON_ID,
+    status: "DRAFT",
+    startAt: new Date(baseGame.startAt),
+    endAt: new Date(baseGame.endAt),
+    timezone: "America/New_York",
+    venueId: VENUE_ID,
+    locationText: null,
+    homeTeamId: TEAM_A,
+    awayTeamId: TEAM_B,
+  });
+  mockPrisma.event.create.mockResolvedValue({ id: EVENT_ID });
+  mockPrisma.seasonGame.findMany.mockResolvedValue([]);
+  mockPrisma.seasonGame.update.mockResolvedValue({ id: GAME_ID });
+  mockPrisma.seasonTeamPlacement.findMany.mockResolvedValue([]);
+});
+
+describe("season game conflict override audit", () => {
+  const existingUpdateGame = {
+    id: GAME_ID,
+    seasonId: SEASON_ID,
+    status: "SCHEDULED",
+    startAt: new Date(baseGame.startAt),
+    endAt: new Date(baseGame.endAt),
+    timezone: "America/New_York",
+    venueId: VENUE_ID,
+    surfaceId: null,
+    segmentId: null,
+    locationText: null,
+    notes: null,
+    homeTeamId: TEAM_A,
+    awayTeamId: TEAM_B,
+    eventId: null,
+    venueReservationId: RESERVATION_ID,
+  };
+
+  beforeEach(() => {
+    mockPrisma.seasonGame.findUnique
+      .mockResolvedValueOnce({
+        ...existingUpdateGame,
+        season: { id: SEASON_ID, leagueId: LEAGUE_ID, teamId: null },
+      })
+      .mockResolvedValue(existingUpdateGame);
+    mockPrisma.venueReservation.findUnique.mockResolvedValue({
+      id: RESERVATION_ID,
+      status: "CONFIRMED",
+      venueId: VENUE_ID,
+      surfaceId: null,
+      segmentId: null,
+      startsAt: existingUpdateGame.startAt,
+      endsAt: existingUpdateGame.endAt,
+      ownerLeagueId: LEAGUE_ID,
+      ownerTeamId: null,
+      ownerVenueOrganizationId: null,
+    });
+  });
+
+  it("does not record a false override when the canonical check finds no conflict", async () => {
+    const result = await updateSeasonGame({
+      gameId: GAME_ID,
+      overrideConflicts: true,
+      overrideReason: "Submitted for review",
+    });
+
+    expect(result).toEqual({ success: true, data: { id: GAME_ID, conflictsOverridden: false } });
+    expect(mockPrisma.seasonGame.update).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.not.objectContaining({
+        conflictOverriddenById: expect.anything(),
+        conflictOverriddenAt: expect.anything(),
+      }),
+    }));
+  });
+
+  it("records an override only when the in-transaction assignment reports a conflict", async () => {
+    mockAssignVenueReservation.mockResolvedValueOnce({ conflictsOverridden: true });
+
+    const result = await updateSeasonGame({
+      gameId: GAME_ID,
+      overrideConflicts: true,
+      overrideReason: "Venue manager approved the overlap",
+    });
+
+    expect(result).toEqual({ success: true, data: { id: GAME_ID, conflictsOverridden: true } });
+    expect(mockPrisma.seasonGame.update).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        conflictOverriddenById: USER_ID,
+        conflictOverriddenAt: expect.any(Date),
+      }),
+    }));
+  });
+
+  it("rejects a concurrent cancellation reloaded inside the serializable callback", async () => {
+    mockPrisma.seasonGame.findUnique
+      .mockReset()
+      .mockResolvedValueOnce({
+        ...existingUpdateGame,
+        season: { id: SEASON_ID, leagueId: LEAGUE_ID, teamId: null },
+      })
+      .mockResolvedValueOnce({ ...existingUpdateGame, status: "CANCELED" });
+
+    const result = await updateSeasonGame({
+      gameId: GAME_ID,
+      notes: "This write must lose to cancellation",
+      overrideConflicts: false,
+    });
+
+    expect(result).toEqual(expect.objectContaining({
+      success: false,
+      error: "Canceled games cannot be edited",
+    }));
+    expect(mockPrisma.seasonGame.update).not.toHaveBeenCalled();
+  });
+
+  it("derives omitted slot values from the transaction reload, not a stale snapshot", async () => {
+    const transactionStart = new Date("2026-09-12T20:00:00.000Z");
+    const transactionEnd = new Date("2026-09-12T21:30:00.000Z");
+    mockPrisma.seasonGame.findUnique
+      .mockReset()
+      .mockResolvedValueOnce({
+        ...existingUpdateGame,
+        venueId: null,
+        venueReservationId: null,
+        season: { id: SEASON_ID, leagueId: LEAGUE_ID, teamId: null },
+      })
+      .mockResolvedValueOnce({
+        ...existingUpdateGame,
+        startAt: transactionStart,
+        endAt: transactionEnd,
+        venueId: null,
+        venueReservationId: null,
+      });
+
+    const result = await updateSeasonGame({
+      gameId: GAME_ID,
+      notes: "Keep the concurrent slot",
+      overrideConflicts: false,
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockPrisma.seasonGame.update).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        startAt: transactionStart,
+        endAt: transactionEnd,
+        venueId: null,
+        notes: "Keep the concurrent slot",
+      }),
+    }));
+  });
+
+  describe("season placement score eligibility", () => {
+    const scoredGame = {
+      id: GAME_ID,
+      seasonId: SEASON_ID,
+      status: "SCHEDULED",
+      homeTeamId: TEAM_A,
+      awayTeamId: TEAM_B,
+      homeTeam: { division: { ageClassification: "U8" } },
+      awayTeam: { division: { ageClassification: "U18" } },
+    };
+
+    beforeEach(() => {
+      mockPrisma.seasonGame.findUnique.mockReset().mockResolvedValue(scoredGame);
+    });
+
+    it("treats an explicit null season placement as unclassified instead of falling back", async () => {
+      mockPrisma.seasonTeamPlacement.findMany.mockResolvedValue([
+        { teamId: TEAM_A, division: null },
+        { teamId: TEAM_B, division: null },
+      ]);
+
+      const result = await recordSeasonGameScore({
+        gameId: GAME_ID,
+        homeScore: 2,
+        awayScore: 1,
+      });
+
+      expect(result.success).toBe(true);
+      expect(mockPrisma.seasonGame.update).toHaveBeenCalledWith(expect.objectContaining({
+        data: expect.objectContaining({ homeScore: 2, awayScore: 1, status: "COMPLETED" }),
+      }));
+    });
+
+    it("uses a moved season division instead of the team's current division", async () => {
+      mockPrisma.seasonGame.findUnique.mockResolvedValue({
+        ...scoredGame,
+        homeTeam: { division: { ageClassification: "U18" } },
+      });
+      mockPrisma.seasonTeamPlacement.findMany.mockResolvedValue([
+        { teamId: TEAM_A, division: { ageClassification: "U8" } },
+      ]);
+
+      const result = await recordSeasonGameScore({
+        gameId: GAME_ID,
+        homeScore: 2,
+        awayScore: 1,
+      });
+
+      expect(result).toEqual(expect.objectContaining({
+        success: false,
+        error: expect.stringContaining("Scores are not recorded"),
+      }));
+      expect(mockPrisma.seasonGame.update).not.toHaveBeenCalled();
+    });
+  });
+
+  it("does not record a false override while creating when the conflict cleared", async () => {
+    mockPrisma.seasonGame.findUnique.mockReset().mockResolvedValue(undefined);
+    mockPrisma.venueReservation.findUnique.mockResolvedValue({
+      id: RESERVATION_ID,
+      status: "CONFIRMED",
+      venueId: VENUE_ID,
+      surfaceId: null,
+      segmentId: null,
+      startsAt: new Date(baseGame.startAt),
+      endsAt: new Date(baseGame.endAt),
+      ownerLeagueId: LEAGUE_ID,
+      ownerTeamId: null,
+      ownerVenueOrganizationId: null,
+    });
+    mockAssignVenueReservation.mockResolvedValue({ conflictsOverridden: false });
+
+    const result = await createSeasonGame({
+      ...baseGame,
+      publish: false,
+      reservationId: RESERVATION_ID,
+      overrideConflicts: true,
+      overrideReason: "Conflict shown during preview",
+    });
+
+    expect(result).toEqual({
+      success: true,
+      data: { id: GAME_ID, conflictsOverridden: false },
+    });
+    expect(mockPrisma.seasonGame.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.not.objectContaining({
+          conflictOverriddenById: expect.anything(),
+          conflictOverriddenAt: expect.anything(),
+        }),
+      }),
+    );
+    expect(mockPrisma.seasonGame.update).not.toHaveBeenCalled();
+  });
+});
+
+describe("shared SeasonGame/Event reservation", () => {
+  it("threads one reservation through the SeasonGame and participant Event, while fan-out keeps RSVP rows unique", async () => {
+    // This test covers the legacy transaction double, which intentionally
+    // lacks the canonical reservation model.
+    mockPrisma.venueReservation.findUnique = undefined as never;
+    const result = await createSeasonGame({
+      ...baseGame,
+      reservationId: RESERVATION_ID,
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockPrisma.seasonGame.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          venueReservationId: RESERVATION_ID,
+        }),
+      }),
+    );
+    expect(mockPrisma.event.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          venueReservationId: RESERVATION_ID,
+          rsvps: {
+            create: [
+              { userId: "p1", status: "NO_RESPONSE" },
+              { userId: "p2", status: "NO_RESPONSE" },
+            ],
+          },
+        }),
+      }),
+    );
+  });
+});
+
+describe("bulk publication", () => {
+  it("rechecks every draft at publish time and reports per-item outcomes", async () => {
+    mockPrisma.seasonGame.findMany.mockResolvedValue([
+      {
+        id: GAME_ID,
+        seasonId: SEASON_ID,
+        status: "DRAFT",
+        startAt: new Date(baseGame.startAt),
+        endAt: new Date(baseGame.endAt),
+        timezone: "America/New_York",
+        venueId: VENUE_ID,
+        locationText: null,
+        homeTeamId: TEAM_A,
+        awayTeamId: TEAM_B,
+        venueReservationId: RESERVATION_ID,
+      },
+      {
+        id: "clgame0000000000000002",
+        seasonId: SEASON_ID,
+        status: "DRAFT",
+        startAt: new Date("2026-09-06T22:00:00.000Z"),
+        endAt: new Date("2026-09-06T23:30:00.000Z"),
+        timezone: "America/New_York",
+        venueId: VENUE_ID,
+        locationText: null,
+        homeTeamId: TEAM_B,
+        awayTeamId: TEAM_A,
+        venueReservationId: "clreservation0000000002",
+      },
+    ]);
+
+    const result = await publishSeasonGames({ seasonId: SEASON_ID });
+
+    expect(result).toMatchObject({
+      success: true,
+      data: { published: 1, failed: 1 },
+      details: {
+        outcomes: [
+          { gameId: GAME_ID, status: "published" },
+          { gameId: "clgame0000000000000002", status: "conflict" },
+        ],
+      },
+    });
+    expect(mockPrisma.event.create).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns one ordered outcome for every explicitly requested game id", async () => {
+    const missingId = "clgame0000000000000002";
+    const wrongSeasonId = "clgame0000000000000003";
+    const publishedId = "clgame0000000000000004";
+    const canceledId = "clgame0000000000000005";
+    const draftId = "clgame0000000000000006";
+    const venueLess = (id: string, seasonId: string, status: string) => ({
+      id,
+      seasonId,
+      status,
+      startAt: new Date(baseGame.startAt),
+      endAt: new Date(baseGame.endAt),
+      timezone: "America/New_York",
+      venueId: null,
+      surfaceId: null,
+      segmentId: null,
+      locationText: "Community room",
+      homeTeamId: TEAM_A,
+      awayTeamId: TEAM_B,
+      venueReservationId: null,
+    });
+    mockPrisma.seasonGame.findMany.mockResolvedValue([
+      venueLess(wrongSeasonId, "clseason000000000000099", "DRAFT"),
+      venueLess(publishedId, SEASON_ID, "SCHEDULED"),
+      venueLess(canceledId, SEASON_ID, "CANCELED"),
+      venueLess(draftId, SEASON_ID, "DRAFT"),
+    ]);
+
+    const result = await publishSeasonGames({
+      seasonId: SEASON_ID,
+      gameIds: [missingId, wrongSeasonId, publishedId, canceledId, draftId],
+    });
+
+    expect(result).toMatchObject({
+      success: true,
+      data: { published: 1, failed: 4 },
+      details: {
+        outcomes: [
+          { gameId: missingId, status: "missing" },
+          { gameId: wrongSeasonId, status: "wrong-season" },
+          { gameId: publishedId, status: "already-published" },
+          { gameId: canceledId, status: "no-longer-draft" },
+          { gameId: draftId, status: "published" },
+        ],
+      },
+    });
+  });
+
+  it("reports a game moved after selection instead of silently omitting it", async () => {
+      const draft = {
+        id: GAME_ID,
+        seasonId: SEASON_ID,
+        status: "DRAFT",
+        startAt: new Date(baseGame.startAt),
+        endAt: new Date(baseGame.endAt),
+        timezone: "America/New_York",
+        venueId: null,
+        surfaceId: null,
+        segmentId: null,
+        locationText: null,
+        homeTeamId: TEAM_A,
+        awayTeamId: TEAM_B,
+        venueReservationId: null,
+      };
+      mockPrisma.seasonGame.findMany.mockResolvedValue([draft]);
+      mockPrisma.seasonGame.findUnique.mockResolvedValue({
+        ...draft,
+        seasonId: "clseason000000000000099",
+        eventId: null,
+      });
+
+      const result = await publishSeasonGames({
+        seasonId: SEASON_ID,
+        gameIds: [GAME_ID],
+      });
+
+      expect(result).toMatchObject({
+        success: true,
+        data: { published: 0, failed: 1 },
+        details: {
+          outcomes: [{ gameId: GAME_ID, status: "wrong-season" }],
+        },
+    });
+  });
+});
+
+describe("draft reservation lifecycle", () => {
+  it("detaches confirmed inventory without releasing it when deleting a draft", async () => {
+    mockPrisma.season.findUnique.mockResolvedValue({
+      leagueId: LEAGUE_ID,
+      teamId: null,
+    });
+    mockPrisma.seasonGame.findUnique.mockResolvedValue({
+      id: GAME_ID,
+      seasonId: SEASON_ID,
+      status: "DRAFT",
+      homeTeamId: TEAM_A,
+      awayTeamId: TEAM_B,
+      eventId: null,
+      venueReservationId: RESERVATION_ID,
+    });
+
+    const result = await deleteDraftGame({ gameId: GAME_ID });
+
+    expect(result).toEqual({ success: true, data: { id: GAME_ID } });
+    expect(mockPrisma.seasonGame.update).toHaveBeenCalledWith({
+      where: { id: GAME_ID },
+      data: { venueReservationId: null },
+    });
+    expect(mockPrisma.seasonGame.delete).toHaveBeenCalledWith({
+      where: { id: GAME_ID },
+    });
+  });
+});

--- a/__tests__/lib/actions/season-generation.test.ts
+++ b/__tests__/lib/actions/season-generation.test.ts
@@ -1,0 +1,319 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockRequireSeasonManager,
+  mockFindBookingConflicts,
+  mockPrisma,
+} = vi.hoisted(() => ({
+  mockRequireSeasonManager: vi.fn(),
+  mockFindBookingConflicts: vi.fn(),
+  mockPrisma: {
+    season: { findUnique: vi.fn(), update: vi.fn() },
+    seasonPhase: { findUnique: vi.fn(), update: vi.fn() },
+    team: { count: vi.fn(), findMany: vi.fn() },
+    teamMember: { count: vi.fn() },
+    venue: { findUnique: vi.fn() },
+    venueReservation: { findMany: vi.fn() },
+    seasonGame: { create: vi.fn() },
+    $transaction: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/actions/seasons", () => ({
+  requireSeasonManager: (...args: unknown[]) => mockRequireSeasonManager(...args),
+}));
+
+vi.mock("@/lib/db/prisma", () => ({ prisma: mockPrisma }));
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("@/lib/utils/availability", () => ({
+  findBookingConflicts: (...args: unknown[]) => mockFindBookingConflicts(...args),
+}));
+
+import { generateRoundRobin, previewRoundRobin } from "@/lib/actions/season-generation";
+
+const SEASON_ID = "clseason000000000000001";
+const LEAGUE_ID = "clleague0000000000000001";
+const VENUE_ID = "clvenue00000000000000001";
+const TEAM_A = "clteam00000000000000001";
+const TEAM_B = "clteam00000000000000002";
+const TEAM_C = "clteam00000000000000003";
+const RESERVATION_ID = "clreservation0000000001";
+const USER_ID = "cluser000000000000000001";
+
+const baseInput = {
+  seasonId: SEASON_ID,
+  teamIds: [TEAM_A, TEAM_B],
+  startDate: "2026-09-01",
+  endDate: "2026-09-30",
+  eligibleDays: [6],
+  startTime: "18:00",
+  defaultVenueId: VENUE_ID,
+  rounds: 1,
+  gameDurationMinutes: 90,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockRequireSeasonManager.mockResolvedValue({
+    season: { id: SEASON_ID, leagueId: LEAGUE_ID, teamId: null },
+    userId: USER_ID,
+  });
+  mockPrisma.team.count.mockResolvedValue(2);
+  mockPrisma.team.findMany.mockResolvedValue([
+    { id: TEAM_A, name: "Arrows" },
+    { id: TEAM_B, name: "Blizzards" },
+  ]);
+  mockPrisma.venue.findUnique.mockResolvedValue({ timezone: "America/New_York" });
+  mockPrisma.venueReservation.findMany.mockResolvedValue([
+    {
+      id: RESERVATION_ID,
+      venueId: VENUE_ID,
+      startsAt: new Date("2026-09-05T22:00:00.000Z"),
+      endsAt: new Date("2026-09-05T23:30:00.000Z"),
+      status: "CONFIRMED",
+      ownerLeagueId: LEAGUE_ID,
+      ownerTeamId: null,
+      ownerVenueOrganizationId: null,
+      assignedById: null,
+    },
+  ]);
+  mockPrisma.seasonGame.create.mockResolvedValue({ id: "clgame0000000000000001" });
+  mockPrisma.season.update.mockResolvedValue({ id: SEASON_ID });
+  mockPrisma.seasonPhase.update.mockResolvedValue({ id: "clphase000000000000001" });
+  mockPrisma.$transaction.mockImplementation(async (callback: (tx: typeof mockPrisma) => unknown) =>
+    callback(mockPrisma)
+  );
+});
+
+describe("reservation-driven generation", () => {
+  it("uses confirmed unassigned reservation inventory as the source of drafted games", async () => {
+    mockFindBookingConflicts.mockResolvedValue([]);
+
+    const result = await generateRoundRobin(baseInput);
+
+    expect(mockPrisma.venueReservation.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          venueId: VENUE_ID,
+          status: "CONFIRMED",
+        }),
+      }),
+    );
+    expect(mockPrisma.seasonGame.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          venueReservationId: RESERVATION_ID,
+        }),
+      }),
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("excludes only the selected reservation when previewing conflicts", async () => {
+    mockFindBookingConflicts.mockResolvedValue([{
+      source: "venueReservation",
+      title: "Different reservation at the same time",
+      startAt: new Date("2026-09-05T22:00:00.000Z"),
+      endAt: new Date("2026-09-05T23:30:00.000Z"),
+      surfaceId: null,
+      segmentId: null,
+      segmentName: null,
+    }]);
+
+    const result = await previewRoundRobin(baseInput);
+
+    expect(mockFindBookingConflicts).toHaveBeenCalledWith(expect.objectContaining({
+      excludeReservationIds: [RESERVATION_ID],
+    }));
+    expect(result).toMatchObject({
+      success: true,
+      data: {
+        games: [
+          expect.objectContaining({
+            venueReservationId: RESERVATION_ID,
+            conflicts: [expect.objectContaining({
+              title: "Different reservation at the same time",
+            })],
+          }),
+        ],
+      },
+    });
+  });
+
+  it("previews and persists only reservation-slotted games", async () => {
+    mockFindBookingConflicts.mockResolvedValue([]);
+    mockPrisma.team.count.mockResolvedValue(3);
+    mockPrisma.team.findMany.mockResolvedValue([
+      { id: TEAM_A, name: "Arrows" },
+      { id: TEAM_B, name: "Blizzards" },
+      { id: TEAM_C, name: "Comets" },
+    ]);
+
+    const input = {
+      ...baseInput,
+      teamIds: [TEAM_A, TEAM_B, TEAM_C],
+    };
+    const result = await previewRoundRobin(input);
+
+    expect(result).toMatchObject({
+      success: true,
+      data: {
+        totalPairings: 3,
+        games: [
+          expect.objectContaining({
+            venueReservationId: RESERVATION_ID,
+          }),
+        ],
+        unslottedCount: 2,
+        unslottedPairings: [
+          expect.objectContaining({ reason: "NO_RESERVATION" }),
+          expect.objectContaining({ reason: "NO_RESERVATION" }),
+        ],
+      },
+    });
+    if (result.success) {
+      expect(result.data.games).toHaveLength(1);
+    }
+
+    mockPrisma.seasonGame.create.mockClear();
+    const generated = await generateRoundRobin(input);
+
+    expect(generated).toMatchObject({
+      success: true,
+      data: {
+        createdIds: ["clgame0000000000000001"],
+        unslottedCount: 2,
+      },
+    });
+    expect(mockPrisma.seasonGame.create).toHaveBeenCalledTimes(1);
+  });
+
+  it("allocates pairings to confirmed inventory even when legacy generated wall time differs", async () => {
+    mockFindBookingConflicts.mockResolvedValue([]);
+    mockPrisma.venueReservation.findMany.mockResolvedValue([{
+      id: RESERVATION_ID,
+      venueId: VENUE_ID,
+      startsAt: new Date("2026-09-12T20:15:00.000Z"),
+      endsAt: new Date("2026-09-12T21:45:00.000Z"),
+      status: "CONFIRMED",
+      usageStatus: "PENDING",
+      ownerLeagueId: LEAGUE_ID,
+      ownerTeamId: null,
+      ownerVenueOrganizationId: null,
+    }]);
+
+    const result = await generateRoundRobin(baseInput);
+
+    expect(result.success).toBe(true);
+    expect(mockPrisma.seasonGame.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          startAt: new Date("2026-09-12T20:15:00.000Z"),
+          endAt: new Date("2026-09-12T21:45:00.000Z"),
+          venueReservationId: RESERVATION_ID,
+        }),
+      }),
+    );
+  });
+
+  it("preserves explicitly venue-less generation without inventing reservations", async () => {
+    mockFindBookingConflicts.mockResolvedValue([]);
+
+    const result = await generateRoundRobin({
+      ...baseInput,
+      defaultVenueId: undefined,
+    });
+
+    expect(result).toMatchObject({
+      success: true,
+      data: { createdIds: ["clgame0000000000000001"], unslottedCount: 0 },
+    });
+    expect(mockPrisma.venueReservation.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.not.objectContaining({ venueId: VENUE_ID }),
+      }),
+    );
+    expect(mockPrisma.seasonGame.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          venueId: null,
+          venueReservationId: null,
+        }),
+      }),
+    );
+  });
+
+  it("does not assign team-owned inventory to a game that omits its owner", async () => {
+    mockFindBookingConflicts.mockResolvedValue([]);
+    mockPrisma.team.count.mockResolvedValue(3);
+    mockPrisma.team.findMany.mockResolvedValue([
+      { id: TEAM_A, name: "Arrows" },
+      { id: TEAM_B, name: "Blizzards" },
+      { id: TEAM_C, name: "Comets" },
+    ]);
+    mockPrisma.venueReservation.findMany.mockResolvedValue([
+      {
+        id: RESERVATION_ID,
+        venueId: VENUE_ID,
+        startsAt: new Date("2026-09-19T22:00:00.000Z"),
+        endsAt: new Date("2026-09-19T23:30:00.000Z"),
+        status: "CONFIRMED",
+        usageStatus: "PENDING",
+        ownerLeagueId: null,
+        ownerTeamId: TEAM_C,
+        ownerVenueOrganizationId: null,
+      },
+    ]);
+
+    const result = await generateRoundRobin({
+      ...baseInput,
+      teamIds: [TEAM_A, TEAM_B, TEAM_C],
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockPrisma.seasonGame.create).toHaveBeenCalledTimes(1);
+    expect(mockPrisma.seasonGame.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          venueReservationId: RESERVATION_ID,
+        }),
+      }),
+    );
+    expect(result).toMatchObject({
+      success: true,
+      data: {
+        createdIds: ["clgame0000000000000001"],
+        unslottedCount: 2,
+        unslottedPairings: expect.arrayContaining([
+          expect.objectContaining({ reason: "NO_RESERVATION" }),
+        ]),
+      },
+    });
+  });
+});
+
+describe("publication-time recheck", () => {
+  it("rechecks every generated game before materializing the draft set", async () => {
+    mockFindBookingConflicts
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        {
+          source: "seasonGame",
+          title: "Arrows vs Blizzards",
+          startAt: new Date("2026-09-05T22:00:00.000Z"),
+          endAt: new Date("2026-09-05T23:30:00.000Z"),
+          surfaceId: null,
+          segmentId: null,
+          segmentName: null,
+        },
+      ]);
+
+    const preview = await previewRoundRobin(baseInput);
+    const result = await generateRoundRobin(baseInput);
+
+    expect(preview.success).toBe(true);
+    expect(mockFindBookingConflicts).toHaveBeenCalled();
+    expect(mockPrisma.seasonGame.create).not.toHaveBeenCalled();
+    expect(result.success).toBe(false);
+  });
+});

--- a/__tests__/lib/actions/seasons.test.ts
+++ b/__tests__/lib/actions/seasons.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockPrisma, mockAuth } = vi.hoisted(() => ({
+  mockPrisma: {
+    season: { findUnique: vi.fn(), create: vi.fn(), update: vi.fn() },
+  },
+  mockAuth: {
+    getUserLeagueRole: vi.fn(),
+    isTeamAdmin: vi.fn(),
+    requireLeagueRole: vi.fn(),
+    requireTeamAdmin: vi.fn(),
+    requireTeamMember: vi.fn(),
+    requireUserId: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/db/prisma", () => ({ prisma: mockPrisma }));
+vi.mock("@/lib/auth/session", () => mockAuth);
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+
+import {
+  createSeason,
+  getSeasonDetail,
+  updateSeason,
+} from "@/lib/actions/seasons";
+
+const season = {
+  id: "season-1",
+  leagueId: "league-1",
+  teamId: null,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockAuth.requireLeagueRole.mockResolvedValue("user-1");
+  mockAuth.getUserLeagueRole.mockResolvedValue("MEMBER");
+  mockAuth.isTeamAdmin.mockResolvedValue(false);
+  mockPrisma.season.findUnique
+    .mockResolvedValueOnce(season)
+    .mockResolvedValueOnce({ id: season.id, teamPlacements: [] });
+});
+
+describe("getSeasonDetail", () => {
+  it("does not select private placement notes for ordinary league members", async () => {
+    await getSeasonDetail(season.id);
+
+    const detailQuery = mockPrisma.season.findUnique.mock.calls[1][0];
+    expect(detailQuery.include.teamPlacements.select).not.toHaveProperty("privateNote");
+  });
+});
+
+describe("season schedule visibility mutations", () => {
+  it("persists an authorized visibility choice on create", async () => {
+    mockPrisma.season.create.mockResolvedValue({ id: "clseason000000000000001", name: "Fall" });
+
+    const result = await createSeason({
+      name: "Fall",
+      startDate: new Date("2026-09-01T00:00:00.000Z"),
+      endDate: new Date("2026-12-01T00:00:00.000Z"),
+      leagueId: "clleague0000000000000001",
+      scheduleVisibility: "AUTHENTICATED",
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockAuth.requireLeagueRole).toHaveBeenCalledWith(
+      "clleague0000000000000001",
+      "LEAGUE_ADMIN",
+    );
+    expect(mockPrisma.season.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({ scheduleVisibility: "AUTHENTICATED" }),
+    }));
+  });
+
+  it("persists an authorized visibility update", async () => {
+    mockPrisma.season.findUnique.mockReset().mockResolvedValue({
+      id: "clseason000000000000001",
+      name: "Fall",
+      startDate: new Date("2026-09-01T00:00:00.000Z"),
+      endDate: new Date("2026-12-01T00:00:00.000Z"),
+      leagueId: "clleague0000000000000001",
+      teamId: null,
+      league: { sport: "HOCKEY" },
+      team: null,
+    });
+    mockPrisma.season.update.mockResolvedValue({ id: "clseason000000000000001" });
+
+    const result = await updateSeason({
+      seasonId: "clseason000000000000001",
+      scheduleVisibility: "PUBLIC",
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockPrisma.season.update).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({ scheduleVisibility: "PUBLIC" }),
+    }));
+  });
+
+  it("rejects an unknown visibility value", async () => {
+    const result = await createSeason({
+      name: "Fall",
+      startDate: new Date("2026-09-01T00:00:00.000Z"),
+      endDate: new Date("2026-12-01T00:00:00.000Z"),
+      leagueId: "clleague0000000000000001",
+      scheduleVisibility: "EVERYONE" as "PUBLIC",
+    });
+
+    expect(result.success).toBe(false);
+    expect(mockPrisma.season.create).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/lib/actions/signup-events.test.ts
+++ b/__tests__/lib/actions/signup-events.test.ts
@@ -11,6 +11,9 @@ const {
   mockIsStripeEnabled,
   mockUpdatedEmail,
   mockCanceledEmail,
+  mockCreateVenueReservation,
+  mockAssignVenueReservation,
+  mockTransitionVenueReservation,
   mockPrisma,
 } = vi.hoisted(() => ({
   mockRequireUserId: vi.fn(),
@@ -21,12 +24,24 @@ const {
   mockIsStripeEnabled: vi.fn(),
   mockUpdatedEmail: vi.fn(),
   mockCanceledEmail: vi.fn(),
+  mockCreateVenueReservation: vi.fn(),
+  mockAssignVenueReservation: vi.fn(),
+  mockTransitionVenueReservation: vi.fn(),
   mockPrisma: {
     $transaction: vi.fn(),
-    signupEvent: { create: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), findMany: vi.fn() },
+    signupEvent: {
+      create: vi.fn(),
+      findUnique: vi.fn(),
+      findFirst: vi.fn(),
+      update: vi.fn(),
+      updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+      findMany: vi.fn(),
+    },
     signupSlot: { update: vi.fn(), create: vi.fn(), deleteMany: vi.fn() },
     eventRegistrationPhase: { deleteMany: vi.fn(), create: vi.fn() },
     eventRegistration: { findMany: vi.fn(), count: vi.fn() },
+    eventGame: { findMany: vi.fn().mockResolvedValue([]), update: vi.fn() },
+    auditLog: { create: vi.fn() },
     eventManager: { findUnique: vi.fn(), findMany: vi.fn() },
     league: { findUnique: vi.fn(), update: vi.fn() },
     venue: { findUnique: vi.fn(), findMany: vi.fn() },
@@ -35,6 +50,7 @@ const {
     teamMember: { findMany: vi.fn() },
     user: { findUnique: vi.fn() },
     eventInvitation: { findFirst: vi.fn() },
+    venueReservation: undefined as unknown as Record<string, ReturnType<typeof vi.fn>>,
   },
 }));
 
@@ -58,8 +74,26 @@ vi.mock("@/lib/email/templates", () => ({
 }));
 
 vi.mock("@/lib/actions/venue-organizations", () => ({}));
+vi.mock("@/lib/services/venue-reservations", () => ({
+  assignVenueReservation: (...args: unknown[]) => mockAssignVenueReservation(...args),
+  createVenueReservation: (...args: unknown[]) => mockCreateVenueReservation(...args),
+  transitionVenueReservation: (...args: unknown[]) => mockTransitionVenueReservation(...args),
+  VenueReservationConflictError: class extends Error {
+    conflicts: unknown[];
+    constructor(conflicts: unknown[]) {
+      super("conflict");
+      this.conflicts = conflicts;
+    }
+  },
+  VenueReservationLifecycleError: class extends Error {},
+}));
 
-import { createSignupEvent, publishSignupEvent, cancelSignupEvent } from "@/lib/actions/signup-events";
+import {
+  createSignupEvent,
+  publishSignupEvent,
+  cancelSignupEvent,
+  updateSignupEvent,
+} from "@/lib/actions/signup-events";
 
 const futureDate = (hours: number) => new Date(Date.now() + hours * 60 * 60 * 1000);
 
@@ -261,11 +295,74 @@ describe("publishSignupEvent", () => {
       where: { id: "league-1" },
       data: { slug: "great-falls-hockey-association" },
     });
-    expect(mockPrisma.signupEvent.update).toHaveBeenCalledWith(
+    expect(mockPrisma.signupEvent.updateMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: { id: eventId },
+        where: expect.objectContaining({ id: eventId, status: "DRAFT" }),
         data: expect.objectContaining({ status: "PUBLISHED" }),
       })
+    );
+  });
+
+  it("atomically materializes child reservations without a conflicting parent claim", async () => {
+    const draft = {
+      id: eventId,
+      status: "DRAFT",
+      visibility: "PUBLIC",
+      linkToken: null,
+      acceptsOnlinePayment: false,
+      acceptsManualPayment: true,
+      hostTeamId: null,
+      venueId: "clvenue0000000000000001",
+      startAt: futureDate(24 * 7),
+      endAt: futureDate(24 * 7 + 2),
+      timezone: "America/New_York",
+      venueReservationId: null,
+      venue: { slug: "test-rink" },
+      hostOrganization: { id: "org-1", stripeAccountId: null, stripeChargesEnabled: false },
+      hostLeague: null,
+      slots: [{ id: "slot-1", priceAmount: null }],
+    };
+    mockRequireUserId.mockResolvedValue("user-1");
+    mockPrisma.signupEvent.findUnique.mockResolvedValue(draft);
+    mockPrisma.venueReservation = {};
+    mockPrisma.eventGame.findMany.mockResolvedValueOnce([
+      {
+        id: "game-1",
+        startAt: draft.startAt,
+        endAt: futureDate(24 * 7 + 1),
+        surfaceId: "surface-1",
+        segmentId: null,
+        venueReservationId: null,
+      },
+      {
+        id: "game-2",
+        startAt: futureDate(24 * 7 + 1),
+        endAt: draft.endAt,
+        surfaceId: "surface-1",
+        segmentId: null,
+        venueReservationId: null,
+      },
+    ]);
+    mockCreateVenueReservation
+      .mockResolvedValueOnce({ id: "reservation-1" })
+      .mockResolvedValueOnce({ id: "reservation-2" });
+
+    const result = await publishSignupEvent({ eventId });
+
+    expect(result.success).toBe(true);
+    expect(mockCreateVenueReservation).toHaveBeenCalledTimes(2);
+    expect(mockAssignVenueReservation).toHaveBeenCalledTimes(2);
+    expect(mockAssignVenueReservation).toHaveBeenNthCalledWith(
+      1,
+      expect.anything(),
+      expect.objectContaining({ targetType: "EVENT_GAME", targetId: "game-1" }),
+    );
+    expect(mockAssignVenueReservation).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ targetType: "SIGNUP_EVENT" }),
+    );
+    expect(mockPrisma.signupEvent.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: eventId, status: "DRAFT" } }),
     );
   });
 
@@ -340,5 +437,334 @@ describe("cancelSignupEvent", () => {
 
     expect(result).toEqual({ success: false, error: "This event is already canceled." });
     expect(mockPrisma.signupEvent.update).not.toHaveBeenCalled();
+  });
+
+  it("atomically replaces a published event reservation when its window moves", async () => {
+    const eventId = "cldevent0000000000000001";
+    const oldStart = futureDate(24 * 8);
+    const oldEnd = futureDate(24 * 8 + 2);
+    const newStart = futureDate(24 * 9);
+    const newEnd = futureDate(24 * 9 + 2);
+    const existing = {
+      id: eventId,
+      status: "PUBLISHED",
+      venueReservationId: "cloldreservation00000001",
+      startAt: oldStart,
+      endAt: oldEnd,
+      venueId: "clvenue0000000000000001",
+      locationText: null,
+      visibility: "PUBLIC",
+      linkToken: null,
+      title: "Mite Night",
+      timezone: "America/New_York",
+      hostOrganizationId: null,
+      hostLeagueId: "cldleague0000000000000001",
+      hostTeamId: null,
+      venue: { slug: null },
+      hostLeague: { slug: "gfha", name: "GFHA" },
+      hostOrganization: null,
+      hostTeam: null,
+      slots: [],
+    };
+    mockRequireEventManager.mockResolvedValue("user-1");
+    mockPrisma.venueReservation = { findUnique: vi.fn() };
+    mockPrisma.venue.findUnique.mockResolvedValue({ timezone: "America/New_York" });
+    mockPrisma.$transaction.mockImplementation(async (callback: (tx: unknown) => unknown) =>
+      callback(mockPrisma));
+    mockPrisma.signupEvent.findUnique
+      .mockResolvedValueOnce(existing)
+      .mockResolvedValueOnce({
+        id: eventId,
+        status: "PUBLISHED",
+        venueReservationId: existing.venueReservationId,
+        hostOrganizationId: null,
+        hostLeagueId: existing.hostLeagueId,
+        hostTeamId: null,
+        timezone: existing.timezone,
+        venueId: existing.venueId,
+      });
+    mockPrisma.venueReservation.findUnique.mockResolvedValue({ id: existing.venueReservationId, eventGames: [] });
+    mockCreateVenueReservation.mockResolvedValue({ id: "clnewreservation0000001" });
+    mockPrisma.signupEvent.update.mockResolvedValue({});
+
+    const result = await updateSignupEvent({
+      ...validCreateInput,
+      eventId,
+      startAt: newStart,
+      endAt: newEnd,
+      venueId: existing.venueId,
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockTransitionVenueReservation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        reservationId: existing.venueReservationId,
+        nextStatus: "CANCELED",
+      }),
+    );
+    expect(mockCreateVenueReservation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ startsAt: newStart, endsAt: newEnd }),
+    );
+    expect(mockAssignVenueReservation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        targetType: "SIGNUP_EVENT",
+        targetId: eventId,
+      }),
+    );
+    expect(mockPrisma.signupEvent.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ venueReservationId: "clnewreservation0000001" }),
+      }),
+    );
+  });
+
+  it("does not update the event when the replacement reservation conflicts", async () => {
+    const eventId = "cldevent0000000000000001";
+    const existing = {
+      id: eventId,
+      status: "PUBLISHED",
+      venueReservationId: "cloldreservation00000001",
+      startAt: futureDate(24 * 8),
+      endAt: futureDate(24 * 8 + 2),
+      venueId: "clvenue0000000000000001",
+      locationText: null,
+      visibility: "PUBLIC",
+      linkToken: null,
+      title: "Mite Night",
+      timezone: "America/New_York",
+      hostOrganizationId: null,
+      hostLeagueId: "cldleague0000000000000001",
+      hostTeamId: null,
+      venue: { slug: null },
+      hostLeague: { slug: "gfha", name: "GFHA" },
+      hostOrganization: null,
+      hostTeam: null,
+      slots: [],
+    };
+    mockRequireEventManager.mockResolvedValue("user-1");
+    mockPrisma.venueReservation = { findUnique: vi.fn() };
+    mockPrisma.venue.findUnique.mockResolvedValue({ timezone: "America/New_York" });
+    mockPrisma.$transaction.mockImplementation(async (callback: (tx: unknown) => unknown) =>
+      callback(mockPrisma));
+    mockPrisma.signupEvent.findUnique
+      .mockResolvedValueOnce(existing)
+      .mockResolvedValueOnce({
+        id: eventId,
+        status: "PUBLISHED",
+        venueReservationId: existing.venueReservationId,
+        hostOrganizationId: null,
+        hostLeagueId: existing.hostLeagueId,
+        hostTeamId: null,
+        timezone: existing.timezone,
+        venueId: existing.venueId,
+      });
+    mockPrisma.venueReservation.findUnique.mockResolvedValue({ id: existing.venueReservationId, eventGames: [] });
+    mockCreateVenueReservation.mockRejectedValue(new Error("That venue space is no longer available."));
+
+    const result = await updateSignupEvent({
+      ...validCreateInput,
+      eventId,
+      startAt: futureDate(24 * 9),
+      endAt: futureDate(24 * 9 + 2),
+      venueId: existing.venueId,
+    });
+
+    expect(result.success).toBe(false);
+    expect(mockPrisma.signupEvent.update).not.toHaveBeenCalled();
+  });
+
+  it("rejects a published reschedule when child games have independent reservations", async () => {
+    const existing = {
+      id: eventId,
+      status: "PUBLISHED",
+      venueReservationId: null,
+      startAt: futureDate(24 * 8),
+      endAt: futureDate(24 * 8 + 2),
+      venueId: "clvenue0000000000000001",
+      locationText: null,
+      visibility: "PUBLIC",
+      linkToken: null,
+      title: "Mite Night",
+      timezone: "America/New_York",
+      hostOrganizationId: null,
+      hostLeagueId: "cldleague0000000000000001",
+      hostTeamId: null,
+      venue: { slug: null },
+      hostLeague: { slug: "gfha", name: "GFHA" },
+      hostOrganization: null,
+      hostTeam: null,
+      slots: [],
+    };
+    mockPrisma.venueReservation = { findUnique: vi.fn() };
+    mockPrisma.venue.findUnique.mockResolvedValue({ timezone: "America/New_York" });
+    mockPrisma.$transaction.mockImplementation(async (callback: (tx: unknown) => unknown) =>
+      callback(mockPrisma));
+    mockPrisma.signupEvent.findUnique
+      .mockResolvedValueOnce(existing)
+      .mockResolvedValueOnce({
+        id: eventId,
+        status: "PUBLISHED",
+        venueReservationId: null,
+        hostOrganizationId: null,
+        hostLeagueId: existing.hostLeagueId,
+        hostTeamId: null,
+        timezone: existing.timezone,
+        venueId: existing.venueId,
+      });
+    mockPrisma.eventGame.findMany.mockResolvedValue([{ id: "game-1" }]);
+
+    const result = await updateSignupEvent({
+      ...validCreateInput,
+      eventId,
+      startAt: futureDate(24 * 9),
+      endAt: futureDate(24 * 9 + 2),
+      venueId: existing.venueId,
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error: "Published events with games cannot be rescheduled.",
+    });
+    expect(mockCreateVenueReservation).not.toHaveBeenCalled();
+    expect(mockPrisma.eventGame.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { eventId } }),
+    );
+  });
+});
+
+describe("SignupEvent lifecycle concurrency", () => {
+  const eventId = "cldevent0000000000000001";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireEventManager.mockResolvedValue("user-1");
+    mockRequireUserId.mockResolvedValue("user-1");
+  });
+
+  it("does not publish after a concurrent cancel changes the draft state", async () => {
+    const draft = {
+      id: eventId,
+      status: "DRAFT",
+      visibility: "PUBLIC",
+      linkToken: null,
+      acceptsOnlinePayment: false,
+      acceptsManualPayment: true,
+      hostTeamId: null,
+      venueId: null,
+      startAt: null,
+      endAt: null,
+      timezone: "America/New_York",
+      venueReservationId: null,
+      venue: null,
+      hostOrganization: null,
+      hostLeague: null,
+      slots: [{ id: "slot-1", priceAmount: null }],
+    };
+    mockPrisma.signupEvent.findUnique
+      .mockResolvedValueOnce(draft)
+      .mockResolvedValueOnce({ ...draft, status: "CANCELED" });
+    mockPrisma.$transaction.mockImplementation(async (callback: (tx: unknown) => unknown) =>
+      callback(mockPrisma));
+
+    const result = await publishSignupEvent({ eventId });
+
+    expect(result).toEqual({ success: false, error: "This event is no longer a draft." });
+    expect(mockPrisma.signupEvent.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("does not report cancellation success after a concurrent lifecycle update wins", async () => {
+    mockPrisma.signupEvent.findUnique
+      .mockResolvedValueOnce({
+        id: eventId,
+        status: "PUBLISHED",
+        title: "Mite Night",
+        venue: null,
+        hostLeague: null,
+        hostOrganization: null,
+        hostTeam: null,
+        venueReservationId: null,
+      })
+      .mockResolvedValueOnce({
+        id: eventId,
+        status: "PUBLISHED",
+        venueReservationId: null,
+        hostLeagueId: null,
+        hostTeamId: null,
+      });
+    mockPrisma.eventRegistration.findMany.mockResolvedValue([]);
+    mockPrisma.eventRegistration.count.mockResolvedValue(0);
+    mockPrisma.eventGame.findMany.mockResolvedValue([]);
+    mockPrisma.signupEvent.updateMany.mockResolvedValue({ count: 0 });
+    mockPrisma.$transaction.mockImplementation(async (callback: (tx: unknown) => unknown) =>
+      callback(mockPrisma));
+
+    const result = await cancelSignupEvent({ eventId });
+
+    expect(result).toEqual({
+      success: false,
+      error: "This event changed while it was being canceled.",
+    });
+    expect(mockCanceledEmail).not.toHaveBeenCalled();
+  });
+
+  it("cancels active child game reservations and records child lifecycle changes", async () => {
+    mockPrisma.signupEvent.findUnique
+      .mockResolvedValueOnce({
+        id: eventId,
+        status: "PUBLISHED",
+        title: "Mite Night",
+        venue: null,
+        hostLeague: null,
+        hostOrganization: null,
+        hostTeam: null,
+        venueReservationId: null,
+      })
+      .mockResolvedValueOnce({
+        id: eventId,
+        status: "PUBLISHED",
+        venueReservationId: null,
+        hostLeagueId: "league-1",
+        hostTeamId: "team-1",
+      });
+    mockPrisma.eventRegistration.findMany.mockResolvedValue([]);
+    mockPrisma.eventRegistration.count.mockResolvedValue(0);
+    mockPrisma.eventGame.findMany.mockResolvedValue([
+      {
+        id: "game-1",
+        status: "SCHEDULED",
+        venueReservationId: "reservation-child",
+        venueReservation: { id: "reservation-child", status: "CONFIRMED" },
+      },
+    ]);
+    mockPrisma.venueReservation = {};
+    mockPrisma.signupEvent.updateMany.mockResolvedValue({ count: 1 });
+    mockPrisma.$transaction.mockImplementation(async (callback: (tx: unknown) => unknown) =>
+      callback(mockPrisma));
+
+    const result = await cancelSignupEvent({ eventId });
+
+    expect(result.success).toBe(true);
+    expect(mockTransitionVenueReservation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        reservationId: "reservation-child",
+        nextStatus: "CANCELED",
+      }),
+    );
+    expect(mockPrisma.eventGame.update).toHaveBeenCalledWith({
+      where: { id: "game-1" },
+      data: { status: "CANCELED" },
+    });
+    expect(mockPrisma.auditLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          action: "EVENT_GAME_CANCELED",
+          resourceId: "game-1",
+        }),
+      }),
+    );
   });
 });

--- a/__tests__/lib/actions/venue-content-lessons.test.ts
+++ b/__tests__/lib/actions/venue-content-lessons.test.ts
@@ -6,6 +6,7 @@ const { mockRequireVenueContentManager, mockPrisma } = vi.hoisted(() => ({
   mockRequireVenueContentManager: vi.fn(),
   mockPrisma: {
     venue: { findFirst: vi.fn() },
+    surfaceSegment: { findFirst: vi.fn() },
     lessonOffering: { create: vi.fn(), update: vi.fn() },
     venueScheduleBlock: { create: vi.fn() },
   },
@@ -25,11 +26,14 @@ import {
 
 const ORGANIZATION_ID = "clorgxxxxxxxxxxxxxxxxxxxxxxx";
 const VENUE_ID = "clvenxxxxxxxxxxxxxxxxxxxxxxx";
+const SURFACE_ID = "clsurxxxxxxxxxxxxxxxxxxxxxxx";
+const SEGMENT_ID = "clsegxxxxxxxxxxxxxxxxxxxxxxx";
 
 beforeEach(() => {
   vi.clearAllMocks();
   mockRequireVenueContentManager.mockResolvedValue("clusrxxxxxxxxxxxxxxxxxxxxxxx");
   mockPrisma.venue.findFirst.mockResolvedValue({ id: VENUE_ID, organizationId: ORGANIZATION_ID, slug: "north-rink" });
+  mockPrisma.surfaceSegment.findFirst.mockResolvedValue({ id: SEGMENT_ID });
 });
 
 describe("venue lessons and specialty events", () => {
@@ -55,6 +59,8 @@ describe("venue lessons and specialty events", () => {
     const result = await publishSpecialtyEvent({
       organizationId: ORGANIZATION_ID,
       venueId: VENUE_ID,
+      surfaceId: SURFACE_ID,
+      segmentId: SEGMENT_ID,
       title: "Holiday Skate",
       activityType: "SPECIALTY_EVENT",
       startsAt: "2026-12-01T18:00:00Z",
@@ -68,6 +74,8 @@ describe("venue lessons and specialty events", () => {
         data: expect.objectContaining({
           activityType: "SPECIALTY_EVENT",
           visibility: "PUBLIC",
+          surfaceId: SURFACE_ID,
+          segmentId: SEGMENT_ID,
         }),
       })
     );

--- a/__tests__/lib/actions/venue-requests.test.ts
+++ b/__tests__/lib/actions/venue-requests.test.ts
@@ -589,7 +589,7 @@ describe("decideIceTimeRequest full/partial/decline approval (T017 -> T023 inten
       expect.objectContaining({
         surfaceId: null,
         segmentId: null,
-        overrideReason: "Tournament setup uses the full venue",
+        venueWideReason: "Tournament setup uses the full venue",
       }),
     );
   });

--- a/__tests__/lib/actions/venue-schedules-surfaces.test.ts
+++ b/__tests__/lib/actions/venue-schedules-surfaces.test.ts
@@ -35,10 +35,18 @@ const { mockRequireVenueScheduleManager, mockPrisma, mockLogVenueActivity } = vi
     practiceSession: {
       findMany: vi.fn(),
     },
+    venueReservation: {
+      findMany: vi.fn(),
+    },
+    iceTimeRequest: {
+      findMany: vi.fn(),
+    },
+    $transaction: vi.fn(),
   },
 }));
 
 vi.mock("@/lib/auth/session", () => ({
+  VENUE_SCHEDULE_ROLES: ["OWNER", "MANAGER", "SCHEDULER"],
   requireVenueScheduleManager: (...args: unknown[]) => mockRequireVenueScheduleManager(...args),
 }));
 
@@ -78,6 +86,11 @@ beforeEach(() => {
   mockPrisma.eventGame.findMany.mockResolvedValue([]);
   mockPrisma.venueScheduleBlock.findMany.mockResolvedValue([]);
   mockPrisma.practiceSession.findMany.mockResolvedValue([]);
+  mockPrisma.venueReservation.findMany.mockResolvedValue([]);
+  mockPrisma.iceTimeRequest.findMany.mockResolvedValue([]);
+  mockPrisma.$transaction.mockImplementation(
+    async (callback: (tx: typeof mockPrisma) => unknown) => callback(mockPrisma),
+  );
   mockLogVenueActivity.mockResolvedValue({ id: "cllogxxxxxxxxxxxxxxxxxxxxxxx" });
 });
 
@@ -172,6 +185,68 @@ describe("ice surface actions", () => {
         })
       );
     }
+    expect(mockPrisma.iceSurface.update).not.toHaveBeenCalled();
+  });
+
+  it("refuses to archive when an active canonical reservation references the surface", async () => {
+    mockPrisma.venueReservation.findMany.mockResolvedValue([
+      {
+        id: "clreservationxxxxxxxxxxxxxxxxx",
+        startsAt: new Date("2027-01-10T18:00:00Z"),
+        endsAt: new Date("2027-01-10T19:30:00Z"),
+        surfaceId: SURFACE_ID,
+        segmentId: null,
+        sourceScheduleBlock: null,
+      },
+    ]);
+
+    const result = await archiveIceSurface({
+      organizationId: ORGANIZATION_ID,
+      venueId: VENUE_ID,
+      surfaceId: SURFACE_ID,
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.details).toEqual(
+        expect.objectContaining({
+          futureBookings: expect.arrayContaining([
+            expect.objectContaining({ source: "venueReservation" }),
+          ]),
+        }),
+      );
+    }
+    expect(mockPrisma.venueReservation.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          venueId: VENUE_ID,
+          surfaceId: SURFACE_ID,
+        }),
+      }),
+    );
+  });
+
+  it("cannot bypass the reservation guard through generic surface update", async () => {
+    mockPrisma.venueReservation.findMany.mockResolvedValue([{
+      id: "clreservationxxxxxxxxxxxxxxxxx",
+      startsAt: new Date("2027-01-10T18:00:00Z"),
+      endsAt: new Date("2027-01-10T19:30:00Z"),
+      surfaceId: SURFACE_ID,
+      segmentId: null,
+      sourceScheduleBlock: null,
+    }]);
+
+    const result = await updateIceSurface({
+      organizationId: ORGANIZATION_ID,
+      venueId: VENUE_ID,
+      surfaceId: SURFACE_ID,
+      name: "Main",
+      surfaceType: "ICE",
+      isActive: false,
+    });
+
+    expect(result.success).toBe(false);
+    expect(mockPrisma.$transaction).toHaveBeenCalled();
     expect(mockPrisma.iceSurface.update).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/lib/actions/venue-schedules.test.ts
+++ b/__tests__/lib/actions/venue-schedules.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Prisma } from "@prisma/client";
 
 vi.mock("next/cache", () => ({
   revalidatePath: vi.fn(),
@@ -10,11 +11,13 @@ const {
   mockLogVenueActivity,
   mockFindBookingConflicts,
   mockPopulateVenueOfferingAvailability,
+  mockGetVenueBookings,
 } = vi.hoisted(() => ({
   mockRequireVenueScheduleManager: vi.fn(),
   mockLogVenueActivity: vi.fn(),
   mockFindBookingConflicts: vi.fn(),
   mockPopulateVenueOfferingAvailability: vi.fn(),
+  mockGetVenueBookings: vi.fn(),
   mockPrisma: {
     venue: {
       findFirst: vi.fn(),
@@ -25,6 +28,11 @@ const {
       findFirst: vi.fn(),
       findMany: vi.fn(),
     },
+    venueStaff: {
+      findFirst: vi.fn(),
+    },
+    venueReservation: undefined as unknown,
+    $transaction: vi.fn(),
     iceSurface: {
       findMany: vi.fn(),
     },
@@ -37,7 +45,16 @@ const {
   },
 }));
 
+const {
+  mockCreateVenueReservation,
+  mockTransitionVenueReservation,
+} = vi.hoisted(() => ({
+  mockCreateVenueReservation: vi.fn(),
+  mockTransitionVenueReservation: vi.fn(),
+}));
+
 vi.mock("@/lib/auth/session", () => ({
+  VENUE_SCHEDULE_ROLES: ["OWNER", "MANAGER", "SCHEDULER"],
   requireVenueScheduleManager: (...args: unknown[]) => mockRequireVenueScheduleManager(...args),
 }));
 
@@ -46,11 +63,24 @@ vi.mock("@/lib/auth/session", () => ({
 // __tests__/lib/utils/availability.test.ts.
 vi.mock("@/lib/utils/availability", () => ({
   findBookingConflicts: (...args: unknown[]) => mockFindBookingConflicts(...args),
+  getVenueBookings: (...args: unknown[]) => mockGetVenueBookings(...args),
 }));
 
 vi.mock("@/lib/services/venue-reservation-availability", () => ({
   populateVenueOfferingAvailability: (...args: unknown[]) =>
     mockPopulateVenueOfferingAvailability(...args),
+}));
+
+vi.mock("@/lib/services/venue-reservations", () => ({
+  createVenueReservation: (...args: unknown[]) => mockCreateVenueReservation(...args),
+  transitionVenueReservation: (...args: unknown[]) => mockTransitionVenueReservation(...args),
+  VenueReservationConflictError: class VenueReservationConflictError extends Error {
+    conflicts: unknown[];
+    constructor(conflicts: unknown[]) {
+      super("conflict");
+      this.conflicts = conflicts;
+    }
+  },
 }));
 
 vi.mock("@/lib/db/prisma", () => ({
@@ -78,6 +108,7 @@ import {
   cancelScheduleBlock,
   createScheduleBlock,
   getVenueScheduleAdminData,
+  getVenueScheduleBoard,
   getPublicVenueSchedule,
   publishScheduleBlock,
   updateScheduleBlock,
@@ -88,16 +119,44 @@ const ORGANIZATION_ID = "clorgxxxxxxxxxxxxxxxxxxxxxxx";
 const VENUE_ID = "clvenxxxxxxxxxxxxxxxxxxxxxxx";
 const BLOCK_ID = "clblkxxxxxxxxxxxxxxxxxxxxxxx";
 
+function occupyingBlock(overrides: Record<string, unknown> = {}) {
+  return {
+    id: BLOCK_ID,
+    venueId: VENUE_ID,
+    surfaceId: null,
+    segmentId: null,
+    startsAt: new Date("2026-09-01T18:00:00.000Z"),
+    endsAt: new Date("2026-09-01T19:00:00.000Z"),
+    status: "PUBLISHED",
+    intent: "VENUE_ACTIVITY",
+    recurrenceRule: null,
+    recurrenceEndDate: null,
+    reservationOccurrences: [],
+    venue: {
+      organizationId: ORGANIZATION_ID,
+      slug: "north-rink",
+      timezone: "America/New_York",
+    },
+    ...overrides,
+  };
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   mockRequireVenueScheduleManager.mockResolvedValue(USER_ID);
   mockPrisma.venue.findFirst.mockResolvedValue({ id: VENUE_ID, organizationId: ORGANIZATION_ID });
   mockPrisma.venueScheduleBlock.findMany.mockResolvedValue([]);
+  mockPrisma.venueStaff.findFirst.mockResolvedValue({ id: "venue-staff-1" });
   mockPrisma.iceSurface.findMany.mockResolvedValue([]);
   mockPrisma.venueOperatingHour.findMany.mockResolvedValue([]);
   mockFindBookingConflicts.mockResolvedValue([]);
   mockPopulateVenueOfferingAvailability.mockResolvedValue([]);
+  mockGetVenueBookings.mockResolvedValue([]);
   mockLogVenueActivity.mockResolvedValue({ id: "cllogxxxxxxxxxxxxxxxxxxxxxxx" });
+  mockCreateVenueReservation.mockResolvedValue({ id: "reservation-new" });
+  mockTransitionVenueReservation.mockResolvedValue({ id: "reservation-old" });
+  mockPrisma.venueReservation = undefined;
+  mockPrisma.$transaction.mockReset();
 });
 
 describe("schedule block actions", () => {
@@ -489,6 +548,474 @@ describe("admin schedule availability", () => {
     expect(mockPopulateVenueOfferingAvailability).toHaveBeenCalledWith(
       mockPrisma,
       expect.objectContaining({ mode: "STAFF" }),
+    );
+  });
+});
+
+describe("venue activity and closure recurrence materialization", () => {
+  it.each([
+    ["CLOSURE", "Maintenance window"],
+    ["OPEN_SKATE", "Community skate"],
+  ])("materializes recurring %s blocks into concrete bookings", async (activityType, title) => {
+    mockPrisma.venue.findFirst.mockResolvedValue({
+      id: VENUE_ID,
+      organizationId: ORGANIZATION_ID,
+      slug: "north-rink",
+      timezone: "America/New_York",
+    });
+    mockPrisma.venueScheduleBlock.findMany.mockResolvedValue([
+      {
+        id: BLOCK_ID,
+        title,
+        description: null,
+        activityType,
+        audience: "PUBLIC",
+        visibility: "PUBLIC",
+        status: "DRAFT",
+        startsAt: new Date("2026-09-01T18:00:00.000Z"),
+        endsAt: new Date("2026-09-01T19:00:00.000Z"),
+        recurrenceRule: "FREQ=WEEKLY;COUNT=2",
+        recurrenceStartDate: new Date("2026-09-01T18:00:00.000Z"),
+        recurrenceEndDate: new Date("2026-09-08T18:00:00.000Z"),
+        capacity: null,
+        priceAmount: null,
+        priceCurrency: "USD",
+        priceLabel: null,
+        registrationMode: "INFO_ONLY",
+        externalRegistrationUrl: null,
+        surfaceId: null,
+        segmentId: null,
+        segment: null,
+      },
+    ]);
+
+    const result = await getVenueScheduleBoard({
+      organizationId: ORGANIZATION_ID,
+      venueId: VENUE_ID,
+      from: new Date("2026-08-31T00:00:00.000Z"),
+      to: new Date("2026-09-15T00:00:00.000Z"),
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const matchingBookings = result.data.bookings.filter((booking) => booking.title === title);
+      expect(matchingBookings).toHaveLength(2);
+      expect(result.data.blocks[0]).toEqual(
+        expect.objectContaining({
+          activityType,
+          status: "DRAFT",
+          recurrenceRule: "FREQ=WEEKLY;COUNT=2",
+        }),
+      );
+    }
+  });
+
+  it("replaces obsolete published occurrences and rechecks new ones", async () => {
+    mockPrisma.venue.findFirst.mockResolvedValue({
+      id: VENUE_ID,
+      organizationId: ORGANIZATION_ID,
+      slug: "north-rink",
+      timezone: "America/New_York",
+    });
+    const oldStart = new Date("2026-09-01T18:00:00.000Z");
+    const oldEnd = new Date("2026-09-01T19:00:00.000Z");
+    const newStart = new Date("2026-09-02T18:00:00.000Z");
+    const newEnd = new Date("2026-09-02T19:00:00.000Z");
+    mockPrisma.venueScheduleBlock.findFirst.mockResolvedValue(occupyingBlock({
+      startsAt: oldStart,
+      endsAt: oldEnd,
+    }));
+    mockPrisma.venueScheduleBlock.update.mockResolvedValue(occupyingBlock({
+      startsAt: newStart,
+      endsAt: newEnd,
+    }));
+    mockPrisma.venueReservation = {
+      findMany: vi.fn().mockResolvedValue([{
+        id: "reservation-old",
+        startsAt: oldStart,
+        endsAt: oldEnd,
+        status: "CONFIRMED",
+      }]),
+      update: vi.fn(),
+    };
+    mockPrisma.$transaction.mockImplementation((work: (tx: unknown) => unknown) =>
+      work(mockPrisma),
+    );
+
+    const result = await updateScheduleBlock({
+      organizationId: ORGANIZATION_ID,
+      venueId: VENUE_ID,
+      scheduleBlockId: BLOCK_ID,
+      title: "Rescheduled maintenance",
+      activityType: "CLOSURE",
+      startsAt: newStart.toISOString(),
+      endsAt: newEnd.toISOString(),
+      status: "PUBLISHED",
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockTransitionVenueReservation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        reservationId: "reservation-old",
+        nextStatus: "CANCELED",
+      }),
+    );
+    expect(mockCreateVenueReservation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        sourceScheduleBlockId: BLOCK_ID,
+        startsAt: newStart,
+        endsAt: newEnd,
+      }),
+    );
+  });
+
+  it("replaces an occurrence when its surface or segment scope changes", async () => {
+    const oldSurfaceId = "csurfacexxxxxxxxxxxxxxxxxx";
+    const newSurfaceId = "csurfaceyyyyyyyyyyyyyyyyyy";
+    const newSegmentId = "csegmentxxxxxxxxxxxxxxxxxx";
+    const startsAt = new Date("2026-09-02T18:00:00.000Z");
+    const endsAt = new Date("2026-09-02T19:00:00.000Z");
+    mockPrisma.venueScheduleBlock.findFirst.mockResolvedValue(occupyingBlock({
+      surfaceId: oldSurfaceId,
+      startsAt,
+      endsAt,
+    }));
+    mockPrisma.venueScheduleBlock.update.mockResolvedValue(occupyingBlock({
+      surfaceId: newSurfaceId,
+      segmentId: newSegmentId,
+      startsAt,
+      endsAt,
+    }));
+    mockPrisma.surfaceSegment.findFirst.mockResolvedValue({
+      id: newSegmentId,
+      isActive: true,
+      surfaceId: newSurfaceId,
+      surface: { venueId: VENUE_ID },
+    });
+    mockPrisma.venueReservation = {
+      findMany: vi.fn().mockResolvedValue([
+        {
+          id: "reservation-old",
+          venueId: VENUE_ID,
+          surfaceId: oldSurfaceId,
+          segmentId: null,
+          startsAt,
+          endsAt,
+          status: "CONFIRMED",
+        },
+      ]),
+      update: vi.fn(),
+    };
+    mockPrisma.$transaction.mockImplementation((work: (tx: unknown) => unknown) =>
+      work(mockPrisma),
+    );
+
+    const result = await updateScheduleBlock({
+      organizationId: ORGANIZATION_ID,
+      venueId: VENUE_ID,
+      scheduleBlockId: BLOCK_ID,
+      title: "Segmented maintenance",
+      activityType: "CLOSURE",
+      startsAt: startsAt.toISOString(),
+      endsAt: endsAt.toISOString(),
+      status: "PUBLISHED",
+      surfaceId: newSurfaceId,
+      segmentId: newSegmentId,
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockTransitionVenueReservation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        reservationId: "reservation-old",
+        nextStatus: "CANCELED",
+      }),
+    );
+    expect(mockCreateVenueReservation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        surfaceId: newSurfaceId,
+        segmentId: newSegmentId,
+        startsAt,
+        endsAt,
+      }),
+    );
+  });
+
+  it("cancels all source reservations atomically when a block is canceled", async () => {
+    mockPrisma.venue.findFirst.mockResolvedValue({
+      id: VENUE_ID,
+      organizationId: ORGANIZATION_ID,
+      slug: "north-rink",
+      timezone: "America/New_York",
+    });
+    mockPrisma.venueScheduleBlock.findFirst.mockResolvedValue(occupyingBlock());
+    mockPrisma.venueScheduleBlock.update.mockResolvedValue({
+      id: BLOCK_ID,
+      status: "CANCELED",
+    });
+    mockPrisma.venueReservation = {
+      findMany: vi.fn().mockResolvedValue([
+        { id: "reservation-1" },
+        { id: "reservation-2" },
+      ]),
+      update: vi.fn(),
+    };
+    mockPrisma.$transaction.mockImplementation((work: (tx: unknown) => unknown) =>
+      work(mockPrisma),
+    );
+
+    const result = await cancelScheduleBlock({
+      organizationId: ORGANIZATION_ID,
+      venueId: VENUE_ID,
+      scheduleBlockId: BLOCK_ID,
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockTransitionVenueReservation).toHaveBeenCalledTimes(2);
+    expect(mockTransitionVenueReservation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        nextStatus: "CANCELED",
+        allowAssignedDisposition: true,
+      }),
+    );
+  });
+
+  it("reports a failed occurrence reconciliation so the transaction can roll back", async () => {
+    mockPrisma.venue.findFirst.mockResolvedValue({
+      id: VENUE_ID,
+      organizationId: ORGANIZATION_ID,
+      slug: "north-rink",
+      timezone: "America/New_York",
+    });
+    mockPrisma.venueScheduleBlock.findFirst.mockResolvedValue(occupyingBlock());
+    mockPrisma.venueScheduleBlock.update.mockResolvedValue(occupyingBlock());
+    mockPrisma.venueReservation = {
+      findMany: vi.fn().mockResolvedValue([]),
+      update: vi.fn(),
+    };
+    mockCreateVenueReservation.mockRejectedValueOnce(new Error("conflict"));
+    mockPrisma.$transaction.mockImplementation((work: (tx: unknown) => unknown) =>
+      work(mockPrisma),
+    );
+
+    const result = await updateScheduleBlock({
+      organizationId: ORGANIZATION_ID,
+      venueId: VENUE_ID,
+      scheduleBlockId: BLOCK_ID,
+      title: "Broken replacement",
+      activityType: "CLOSURE",
+      startsAt: "2026-09-03T18:00:00Z",
+      endsAt: "2026-09-03T19:00:00Z",
+      status: "PUBLISHED",
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error: "Failed to update schedule block.",
+    });
+  });
+
+  it("uses the block status reloaded inside the update transaction", async () => {
+    const startsAt = new Date("2026-09-04T18:00:00.000Z");
+    const endsAt = new Date("2026-09-04T19:00:00.000Z");
+    mockPrisma.venueScheduleBlock.findFirst.mockResolvedValue(occupyingBlock({
+      startsAt,
+      endsAt,
+      status: "PUBLISHED",
+    }));
+    mockPrisma.venueScheduleBlock.update.mockResolvedValue(occupyingBlock({
+      startsAt,
+      endsAt,
+      status: "DRAFT",
+    }));
+    mockPrisma.venueReservation = {
+      findMany: vi.fn().mockResolvedValue([{ id: "reservation-concurrent" }]),
+      update: vi.fn(),
+    };
+    let insideTransaction = false;
+    mockPrisma.$transaction.mockImplementation(
+      async (work: (tx: typeof mockPrisma) => unknown) => {
+        insideTransaction = true;
+        try {
+          return await work(mockPrisma);
+        } finally {
+          insideTransaction = false;
+        }
+      },
+    );
+    mockPrisma.venueScheduleBlock.findFirst.mockImplementation(async () => {
+      expect(insideTransaction).toBe(true);
+      return occupyingBlock({ startsAt, endsAt, status: "PUBLISHED" });
+    });
+
+    const result = await updateScheduleBlock({
+      organizationId: ORGANIZATION_ID,
+      venueId: VENUE_ID,
+      scheduleBlockId: BLOCK_ID,
+      title: "Draft concurrent closure",
+      activityType: "CLOSURE",
+      startsAt: startsAt.toISOString(),
+      endsAt: endsAt.toISOString(),
+      status: "DRAFT",
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockTransitionVenueReservation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ reservationId: "reservation-concurrent" }),
+    );
+    expect(mockPrisma.venueScheduleBlock.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          venue: { organizationId: ORGANIZATION_ID },
+        }),
+        select: expect.objectContaining({ reservationOccurrences: expect.anything() }),
+      }),
+    );
+  });
+
+  it("reloads recurrence and authorization scope on a publish retry", async () => {
+    const first = occupyingBlock({
+      status: "DRAFT",
+      recurrenceRule: null,
+      recurrenceEndDate: null,
+    });
+    const concurrentlyChanged = occupyingBlock({
+      status: "DRAFT",
+      recurrenceRule: "FREQ=WEEKLY",
+      recurrenceEndDate: null,
+    });
+    mockPrisma.venueScheduleBlock.findFirst
+      .mockResolvedValueOnce(first)
+      .mockResolvedValueOnce(concurrentlyChanged);
+    mockPrisma.venueScheduleBlock.update.mockResolvedValue({
+      id: BLOCK_ID,
+      status: "PUBLISHED",
+    });
+    mockPrisma.venueReservation = {
+      findMany: vi.fn().mockResolvedValue([]),
+      update: vi.fn(),
+    };
+    let attempt = 0;
+    mockPrisma.$transaction.mockImplementation(
+      async (work: (tx: typeof mockPrisma) => unknown) => {
+        attempt += 1;
+        const result = await work(mockPrisma);
+        if (attempt === 1) {
+          throw new Prisma.PrismaClientKnownRequestError("write conflict", {
+            code: "P2034",
+            clientVersion: "test",
+          });
+        }
+        return result;
+      },
+    );
+
+    const result = await publishScheduleBlock({
+      organizationId: ORGANIZATION_ID,
+      venueId: VENUE_ID,
+      scheduleBlockId: BLOCK_ID,
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error: "Occupying recurring blocks must have an end date.",
+    });
+    expect(mockPrisma.venueScheduleBlock.findFirst).toHaveBeenCalledTimes(2);
+    expect(mockPrisma.venueStaff.findFirst).toHaveBeenCalledTimes(2);
+    for (const [query] of mockPrisma.venueScheduleBlock.findFirst.mock.calls) {
+      expect(query).toEqual(expect.objectContaining({
+        where: expect.objectContaining({
+          venue: { organizationId: ORGANIZATION_ID },
+        }),
+        select: expect.objectContaining({ reservationOccurrences: expect.anything() }),
+      }));
+    }
+    expect(mockLogVenueActivity).not.toHaveBeenCalled();
+  });
+
+  it("rechecks schedule-manager authorization inside every update retry", async () => {
+    mockPrisma.venueScheduleBlock.findFirst.mockResolvedValue(occupyingBlock());
+    mockPrisma.venueScheduleBlock.update.mockResolvedValue(occupyingBlock());
+    mockPrisma.venueReservation = {
+      findMany: vi.fn().mockResolvedValue([]),
+      update: vi.fn(),
+    };
+    mockPrisma.venueStaff.findFirst
+      .mockResolvedValueOnce({ id: "venue-staff-1" })
+      .mockResolvedValueOnce(null);
+    let attempt = 0;
+    mockPrisma.$transaction.mockImplementation(
+      async (work: (tx: typeof mockPrisma) => unknown) => {
+        attempt += 1;
+        const result = await work(mockPrisma);
+        if (attempt === 1) {
+          throw new Prisma.PrismaClientKnownRequestError("write conflict", {
+            code: "P2034",
+            clientVersion: "test",
+          });
+        }
+        return result;
+      },
+    );
+
+    const result = await updateScheduleBlock({
+      organizationId: ORGANIZATION_ID,
+      venueId: VENUE_ID,
+      scheduleBlockId: BLOCK_ID,
+      title: "Concurrent closure",
+      activityType: "CLOSURE",
+      startsAt: "2026-09-03T18:00:00Z",
+      endsAt: "2026-09-03T19:00:00Z",
+      status: "PUBLISHED",
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error: "Unauthorized: You do not have permission to manage this venue",
+    });
+    expect(mockPrisma.venueStaff.findFirst).toHaveBeenCalledTimes(2);
+    expect(mockLogVenueActivity).not.toHaveBeenCalled();
+  });
+
+  it("uses fresh cancel intent and linked-reservation state in the transaction", async () => {
+    mockPrisma.venueScheduleBlock.findFirst.mockResolvedValue(occupyingBlock({
+      status: "PUBLISHED",
+      intent: "OFFERING",
+      reservationOccurrences: [{ id: "reservation-linked", status: "CONFIRMED" }],
+    }));
+    mockPrisma.venueScheduleBlock.update.mockResolvedValue({
+      id: BLOCK_ID,
+      status: "CANCELED",
+    });
+    mockPrisma.venueReservation = {
+      findMany: vi.fn().mockResolvedValue([{ id: "reservation-linked" }]),
+      update: vi.fn(),
+    };
+    mockPrisma.$transaction.mockImplementation(
+      async (work: (tx: typeof mockPrisma) => unknown) => work(mockPrisma),
+    );
+
+    const result = await cancelScheduleBlock({
+      organizationId: ORGANIZATION_ID,
+      venueId: VENUE_ID,
+      scheduleBlockId: BLOCK_ID,
+    });
+
+    expect(result.success).toBe(true);
+    const reservationClient = mockPrisma.venueReservation as {
+      findMany: ReturnType<typeof vi.fn>;
+    };
+    expect(reservationClient.findMany).not.toHaveBeenCalled();
+    expect(mockTransitionVenueReservation).not.toHaveBeenCalled();
+    expect(mockPrisma.venueScheduleBlock.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        select: expect.objectContaining({ reservationOccurrences: expect.anything() }),
+      }),
     );
   });
 });

--- a/__tests__/lib/actions/venue-skill-level-filters.test.ts
+++ b/__tests__/lib/actions/venue-skill-level-filters.test.ts
@@ -11,7 +11,10 @@ const { mockPrisma } = vi.hoisted(() => ({
   },
 }));
 
-vi.mock("@/lib/auth/session", () => ({ requireVenueContentManager: vi.fn() }));
+vi.mock("@/lib/auth/session", () => ({
+  VENUE_SCHEDULE_ROLES: ["OWNER", "MANAGER", "SCHEDULER"],
+  requireVenueContentManager: vi.fn(),
+}));
 vi.mock("@/lib/db/prisma", () => ({ prisma: mockPrisma }));
 vi.mock("@/lib/email/templates", () => ({ sendVenueRelationshipInvitationEmail: vi.fn() }));
 

--- a/__tests__/lib/actions/venue-surfaces.test.ts
+++ b/__tests__/lib/actions/venue-surfaces.test.ts
@@ -1,0 +1,222 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Prisma } from "@prisma/client";
+
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+
+const {
+  mockRequireVenueScheduleManager,
+  mockPrisma,
+  mockLogVenueActivity,
+} = vi.hoisted(() => ({
+  mockRequireVenueScheduleManager: vi.fn(),
+  mockLogVenueActivity: vi.fn(),
+  mockPrisma: {
+    surfaceSegment: { findUnique: vi.fn(), update: vi.fn() },
+    seasonGame: { findMany: vi.fn() },
+    eventGame: { findMany: vi.fn() },
+    venueScheduleBlock: { findMany: vi.fn() },
+    practiceSession: { findMany: vi.fn() },
+    venueReservation: { findMany: vi.fn() },
+    iceTimeRequest: { findMany: vi.fn() },
+    $transaction: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/auth/session", () => ({
+  requireVenueScheduleManager: (...args: unknown[]) =>
+    mockRequireVenueScheduleManager(...args),
+}));
+vi.mock("@/lib/db/prisma", () => ({ prisma: mockPrisma }));
+vi.mock("@/lib/services/venue-activity", () => ({
+  logVenueActivity: (...args: unknown[]) => mockLogVenueActivity(...args),
+}));
+
+import { setSegmentActive } from "@/lib/actions/venue-surfaces";
+
+const ORGANIZATION_ID = "clorgxxxxxxxxxxxxxxxxxxxxxxx";
+const VENUE_ID = "clvenxxxxxxxxxxxxxxxxxxxxxxx";
+const SURFACE_ID = "clsurxxxxxxxxxxxxxxxxxxxxxxx";
+const SEGMENT_ID = "clsegxxxxxxxxxxxxxxxxxxxxxxx";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockRequireVenueScheduleManager.mockResolvedValue("clusrxxxxxxxxxxxxxxxxxxxxxxx");
+  mockPrisma.surfaceSegment.findUnique.mockResolvedValue({
+    id: SEGMENT_ID,
+    name: "North",
+    isActive: true,
+    surfaceId: SURFACE_ID,
+    surface: {
+      name: "Main",
+      venueId: VENUE_ID,
+      venue: { organizationId: ORGANIZATION_ID, slug: "rink" },
+    },
+  });
+  mockPrisma.venueReservation.findMany.mockResolvedValue([]);
+  mockPrisma.seasonGame.findMany.mockResolvedValue([]);
+  mockPrisma.eventGame.findMany.mockResolvedValue([]);
+  mockPrisma.venueScheduleBlock.findMany.mockResolvedValue([]);
+  mockPrisma.practiceSession.findMany.mockResolvedValue([]);
+  mockPrisma.iceTimeRequest.findMany.mockResolvedValue([]);
+  mockPrisma.surfaceSegment.update.mockResolvedValue({ id: SEGMENT_ID, isActive: false });
+  mockPrisma.$transaction.mockImplementation(
+    async (callback: (tx: typeof mockPrisma) => unknown) => callback(mockPrisma),
+  );
+  mockLogVenueActivity.mockResolvedValue({ id: "cllogxxxxxxxxxxxxxxxxxxxxxxx" });
+});
+
+describe("segment deactivation guards", () => {
+  it("reads active canonical reservations and retains exact venue/surface scope", async () => {
+    mockPrisma.venueReservation.findMany.mockResolvedValue([
+      {
+        id: "clreservationxxxxxxxxxxxxxxxxx",
+        startsAt: new Date("2027-01-10T18:00:00Z"),
+        endsAt: new Date("2027-01-10T19:30:00Z"),
+        surfaceId: SURFACE_ID,
+        segmentId: SEGMENT_ID,
+        sourceScheduleBlock: null,
+      },
+    ]);
+
+    const result = await setSegmentActive({ segmentId: SEGMENT_ID, isActive: false });
+
+    expect(result.success).toBe(false);
+    expect(mockPrisma.venueReservation.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          venueId: VENUE_ID,
+          surfaceId: SURFACE_ID,
+          segmentId: { in: [SEGMENT_ID] },
+        }),
+      }),
+    );
+  });
+
+  it("retains an active published offering as a deactivation reference", async () => {
+    mockPrisma.venueScheduleBlock.findMany.mockResolvedValue([
+      {
+        id: "clblockxxxxxxxxxxxxxxxxxxxxxxx",
+        title: "Public skate requests",
+        startsAt: new Date("2027-01-10T18:00:00Z"),
+        endsAt: new Date("2027-01-10T19:30:00Z"),
+        surfaceId: SURFACE_ID,
+        segmentId: SEGMENT_ID,
+        segment: { name: "North" },
+        recurrenceRule: null,
+        recurrenceEndDate: null,
+        venue: { timezone: "America/New_York" },
+        reservationOccurrences: [],
+      },
+    ]);
+
+    const result = await setSegmentActive({ segmentId: SEGMENT_ID, isActive: false });
+
+    expect(result.success).toBe(false);
+    expect(mockPrisma.venueScheduleBlock.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          venueId: VENUE_ID,
+          surfaceId: SURFACE_ID,
+          intent: { in: ["OFFERING", "VENUE_ACTIVITY", "CLOSURE"] },
+        }),
+      }),
+    );
+  });
+
+  it("dual-reads unlinked legacy bookings alongside canonical reservations", async () => {
+    mockPrisma.venueReservation.findMany.mockResolvedValue([
+      {
+        id: "clreservationxxxxxxxxxxxxxxxxx",
+        startsAt: new Date("2027-01-10T18:00:00Z"),
+        endsAt: new Date("2027-01-10T19:30:00Z"),
+        surfaceId: SURFACE_ID,
+        segmentId: SEGMENT_ID,
+        sourceScheduleBlock: null,
+      },
+    ]);
+    mockPrisma.seasonGame.findMany.mockResolvedValue([
+      {
+        id: "clgamexxxxxxxxxxxxxxxxxxxxxxxx",
+        startAt: new Date("2027-01-11T18:00:00Z"),
+        endAt: new Date("2027-01-11T19:30:00Z"),
+        surfaceId: SURFACE_ID,
+        segmentId: SEGMENT_ID,
+        segment: { name: "North" },
+        homeTeam: { name: "A" },
+        awayTeam: { name: "B" },
+      },
+    ]);
+
+    const result = await setSegmentActive({ segmentId: SEGMENT_ID, isActive: false });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const details = result.details as
+        | { futureBookings?: Array<{ source: string }> }
+        | undefined;
+      expect(details?.futureBookings).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ source: "venueReservation" }),
+          expect.objectContaining({ source: "seasonGame" }),
+        ]),
+      );
+    }
+  });
+
+  it("rechecks active state and reservations on a serializable retry", async () => {
+    mockPrisma.surfaceSegment.findUnique
+      .mockResolvedValueOnce({
+        id: SEGMENT_ID,
+        name: "North",
+        isActive: true,
+        surfaceId: SURFACE_ID,
+        surface: {
+          name: "Main",
+          venueId: VENUE_ID,
+          venue: { organizationId: ORGANIZATION_ID, slug: "rink" },
+        },
+      })
+      .mockResolvedValue({
+        id: SEGMENT_ID,
+        name: "North",
+        isActive: true,
+        surfaceId: SURFACE_ID,
+        surface: {
+          name: "Main",
+          venueId: VENUE_ID,
+          venue: { organizationId: ORGANIZATION_ID, slug: "rink" },
+        },
+      });
+    mockPrisma.venueReservation.findMany
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{
+        id: "clreservationxxxxxxxxxxxxxxxxx",
+        startsAt: new Date("2027-01-10T18:00:00Z"),
+        endsAt: new Date("2027-01-10T19:30:00Z"),
+        surfaceId: SURFACE_ID,
+        segmentId: SEGMENT_ID,
+        sourceScheduleBlock: null,
+      }]);
+    let attempt = 0;
+    mockPrisma.$transaction.mockImplementation(
+      async (callback: (tx: typeof mockPrisma) => unknown) => {
+        attempt += 1;
+        const result = await callback(mockPrisma);
+        if (attempt === 1) {
+          throw new Prisma.PrismaClientKnownRequestError("write conflict", {
+            code: "P2034",
+            clientVersion: "test",
+          });
+        }
+        return result;
+      },
+    );
+
+    const result = await setSegmentActive({ segmentId: SEGMENT_ID, isActive: false });
+
+    expect(result.success).toBe(false);
+    expect(mockPrisma.surfaceSegment.findUnique).toHaveBeenCalledTimes(3);
+    expect(mockPrisma.venueReservation.findMany).toHaveBeenCalledTimes(2);
+    expect(mockPrisma.surfaceSegment.update).toHaveBeenCalledTimes(1);
+  });
+});

--- a/__tests__/lib/data/association-operations.test.ts
+++ b/__tests__/lib/data/association-operations.test.ts
@@ -1,0 +1,291 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockPrisma, mockAuth } = vi.hoisted(() => ({
+  mockPrisma: {
+    iceTimeRequest: { findMany: vi.fn() },
+    venueReservation: { findMany: vi.fn() },
+    venueReservationOverride: { findMany: vi.fn() },
+    seasonGame: { findMany: vi.fn() },
+    season: { findMany: vi.fn() },
+    team: { findMany: vi.fn() },
+    teamGearNeed: { findMany: vi.fn() },
+    gearReservation: { findMany: vi.fn() },
+    notificationOutbox: { findMany: vi.fn() },
+  },
+  mockAuth: { requireLeagueRole: vi.fn() },
+}));
+
+vi.mock("@/lib/db/prisma", () => ({ prisma: mockPrisma }));
+vi.mock("@/lib/auth/session", () => mockAuth);
+
+import { getAssociationOperationsData } from "@/lib/data/association-operations";
+
+const from = new Date("2026-09-01T00:00:00.000Z");
+const to = new Date("2026-10-01T00:00:00.000Z");
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockAuth.requireLeagueRole.mockResolvedValue("user-1");
+  for (const model of Object.values(mockPrisma)) model.findMany.mockResolvedValue([]);
+});
+
+describe("getAssociationOperationsData", () => {
+  it("does not read another league when authorization fails", async () => {
+    mockAuth.requireLeagueRole.mockRejectedValue(new Error("Unauthorized"));
+    await expect(getAssociationOperationsData("league-b", { from, to })).rejects.toThrow("Unauthorized");
+    for (const model of Object.values(mockPrisma)) expect(model.findMany).not.toHaveBeenCalled();
+  });
+
+  it("authenticates and authorizes the exact league before reading", async () => {
+    await getAssociationOperationsData("league-a", { from, to });
+    expect(mockAuth.requireLeagueRole).toHaveBeenCalledWith("league-a", "LEAGUE_ADMIN");
+    for (const model of Object.values(mockPrisma)) expect(model.findMany).toHaveBeenCalled();
+  });
+
+  it("puts the league boundary in every tenant-sensitive query", async () => {
+    await getAssociationOperationsData("league-a", { from, to });
+    expect(mockPrisma.iceTimeRequest.findMany.mock.calls[0][0].where).toEqual(
+      expect.objectContaining({ OR: expect.arrayContaining([{ requesterLeagueId: "league-a" }]) }),
+    );
+    expect(mockPrisma.venueReservation.findMany.mock.calls[0][0].where.OR).toEqual(
+      expect.arrayContaining([{ ownerLeagueId: "league-a" }]),
+    );
+    expect(mockPrisma.venueReservationOverride.findMany.mock.calls[0][0].where.reservation.OR).toEqual(
+      expect.arrayContaining([{ ownerLeagueId: "league-a" }]),
+    );
+    expect(mockPrisma.venueReservationOverride.findMany.mock.calls[0][0].where).toEqual(
+      expect.objectContaining({
+        reason: "Legacy commitments overlap during venue reservation migration",
+        candidateSnapshot: {
+          path: ["migrationSource"],
+          not: expect.anything(),
+        },
+      }),
+    );
+    expect(mockPrisma.seasonGame.findMany.mock.calls[0][0].where.season).toEqual({ leagueId: "league-a" });
+    expect(mockPrisma.season.findMany.mock.calls[0][0].where).toEqual(
+      expect.objectContaining({ leagueId: "league-a" }),
+    );
+    expect(mockPrisma.team.findMany.mock.calls[0][0].where).toEqual(
+      expect.objectContaining({ leagueId: "league-a" }),
+    );
+    expect(mockPrisma.teamGearNeed.findMany.mock.calls[0][0].where).toEqual(
+      expect.objectContaining({ leagueId: "league-a" }),
+    );
+    expect(mockPrisma.gearReservation.findMany.mock.calls[0][0].where).toEqual(
+      expect.objectContaining({ leagueId: "league-a" }),
+    );
+    expect(mockPrisma.notificationOutbox.findMany.mock.calls[0][0].where).toEqual(
+      expect.objectContaining({
+        leagueId: "league-a",
+        eventType: { startsWith: "gear." },
+      }),
+    );
+  });
+
+  it("returns operational summaries while excluding sensitive source fields", async () => {
+    mockPrisma.iceTimeRequest.findMany.mockResolvedValue([{
+      id: "request-1",
+      status: "SUBMITTED",
+      requestedStartAt: new Date("2026-09-03T10:00:00.000Z"),
+      requestedEndAt: new Date("2026-09-03T11:00:00.000Z"),
+      requesterTeam: { name: "Hawks" },
+      contactEmail: "private@example.test",
+      notes: "private request note",
+    }]);
+    mockPrisma.venueReservation.findMany.mockResolvedValue([{
+      id: "reservation-1",
+      startsAt: new Date("2026-09-04T10:00:00.000Z"),
+      endsAt: new Date("2026-09-04T11:00:00.000Z"),
+      venue: { name: "Main rink" },
+      ownerTeam: null,
+      events: [],
+      seasonGames: [],
+      signupEvents: [],
+      practiceSessions: [],
+      proposalEntries: [],
+      privateReason: "do not expose",
+    }]);
+    mockPrisma.teamGearNeed.findMany.mockResolvedValue([{
+      id: "need-1",
+      title: "Goalie gear",
+      team: { name: "Hawks" },
+      lines: [{ requestedQty: 2, fulfilledQty: 0, wishlistToken: "secret" }],
+    }]);
+    mockPrisma.gearReservation.findMany.mockResolvedValue([{
+      id: "gear-1",
+      requestedEndDate: new Date("2026-08-01T00:00:00.000Z"),
+      approvedEndDate: null,
+      team: { name: "Hawks" },
+      custodianEmailSnapshot: "custodian@example.test",
+      requestNotes: "private",
+    }]);
+    mockPrisma.notificationOutbox.findMany.mockResolvedValue([{
+      status: "FAILED",
+      scheduledAt: new Date("2026-09-02T00:00:00.000Z"),
+      recipientEmail: "recipient@example.test",
+      payload: { secret: true },
+    }]);
+
+    const result = await getAssociationOperationsData("league-a", { from, to });
+    expect(result.counts).toEqual(expect.objectContaining({
+      pendingIceRequests: 1,
+      unassignedReservations: 1,
+      urgentGearNeeds: 1,
+      overdueGearCustody: 1,
+      outboxFailed: 1,
+    }));
+    expect(JSON.stringify(result)).not.toContain("private@example.test");
+    expect(JSON.stringify(result)).not.toContain("custodian@example.test");
+    expect(JSON.stringify(result)).not.toContain("recipient@example.test");
+    expect(JSON.stringify(result)).not.toContain("secret");
+  });
+
+  it("keeps gear custody out of venue occupancy and reports only assigned reservations", async () => {
+    mockPrisma.venueReservation.findMany.mockResolvedValue([{
+      id: "venue-1",
+      startsAt: from,
+      endsAt: to,
+      venue: { name: "Main rink" },
+      ownerTeam: { name: "Hawks" },
+      events: [{ id: "event-1" }],
+      seasonGames: [],
+      signupEvents: [],
+      eventGames: [],
+      practiceSessions: [],
+      proposalEntries: [],
+    }]);
+    mockPrisma.gearReservation.findMany.mockResolvedValue([{
+      id: "gear-1",
+      requestedEndDate: new Date("2026-08-01T00:00:00.000Z"),
+      approvedEndDate: null,
+      team: { name: "Hawks" },
+    }]);
+
+    const result = await getAssociationOperationsData("league-a", { from, to });
+    expect(result.unassignedReservations).toHaveLength(0);
+    expect(result.upcomingReservations.map((item) => item.id)).toEqual(["venue-1"]);
+    expect(result.upcomingReservations.map((item) => item.id)).not.toContain("gear-1");
+  });
+
+  it("does not classify reservations linked only to an event game as unassigned", async () => {
+    mockPrisma.venueReservation.findMany.mockResolvedValue([{
+      id: "event-game-reservation",
+      startsAt: from,
+      endsAt: to,
+      venue: { name: "Main rink" },
+      ownerTeam: null,
+      events: [],
+      seasonGames: [],
+      signupEvents: [],
+      eventGames: [{ id: "event-game-1" }],
+      practiceSessions: [],
+      proposalEntries: [],
+    }]);
+
+    const result = await getAssociationOperationsData("league-a", { from, to });
+
+    expect(result.counts.unassignedReservations).toBe(0);
+    expect(result.unassignedReservations).toHaveLength(0);
+    expect(mockPrisma.venueReservation.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        select: expect.objectContaining({
+          eventGames: { select: { id: true }, take: 1 },
+        }),
+      }),
+    );
+  });
+
+  it("uses the approved gear end date as the effective overdue deadline", async () => {
+    mockPrisma.gearReservation.findMany.mockResolvedValue([
+      {
+        id: "gear-approved-future",
+        requestedEndDate: new Date("2020-08-01T00:00:00.000Z"),
+        approvedEndDate: new Date("2099-08-01T00:00:00.000Z"),
+        team: { name: "Hawks" },
+      },
+      {
+        id: "gear-approved-past",
+        requestedEndDate: new Date("2099-08-01T00:00:00.000Z"),
+        approvedEndDate: new Date("2020-08-01T00:00:00.000Z"),
+        team: { name: "Otters" },
+      },
+    ]);
+
+    const result = await getAssociationOperationsData("league-a", { from, to });
+
+    expect(result.counts.overdueGearCustody).toBe(1);
+    expect(result.gear.overdueCustody.map((item) => item.id)).toEqual(["gear-approved-past"]);
+    expect(mockPrisma.gearReservation.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          OR: [
+            { approvedEndDate: { lt: expect.any(Date) } },
+            { approvedEndDate: null, requestedEndDate: { lt: expect.any(Date) } },
+          ],
+        }),
+      }),
+    );
+  });
+
+  it("matches scheduled teams by ID when team names are duplicated", async () => {
+    mockPrisma.team.findMany.mockResolvedValue([
+      { id: "team-a", name: "Hawks" },
+      { id: "team-b", name: "Hawks" },
+      { id: "team-c", name: "Otters" },
+    ]);
+    mockPrisma.seasonGame.findMany.mockResolvedValue([{
+      id: "game-1",
+      status: "SCHEDULED",
+      startAt: new Date("2026-09-03T10:00:00.000Z"),
+      endAt: new Date("2026-09-03T11:00:00.000Z"),
+      updatedAt: new Date("2026-09-01T00:00:00.000Z"),
+      venueReservationId: "reservation-1",
+      conflictOverriddenAt: new Date("2026-09-01T00:00:00.000Z"),
+      phase: null,
+      homeTeam: { id: "team-a", name: "Hawks" },
+      awayTeam: { id: "team-c", name: "Otters" },
+    }]);
+
+    const result = await getAssociationOperationsData("league-a", { from, to });
+
+    expect(result.unscheduledTeams.map((team) => team.id)).toEqual(["team-b"]);
+  });
+
+  it("reports a missing reservation only for games that claim a venue", async () => {
+    mockPrisma.seasonGame.findMany.mockResolvedValue([
+      {
+        id: "game-with-venue",
+        status: "SCHEDULED",
+        startAt: from,
+        endAt: to,
+        updatedAt: from,
+        venueId: "venue-1",
+        venueReservationId: null,
+        conflictOverriddenAt: null,
+        phase: null,
+        homeTeam: { id: "team-a", name: "Hawks" },
+        awayTeam: { id: "team-b", name: "Otters" },
+      },
+      {
+        id: "game-without-venue",
+        status: "SCHEDULED",
+        startAt: from,
+        endAt: to,
+        updatedAt: from,
+        venueId: null,
+        venueReservationId: null,
+        conflictOverriddenAt: null,
+        phase: null,
+        homeTeam: { id: "team-c", name: "Foxes" },
+        awayTeam: { id: "team-d", name: "Bears" },
+      },
+    ]);
+
+    const result = await getAssociationOperationsData("league-a", { from, to });
+
+    expect(result.unresolvedConflicts.map((game) => game.id)).toEqual([
+      "game-with-venue",
+    ]);
+  });
+});

--- a/__tests__/lib/data/calendar.test.ts
+++ b/__tests__/lib/data/calendar.test.ts
@@ -6,6 +6,7 @@ const { mockPrisma, mockAuth, mockDashboard } = vi.hoisted(() => ({
     practiceSession: { findMany: vi.fn() },
     signupEvent: { findMany: vi.fn() },
     venueStaff: { findMany: vi.fn() },
+    team: { findMany: vi.fn() },
   },
   mockAuth: {
     getViewableTeamIds: vi.fn(),
@@ -95,24 +96,58 @@ describe("getUserCalendarItems event privacy", () => {
     mockPrisma.practiceSession.findMany.mockResolvedValue([]);
     mockPrisma.signupEvent.findMany.mockResolvedValue([]);
     mockPrisma.venueStaff.findMany.mockResolvedValue([]);
+    mockPrisma.team.findMany.mockResolvedValue([]);
   });
 
-  it("does not broaden a team-scoped participant Event to every league member", async () => {
+  it("defaults an ordinary league member to least-privilege team scope", async () => {
+    mockDashboard.getViewerMemberships.mockResolvedValue({
+      teams: [{
+        role: "MEMBER",
+        team: { id: "team-1", name: "Hawks", leagueId: "league-1" },
+      }],
+      leagues: [{
+        role: "MEMBER",
+        league: { id: "league-1", name: "Association" },
+      }],
+    });
+    mockPrisma.team.findMany.mockResolvedValue([{ id: "team-1" }]);
+
     await getUserCalendarItems({
       from: "2026-09-01T00:00:00.000Z",
       to: "2026-10-01T00:00:00.000Z",
     });
 
-    expect(mockPrisma.event.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: expect.objectContaining({
-          AND: expect.arrayContaining([
-            {
-              OR: [{ leagueId: { in: ["league-1"] } }],
-            },
-          ]),
-        }),
-      }),
+    const eventQueries = mockPrisma.event.findMany.mock.calls.map(([args]) =>
+      JSON.stringify(args.where),
     );
+    expect(eventQueries.some((query) => query.includes("team-1"))).toBe(true);
+    expect(eventQueries.every((query) => !query.includes('"leagueId":{"in":["league-1"]}'))).toBe(true);
+  });
+
+  it("resolves each league role independently for member privacy and admin aggregation", async () => {
+    mockDashboard.getViewerMemberships.mockResolvedValue({
+      teams: [],
+      leagues: [
+        { role: "MEMBER", league: { id: "league-member", name: "Member league" } },
+        { role: "LEAGUE_ADMIN", league: { id: "league-admin", name: "Admin league" } },
+      ],
+    });
+    mockPrisma.team.findMany.mockImplementation(async ({ where }) =>
+      where.leagueId === "league-member"
+        ? [{ id: "member-team" }]
+        : [{ id: "admin-team-a" }, { id: "admin-team-b" }],
+    );
+
+    await getUserCalendarItems({
+      from: "2026-09-01T00:00:00.000Z",
+      to: "2026-10-01T00:00:00.000Z",
+    });
+
+    const eventQueries = mockPrisma.event.findMany.mock.calls.map(([args]) =>
+      JSON.stringify(args.where),
+    );
+    expect(eventQueries.some((query) => query.includes("member-team"))).toBe(true);
+    expect(eventQueries.every((query) => !query.includes('"leagueId":{"in":["league-member"]}'))).toBe(true);
+    expect(eventQueries.some((query) => query.includes('"leagueId":{"in":["league-admin"]}'))).toBe(true);
   });
 });

--- a/__tests__/lib/data/schedule-items.test.ts
+++ b/__tests__/lib/data/schedule-items.test.ts
@@ -1,6 +1,31 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { deduplicateAssociationScheduleItems } from "@/lib/data/schedule-items";
+const { mockPrisma } = vi.hoisted(() => ({
+  mockPrisma: {
+    event: { findMany: vi.fn() },
+    seasonGame: { findMany: vi.fn() },
+    practiceSession: { findMany: vi.fn() },
+    signupEvent: { findMany: vi.fn() },
+    eventGame: { findMany: vi.fn() },
+    venueReservation: { findMany: vi.fn() },
+    team: { findMany: vi.fn() },
+    leagueUser: { findFirst: vi.fn() },
+  },
+}));
+const { mockCanViewSignupEvent } = vi.hoisted(() => ({
+  mockCanViewSignupEvent: vi.fn(),
+}));
+vi.mock("@/lib/db/prisma", () => ({ prisma: mockPrisma }));
+vi.mock("@/lib/utils/event-access", () => ({
+  canViewSignupEvent: mockCanViewSignupEvent,
+  isSignupEventManager: vi.fn(),
+}));
+
+import {
+  deduplicateAssociationScheduleItems,
+  getLeagueScheduleItems,
+  getScheduleItems,
+} from "@/lib/data/schedule-items";
 import type { AssociationScheduleItemView } from "@/types/association-operations";
 
 const startsAt = new Date("2026-09-07T10:00:00.000Z");
@@ -25,6 +50,161 @@ function scheduleItem(
     ...overrides,
   };
 }
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockCanViewSignupEvent.mockResolvedValue(false);
+  for (const model of Object.values(mockPrisma)) {
+    if ("findMany" in model) model.findMany.mockResolvedValue([]);
+  }
+  mockPrisma.leagueUser.findFirst.mockResolvedValue(null);
+});
+
+describe("getLeagueScheduleItems viewer scope", () => {
+  it("returns no private schedule without an authenticated viewer", async () => {
+    const result = await getLeagueScheduleItems("league-1");
+
+    expect(result).toEqual([]);
+    expect(mockPrisma.team.findMany).not.toHaveBeenCalled();
+    expect(mockPrisma.event.findMany).not.toHaveBeenCalled();
+  });
+
+  it("includes every active team commitment for a league administrator", async () => {
+    mockPrisma.leagueUser.findFirst.mockResolvedValue({ role: "LEAGUE_ADMIN" });
+    mockPrisma.team.findMany.mockResolvedValue([{ id: "team-a" }, { id: "team-b" }]);
+
+    await getLeagueScheduleItems("league-1", { userId: "admin-1" });
+
+    expect(mockPrisma.team.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { leagueId: "league-1", isActive: true },
+      }),
+    );
+    const practiceWhere = mockPrisma.practiceSession.findMany.mock.calls[0][0].where;
+    expect(JSON.stringify(practiceWhere)).toContain("team-a");
+    expect(JSON.stringify(practiceWhere)).toContain("team-b");
+    expect(JSON.stringify(practiceWhere)).not.toContain("isShared");
+    const reservationWhere = mockPrisma.venueReservation.findMany.mock.calls[0][0].where;
+    expect(JSON.stringify(reservationWhere)).toContain("ownerLeagueId");
+    expect(JSON.stringify(reservationWhere)).toContain("ownerTeamId");
+  });
+
+  it("limits a member to viewer-authorized team commitments and safe season visibility", async () => {
+    mockPrisma.leagueUser.findFirst.mockResolvedValue({ role: "MEMBER" });
+    mockPrisma.team.findMany
+      .mockResolvedValueOnce([{ id: "team-a" }])
+      .mockResolvedValueOnce([{ id: "team-a" }, { id: "guardian-team" }]);
+
+    await getLeagueScheduleItems("league-1", { userId: "member-1" });
+
+    expect(mockPrisma.team.findMany).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        where: expect.objectContaining({
+          leagueId: "league-1",
+          members: { some: { userId: "member-1" } },
+        }),
+      }),
+    );
+    expect(mockPrisma.team.findMany).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        where: expect.objectContaining({
+          leagueId: "league-1",
+          OR: expect.any(Array),
+        }),
+      }),
+    );
+    const eventWhere = mockPrisma.event.findMany.mock.calls[0][0].where;
+    expect(JSON.stringify(eventWhere)).toContain("team-a");
+    expect(JSON.stringify(eventWhere)).toContain("guardian-team");
+    expect(JSON.stringify(eventWhere)).not.toContain('"leagueId":{"in":["league-1"]}');
+    const practiceWhere = mockPrisma.practiceSession.findMany.mock.calls[0][0].where;
+    expect(JSON.stringify(practiceWhere)).toContain("team-a");
+    expect(JSON.stringify(practiceWhere)).not.toContain("guardian-team");
+    const seasonWhere = mockPrisma.seasonGame.findMany.mock.calls[0][0].where;
+    expect(seasonWhere.AND).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        OR: expect.arrayContaining([
+          {
+            season: {
+              leagueId: { in: ["league-1"] },
+              scheduleVisibility: { in: ["PUBLIC", "AUTHENTICATED"] },
+            },
+          },
+          {
+            AND: [
+              {
+                OR: [
+                  { homeTeamId: { in: ["team-a"] } },
+                  { awayTeamId: { in: ["team-a"] } },
+                ],
+              },
+              {
+                season: {
+                  scheduleVisibility: {
+                    in: ["RELATIONSHIP_ONLY", "PRIVATE"],
+                  },
+                },
+              },
+            ],
+          },
+        ]),
+      }),
+    ]));
+    expect(JSON.stringify(seasonWhere)).not.toContain('"notes":true');
+    const reservationWhere = mockPrisma.venueReservation.findMany.mock.calls[0][0].where;
+    expect(JSON.stringify(reservationWhere)).not.toContain("ownerLeagueId");
+    expect(JSON.stringify(reservationWhere)).toContain("ownerTeamId");
+  });
+
+  it("returns league-wide authenticated and participant-private games for members", async () => {
+    mockPrisma.leagueUser.findFirst.mockResolvedValue({ role: "MEMBER" });
+    mockPrisma.team.findMany
+      .mockResolvedValueOnce([{ id: "team-a" }])
+      .mockResolvedValueOnce([{ id: "team-a" }])
+      .mockResolvedValueOnce([{ id: "team-a" }, { id: "team-b" }]);
+    mockPrisma.seasonGame.findMany.mockResolvedValue([
+      {
+        id: "league-wide",
+        status: "SCHEDULED",
+        startAt: startsAt,
+        endAt: new Date("2026-09-07T11:00:00.000Z"),
+        homeTeam: { id: "team-b", name: "B" },
+        awayTeam: { id: "team-c", name: "C" },
+      },
+      {
+        id: "participant-private",
+        status: "SCHEDULED",
+        startAt: new Date("2026-09-08T10:00:00.000Z"),
+        endAt: new Date("2026-09-08T11:00:00.000Z"),
+        homeTeam: { id: "team-a", name: "A" },
+        awayTeam: { id: "team-b", name: "B" },
+      },
+    ]);
+
+    const result = await getLeagueScheduleItems("league-1", { userId: "member-1" });
+
+    expect(result.filter((item) => item.source === "seasonGame").map((item) => item.sourceId))
+      .toEqual(["league-wide", "participant-private"]);
+  });
+
+  it("uses all league teams but only published public sources for public scope", async () => {
+    mockPrisma.team.findMany.mockResolvedValue([{ id: "team-a" }, { id: "team-b" }]);
+
+    await getLeagueScheduleItems("league-1", { publicOnly: true });
+
+    expect(mockPrisma.leagueUser.findFirst).not.toHaveBeenCalled();
+    const signupWhere = mockPrisma.signupEvent.findMany.mock.calls[0][0].where;
+    expect(signupWhere).toEqual(expect.objectContaining({
+      status: "PUBLISHED",
+      visibility: "PUBLIC",
+    }));
+    const reservationWhere = mockPrisma.venueReservation.findMany.mock.calls[0][0].where;
+    expect(JSON.stringify(reservationWhere)).not.toContain("ownerLeagueId");
+    expect(JSON.stringify(reservationWhere)).toContain('"visibility":"PUBLIC"');
+  });
+});
 
 describe("deduplicateAssociationScheduleItems", () => {
   it("keeps unlinked recurring occurrences with the same source ID distinct", () => {
@@ -182,6 +362,321 @@ describe("deduplicateAssociationScheduleItems", () => {
       `event:earliest:${earlier.toISOString()}`,
       `event:aaa:${sameInstant.toISOString()}`,
       `event:zzz:${sameInstant.toISOString()}`,
+    ]);
+  });
+});
+
+describe("getScheduleItems public sources", () => {
+  it("excludes bare Event rows and reads only published public signup events", async () => {
+    mockPrisma.signupEvent.findMany.mockResolvedValue([{
+      id: "signup-public",
+      title: "Public clinic",
+      category: "CLINIC",
+      startAt: startsAt,
+      endAt: new Date("2026-09-07T11:00:00.000Z"),
+      timezone: "UTC",
+      venueId: null,
+      venue: null,
+      hostTeamId: null,
+      hostTeam: null,
+      hostLeague: { id: "league-1", name: "League" },
+      venueReservationId: null,
+      venueReservation: null,
+    }]);
+
+    const result = await getScheduleItems({ leagueIds: ["league-1"], publicOnly: true });
+
+    expect(mockPrisma.event.findMany).not.toHaveBeenCalled();
+    expect(mockPrisma.signupEvent.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          status: "PUBLISHED",
+          visibility: "PUBLIC",
+        }),
+      }),
+    );
+    const reservationWhere = mockPrisma.venueReservation.findMany.mock.calls[0][0].where;
+    expect(reservationWhere.OR).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ events: expect.anything() }),
+      ]),
+    );
+    expect(result.map((item) => item.source)).toEqual(["signupEvent"]);
+  });
+
+  it("deduplicates a public season game alias while preserving its Event RSVP URL", async () => {
+    mockPrisma.seasonGame.findMany.mockResolvedValue([{
+      id: "season-game-1",
+      status: "SCHEDULED",
+      startAt: startsAt,
+      endAt: new Date("2026-09-07T11:00:00.000Z"),
+      timezone: "UTC",
+      venueId: null,
+      surfaceId: null,
+      segmentId: null,
+      updatedAt: null,
+      homeTeam: { id: "team-a", name: "Hawks" },
+      awayTeam: { id: "team-b", name: "Otters" },
+      venue: null,
+      venueReservationId: null,
+      venueReservation: null,
+      event: { id: "event-rsvp" },
+    }]);
+
+    const result = await getScheduleItems({ leagueIds: ["league-1"], publicOnly: true });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual(expect.objectContaining({
+      source: "seasonGame",
+      title: "Hawks vs Otters",
+      href: "/events/event-rsvp",
+    }));
+    expect(mockPrisma.seasonGame.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          AND: expect.arrayContaining([
+            { season: { scheduleVisibility: "PUBLIC" } },
+          ]),
+        }),
+      }),
+    );
+  });
+
+  it("requires the parent signup event to be published, public, and teams-published before exposing matchups", async () => {
+    mockPrisma.eventGame.findMany.mockResolvedValue([{
+      id: "event-game-1",
+      name: "Semifinal",
+      status: "SCHEDULED",
+      startAt: startsAt,
+      endAt: new Date("2026-09-07T11:00:00.000Z"),
+      surfaceId: null,
+      segmentId: null,
+      event: {
+        id: "signup-event-1",
+        title: "Tournament",
+        status: "PUBLISHED",
+        visibility: "PUBLIC",
+        linkToken: null,
+        teamsPublishedAt: new Date("2026-09-01T00:00:00.000Z"),
+        timezone: "UTC",
+        venueId: null,
+        venue: null,
+      },
+      venueReservationId: null,
+      venueReservation: null,
+      homeTeam: { id: "event-team-a", name: "Hawks" },
+      awayTeam: { id: "event-team-b", name: "Otters" },
+    }]);
+
+    const result = await getScheduleItems({ leagueIds: ["league-1"], publicOnly: true });
+
+    expect(result).toEqual([
+      expect.objectContaining({ source: "eventGame", title: "Semifinal" }),
+    ]);
+    expect(mockPrisma.eventGame.findMany).toHaveBeenCalledWith(expect.objectContaining({
+      where: expect.objectContaining({
+        AND: expect.arrayContaining([
+          {
+            event: {
+              status: "PUBLISHED",
+              visibility: "PUBLIC",
+              teamsPublishedAt: { not: null },
+            },
+          },
+        ]),
+      }),
+    }));
+  });
+
+  it("scopes public venue-block reservations to the requested association tenant", async () => {
+    await getScheduleItems({ leagueIds: ["league-a"], publicOnly: true });
+
+    const reservationWhere = mockPrisma.venueReservation.findMany.mock.calls[0][0].where;
+    const publicBlockScope = reservationWhere.OR.find(
+      (scope: Record<string, unknown>) => "OR" in scope,
+    ) as { OR: Array<Record<string, unknown>> };
+    const sourceScopes = publicBlockScope.OR.filter(
+      (scope) => "sourceScheduleBlock" in scope,
+    );
+    expect(sourceScopes).toHaveLength(2);
+    expect(sourceScopes).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        sourceScheduleBlock: expect.objectContaining({
+          venue: expect.objectContaining({
+            is: expect.objectContaining({ leagueId: { in: ["league-a"] } }),
+          }),
+        }),
+      }),
+      expect.objectContaining({
+        sourceScheduleBlock: expect.objectContaining({
+          venue: expect.objectContaining({
+            is: expect.objectContaining({
+              relationships: {
+                some: expect.objectContaining({
+                  leagueId: { in: ["league-a"] },
+                  status: "ACTIVE",
+                }),
+              },
+            }),
+          }),
+        }),
+      }),
+    ]));
+  });
+});
+
+describe("getScheduleItems private source privacy", () => {
+  it("defaults direct private reads to member scope instead of association aggregation", async () => {
+    await getScheduleItems({
+      leagueIds: ["league-1"],
+      teamIds: ["team-direct"],
+      userId: "user-1",
+    });
+
+    const eventWhere = mockPrisma.event.findMany.mock.calls[0][0].where;
+    expect(JSON.stringify(eventWhere)).toContain("team-direct");
+    expect(JSON.stringify(eventWhere)).not.toContain(
+      '"leagueId":{"in":["league-1"]}',
+    );
+  });
+
+  it("limits practices to direct teams and shared or viewer-created sessions", async () => {
+    await getScheduleItems({
+      leagueIds: ["league-1"],
+      teamIds: ["team-direct"],
+      venueIds: ["venue-1"],
+      userId: "user-1",
+    });
+
+    expect(mockPrisma.practiceSession.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          AND: expect.arrayContaining([
+            { OR: [{ teamId: { in: ["team-direct"] } }] },
+            { OR: [{ isShared: true }, { createdById: "user-1" }] },
+          ]),
+        },
+      }),
+    );
+    const practiceWhere = mockPrisma.practiceSession.findMany.mock.calls[0][0].where;
+    expect(JSON.stringify(practiceWhere)).not.toContain("league-1");
+    expect(JSON.stringify(practiceWhere)).not.toContain("venue-1");
+  });
+
+  it("does not let league, venue, or guardian-derived host scope expose signup drafts", async () => {
+    mockPrisma.signupEvent.findMany.mockResolvedValue([{
+      id: "private-signup",
+      title: "Private signup",
+      category: "OTHER",
+      status: "DRAFT",
+      visibility: "PRIVATE",
+      linkToken: null,
+      startAt: startsAt,
+      endAt: new Date("2026-09-07T11:00:00.000Z"),
+      hostTeamId: "team-guardian",
+      hostTeam: { id: "team-guardian", name: "Guardian team" },
+      hostLeague: { id: "league-1", name: "League" },
+      venueReservationId: null,
+      venueReservation: null,
+    }]);
+
+    const result = await getScheduleItems({
+      leagueIds: ["league-1"],
+      teamIds: ["team-guardian"],
+      venueIds: ["venue-1"],
+      userId: "user-1",
+    });
+
+    const signupWhere = mockPrisma.signupEvent.findMany.mock.calls[0][0].where;
+    const privateScopes = signupWhere.AND.find(
+      (entry: { OR?: unknown[] }) => Array.isArray(entry.OR),
+    ) as { OR: Array<Record<string, unknown>> };
+    expect(privateScopes.OR).toEqual(expect.arrayContaining([
+      { hostLeagueId: { in: ["league-1"] } },
+      { hostTeamId: { in: ["team-guardian"] } },
+      { venueId: { in: ["venue-1"] } },
+    ]));
+    expect(result.some((item) => item.source === "signupEvent")).toBe(false);
+    expect(mockCanViewSignupEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "private-signup", visibility: "PRIVATE" }),
+      { userId: "user-1" },
+    );
+  });
+
+  it("does not expose a private event game to host-team members without event access", async () => {
+    mockPrisma.eventGame.findMany.mockResolvedValue([{
+      id: "private-game",
+      name: "Private matchup",
+      status: "SCHEDULED",
+      startAt: startsAt,
+      endAt: new Date("2026-09-07T11:00:00.000Z"),
+      surfaceId: null,
+      segmentId: null,
+      event: {
+        id: "private-event",
+        title: "Private event",
+        status: "PUBLISHED",
+        visibility: "PRIVATE",
+        linkToken: "public-link-token",
+        teamsPublishedAt: new Date("2026-09-01T00:00:00.000Z"),
+        timezone: "UTC",
+        venueId: null,
+        venue: null,
+      },
+      venueReservationId: null,
+      venueReservation: null,
+      homeTeam: { id: "event-team-a", name: "Hawks" },
+      awayTeam: { id: "event-team-b", name: "Otters" },
+    }]);
+
+    const result = await getScheduleItems({
+      leagueIds: ["league-1"],
+      teamIds: ["host-team"],
+      userId: "member-1",
+    });
+
+    expect(result.some((item) => item.source === "eventGame")).toBe(false);
+    expect(mockCanViewSignupEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "private-event", visibility: "PRIVATE" }),
+      { userId: "member-1" },
+    );
+    expect(mockCanViewSignupEvent.mock.calls[0][1]).not.toHaveProperty("linkToken");
+  });
+
+  it("allows a registrant or invitee through the canonical signup-event gate", async () => {
+    mockCanViewSignupEvent.mockResolvedValue(true);
+    mockPrisma.eventGame.findMany.mockResolvedValue([{
+      id: "authorized-game",
+      name: "Authorized matchup",
+      status: "SCHEDULED",
+      startAt: startsAt,
+      endAt: new Date("2026-09-07T11:00:00.000Z"),
+      surfaceId: null,
+      segmentId: null,
+      event: {
+        id: "invite-event",
+        title: "Invite event",
+        status: "PUBLISHED",
+        visibility: "INVITE_ONLY",
+        linkToken: null,
+        teamsPublishedAt: new Date("2026-09-01T00:00:00.000Z"),
+        timezone: "UTC",
+        venueId: null,
+        venue: null,
+      },
+      venueReservationId: null,
+      venueReservation: null,
+      homeTeam: { id: "event-team-a", name: "Hawks" },
+      awayTeam: { id: "event-team-b", name: "Otters" },
+    }]);
+
+    const result = await getScheduleItems({
+      leagueIds: ["league-1"],
+      userId: "registrant-1",
+    });
+
+    expect(result).toEqual([
+      expect.objectContaining({ source: "eventGame", title: "Authorized matchup" }),
     ]);
   });
 });

--- a/__tests__/lib/services/gear-reminders.test.ts
+++ b/__tests__/lib/services/gear-reminders.test.ts
@@ -42,6 +42,7 @@ function reservation(overrides: Record<string, unknown> = {}) {
     requestedById: null,
     requestedEndDate: new Date("2026-08-30T00:00:00.000Z"),
     approvedEndDate: new Date("2026-08-18T00:00:00.000Z"),
+    custodyStartedAt: new Date("2026-08-01T00:00:00.000Z"),
     ...overrides,
   };
 }
@@ -86,6 +87,12 @@ describe("gear custody reminders", () => {
           "gear.reservation.due_soon:crrrrrrrrrrrrrrrrrrrrrrrr:gear.reservation.due_soon:2026-08-18",
         ),
       })],
+    }));
+    expect(mocks.reservationFindMany).toHaveBeenCalledWith(expect.objectContaining({
+      where: expect.objectContaining({
+        status: "FULFILLED",
+        custodyStartedAt: { not: null },
+      }),
     }));
   });
 
@@ -258,6 +265,7 @@ describe("stale gear custody reminder cancellation", () => {
     mocks.reservationFindMany.mockResolvedValue([{
       id: "crrrrrrrrrrrrrrrrrrrrrrrr",
       status: "FULFILLED",
+      custodyStartedAt: new Date("2026-08-01T00:00:00.000Z"),
       requestedEndDate: new Date("2026-08-30T00:00:00.000Z"),
       approvedEndDate: new Date("2026-08-25T00:00:00.000Z"),
     }]);
@@ -275,6 +283,7 @@ describe("stale gear custody reminder cancellation", () => {
     mocks.reservationFindMany.mockResolvedValue([{
       id: "crrrrrrrrrrrrrrrrrrrrrrrr",
       status: "FULFILLED",
+      custodyStartedAt: new Date("2026-08-01T00:00:00.000Z"),
       requestedEndDate: new Date("2026-08-10T00:00:00.000Z"),
       approvedEndDate: new Date("2026-08-10T00:00:00.000Z"),
     }]);
@@ -290,11 +299,28 @@ describe("stale gear custody reminder cancellation", () => {
     mocks.reservationFindMany.mockResolvedValue([{
       id: "crrrrrrrrrrrrrrrrrrrrrrrr",
       status: "FULFILLED",
+      custodyStartedAt: new Date("2026-08-01T00:00:00.000Z"),
       requestedEndDate: new Date("2026-08-30T00:00:00.000Z"),
       approvedEndDate: new Date("2026-08-18T00:00:00.000Z"),
     }]);
 
     await expect(cancelStaleGearCustodyReminders(NOW)).resolves.toEqual({ inspected: 1, canceled: 0 });
     expect(mocks.outboxUpdateMany).not.toHaveBeenCalled();
+  });
+
+  it("cancels a pending custody reminder when pickup never started", async () => {
+    mocks.outboxFindMany.mockResolvedValue([pendingRow()]);
+    mocks.reservationFindMany.mockResolvedValue([{
+      id: "crrrrrrrrrrrrrrrrrrrrrrrr",
+      status: "FULFILLED",
+      custodyStartedAt: null,
+      requestedEndDate: new Date("2026-08-30T00:00:00.000Z"),
+      approvedEndDate: new Date("2026-08-18T00:00:00.000Z"),
+    }]);
+
+    await expect(cancelStaleGearCustodyReminders(NOW)).resolves.toEqual({
+      inspected: 1,
+      canceled: 1,
+    });
   });
 });

--- a/__tests__/lib/services/league-reporting.test.ts
+++ b/__tests__/lib/services/league-reporting.test.ts
@@ -14,6 +14,7 @@ vi.mock('@/lib/db/prisma', () => ({
     prisma: {
         team: {
             count: vi.fn(),
+            findMany: vi.fn(),
         },
         player: {
             count: vi.fn(),
@@ -29,12 +30,21 @@ vi.mock('@/lib/db/prisma', () => ({
         league: {
             findUnique: vi.fn(),
         },
+        leagueUser: {
+            findFirst: vi.fn(),
+        },
     },
 }));
 
 describe('League Reporting Service', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        vi.mocked(prisma.leagueUser.findFirst).mockResolvedValue({
+            role: 'LEAGUE_ADMIN',
+        } as unknown as Awaited<ReturnType<typeof prisma.leagueUser.findFirst>>);
+        vi.mocked(prisma.team.findMany).mockResolvedValue([
+            { id: 'team-a' },
+        ] as unknown as Awaited<ReturnType<typeof prisma.team.findMany>>);
     });
 
     describe('generateLeagueRosterCSV', () => {
@@ -62,7 +72,7 @@ describe('League Reporting Service', () => {
                 },
             ] as unknown as Awaited<ReturnType<typeof prisma.player.findMany>>);
 
-            const csv = await generateLeagueRosterCSV(leagueId);
+            const csv = await generateLeagueRosterCSV(leagueId, 'viewer-1');
 
             expect(csv).toContain('Player Name,Email,Phone,Team,Division,Jersey Number,Position,Date Added');
             expect(csv).toContain('John Doe');
@@ -98,7 +108,7 @@ describe('League Reporting Service', () => {
                 },
             ] as unknown as Awaited<ReturnType<typeof prisma.player.findMany>>);
 
-            const csv = await generateLeagueRosterCSV(leagueId);
+            const csv = await generateLeagueRosterCSV(leagueId, 'viewer-1');
 
             expect(csv).toContain('Unassigned');
         });
@@ -127,7 +137,11 @@ describe('League Reporting Service', () => {
                 },
             ] as unknown as Awaited<ReturnType<typeof prisma.player.findMany>>);
 
-            const csv = await generateLeagueRosterCSV(leagueId, { includeAdminFields: true });
+            const csv = await generateLeagueRosterCSV(
+                leagueId,
+                'viewer-1',
+                { includeAdminFields: true },
+            );
 
             expect(csv).toContain('Emergency Contact Name,Emergency Contact Phone,USA Hockey Member ID');
             expect(csv).toContain('Jane Doe');
@@ -141,6 +155,28 @@ describe('League Reporting Service', () => {
                         usahMemberId: true,
                     }),
                 })
+            );
+        });
+
+        it('never exposes admin-only roster fields to a non-admin caller', async () => {
+            vi.mocked(prisma.leagueUser.findFirst).mockResolvedValue({
+                role: 'MEMBER',
+            } as unknown as Awaited<ReturnType<typeof prisma.leagueUser.findFirst>>);
+            vi.mocked(prisma.player.findMany).mockResolvedValue([]);
+
+            const csv = await generateLeagueRosterCSV(
+                'league-1',
+                'member-1',
+                { includeAdminFields: true },
+            );
+
+            expect(csv).not.toContain('Emergency Contact Name');
+            expect(prisma.player.findMany).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    select: expect.not.objectContaining({
+                        emergencyContact: true,
+                    }),
+                }),
             );
         });
 
@@ -172,7 +208,7 @@ describe('League Reporting Service', () => {
             vi.mocked(prisma.player.count).mockResolvedValue(1);
             vi.mocked(prisma.event.count).mockResolvedValue(0);
 
-            const pdfBase64 = await generateLeagueRosterPDF(leagueId);
+            const pdfBase64 = await generateLeagueRosterPDF(leagueId, 'viewer-1');
             const pdfHeader = Buffer.from(pdfBase64, 'base64').toString('utf8', 0, 8);
 
             expect(pdfHeader).toBe('%PDF-1.4');
@@ -180,6 +216,14 @@ describe('League Reporting Service', () => {
     });
 
     describe('generateLeagueScheduleCSV', () => {
+        it('requires the authenticated caller identity instead of assuming an admin viewer', async () => {
+            await expect(
+                generateLeagueScheduleCSV('league-1', ''),
+            ).rejects.toThrow('Authenticated user identity is required');
+            expect(prisma.leagueUser.findFirst).not.toHaveBeenCalled();
+            expect(prisma.event.findMany).not.toHaveBeenCalled();
+        });
+
         it('should generate CSV with event schedule data', async () => {
             const leagueId = 'league-1';
 
@@ -203,12 +247,20 @@ describe('League Reporting Service', () => {
                 },
             ] as unknown as Awaited<ReturnType<typeof prisma.event.findMany>>);
 
-            const csv = await generateLeagueScheduleCSV(leagueId);
+            const csv = await generateLeagueScheduleCSV(leagueId, 'viewer-1');
 
             expect(csv).toContain('Date,Time,Event Type,Title');
             expect(csv).toContain('Practice Session');
             expect(csv).toContain('PRACTICE');
             expect(csv).toContain('Field 1');
+            expect(prisma.leagueUser.findFirst).toHaveBeenCalledWith({
+                where: {
+                    leagueId,
+                    userId: 'viewer-1',
+                    league: { isActive: true },
+                },
+                select: { role: true },
+            });
         });
 
         it('should handle games with home and away teams', async () => {
@@ -238,10 +290,37 @@ describe('League Reporting Service', () => {
                 },
             ] as unknown as Awaited<ReturnType<typeof prisma.event.findMany>>);
 
-            const csv = await generateLeagueScheduleCSV(leagueId);
+            const csv = await generateLeagueScheduleCSV(leagueId, 'viewer-1');
 
             expect(csv).toContain('Team A');
             expect(csv).toContain('Team B');
+        });
+
+        it('uses the authenticated member role instead of implicitly aggregating the league', async () => {
+            vi.mocked(prisma.leagueUser.findFirst).mockResolvedValue({
+                role: 'MEMBER',
+            } as unknown as Awaited<ReturnType<typeof prisma.leagueUser.findFirst>>);
+            vi.mocked(prisma.team.findMany).mockResolvedValue([
+                { id: 'member-team' },
+            ] as unknown as Awaited<ReturnType<typeof prisma.team.findMany>>);
+            vi.mocked(prisma.event.findMany).mockResolvedValue([]);
+
+            await generateLeagueScheduleCSV('league-1', 'member-1');
+
+            const eventWhere = vi.mocked(prisma.event.findMany).mock.calls[0][0]?.where;
+            expect(JSON.stringify(eventWhere)).toContain('member-team');
+            expect(JSON.stringify(eventWhere)).not.toContain(
+                '"leagueId":{"in":["league-1"]}',
+            );
+        });
+
+        it('rejects a schedule export when the viewer is not an active league member', async () => {
+            vi.mocked(prisma.leagueUser.findFirst).mockResolvedValue(null);
+
+            await expect(
+                generateLeagueScheduleCSV('league-1', 'outsider-1'),
+            ).rejects.toThrow('Unauthorized league report export');
+            expect(prisma.event.findMany).not.toHaveBeenCalled();
         });
 
         it('should preserve commas inside quoted CSV cells when generating schedule PDFs', async () => {
@@ -274,7 +353,7 @@ describe('League Reporting Service', () => {
             vi.mocked(prisma.player.count).mockResolvedValue(0);
             vi.mocked(prisma.event.count).mockResolvedValue(1);
 
-            const pdfBase64 = await generateLeagueSchedulePDF(leagueId);
+            const pdfBase64 = await generateLeagueSchedulePDF(leagueId, 'viewer-1');
             const pdfText = Buffer.from(pdfBase64, 'base64').toString('utf8');
 
             expect(pdfText).toContain('Springfield, IL');
@@ -345,7 +424,7 @@ describe('League Reporting Service', () => {
                 },
             ] as unknown as Awaited<ReturnType<typeof prisma.division.findMany>>);
 
-            const csv = await generateAttendanceReportByDivisionCSV(leagueId);
+            const csv = await generateAttendanceReportByDivisionCSV(leagueId, 'viewer-1');
 
             expect(csv).toContain('Division,Team,Total Events,Total RSVPs');
             expect(csv).toContain('Division 1');
@@ -379,7 +458,7 @@ describe('League Reporting Service', () => {
                 },
             ] as unknown as Awaited<ReturnType<typeof prisma.division.findMany>>);
 
-            const csv = await generateAttendanceReportByDivisionCSV(leagueId);
+            const csv = await generateAttendanceReportByDivisionCSV(leagueId, 'viewer-1');
 
             // 4 going out of 5 total = 80% attendance rate
             expect(csv).toContain('80.0');
@@ -430,7 +509,7 @@ describe('League Reporting Service', () => {
                 ],
             } as unknown as Awaited<ReturnType<typeof prisma.league.findUnique>>);
 
-            const csv = await generateFinancialReportCSV(leagueId);
+            const csv = await generateFinancialReportCSV(leagueId, 'viewer-1');
 
             expect(csv).toContain('Scope,Team,Division,Total Players,Total Events,Ice Time Requests,Approved Requests,Pending Requests,Known Scheduled Cost,Currency,Notes');
             expect(csv).toContain('Team A');
@@ -452,7 +531,7 @@ describe('League Reporting Service', () => {
 
             vi.mocked(prisma.league.findUnique).mockResolvedValue(null);
 
-            await expect(generateFinancialReportCSV(leagueId)).rejects.toThrow(
+            await expect(generateFinancialReportCSV(leagueId, 'viewer-1')).rejects.toThrow(
                 'League not found'
             );
         });

--- a/__tests__/lib/services/venue-reservations.test.ts
+++ b/__tests__/lib/services/venue-reservations.test.ts
@@ -4,6 +4,7 @@ import {
   assignVenueReservation,
   assertGenericRescheduleAllowed,
   createVenueReservation,
+  VenueReservationConflictError,
   transitionVenueReservation,
 } from "@/lib/services/venue-reservations";
 
@@ -71,8 +72,14 @@ function makeTx() {
     teamMember: {
       findFirst: vi.fn().mockResolvedValue({ id: "team-member-1" }),
     },
-    venueScheduleBlock: { findFirst: vi.fn().mockResolvedValue(null) },
-    iceTimeRequest: { findUnique: vi.fn().mockResolvedValue(null) },
+    venueScheduleBlock: {
+      findFirst: vi.fn().mockResolvedValue(null),
+      findMany: vi.fn().mockResolvedValue([]),
+    },
+    iceTimeRequest: {
+      findUnique: vi.fn().mockResolvedValue(null),
+      findMany: vi.fn().mockResolvedValue([]),
+    },
     venueReservation: {
       findUnique: vi.fn().mockResolvedValue(reservation()),
       findMany: vi.fn().mockResolvedValue([]),
@@ -82,14 +89,17 @@ function makeTx() {
     segmentCoexistence: { findMany: vi.fn().mockResolvedValue([]) },
     event: {
       findUnique: vi.fn(),
+      findMany: vi.fn().mockResolvedValue([]),
       update: vi.fn().mockResolvedValue({ id: "event-1" }),
     },
     seasonGame: {
       findUnique: vi.fn(),
+      findMany: vi.fn().mockResolvedValue([]),
       update: vi.fn().mockResolvedValue({ id: "season-game-1" }),
     },
     practiceSession: {
       findUnique: vi.fn(),
+      findMany: vi.fn().mockResolvedValue([]),
       update: vi.fn().mockResolvedValue({ id: "practice-1" }),
     },
     signupEvent: {
@@ -98,6 +108,7 @@ function makeTx() {
     },
     eventGame: {
       findUnique: vi.fn(),
+      findMany: vi.fn().mockResolvedValue([]),
       update: vi.fn().mockResolvedValue({ id: "event-game-1" }),
     },
     auditLog: { create: vi.fn().mockResolvedValue({ id: "audit-1" }) },
@@ -374,7 +385,7 @@ describe("createVenueReservation validation", () => {
       startsAt: laterStart,
       endsAt: laterEnd,
       offeringBlockId: "offering-1",
-    }))).resolves.toEqual({ id: venueReservationId });
+    }))).resolves.toMatchObject({ id: venueReservationId });
   });
 
   it.each([
@@ -451,7 +462,7 @@ describe("createVenueReservation validation", () => {
     await expect(createVenueReservation(tx, createInput({
       sourceRequestId: "request-1",
       offeringBlockId: "offering-1",
-    }))).resolves.toEqual({ id: venueReservationId });
+    }))).resolves.toMatchObject({ id: venueReservationId });
     expect(tx.iceTimeRequest.findUnique).toHaveBeenCalledBefore(
       vi.mocked(tx.venueReservation.create),
     );
@@ -490,7 +501,7 @@ describe("createVenueReservation validation", () => {
       ownerVenueOrganizationId: "venue-org-1",
       sourceRequestId: "request-1",
       offeringBlockId: "offering-1",
-    }))).resolves.toEqual({ id: venueReservationId });
+    }))).resolves.toMatchObject({ id: venueReservationId });
     expect(tx.venueReservation.create).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({
@@ -534,7 +545,7 @@ describe("createVenueReservation validation", () => {
     await expect(createVenueReservation(tx, createInput({
       surfaceId: null,
       segmentId: null,
-      overrideReason: "Private venue event",
+      venueWideReason: "Private venue event",
     }))).rejects.toThrow("venue-manager authorization");
     expect(tx.venueReservation.create).not.toHaveBeenCalled();
   });
@@ -547,13 +558,15 @@ describe("createVenueReservation validation", () => {
     }] as never);
 
     await expect(createVenueReservation(tx, createInput({
+      overrideConflicts: true,
       overrideReason: "Approved overlap",
     }))).rejects.toThrow("venue-manager authorization");
 
     vi.mocked(tx.venueStaff.findFirst).mockResolvedValue({ id: "staff-1" } as never);
     await expect(createVenueReservation(tx, createInput({
+      overrideConflicts: true,
       overrideReason: "Approved overlap",
-    }))).resolves.toEqual({ id: venueReservationId });
+    }))).resolves.toMatchObject({ id: venueReservationId });
     expect(tx.venueReservation.create).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({
@@ -566,6 +579,23 @@ describe("createVenueReservation validation", () => {
         }),
       }),
     );
+  });
+
+  it("does not let a venue-wide justification override a conflict", async () => {
+    const tx = makeTx();
+    vi.mocked(tx.venueStaff.findFirst).mockResolvedValue({ id: "staff-1" } as never);
+    vi.mocked(tx.venueReservation.findMany).mockResolvedValue([{
+      ...reservation(),
+      id: "reservation-2",
+    }] as never);
+
+    await expect(createVenueReservation(tx, createInput({
+      ownerLeagueId: undefined,
+      ownerVenueOrganizationId: "venue-org-1",
+      surfaceId: null,
+      segmentId: null,
+      venueWideReason: "Private venue event",
+    }))).rejects.toBeInstanceOf(VenueReservationConflictError);
   });
 });
 
@@ -587,7 +617,7 @@ describe("assignVenueReservation validation", () => {
       targetType,
       targetId,
       actorId: "actor-1",
-    })).resolves.toEqual({ id: venueReservationId });
+    })).resolves.toMatchObject({ id: venueReservationId });
 
     const delegate = {
       EVENT: tx.event,
@@ -612,7 +642,7 @@ describe("assignVenueReservation validation", () => {
       targetType: "PRACTICE",
       targetId,
       actorId: "actor-1",
-    })).resolves.toEqual({ id: venueReservationId });
+    })).resolves.toMatchObject({ id: venueReservationId });
 
     expect(tx.leagueUser.findFirst).toHaveBeenCalledWith({
       where: {
@@ -742,6 +772,93 @@ describe("assignVenueReservation validation", () => {
     expect(tx.practiceSession.update).not.toHaveBeenCalled();
   });
 
+  it("rechecks conflicts for an already-linked target", async () => {
+    const tx = makeTx();
+    vi.mocked(tx.venueReservation.findUnique).mockResolvedValue(reservation({
+      practiceSessions: [{ id: "practice-1", teamId: "team-1" }],
+    }) as never);
+    vi.mocked(tx.venueReservation.findMany).mockResolvedValue([
+      reservation({ id: "reservation-2" }),
+    ] as never);
+    const targetId = setAssignmentTarget(tx, "PRACTICE", "league-1", venueReservationId);
+
+    await expect(assignVenueReservation(tx, {
+      reservationId: "reservation-1",
+      targetType: "PRACTICE",
+      targetId,
+      actorId: "actor-1",
+    })).rejects.toBeInstanceOf(VenueReservationConflictError);
+    expect(tx.practiceSession.update).not.toHaveBeenCalled();
+    expect(tx.auditLog.create).not.toHaveBeenCalled();
+  });
+
+  it("preserves explicit reservation exclusions during assignment rechecks", async () => {
+    const tx = makeTx();
+    const targetId = setAssignmentTarget(tx, "PRACTICE", "league-1", null);
+    const parentReservationId = "parent-reservation-1";
+
+    await assignVenueReservation(tx, {
+      reservationId: "reservation-1",
+      targetType: "PRACTICE",
+      targetId,
+      actorId: "actor-1",
+      excludeReservationIds: [parentReservationId],
+    });
+
+    expect(tx.venueReservation.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          id: { notIn: [venueReservationId, parentReservationId] },
+        }),
+      }),
+    );
+  });
+
+  it("records the actor, reason, and conflict snapshot for an idempotent override", async () => {
+    const tx = makeTx();
+    vi.mocked(tx.venueReservation.findUnique).mockResolvedValue(reservation({
+      practiceSessions: [{ id: "practice-1", teamId: "team-1" }],
+    }) as never);
+    vi.mocked(tx.venueReservation.findMany).mockResolvedValue([
+      reservation({ id: "reservation-2" }),
+    ] as never);
+    vi.mocked(tx.venueStaff.findFirst).mockResolvedValue({ id: "staff-1" } as never);
+    const targetId = setAssignmentTarget(tx, "PRACTICE", "league-1", venueReservationId);
+
+    await assignVenueReservation(tx, {
+      reservationId: "reservation-1",
+      targetType: "PRACTICE",
+      targetId,
+      actorId: "actor-1",
+      overrideConflicts: true,
+      overrideReason: "Tournament director approved the overlap",
+    });
+
+    expect(tx.venueReservation.update).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        assignedById: "actor-1",
+        overrides: {
+          create: expect.objectContaining({
+            actorId: "actor-1",
+            reason: "Tournament director approved the overlap",
+            conflictingReservationIds: ["reservation-2"],
+          }),
+        },
+      }),
+    }));
+    expect(tx.auditLog.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        action: "VENUE_RESERVATION_ASSIGNED",
+        userId: "actor-1",
+        details: expect.objectContaining({
+          targetType: "PRACTICE",
+          targetId,
+          conflictOverrideCount: 1,
+        }),
+      }),
+    }));
+  });
+
   it("uses canonical reservation space for surface Events and segmented SignupEvents", async () => {
     const eventTx = makeTx();
     setAssignmentTarget(eventTx, "EVENT");
@@ -750,7 +867,7 @@ describe("assignVenueReservation validation", () => {
       targetType: "EVENT",
       targetId: "event-1",
       actorId: "actor-1",
-    })).resolves.toEqual({ id: venueReservationId });
+    })).resolves.toMatchObject({ id: venueReservationId });
 
     const signupTx = makeTx();
     setAssignmentTarget(signupTx, "SIGNUP_EVENT");
@@ -759,7 +876,7 @@ describe("assignVenueReservation validation", () => {
       targetType: "SIGNUP_EVENT",
       targetId: "signup-event-1",
       actorId: "actor-1",
-    })).resolves.toEqual({ id: venueReservationId });
+    })).resolves.toMatchObject({ id: venueReservationId });
   });
 
   it("allows an explicitly matched Practice/Event alias to share one reservation", async () => {
@@ -781,7 +898,7 @@ describe("assignVenueReservation validation", () => {
       targetType: "PRACTICE",
       targetId: "practice-1",
       actorId: "actor-1",
-    })).resolves.toEqual({ id: venueReservationId });
+    })).resolves.toMatchObject({ id: venueReservationId });
   });
 });
 
@@ -815,6 +932,7 @@ describe("transitionVenueReservation authorization", () => {
       nextStatus: "CONFIRMED",
       actorId: "actor-1",
       reason: "Approve held inventory",
+      overrideConflicts: true,
       overrideReason: "Approved overlap",
     })).rejects.toThrow("venue-manager authorization");
 
@@ -824,8 +942,9 @@ describe("transitionVenueReservation authorization", () => {
       nextStatus: "CONFIRMED",
       actorId: "actor-1",
       reason: "Approve held inventory",
+      overrideConflicts: true,
       overrideReason: "Approved overlap",
-    })).resolves.toEqual({ id: venueReservationId });
+    })).resolves.toMatchObject({ id: venueReservationId });
   });
 
   it("persists an optional transition snapshot for reschedule bookkeeping", async () => {
@@ -843,7 +962,7 @@ describe("transitionVenueReservation authorization", () => {
       actorId: "actor-1",
       reason: "Moved to a replacement slot",
       snapshot,
-    })).resolves.toEqual({ id: venueReservationId });
+    })).resolves.toMatchObject({ id: venueReservationId });
 
     expect(tx.venueReservation.update).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/__tests__/lib/utils/season-standings.test.ts
+++ b/__tests__/lib/utils/season-standings.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   computeSeasonStandings,
+  overlaySeasonTeamDivisions,
   type SeasonStandingsGame,
 } from "@/lib/utils/season-standings";
 
@@ -15,6 +16,26 @@ const completed = (
   awayTeamId,
   homeScore,
   awayScore,
+});
+
+describe("overlaySeasonTeamDivisions", () => {
+  it("preserves an unprojected legacy division and honors explicit null placement", () => {
+    expect(overlaySeasonTeamDivisions(
+      [
+        { id: "legacy", name: "Legacy", divisionId: "division-old" },
+        { id: "moved", name: "Moved", divisionId: "division-old" },
+        { id: "cleared", name: "Cleared", divisionId: "division-old" },
+      ],
+      [
+        { teamId: "moved", divisionId: "division-new" },
+        { teamId: "cleared", divisionId: null },
+      ],
+    )).toEqual([
+      { id: "legacy", name: "Legacy", divisionId: "division-old" },
+      { id: "moved", name: "Moved", divisionId: "division-new" },
+      { id: "cleared", name: "Cleared", divisionId: null },
+    ]);
+  });
 });
 
 describe("computeSeasonStandings", () => {

--- a/__tests__/lib/utils/validation.test.ts
+++ b/__tests__/lib/utils/validation.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from "vitest";
 import {
   addPlayerSchema,
+  createEventSchema,
+  updateEventSchema,
   updateTeamMemberUsahIdSchema,
 } from "@/lib/utils/validation";
 
@@ -107,6 +109,7 @@ describe("updateTeamMemberUsahIdSchema", () => {
       ...base,
       usahMemberId: "ABC123",
     });
+
     expect(result.success).toBe(true);
   });
 
@@ -150,5 +153,49 @@ describe("updateTeamMemberUsahIdSchema", () => {
       usahMemberId: "ABC@123",
     });
     expect(result.success).toBe(false);
+  });
+});
+
+describe("venue event end time", () => {
+  const base = {
+    type: "PRACTICE" as const,
+    title: "Practice",
+    startAt: new Date("2099-08-01T18:00:00.000Z"),
+    location: "North Rink",
+    teamId: "cteam00000000000000000001",
+    venueId: "cvenue0000000000000000001",
+    overrideConflicts: false,
+  };
+
+  it("requires endAt when creating a venue event", () => {
+    const result = createEventSchema.safeParse(base);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          path: ["endAt"],
+          message: "End date and time is required when a venue is selected",
+        }),
+      ]));
+    }
+  });
+
+  it("requires endAt when updating a venue event", () => {
+    const result = updateEventSchema.safeParse({
+      ...base,
+      id: "cevent0000000000000000001",
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues).toEqual(expect.arrayContaining([
+        expect.objectContaining({ path: ["endAt"] }),
+      ]));
+    }
+  });
+
+  it("keeps endAt optional for events without a venue", () => {
+    expect(createEventSchema.safeParse({ ...base, venueId: "" }).success).toBe(true);
   });
 });

--- a/__tests__/scripts/backfill-season-placements.test.ts
+++ b/__tests__/scripts/backfill-season-placements.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockPrisma } = vi.hoisted(() => ({
+  mockPrisma: {
+    season: { findMany: vi.fn() },
+    team: { findMany: vi.fn() },
+    seasonTeamPlacement: { findUnique: vi.fn(), upsert: vi.fn() },
+    $disconnect: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/db/prisma", () => ({ prisma: mockPrisma }));
+
+import { backfillSeasonPlacements } from "@/scripts/backfill-season-placements";
+
+const NOW = new Date("2026-08-17T12:00:00.000Z");
+const LEAGUE_ID = "clleague0000000000000001";
+const OLD_TEAM = "clteam00000000000000001";
+const GAME_TEAM = "clteam00000000000000002";
+const NEW_TEAM = "clteam00000000000000003";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockPrisma.seasonTeamPlacement.findUnique.mockResolvedValue(null);
+  mockPrisma.seasonTeamPlacement.upsert.mockResolvedValue({ id: "placement" });
+});
+
+describe("season placement backfill candidate history", () => {
+  it("uses only decisions and season games for historical seasons after transfers/new teams", async () => {
+    mockPrisma.season.findMany.mockResolvedValue([{
+      id: "clseason000000000000001",
+      leagueId: LEAGUE_ID,
+      teamId: null,
+      createdById: "creator-1",
+      startDate: new Date("2024-09-01T00:00:00.000Z"),
+      endDate: new Date("2025-03-01T00:00:00.000Z"),
+      archivedAt: null,
+      placements: [{
+        id: "decision-1",
+        teamId: OLD_TEAM,
+        divisionId: "old-division",
+        rank: 1,
+        privateNote: "Historical",
+        decidedById: "decider-1",
+        team: { name: "Old Team Snapshot" },
+        division: { name: "Old Division" },
+      }],
+      games: [{
+        homeTeamId: OLD_TEAM,
+        awayTeamId: GAME_TEAM,
+        homeTeam: { name: "Old Team Snapshot" },
+        awayTeam: { name: "Game Team Snapshot" },
+      }],
+    }]);
+    mockPrisma.team.findMany.mockImplementation(
+      async ({ where }: { where: { id?: { in: string[] }; leagueId?: string } }) => {
+        if (where.leagueId) {
+          return [
+            { id: OLD_TEAM, name: "Transferred Team", divisionId: "new-division", division: { name: "New Division" } },
+            { id: NEW_TEAM, name: "Expansion Team", divisionId: "new-division", division: { name: "New Division" } },
+          ];
+        }
+        return [
+          { id: OLD_TEAM, name: "Transferred Team", divisionId: "new-division", division: { name: "New Division" } },
+          { id: GAME_TEAM, name: "Game Team", divisionId: "new-division", division: { name: "New Division" } },
+        ].filter((team) => where.id?.in.includes(team.id));
+      },
+    );
+
+    const report = await backfillSeasonPlacements({ now: NOW });
+
+    expect(report.teamsScanned).toBe(2);
+    expect(mockPrisma.team.findMany).toHaveBeenCalledTimes(1);
+    expect(mockPrisma.seasonTeamPlacement.upsert).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        create: expect.objectContaining({ teamId: NEW_TEAM }),
+      }),
+    );
+    expect(mockPrisma.seasonTeamPlacement.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        create: expect.objectContaining({
+          teamId: OLD_TEAM,
+          divisionId: "old-division",
+          teamNameSnapshot: "Old Team Snapshot",
+          divisionNameSnapshot: "Old Division",
+        }),
+      }),
+    );
+    expect(mockPrisma.seasonTeamPlacement.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        create: expect.objectContaining({
+          teamId: GAME_TEAM,
+          divisionId: null,
+          teamNameSnapshot: "Game Team Snapshot",
+          divisionNameSnapshot: null,
+        }),
+      }),
+    );
+  });
+
+  it("adds current roster defaults only for a currently applicable season and stays idempotent", async () => {
+    mockPrisma.season.findMany.mockResolvedValue([{
+      id: "clseason000000000000002",
+      leagueId: LEAGUE_ID,
+      teamId: null,
+      createdById: "creator-1",
+      startDate: new Date("2026-08-01T00:00:00.000Z"),
+      endDate: new Date("2027-03-01T00:00:00.000Z"),
+      archivedAt: null,
+      placements: [],
+      games: [],
+    }]);
+    mockPrisma.team.findMany
+      .mockResolvedValueOnce([{ id: NEW_TEAM }])
+      .mockResolvedValueOnce([{
+        id: NEW_TEAM,
+        name: "Expansion Team",
+        divisionId: "current-division",
+        division: { name: "Current Division" },
+      }]);
+    mockPrisma.seasonTeamPlacement.findUnique.mockResolvedValue({ id: "existing" });
+
+    const report = await backfillSeasonPlacements({ now: NOW });
+
+    expect(report).toMatchObject({
+      teamsScanned: 1,
+      placementsCreated: 0,
+      placementsAlreadyPresent: 1,
+    });
+    expect(mockPrisma.seasonTeamPlacement.upsert).not.toHaveBeenCalled();
+  });
+});

--- a/app/(dashboard)/events/[id]/edit/page.tsx
+++ b/app/(dashboard)/events/[id]/edit/page.tsx
@@ -4,6 +4,7 @@ import { Box } from "@mui/material";
 import { redirect, notFound } from "next/navigation";
 import EventForm from "@/components/features/events/EventForm";
 import { PageContainer } from "@/components/ui/PageContainer";
+import { getEventReservationOptions } from "../../venue-reservation-options";
 
 interface EditEventPageProps {
   params: Promise<{
@@ -27,6 +28,7 @@ export default async function EditEventPage({ params }: EditEventPageProps) {
   if (event.userRole !== "ADMIN") {
     redirect(`/events/${id}`);
   }
+  const reservations = await getEventReservationOptions(event.teamId, event.id);
 
   return (
     <PageContainer maxWidth="md">
@@ -40,6 +42,7 @@ export default async function EditEventPage({ params }: EditEventPageProps) {
         <EventForm
           teamId={event.teamId}
           eventId={event.id}
+          reservations={reservations}
           initialData={{
             type: event.type as "GAME" | "PRACTICE",
             title: event.title,
@@ -48,6 +51,7 @@ export default async function EditEventPage({ params }: EditEventPageProps) {
             timezone: event.timezone,
             location: event.location,
             venueId: event.venueId ?? undefined,
+            reservationId: event.venueReservationId ?? undefined,
             opponent: event.opponent || "",
             notes: event.notes || "",
           }}

--- a/app/(dashboard)/events/new/page.tsx
+++ b/app/(dashboard)/events/new/page.tsx
@@ -3,6 +3,7 @@ import { redirect } from "next/navigation";
 import EventForm from "@/components/features/events/EventForm";
 import { getUserAdminTeamContext, getUserTeamContext } from "@/lib/actions/team-context";
 import { PageContainer } from "@/components/ui/PageContainer";
+import { getEventReservationOptions } from "../venue-reservation-options";
 
 export default async function NewEventPage() {
   // Prefer any team the user administers so admins of a non-primary team
@@ -13,6 +14,7 @@ export default async function NewEventPage() {
     const memberContext = await getUserTeamContext();
     redirect(memberContext ? "/calendar" : "/");
   }
+  const reservations = await getEventReservationOptions(context.teamId);
 
   return (
     <PageContainer maxWidth="md">
@@ -23,7 +25,7 @@ export default async function NewEventPage() {
           alignItems: "center",
         }}
       >
-        <EventForm teamId={context.teamId} />
+        <EventForm teamId={context.teamId} reservations={reservations} />
       </Box>
     </PageContainer>
   );

--- a/app/(dashboard)/events/venue-reservation-options.ts
+++ b/app/(dashboard)/events/venue-reservation-options.ts
@@ -1,0 +1,90 @@
+import { prisma } from "@/lib/db/prisma";
+import { requireUserId } from "@/lib/auth/session";
+import type { EventReservationOption } from "@/components/features/events/EventForm";
+
+const unassignedReservation = {
+  events: { none: {} },
+  seasonGames: { none: {} },
+  eventGames: { none: {} },
+  signupEvents: { none: {} },
+  practiceSessions: { none: {} },
+  proposalEntries: { none: {} },
+};
+
+export async function getEventReservationOptions(
+  teamId: string,
+  eventId?: string,
+): Promise<EventReservationOption[]> {
+  const userId = await requireUserId();
+  const [team, currentEvent] = await Promise.all([
+    prisma.team.findUnique({
+      where: { id: teamId },
+      select: { leagueId: true },
+    }),
+    eventId
+      ? prisma.event.findFirst({
+          where: { id: eventId, teamId },
+          select: { venueReservationId: true },
+        })
+      : Promise.resolve(null),
+  ]);
+  const currentReservationId = currentEvent?.venueReservationId ?? null;
+  const mayAssignLeagueInventory = team?.leagueId
+    ? Boolean(await prisma.leagueUser.findFirst({
+        where: {
+          userId,
+          leagueId: team.leagueId,
+          role: "LEAGUE_ADMIN",
+        },
+        select: { id: true },
+      }))
+    : false;
+
+  const rows = await prisma.venueReservation.findMany({
+    where: {
+      status: "CONFIRMED",
+      OR: [
+        { ownerTeamId: teamId },
+        ...(team?.leagueId && mayAssignLeagueInventory
+          ? [{ ownerLeagueId: team.leagueId }]
+          : []),
+        ...(currentReservationId ? [{ id: currentReservationId }] : []),
+      ],
+      AND: [
+        currentReservationId
+          ? {
+              OR: [
+                unassignedReservation,
+                {
+                  id: currentReservationId,
+                  events: { some: { id: eventId, teamId } },
+                },
+              ],
+            }
+          : unassignedReservation,
+      ],
+    },
+    select: {
+      id: true,
+      startsAt: true,
+      endsAt: true,
+      timezone: true,
+      venueId: true,
+      venue: { select: { name: true } },
+      surface: { select: { name: true } },
+      segment: { select: { name: true } },
+    },
+    orderBy: { startsAt: "asc" },
+  });
+
+  return rows.map((row) => ({
+    id: row.id,
+    startsAt: row.startsAt.toISOString(),
+    endsAt: row.endsAt.toISOString(),
+    timezone: row.timezone,
+    venueId: row.venueId,
+    venueName: row.venue.name,
+    surfaceName: row.surface?.name ?? null,
+    segmentName: row.segment?.name ?? null,
+  }));
+}

--- a/app/(dashboard)/league/[leagueId]/operations/page.tsx
+++ b/app/(dashboard)/league/[leagueId]/operations/page.tsx
@@ -1,0 +1,32 @@
+import { notFound } from "next/navigation";
+import { PageContainer } from "@/components/ui/PageContainer";
+import { PageHeader } from "@/components/ui/PageHeader";
+import OperationalDashboard from "@/components/features/association-operations/OperationalDashboard";
+import {
+  getAssociationOperationsData,
+  type AssociationOperationsData,
+} from "@/lib/data/association-operations";
+
+export const dynamic = "force-dynamic";
+
+export default async function AssociationOperationsPage({
+  params,
+}: {
+  params: Promise<{ leagueId: string }>;
+}) {
+  const { leagueId } = await params;
+  let data: AssociationOperationsData | null = null;
+  let error: string | undefined;
+  try {
+    data = await getAssociationOperationsData(leagueId);
+  } catch (caught) {
+    if (caught instanceof Error && caught.message.toLowerCase().includes("unauthorized")) notFound();
+    error = "Operations data could not be loaded.";
+  }
+  return (
+    <PageContainer>
+      <PageHeader title="Association operations" />
+      <OperationalDashboard data={data} error={error} />
+    </PageContainer>
+  );
+}

--- a/app/(dashboard)/practice-planner/[sessionId]/edit/EditSessionWrapper.tsx
+++ b/app/(dashboard)/practice-planner/[sessionId]/edit/EditSessionWrapper.tsx
@@ -46,7 +46,7 @@ export function EditSessionWrapper({
           duration: play.duration,
           instructions: play.instructions || "",
         })),
-        reservationId: session.reservationId,
+        reservationId: session.reservationId ?? undefined,
         // Optional venue booking (006, FR-019); the attachment is replaced
         // wholesale — omitting venueId detaches the practice.
         venueId: session.venueId || undefined,

--- a/app/(dashboard)/practice-planner/new/PracticeSessionEditorWrapper.tsx
+++ b/app/(dashboard)/practice-planner/new/PracticeSessionEditorWrapper.tsx
@@ -36,7 +36,7 @@ export function PracticeSessionEditorWrapper({
           duration: play.duration,
           instructions: play.instructions || "",
         })),
-        reservationId: session.reservationId,
+        reservationId: session.reservationId ?? undefined,
         // Optional venue booking (006, FR-019); omitted fields mean unbooked.
         venueId: session.venueId || undefined,
         surfaceId: session.surfaceId || undefined,

--- a/app/(dashboard)/seasons/[seasonId]/page.tsx
+++ b/app/(dashboard)/seasons/[seasonId]/page.tsx
@@ -8,7 +8,10 @@ import { prisma } from "@/lib/db/prisma";
 import { requireUserId } from "@/lib/auth/session";
 import { STATS_MIN_AGE_LEVEL } from "@/lib/env";
 import { AGE_CLASSIFICATION_RANK, isStatsEligible } from "@/lib/utils/age-level";
-import { computeSeasonStandings } from "@/lib/utils/season-standings";
+import {
+  computeSeasonStandings,
+  overlaySeasonTeamDivisions,
+} from "@/lib/utils/season-standings";
 import { SeasonDetail } from "@/components/features/seasons/SeasonDetail";
 import { GenerationWizard } from "@/components/features/seasons/GenerationWizard";
 import { PhaseEditor } from "@/components/features/seasons/PhaseEditor";
@@ -50,9 +53,13 @@ export default async function SeasonDetailPage({
         })) > 0
       : false;
 
+  const seasonPlacementByTeam = new Map(
+    season.teamPlacements.map((placement) => [placement.teamId, placement]),
+  );
+
   // Eligible opponents (FR-008): the league's teams for league seasons; for
   // team-owned seasons, any teams the viewer administers (legacy team scope).
-  const teams = season.leagueId
+  const teamRows = season.leagueId
     ? await prisma.team.findMany({
         where: { leagueId: season.leagueId, isActive: true },
         select: { id: true, name: true, divisionId: true },
@@ -65,6 +72,7 @@ export default async function SeasonDetailPage({
           orderBy: { team: { name: "asc" } },
         })
       ).map((membership) => membership.team);
+  const teams = overlaySeasonTeamDivisions(teamRows, season.teamPlacements);
 
   // League divisions feed the generation wizard's division preselect (FR-018).
   const divisions = season.leagueId
@@ -134,7 +142,12 @@ export default async function SeasonDetailPage({
   // classification; unclassified-only seasons stay score-eligible. Below the
   // stats threshold the whole standings table is suppressed.
   const participantLevels = participatingTeams
-    .map((team) => team.division?.ageClassification)
+    .map((team) => {
+      const placement = seasonPlacementByTeam.get(team.id);
+      return placement
+        ? placement.division?.ageClassification ?? null
+        : team.division?.ageClassification ?? null;
+    })
     .filter((level): level is AgeClassification => Boolean(level));
   const mostRestrictiveLevel =
     participantLevels.length > 0
@@ -148,14 +161,21 @@ export default async function SeasonDetailPage({
   const standingsRows = standingsGated
     ? []
     : computeSeasonStandings(
-        participatingTeams.map((team) => ({ id: team.id, name: team.name })),
+        participatingTeams.map((team) => ({
+          id: team.id,
+          name: seasonPlacementByTeam.get(team.id)?.teamNameSnapshot || team.name,
+        })),
         season.games.map((game) => ({
           status: game.status,
           homeTeamId: game.homeTeamId,
           awayTeamId: game.awayTeamId,
           homeScore: game.homeScore,
           awayScore: game.awayScore,
-        }))
+        })),
+        season.teamPlacements.map((placement) => ({
+          teamId: placement.teamId,
+          teamNameSnapshot: placement.teamNameSnapshot,
+        })),
       );
 
   const phaseGameCounts = new Map<string, number>();
@@ -208,6 +228,7 @@ export default async function SeasonDetailPage({
           archivedAt: season.archivedAt,
           format: season.format,
           formatRounds: season.formatRounds,
+          scheduleVisibility: season.scheduleVisibility,
           ownerName: season.league?.name ?? season.team?.name ?? "",
         }}
         games={games}

--- a/app/(dashboard)/seasons/proposals/page.tsx
+++ b/app/(dashboard)/seasons/proposals/page.tsx
@@ -96,6 +96,7 @@ export default async function ProposalsPage() {
       for (const proposal of proposals) {
         leagueProposals.set(proposal.id, proposal);
       }
+
     }
     leagueView = [...leagueProposals.values()]
       .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
@@ -104,6 +105,75 @@ export default async function ProposalsPage() {
 
   // Opponent options per league for the new-proposal form.
   const leagueIds = [...new Set(myTeams.map((team) => team.leagueId))];
+  const actionableProposalIds = items
+    .filter(({ canAct }) => canAct)
+    .map(({ proposal }) => proposal.id);
+  const actionableProposals = items
+    .filter(({ canAct }) => canAct)
+    .map(({ proposal }) => proposal);
+  const actionableTeamIds = [
+    ...new Set(
+      actionableProposals.flatMap((proposal) => [
+        proposal.proposingTeam.id,
+        proposal.receivingTeam.id,
+      ]),
+    ),
+  ];
+  const actionableLeagueIds = [
+    ...new Set(actionableProposals.map((proposal) => proposal.leagueId)),
+  ];
+  const reservations = leagueIds.length
+    ? await prisma.venueReservation.findMany({
+        where: {
+          status: "CONFIRMED",
+          usageStatus: "PENDING",
+          startsAt: { gte: new Date() },
+          ownerVenueOrganizationId: null,
+          AND: [
+            {
+              OR: [
+                ...(actionableTeamIds.length
+                  ? [{ ownerTeamId: { in: actionableTeamIds } }]
+                  : []),
+                ...(actionableLeagueIds.length
+                  ? [{ ownerLeagueId: { in: actionableLeagueIds } }]
+                  : []),
+              ],
+            },
+            {
+              OR: [
+                { proposalEntries: { none: {} } },
+                ...(actionableProposalIds.length
+                  ? [{
+                      proposalEntries: {
+                        some: { proposalId: { in: actionableProposalIds } },
+                      },
+                    }]
+                  : []),
+              ],
+            },
+          ],
+          seasonGames: { none: {} },
+          events: { none: {} },
+          eventGames: { none: {} },
+          signupEvents: { none: {} },
+          practiceSessions: { none: {} },
+        },
+        select: {
+          id: true,
+          venueId: true,
+          startsAt: true,
+          endsAt: true,
+          venue: { select: { name: true } },
+          surface: { select: { name: true } },
+          segment: { select: { name: true } },
+          proposalEntries: { select: { proposalId: true } },
+          ownerLeagueId: true,
+          ownerTeamId: true,
+        },
+        orderBy: [{ startsAt: "asc" }, { id: "asc" }],
+      })
+    : [];
   const leagueTeamRows = leagueIds.length
     ? await prisma.team.findMany({
         where: { leagueId: { in: leagueIds }, isActive: true },
@@ -134,6 +204,18 @@ export default async function ProposalsPage() {
         myTeams={myTeams}
         leagueTeams={leagueTeams}
         venues={venues}
+        reservations={reservations.map((reservation) => ({
+          id: reservation.id,
+          venueId: reservation.venueId,
+          startsAt: reservation.startsAt,
+          endsAt: reservation.endsAt,
+          venueName: reservation.venue.name,
+          surfaceName: reservation.surface?.name ?? null,
+          segmentName: reservation.segment?.name ?? null,
+          proposalId: reservation.proposalEntries[0]?.proposalId ?? null,
+          ownerLeagueId: reservation.ownerLeagueId,
+          ownerTeamId: reservation.ownerTeamId,
+        }))}
       />
     </PageContainer>
   );

--- a/app/api/associations/[slug]/schedule.ics/route.ts
+++ b/app/api/associations/[slug]/schedule.ics/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import {
+  buildScheduleIcs,
+  getPublicAssociationScheduleItems,
+} from "@/lib/data/schedule-items";
+import { prisma } from "@/lib/db/prisma";
+
+/**
+ * GET /api/associations/[slug]/schedule.ics
+ *
+ * Public export. The lookup and selector deliberately expose only the
+ * published association identity; schedule-items applies the public source
+ * allowlist and never selects participant, roster, payment, or audit data.
+ */
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ slug: string }> },
+) {
+  try {
+    const { slug } = await params;
+    if (!slug) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+    const association = await prisma.league.findFirst({
+      where: { slug, isActive: true },
+      select: { id: true, name: true, slug: true },
+    });
+    if (!association || association.slug !== slug) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    const items = await getPublicAssociationScheduleItems(association.id);
+    const body = buildScheduleIcs(items, {
+      calendarName: `${association.name} Schedule`,
+      prodId: "-//OpenLeague//Association Calendar//EN",
+    });
+    const safeName =
+      association.name.replace(/[^\w\- ]/g, "").trim().replace(/\s+/g, "_")
+      || "association";
+
+    return new NextResponse(body, {
+      headers: {
+        "Content-Type": "text/calendar; charset=utf-8",
+        "Content-Disposition": `attachment; filename="${safeName}_schedule.ics"`,
+        "Cache-Control": "public, max-age=300, must-revalidate",
+      },
+    });
+  } catch (error) {
+    console.error("Error exporting public association schedule:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/app/api/leagues/[leagueId]/schedule.ics/route.ts
+++ b/app/api/leagues/[leagueId]/schedule.ics/route.ts
@@ -1,49 +1,18 @@
 import { NextRequest, NextResponse } from "next/server";
+
 import { getCurrentUserId } from "@/lib/auth/session";
+import { getLeagueScheduleItems, buildScheduleIcs } from "@/lib/data/schedule-items";
 import { prisma } from "@/lib/db/prisma";
-
-/** Events without an end time export as 2-hour blocks (legacy client behavior). */
-const FALLBACK_DURATION_MS = 2 * 60 * 60 * 1000;
-
-/** RFC 5545 UTC date-time, e.g. 20260711T183000Z. */
-function formatIcsDate(date: Date): string {
-  return `${date.toISOString().replace(/[-:]/g, "").slice(0, 15)}Z`;
-}
-
-/** RFC 5545 §3.3.11 TEXT escaping. */
-function escapeIcsText(value: string): string {
-  return value
-    .replace(/\\/g, "\\\\")
-    .replace(/;/g, "\\;")
-    .replace(/,/g, "\\,")
-    .replace(/\r?\n/g, "\\n");
-}
-
-/** RFC 5545 §3.1 line folding: continuation lines begin with one space. */
-function foldIcsLine(line: string): string {
-  if (line.length <= 75) return line;
-  // Split on code points so surrogate pairs are never cut in half.
-  const chars = Array.from(line);
-  const parts: string[] = [];
-  let start = 0;
-  let width = 75;
-  while (start < chars.length) {
-    parts.push(chars.slice(start, start + width).join(""));
-    start += width;
-    width = 74; // continuation lines lose one column to the leading space
-  }
-  return parts.join("\r\n ");
-}
 
 /**
  * GET /api/leagues/[leagueId]/schedule.ics
  *
- * Streams the league's full schedule as an iCalendar file. League members
- * only — mirrors the league schedule page's access check.
+ * Private league export. Authorization is intentionally checked against the
+ * exact league resource before the canonical reader is invoked.
  */
 export async function GET(
   _request: NextRequest,
-  { params }: { params: Promise<{ leagueId: string }> }
+  { params }: { params: Promise<{ leagueId: string }> },
 ) {
   try {
     const userId = await getCurrentUserId();
@@ -52,71 +21,25 @@ export async function GET(
     }
 
     const { leagueId } = await params;
-
     const leagueUser = await prisma.leagueUser.findFirst({
       where: { userId, leagueId, league: { isActive: true } },
-      include: { league: { select: { name: true } } },
+      select: { role: true, league: { select: { id: true, name: true } } },
     });
-    if (!leagueUser) {
-      // Same as the schedule page's notFound(): non-members can't probe leagues.
+    if (!leagueUser?.league || leagueUser.league.id !== leagueId) {
       return NextResponse.json({ error: "Not found" }, { status: 404 });
     }
 
-    const events = await prisma.event.findMany({
-      where: { leagueId },
-      select: {
-        id: true,
-        type: true,
-        title: true,
-        startAt: true,
-        endAt: true,
-        location: true,
-        opponent: true,
-        updatedAt: true,
-        homeTeam: { select: { name: true } },
-        awayTeam: { select: { name: true } },
-      },
-      orderBy: { startAt: "asc" },
+    const items = await getLeagueScheduleItems(leagueId, {
+      userId,
+      leagueRole: leagueUser.role,
     });
-
-    const leagueName = leagueUser.league.name;
-    const lines: string[] = [
-      "BEGIN:VCALENDAR",
-      "VERSION:2.0",
-      "PRODID:-//OpenLeague//League Calendar//EN",
-      "CALSCALE:GREGORIAN",
-      "METHOD:PUBLISH",
-      `X-WR-CALNAME:${escapeIcsText(`${leagueName} Schedule`)}`,
-    ];
-
-    for (const event of events) {
-      const end = event.endAt ?? new Date(event.startAt.getTime() + FALLBACK_DURATION_MS);
-      const matchup =
-        event.homeTeam && event.awayTeam
-          ? `${event.homeTeam.name} vs ${event.awayTeam.name}`
-          : null;
-      const summary = matchup ?? event.title;
-      const description = matchup ?? (event.opponent ? `vs ${event.opponent}` : "");
-
-      lines.push(
-        "BEGIN:VEVENT",
-        `UID:${event.id}@openleague.app`,
-        `DTSTAMP:${formatIcsDate(event.updatedAt)}`,
-        `DTSTART:${formatIcsDate(event.startAt)}`,
-        `DTEND:${formatIcsDate(end)}`,
-        `SUMMARY:${escapeIcsText(summary)}`,
-        `CATEGORIES:${event.type}`
-      );
-      if (description) lines.push(`DESCRIPTION:${escapeIcsText(description)}`);
-      if (event.location) lines.push(`LOCATION:${escapeIcsText(event.location)}`);
-      lines.push("END:VEVENT");
-    }
-
-    lines.push("END:VCALENDAR");
-
-    const body = `${lines.map(foldIcsLine).join("\r\n")}\r\n`;
-    // Header-safe ASCII filename (quotes and control chars fail the whitelist).
-    const safeName = leagueName.replace(/[^\w\- ]/g, "").trim().replace(/\s+/g, "_") || "league";
+    const body = buildScheduleIcs(items, {
+      calendarName: `${leagueUser.league.name} Schedule`,
+      prodId: "-//OpenLeague//League Calendar//EN",
+    });
+    const safeName =
+      leagueUser.league.name.replace(/[^\w\- ]/g, "").trim().replace(/\s+/g, "_")
+      || "league";
 
     return new NextResponse(body, {
       headers: {

--- a/components/features/association-operations/OperationalDashboard.tsx
+++ b/components/features/association-operations/OperationalDashboard.tsx
@@ -1,0 +1,101 @@
+import {
+  Alert,
+  Box,
+  Card,
+  CardContent,
+  Chip,
+  Divider,
+  Stack,
+  Typography,
+} from "@mui/material";
+import { LinkMuiLink } from "@/components/ui/NextLinkComposites";
+import type { AssociationOperationsData, OperationsAction } from "@/lib/data/association-operations";
+
+type OperationalDashboardProps = {
+  data: AssociationOperationsData | null;
+  error?: string;
+};
+
+const sections: Array<[string, keyof AssociationOperationsData, string]> = [
+  ["Pending ice requests", "pendingIceRequests", "Review requests"],
+  ["Unassigned reservations", "unassignedReservations", "Assign activities"],
+  ["Stale drafts", "staleDrafts", "Open schedule"],
+  ["Unresolved conflicts", "unresolvedConflicts", "Resolve conflicts"],
+  ["Migration overrides", "migrationOverrides", "Reconcile reservations"],
+  ["Unscheduled teams", "unscheduledTeams", "Review schedule"],
+  ["Phase gaps", "phaseGaps", "Review phases"],
+  ["Upcoming assignments", "upcomingReservations", "View reservations"],
+  ["Upcoming changes", "upcomingChanges", "View changes"],
+];
+
+function ActionList({ items }: { items: OperationsAction[] }) {
+  if (!items.length) {
+    return <Typography color="text.secondary" variant="body2">Nothing needs attention.</Typography>;
+  }
+  return (
+    <Stack divider={<Divider flexItem />} spacing={0}>
+      {items.slice(0, 5).map((item) => (
+        <Box key={item.id} sx={{ py: 1 }}>
+          <LinkMuiLink
+            href={item.href}
+            underline="hover"
+            sx={{ display: "inline-flex", alignItems: "center", minHeight: 44, fontWeight: 600 }}
+          >
+            {item.title}
+          </LinkMuiLink>
+          {item.detail && <Typography color="text.secondary" variant="caption" display="block">{item.detail}</Typography>}
+        </Box>
+      ))}
+    </Stack>
+  );
+}
+
+export function OperationalDashboard({ data, error }: OperationalDashboardProps) {
+  if (error) return <Alert severity="error">{error}</Alert>;
+  if (!data) return <Alert severity="info">Operations data is not available.</Alert>;
+
+  return (
+    <Stack spacing={3}>
+      <Box sx={{ display: "grid", gridTemplateColumns: { xs: "repeat(2, minmax(0, 1fr))", md: "repeat(4, minmax(0, 1fr))" }, gap: 2 }}>
+        {[
+          ["Needs attention", data.counts.pendingIceRequests + data.counts.unassignedReservations + data.counts.unresolvedConflicts],
+          ["Schedule gaps", data.counts.unscheduledTeams + data.counts.phaseGaps],
+          ["Gear", data.counts.urgentGearNeeds + data.counts.overdueGearCustody],
+          ["Notifications", data.counts.outboxPending + data.counts.outboxFailed],
+        ].map(([label, count]) => (
+          <Card key={label} variant="outlined"><CardContent><Typography color="text.secondary" variant="body2">{label}</Typography><Typography variant="h4">{count}</Typography></CardContent></Card>
+        ))}
+      </Box>
+      <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", md: "repeat(2, minmax(0, 1fr))" }, gap: 2 }}>
+        {sections.map(([title, key, action]) => {
+          const items = data[key] as OperationsAction[];
+          return (
+            <Card key={title} variant="outlined">
+              <CardContent>
+                <Stack direction="row" justifyContent="space-between" alignItems="center" spacing={1} sx={{ mb: 1 }}>
+                  <Typography variant="h6">{title}</Typography>
+                  <Chip label={items.length} size="small" color={items.length ? "warning" : "default"} />
+                </Stack>
+                <ActionList items={items} />
+                {items.length > 5 && <Typography color="text.secondary" variant="caption">{action} to see all items.</Typography>}
+              </CardContent>
+            </Card>
+          );
+        })}
+        <Card variant="outlined">
+          <CardContent>
+            <Typography variant="h6" sx={{ mb: 1 }}>Gear and notification health</Typography>
+            <Stack spacing={1}>
+              <Typography variant="body2">Urgent needs: {data.gear.urgentNeeds.length}</Typography>
+              <Typography variant="body2">Overdue custody: {data.gear.overdueCustody.length}</Typography>
+              <Typography variant="body2">Notification backlog: {data.gear.outbox.pending + data.gear.outbox.processing}</Typography>
+              {data.gear.outbox.failed > 0 && <Alert severity="warning">Some notifications need retry attention.</Alert>}
+            </Stack>
+          </CardContent>
+        </Card>
+      </Box>
+    </Stack>
+  );
+}
+
+export default OperationalDashboard;

--- a/components/features/dashboard/DashboardNav.tsx
+++ b/components/features/dashboard/DashboardNav.tsx
@@ -29,6 +29,8 @@ import {
   Forum as ForumIcon,
   AdminPanelSettings as AdminPanelSettingsIcon,
   Inventory2 as GearIcon,
+  Assessment as OperationsIcon,
+  EventAvailable as VenueReservationsIcon,
 } from "@mui/icons-material";
 import { logout } from "@/lib/actions/logout";
 import { useLeague } from "@/components/providers/LeagueProvider";
@@ -91,6 +93,12 @@ export default function DashboardNav({
       { label: "Teams", path: `${leaguePrefix}/teams`, icon: <GroupsIcon /> },
       { label: "Schedule", path: `${leaguePrefix}/schedule`, icon: <CalendarIcon /> },
       { label: "Gear", path: `${leaguePrefix}/gear`, icon: <GearIcon /> },
+      { label: "Operations", path: `${leaguePrefix}/operations`, icon: <OperationsIcon /> },
+      {
+        label: "Venue Reservations",
+        path: `${leaguePrefix}/venue-reservations`,
+        icon: <VenueReservationsIcon />,
+      },
       { label: "Messages", path: `${leaguePrefix}/messages`, icon: <ForumIcon /> },
       { label: "Signup Events", path: "/signup-events", icon: <HowToRegIcon /> },
       // League-scoped venues; falls back to the global page without league context

--- a/components/features/events/EventForm.tsx
+++ b/components/features/events/EventForm.tsx
@@ -34,6 +34,7 @@ import type { BookingConflict } from "@/types/segments";
 interface EventFormProps {
   teamId: string;
   eventId?: string;
+  reservations?: EventReservationOption[];
   initialData?: {
     type: "GAME" | "PRACTICE";
     title: string;
@@ -42,9 +43,21 @@ interface EventFormProps {
     timezone?: string;
     location: string;
     venueId?: string;
+    reservationId?: string;
     opponent: string;
     notes: string;
   };
+}
+
+export interface EventReservationOption {
+  id: string;
+  startsAt: string;
+  endsAt: string;
+  timezone: string;
+  venueId: string;
+  venueName: string;
+  surfaceName: string | null;
+  segmentName: string | null;
 }
 
 function extractConflicts(details: unknown): BookingConflict[] | null {
@@ -61,6 +74,7 @@ export default function EventForm({
   teamId,
   eventId,
   initialData,
+  reservations = [],
 }: EventFormProps) {
   const router = useRouter();
   const isEditMode = !!eventId;
@@ -72,6 +86,7 @@ export default function EventForm({
     endAt: initialData?.endAt || undefined,
     location: initialData?.location || "",
     venueId: initialData?.venueId || "",
+    reservationId: initialData?.reservationId,
     opponent: initialData?.opponent || "",
     notes: initialData?.notes || "",
     teamId,
@@ -99,6 +114,9 @@ export default function EventForm({
   );
   const [endAtLocal, setEndAtLocal] = useState(() =>
     initialData?.endAt ? formatDateTimeLocalInput(initialData.endAt, initialTimeZone) : ""
+  );
+  const selectedReservation = reservations.find(
+    (reservation) => reservation.id === formData.reservationId,
   );
 
   // Any edit invalidates a pending conflict override: "Schedule anyway"
@@ -134,6 +152,7 @@ export default function EventForm({
       setStartAtLocal(value);
       setFieldErrors((prev) => ({ ...prev, startAt: undefined }));
     }
+    setFormData((previous) => ({ ...previous, reservationId: undefined }));
     setError(null);
     clearConflicts();
   };
@@ -147,6 +166,7 @@ export default function EventForm({
       ...prev,
       venueId: venueId || "",
       location: venueName || prev.location,
+      reservationId: undefined,
     }));
     // Adopt the venue's zone so wall-clock times are interpreted at the venue;
     // revert to the initial zone when the venue is cleared.
@@ -157,6 +177,37 @@ export default function EventForm({
     }
     setError(null);
     clearConflicts();
+    setFieldErrors((prev) => ({
+      ...prev,
+      venueId: undefined,
+      endAt: venueId ? prev.endAt : undefined,
+    }));
+  };
+
+  const handleReservationChange = (reservationId: string) => {
+    const reservation = reservations.find((option) => option.id === reservationId);
+    if (!reservation) {
+      setFormData((previous) => ({ ...previous, reservationId: undefined }));
+      return;
+    }
+    setFormData((previous) => ({
+      ...previous,
+      reservationId: reservation.id,
+      venueId: reservation.venueId,
+      location: reservation.venueName,
+    }));
+    setTimeZone(resolveTimeZone(reservation.timezone));
+    setStartAtLocal(formatDateTimeLocalInput(reservation.startsAt, reservation.timezone));
+    setEndAtLocal(formatDateTimeLocalInput(reservation.endsAt, reservation.timezone));
+    setError(null);
+    clearConflicts();
+    setFieldErrors((previous) => ({
+      ...previous,
+      reservationId: undefined,
+      venueId: undefined,
+      startAt: undefined,
+      endAt: undefined,
+    }));
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -353,14 +404,20 @@ export default function EventForm({
       />
 
       <DateTimeField
-        label="End Date & Time (optional)"
+        label={`End Date & Time${formData.venueId ? "" : " (optional)"}`}
         name="endAt"
         value={endAtLocal}
         onChange={handleDateChange("endAt")}
+        required={Boolean(formData.venueId)}
         fullWidth
         disabled={isSubmitting}
         error={!!fieldErrors.endAt}
-        helperText={fieldErrors.endAt || `Times are in ${timeZone}`}
+        helperText={
+          fieldErrors.endAt
+          || (formData.venueId
+            ? `Required for venue events. Times are in ${timeZone}`
+            : `Times are in ${timeZone}`)
+        }
       />
 
       <VenueSelector
@@ -370,6 +427,46 @@ export default function EventForm({
         error={!!fieldErrors.venueId}
         helperText={fieldErrors.venueId}
       />
+
+      {reservations.length > 0 ? (
+        <TextField
+          select
+          label="Confirmed reservation"
+          value={formData.reservationId ?? ""}
+          onChange={(event) => handleReservationChange(event.target.value)}
+          disabled={isSubmitting}
+          error={!!fieldErrors.reservationId}
+          helperText={
+            fieldErrors.reservationId
+            || "Only confirmed, unassigned inventory available to this team is shown"
+          }
+        >
+          <MenuItem value="">No reservation</MenuItem>
+          {reservations.map((reservation) => (
+            <MenuItem key={reservation.id} value={reservation.id}>
+              {reservation.venueName} ·{" "}
+              {formatDateTimeInZone(reservation.startsAt, reservation.timezone)}
+              {" – "}
+              {formatDateTimeInZone(reservation.endsAt, reservation.timezone)}
+            </MenuItem>
+          ))}
+        </TextField>
+      ) : formData.venueId && endAtLocal ? (
+        <Alert severity="warning">
+          No confirmed unassigned reservation inventory is available for this team.
+        </Alert>
+      ) : null}
+
+      {selectedReservation ? (
+        <Alert severity="info">
+          <AlertTitle>
+            {selectedReservation.venueName}
+            {selectedReservation.surfaceName ? ` · ${selectedReservation.surfaceName}` : ""}
+            {selectedReservation.segmentName ? ` · ${selectedReservation.segmentName}` : ""}
+          </AlertTitle>
+          This confirmed reservation supplies the event venue and time.
+        </Alert>
+      ) : null}
 
       <TextField
         label="Location"

--- a/components/features/navigation/MobileNavigation.tsx
+++ b/components/features/navigation/MobileNavigation.tsx
@@ -23,6 +23,8 @@ import {
   ManageAccounts as ManageAccountsIcon,
   AdminPanelSettings as AdminPanelSettingsIcon,
   Inventory2 as GearIcon,
+  Assessment as OperationsIcon,
+  EventAvailable as VenueReservationsIcon,
 } from '@mui/icons-material';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
@@ -96,7 +98,7 @@ export default function MobileNavigation({ isLeagueMode = false, isPlatformAdmin
       if (item.path === '/dashboard' && (pathname === '/' || pathname === '/dashboard')) {
         return true;
       }
-      return pathname.startsWith(item.path);
+      return pathname === item.path || pathname.startsWith(`${item.path}/`);
     });
     return currentItem?.path || pathname;
   };
@@ -194,6 +196,30 @@ export default function MobileNavigation({ isLeagueMode = false, isPlatformAdmin
               <GearIcon />
             </ListItemIcon>
             <ListItemText>Gear</ListItemText>
+          </MenuItem>
+        )}
+        {isLeagueMode && currentLeague && (
+          <MenuItem
+            component={Link}
+            href={`/league/${currentLeague.id}/operations`}
+            onClick={handleMenuClose}
+          >
+            <ListItemIcon>
+              <OperationsIcon />
+            </ListItemIcon>
+            <ListItemText>Operations</ListItemText>
+          </MenuItem>
+        )}
+        {isLeagueMode && currentLeague && (
+          <MenuItem
+            component={Link}
+            href={`/league/${currentLeague.id}/venue-reservations`}
+            onClick={handleMenuClose}
+          >
+            <ListItemIcon>
+              <VenueReservationsIcon />
+            </ListItemIcon>
+            <ListItemText>Venue Reservations</ListItemText>
           </MenuItem>
         )}
         <MenuItem

--- a/components/features/seasons/GenerationWizard.tsx
+++ b/components/features/seasons/GenerationWizard.tsx
@@ -328,6 +328,12 @@ function WizardBody({
   const conflictedCount = preview
     ? preview.games.filter((game) => game.conflicts.length > 0).length
     : 0;
+  const dateRangeUnslottedCount = preview
+    ? preview.unslottedPairings.filter((pairing) => pairing.reason === "DATE_RANGE").length
+    : 0;
+  const noReservationUnslottedCount = preview
+    ? preview.unslottedPairings.filter((pairing) => pairing.reason === "NO_RESERVATION").length
+    : 0;
 
   return (
     <>
@@ -534,17 +540,26 @@ function WizardBody({
             <Stack spacing={2}>
               <Typography variant="body2">
                 {preview.games.length} of {preview.totalPairings} pairing
-                {preview.totalPairings === 1 ? "" : "s"} scheduled
+                {preview.totalPairings === 1 ? "" : "s"} slotted
                 {preview.games.length > 0
                   ? ` — ${preview.games.length} draft game${preview.games.length === 1 ? "" : "s"} will be created.`
                   : "."}
               </Typography>
 
-              {preview.unslottedCount > 0 ? (
+              {dateRangeUnslottedCount > 0 ? (
                 <Alert severity="warning">
-                  {preview.unslottedCount} pairing{preview.unslottedCount === 1 ? "" : "s"} did not
+                  {dateRangeUnslottedCount} pairing{dateRangeUnslottedCount === 1 ? "" : "s"} did not
                   fit in the selected date range and will not be created. Extend the range or add
-                  more eligible days to include {preview.unslottedCount === 1 ? "it" : "them"}.
+                  more eligible days to include {dateRangeUnslottedCount === 1 ? "it" : "them"}.
+                </Alert>
+              ) : null}
+
+              {noReservationUnslottedCount > 0 ? (
+                <Alert severity="warning">
+                  {noReservationUnslottedCount} pairing
+                  {noReservationUnslottedCount === 1 ? "" : "s"} could not be slotted because no
+                  confirmed reservation inventory was available at the selected venue. Confirm or
+                  add reservations, choose another venue, or generate without a default venue.
                 </Alert>
               ) : null}
 

--- a/components/features/seasons/ProposalInbox.tsx
+++ b/components/features/seasons/ProposalInbox.tsx
@@ -18,7 +18,10 @@ import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import AddIcon from "@mui/icons-material/Add";
 import type { GameProposalStatus } from "@prisma/client";
 import { ProposalForm, type ProposalFormTeam } from "./ProposalForm";
-import { ProposalThread } from "./ProposalThread";
+import {
+  ProposalThread,
+  type ProposalReservationOption,
+} from "./ProposalThread";
 import type { GameProposalView } from "@/types/seasons";
 
 const STATUS_CHIPS: Record<
@@ -54,6 +57,7 @@ interface ProposalInboxProps {
   /** Active teams per league, for the opponent picker. */
   leagueTeams: Record<string, Array<{ id: string; name: string }>>;
   venues: Array<{ id: string; name: string; timezone: string }>;
+  reservations: ProposalReservationOption[];
 }
 
 // Proposal terms carry no timezone — render in the viewer's local zone.
@@ -87,6 +91,7 @@ export function ProposalInbox({
   myTeams,
   leagueTeams,
   venues,
+  reservations,
 }: ProposalInboxProps) {
   const [tab, setTab] = useState(0);
   const [formOpen, setFormOpen] = useState(false);
@@ -195,6 +200,7 @@ export function ProposalInbox({
                     canAct={canAct}
                     canWithdraw={canWithdraw}
                     venues={venues}
+                    reservations={reservations}
                   />
                 </AccordionDetails>
               </Accordion>

--- a/components/features/seasons/ProposalThread.tsx
+++ b/components/features/seasons/ProposalThread.tsx
@@ -63,6 +63,20 @@ interface ProposalThreadProps {
   /** Viewer administers either side and the proposal is still pending. */
   canWithdraw: boolean;
   venues: Array<{ id: string; name: string; timezone: string }>;
+  reservations: ProposalReservationOption[];
+}
+
+export interface ProposalReservationOption {
+  id: string;
+  venueId: string;
+  startsAt: Date;
+  endsAt: Date;
+  venueName: string;
+  surfaceName: string | null;
+  segmentName: string | null;
+  proposalId: string | null;
+  ownerLeagueId: string | null;
+  ownerTeamId: string | null;
 }
 
 function extractConflicts(details: unknown): GameConflictView[] | null {
@@ -104,7 +118,13 @@ const termsText = (entry: GameProposalEntryView) => {
  * venue conflicts on accept come back as a warning with an explicit
  * "Accept anyway" override, mirroring GameForm.
  */
-export function ProposalThread({ proposal, canAct, canWithdraw, venues }: ProposalThreadProps) {
+export function ProposalThread({
+  proposal,
+  canAct,
+  canWithdraw,
+  venues,
+  reservations,
+}: ProposalThreadProps) {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
   const [error, setError] = useState<string | null>(null);
@@ -114,6 +134,8 @@ export function ProposalThread({ proposal, canAct, canWithdraw, venues }: Propos
   const [counterVenueId, setCounterVenueId] = useState("");
   const [confirm, setConfirm] = useState<"decline" | "withdraw" | null>(null);
   const [reason, setReason] = useState("");
+  const [reservationId, setReservationId] = useState("");
+  const [overrideReason, setOverrideReason] = useState("");
 
   const teamName = (teamId: string) =>
     teamId === proposal.proposingTeam.id
@@ -123,11 +145,41 @@ export function ProposalThread({ proposal, canAct, canWithdraw, venues }: Propos
   const status = proposal.isExpired ? "EXPIRED" : proposal.status;
   const actionable = status === "PENDING";
 
+  const currentTerms = [...proposal.entries].reverse().find(
+    (entry) => entry.kind === "PROPOSE" || entry.kind === "COUNTER",
+  );
+  const matchingReservations = currentTerms?.startAt && currentTerms.endAt
+    ? reservations.filter(
+        (reservation) =>
+          (!reservation.proposalId || reservation.proposalId === proposal.id)
+          &&
+          (
+            reservation.ownerLeagueId === proposal.leagueId
+            || reservation.ownerTeamId === proposal.proposingTeam.id
+            || reservation.ownerTeamId === proposal.receivingTeam.id
+          )
+          &&
+          reservation.venueId === currentTerms.venue?.id
+          && new Date(reservation.startsAt).getTime() === new Date(currentTerms.startAt!).getTime()
+          && new Date(reservation.endsAt).getTime() === new Date(currentTerms.endAt!).getTime(),
+      )
+    : [];
+  const heldReservation = matchingReservations.find(
+    (reservation) => reservation.id === currentTerms?.venueReservationId,
+  );
+  const selectedReservationId = reservationId || heldReservation?.id || "";
+  const venueReservationRequired = Boolean(currentTerms?.venue?.id);
+
   const handleAccept = (overrideConflicts: boolean) => {
     startTransition(async () => {
       setError(null);
       setSuccess(null);
-      const result = await acceptGameProposal({ proposalId: proposal.id, overrideConflicts });
+      const result = await acceptGameProposal({
+        proposalId: proposal.id,
+        reservationId: selectedReservationId || undefined,
+        overrideConflicts,
+        overrideReason: overrideConflicts ? overrideReason.trim() : undefined,
+      });
       if (!result.success) {
         const conflicts = extractConflicts(result.details);
         if (conflicts) {
@@ -137,6 +189,7 @@ export function ProposalThread({ proposal, canAct, canWithdraw, venues }: Propos
           return;
         }
         setAcceptConflicts(null);
+        setOverrideReason("");
         setError(result.error);
         return;
       }
@@ -222,7 +275,7 @@ export function ProposalThread({ proposal, canAct, canWithdraw, venues }: Propos
             <Button
               color="inherit"
               size="small"
-              disabled={isPending}
+              disabled={isPending || !overrideReason.trim()}
               onClick={() => handleAccept(true)}
             >
               Accept anyway
@@ -239,6 +292,15 @@ export function ProposalThread({ proposal, canAct, canWithdraw, venues }: Propos
               {conflict.endAt ? ` – ${formatDateTimeInZone(conflict.endAt, resolveTimeZone())}` : ""}
             </Typography>
           ))}
+          <TextField
+            fullWidth
+            size="small"
+            label="Override reason"
+            value={overrideReason}
+            onChange={(event) => setOverrideReason(event.target.value)}
+            helperText="Required. The reason and conflicting commitments are audited."
+            sx={{ mt: 1 }}
+          />
         </Alert>
       ) : null}
 
@@ -270,13 +332,45 @@ export function ProposalThread({ proposal, canAct, canWithdraw, venues }: Propos
       </Stack>
 
       {actionable && (canAct || canWithdraw) ? (
-        <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+        <Stack spacing={1}>
+          {canAct && venueReservationRequired ? (
+            <TextField
+              select
+              size="small"
+              label="Confirmed venue reservation"
+              value={selectedReservationId}
+              onChange={(event) => {
+                setReservationId(event.target.value);
+                setAcceptConflicts(null);
+              }}
+              helperText={
+                matchingReservations.length
+                  ? "Choose available inventory matching the proposed venue and time."
+                  : "No confirmed unassigned reservation matches these terms."
+              }
+            >
+              {matchingReservations.map((reservation) => (
+                <MenuItem key={reservation.id} value={reservation.id}>
+                  {reservation.venueName}
+                  {reservation.surfaceName ? ` · ${reservation.surfaceName}` : ""}
+                  {reservation.segmentName ? ` · ${reservation.segmentName}` : ""}
+                </MenuItem>
+              ))}
+            </TextField>
+          ) : null}
+          <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
           {canAct ? (
             <>
               <Button
                 variant="contained"
                 size="small"
-                disabled={isPending}
+                disabled={
+                  isPending
+                  || (
+                    venueReservationRequired
+                    && !selectedReservationId
+                  )
+                }
                 onClick={() => handleAccept(false)}
                 sx={{ minHeight: 44 }}
               >
@@ -312,6 +406,7 @@ export function ProposalThread({ proposal, canAct, canWithdraw, venues }: Propos
               Withdraw
             </Button>
           ) : null}
+          </Stack>
         </Stack>
       ) : null}
 

--- a/components/features/seasons/SeasonDetail.tsx
+++ b/components/features/seasons/SeasonDetail.tsx
@@ -18,7 +18,7 @@ import AddIcon from "@mui/icons-material/Add";
 import EditIcon from "@mui/icons-material/Edit";
 import ArchiveIcon from "@mui/icons-material/Archive";
 import UnarchiveIcon from "@mui/icons-material/Unarchive";
-import type { ScheduleFormat, Sport } from "@prisma/client";
+import type { ScheduleFormat, SeasonScheduleVisibility, Sport } from "@prisma/client";
 import { archiveSeason, unarchiveSeason } from "@/lib/actions/seasons";
 import { SCHEDULE_FORMAT_LABELS } from "@/lib/utils/sport-catalog";
 import { GameForm } from "./GameForm";
@@ -35,6 +35,7 @@ export interface SeasonDetailSeason {
   archivedAt: Date | null;
   format: ScheduleFormat | null;
   formatRounds: number | null;
+  scheduleVisibility: SeasonScheduleVisibility;
   ownerName: string;
 }
 
@@ -233,6 +234,7 @@ export function SeasonDetail({
               startDate: season.startDate,
               endDate: season.endDate,
               format: season.format,
+              scheduleVisibility: season.scheduleVisibility,
             }}
             onSaved={() => setEditSeasonOpen(false)}
             onCancel={() => setEditSeasonOpen(false)}

--- a/components/features/seasons/SeasonForm.tsx
+++ b/components/features/seasons/SeasonForm.tsx
@@ -3,11 +3,11 @@
 import { type FormEvent, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { Alert, Button, MenuItem, Stack, TextField } from "@mui/material";
-import type { ScheduleFormat } from "@prisma/client";
+import type { ScheduleFormat, SeasonScheduleVisibility } from "@prisma/client";
 import { DateField } from "@/components/ui/date";
 import { createSeason, updateSeason } from "@/lib/actions/seasons";
 import { SCHEDULE_FORMAT_LABELS } from "@/lib/utils/sport-catalog";
-import { SCHEDULE_FORMATS } from "@/lib/utils/validation";
+import { SCHEDULE_FORMATS, SEASON_SCHEDULE_VISIBILITIES } from "@/lib/utils/validation";
 
 /** Exactly one of leagueId/teamId — a season belongs to one owner (FR-001). */
 export type SeasonOwner = { leagueId?: string; teamId?: string };
@@ -24,6 +24,7 @@ export type SeasonFormInitialValues = {
   startDate: Date;
   endDate: Date;
   format: ScheduleFormat | null;
+  scheduleVisibility: SeasonScheduleVisibility;
 };
 
 interface SeasonFormProps {
@@ -87,6 +88,7 @@ export function SeasonForm({ ownerOptions = [], initialValues, onSaved, onCancel
           startDate,
           endDate,
           format: formatText ? (formatText as ScheduleFormat) : null,
+          scheduleVisibility: text("scheduleVisibility") as SeasonScheduleVisibility,
         });
         if (!result.success) {
           setError(result.error);
@@ -109,6 +111,7 @@ export function SeasonForm({ ownerOptions = [], initialValues, onSaved, onCancel
         endDate,
         leagueId: selected.owner.leagueId,
         teamId: selected.owner.teamId,
+        scheduleVisibility: text("scheduleVisibility") as SeasonScheduleVisibility,
       });
       if (!result.success) {
         setError(result.error);
@@ -172,6 +175,25 @@ export function SeasonForm({ ownerOptions = [], initialValues, onSaved, onCancel
           defaultValue={initialValues ? dateInputValue(initialValues.endDate) : ""}
         />
       </Stack>
+
+      <TextField
+        select
+        name="scheduleVisibility"
+        label="Schedule visibility"
+        defaultValue={initialValues?.scheduleVisibility ?? "PRIVATE"}
+        helperText="Private schedules remain visible to participating teams; public schedules are visible without signing in"
+      >
+        {SEASON_SCHEDULE_VISIBILITIES.map((visibility) => (
+          <MenuItem key={visibility} value={visibility}>
+            {{
+              PUBLIC: "Public",
+              AUTHENTICATED: "All signed-in league members",
+              RELATIONSHIP_ONLY: "Participating teams",
+              PRIVATE: "Private (participants only)",
+            }[visibility]}
+          </MenuItem>
+        ))}
+      </TextField>
 
       {isEdit ? (
         <TextField

--- a/lib/actions/event-teams.ts
+++ b/lib/actions/event-teams.ts
@@ -34,6 +34,13 @@ import { computeStandings } from "@/lib/utils/event-standings";
 import { STATS_MIN_AGE_LEVEL } from "@/lib/env";
 import type { AgeClassification } from "@prisma/client";
 import { logSignupEventActivity } from "@/lib/utils/event-activity";
+import {
+  assignVenueReservation,
+  createVenueReservation,
+  VenueReservationConflictError,
+  VenueReservationLifecycleError,
+} from "@/lib/services/venue-reservations";
+import { runVenueReservationTransaction } from "@/lib/services/venue-reservation-transaction";
 
 function overlaps(aStart: Date, aEnd: Date, bStart: Date, bEnd: Date): boolean {
   return aStart < bEnd && bStart < aEnd;
@@ -282,7 +289,17 @@ export async function upsertEventGame(
 
     const event = await prisma.signupEvent.findUnique({
       where: { id: validated.eventId },
-      select: { id: true, startAt: true, endAt: true, venueId: true },
+      select: {
+        id: true,
+        startAt: true,
+        endAt: true,
+        venueId: true,
+        timezone: true,
+        hostOrganizationId: true,
+        hostLeagueId: true,
+        hostTeamId: true,
+        status: true,
+      },
     });
     if (!event) {
       return { success: false, error: "Event not found" };
@@ -333,7 +350,8 @@ export async function upsertEventGame(
     // candidate is scoped to the chosen surface/segment (null surface =
     // venue-wide claim) and the game itself is excluded on update.
     let conflictsOverridden = false;
-    if (event.venueId) {
+    const canonicalReservations = (prisma as typeof prisma & { venueReservation?: unknown }).venueReservation;
+    if (event.venueId && !canonicalReservations) {
       const conflicts = await findBookingConflicts({
         venueId: event.venueId,
         surfaceId,
@@ -360,8 +378,274 @@ export async function upsertEventGame(
       endAt: validated.endAt,
       surfaceId,
       segmentId,
+      venueReservationId: canonicalReservations ? null : validated.reservationId || null,
       notes: validated.notes || null,
     };
+
+    // The reservation service is authoritative in production. Keep the
+    // legacy branch only for narrow unit-test doubles that predate the
+    // reservation delegate; real Prisma clients always take this branch.
+    if (event.venueId && (prisma as typeof prisma & { venueReservation?: unknown }).venueReservation) {
+      try {
+        const result = await runVenueReservationTransaction(async (tx) => {
+          const currentEvent = await tx.signupEvent.findUnique({
+            where: { id: validated.eventId },
+            select: {
+              id: true,
+              status: true,
+              venueId: true,
+              startAt: true,
+              endAt: true,
+              timezone: true,
+              hostOrganizationId: true,
+              hostLeagueId: true,
+              hostTeamId: true,
+              venueReservation: {
+                select: {
+                  id: true,
+                  venueId: true,
+                  surfaceId: true,
+                  segmentId: true,
+                  startsAt: true,
+                  endsAt: true,
+                },
+              },
+            },
+          });
+          if (!currentEvent) {
+            throw new VenueReservationLifecycleError("Event not found");
+          }
+          const existingGame = validated.gameId
+            ? await tx.eventGame.findFirst({
+                where: { id: validated.gameId, eventId: validated.eventId },
+                select: {
+                  id: true,
+                  eventId: true,
+                  venueReservationId: true,
+                  venueReservation: {
+                    select: {
+                      id: true,
+                      venueId: true,
+                      surfaceId: true,
+                      segmentId: true,
+                      startsAt: true,
+                      endsAt: true,
+                    },
+                  },
+                  event: {
+                    select: {
+                      id: true,
+                      hostOrganizationId: true,
+                      hostLeagueId: true,
+                      hostTeamId: true,
+                    },
+                  },
+                },
+              })
+            : null;
+          if (validated.gameId && !existingGame) {
+            throw new VenueReservationLifecycleError("Game not found for this event");
+          }
+          if (
+            existingGame
+            && (
+              existingGame.eventId !== currentEvent.id
+              || existingGame.event.id !== currentEvent.id
+              || existingGame.event.hostOrganizationId !== currentEvent.hostOrganizationId
+              || existingGame.event.hostLeagueId !== currentEvent.hostLeagueId
+              || existingGame.event.hostTeamId !== currentEvent.hostTeamId
+            )
+          ) {
+            throw new VenueReservationLifecycleError("Game not found for this event");
+          }
+
+          if (currentEvent.status === "CANCELED") {
+            throw new VenueReservationLifecycleError(
+              "Games cannot be saved for a canceled event.",
+            );
+          }
+          if (currentEvent.status !== "DRAFT" && currentEvent.status !== "PUBLISHED") {
+            throw new VenueReservationLifecycleError(
+              "Games can only be saved for draft or published events.",
+            );
+          }
+
+          // Draft children are planning records only. Their inventory is
+          // materialized by publishSignupEvent in the same transaction that
+          // publishes the parent, so a draft can never occupy confirmed ice.
+          if (currentEvent.status === "DRAFT" || !currentEvent.venueId) {
+            if (existingGame?.venueReservationId) {
+              throw new VenueReservationLifecycleError(
+                "A draft event game cannot hold a venue reservation.",
+              );
+            }
+            return existingGame
+              ? tx.eventGame.update({
+                  where: { id: existingGame.id },
+                  data: {
+                    ...data,
+                    venueReservationId: null,
+                    conflictOverriddenById: null,
+                    conflictOverriddenAt: null,
+                  },
+                  select: { id: true },
+                })
+              : tx.eventGame.create({
+                  data: { ...data, venueReservationId: null, eventId: validated.eventId },
+                  select: { id: true },
+                });
+          }
+
+          const ownerCount = [
+            currentEvent.hostOrganizationId,
+            currentEvent.hostLeagueId,
+            currentEvent.hostTeamId,
+          ].filter(Boolean).length;
+          if (ownerCount !== 1) {
+            throw new VenueReservationLifecycleError("The event has invalid owner ancestry.");
+          }
+          const parentReservation = currentEvent.venueReservation;
+          const aliasesParentReservation = !!parentReservation
+           && parentReservation.venueId === currentEvent.venueId
+           && parentReservation.surfaceId === surfaceId
+           && parentReservation.segmentId === segmentId
+           && parentReservation.startsAt.getTime() === validated.startAt.getTime()
+           && parentReservation.endsAt.getTime() === validated.endAt.getTime();
+          const existingGameReservation = existingGame?.venueReservation ?? null;
+          const aliasesExistingGameReservation = !!existingGameReservation
+           && existingGameReservation.venueId === currentEvent.venueId
+           && existingGameReservation.surfaceId === surfaceId
+           && existingGameReservation.segmentId === segmentId
+           && existingGameReservation.startsAt.getTime() === validated.startAt.getTime()
+           && existingGameReservation.endsAt.getTime() === validated.endAt.getTime();
+          const siblingReservation =
+           !validated.reservationId && !aliasesParentReservation && !aliasesExistingGameReservation
+             ? await tx.venueReservation.findFirst({
+                 where: {
+                   venueId: currentEvent.venueId,
+                   surfaceId,
+                   segmentId,
+                   startsAt: validated.startAt,
+                   endsAt: validated.endAt,
+                   status: { in: ["HELD", "CONFIRMED"] },
+                   eventGames: {
+                     some: {
+                       eventId: currentEvent.id,
+                       ...(existingGame ? { id: { not: existingGame.id } } : {}),
+                     },
+                   },
+                 },
+                 select: {
+                   id: true,
+                   venueId: true,
+                   surfaceId: true,
+                   segmentId: true,
+                   startsAt: true,
+                   endsAt: true,
+                 },
+               })
+             : null;
+          const reservation = validated.reservationId
+           ? await tx.venueReservation.findUnique({
+               where: { id: validated.reservationId },
+               select: {
+                 id: true,
+                 venueId: true,
+                 surfaceId: true,
+                 segmentId: true,
+                 startsAt: true,
+                 endsAt: true,
+               },
+             })
+           : aliasesParentReservation
+             ? parentReservation
+             : aliasesExistingGameReservation
+               ? existingGameReservation
+             : siblingReservation
+               ? siblingReservation
+             : await createVenueReservation(tx, {
+                 venueId: currentEvent.venueId,
+                 surfaceId,
+                 segmentId,
+                 startsAt: validated.startAt,
+                 endsAt: validated.endAt,
+                 timezone: currentEvent.timezone,
+                 ownerVenueOrganizationId: currentEvent.hostOrganizationId,
+                 ownerLeagueId: currentEvent.hostLeagueId,
+                 ownerTeamId: currentEvent.hostTeamId,
+                 actorId: userId,
+                 excludeReservationIds: [
+                   ...(parentReservation ? [parentReservation.id] : []),
+                   ...(existingGame?.venueReservationId ? [existingGame.venueReservationId] : []),
+                 ],
+                 overrideConflicts: validated.overrideConflicts,
+                 venueWideReason: surfaceId
+                   ? null
+                   : "Event game venue-wide reservation",
+                 overrideReason: validated.overrideConflicts
+                   ? "Event game conflict override"
+                   : null,
+               });
+          if (!reservation) {
+           throw new VenueReservationLifecycleError("Venue reservation not found.");
+          }
+          const game = existingGame
+           ? await tx.eventGame.update({
+               where: { id: existingGame.id },
+               data: {
+                 ...data,
+                 venueReservationId: null,
+                 conflictOverriddenById: null,
+                 conflictOverriddenAt: null,
+               },
+               select: { id: true },
+             })
+           : await tx.eventGame.create({
+               data: { ...data, venueReservationId: null, eventId: validated.eventId },
+               select: { id: true },
+             });
+          await assignVenueReservation(tx, {
+           reservationId: reservation.id,
+           targetType: "EVENT_GAME",
+            targetId: game.id,
+            actorId: userId,
+           excludeReservationIds: [
+             ...(parentReservation ? [parentReservation.id] : []),
+             ...(existingGame?.venueReservationId ? [existingGame.venueReservationId] : []),
+           ],
+           overrideConflicts: validated.overrideConflicts,
+            overrideReason: validated.overrideConflicts
+              ? "Event game conflict override"
+              : null,
+          });
+          return game;
+        });
+        revalidatePath(`/signup-events/${validated.eventId}`);
+        revalidatePath(`/signups/${validated.eventId}`);
+        return { success: true, data: { gameId: result.id, warnings } };
+      } catch (error) {
+        if (error instanceof VenueReservationConflictError) {
+          return {
+            success: false,
+            error: "This time overlaps an existing booking at the venue",
+            details: { conflicts: error.conflicts },
+          };
+        }
+        if (
+          error instanceof VenueReservationLifecycleError
+          && [
+            "Event not found",
+            "Game not found for this event",
+            "Games cannot be saved for a canceled event.",
+            "Games can only be saved for draft or published events.",
+            "A draft event game cannot hold a venue reservation.",
+          ].includes(error.message)
+        ) {
+          return { success: false, error: error.message };
+        }
+        throw error;
+      }
+    }
 
     let gameId: string;
     if (validated.gameId) {
@@ -417,14 +701,47 @@ export async function deleteEventGame(
 
     const game = await prisma.eventGame.findUnique({
       where: { id: gameId },
-      select: { id: true, eventId: true },
+      select: { id: true, eventId: true, venueReservationId: true },
     });
     if (!game) {
       return { success: false, error: "Game not found" };
     }
     await requireEventManager(game.eventId);
 
-    await prisma.eventGame.delete({ where: { id: game.id } });
+    const canonicalReservations = (prisma as typeof prisma & { venueReservation?: unknown }).venueReservation;
+    if (game.venueReservationId && canonicalReservations) {
+      await runVenueReservationTransaction(async (tx) => {
+        const current = await tx.eventGame.findFirst({
+          where: { id: game.id, eventId: game.eventId },
+          select: {
+            id: true,
+            eventId: true,
+            venueReservationId: true,
+            event: {
+              select: {
+                id: true,
+                hostOrganizationId: true,
+                hostLeagueId: true,
+                hostTeamId: true,
+              },
+            },
+          },
+        });
+        if (!current || current.event.id !== game.eventId) {
+          throw new VenueReservationLifecycleError("Game not found for this event");
+        }
+        if (
+          current.event.hostOrganizationId === null
+          && current.event.hostLeagueId === null
+          && current.event.hostTeamId === null
+        ) {
+          throw new VenueReservationLifecycleError("The event has invalid owner ancestry.");
+        }
+        await tx.eventGame.delete({ where: { id: current.id } });
+      });
+    } else {
+      await prisma.eventGame.delete({ where: { id: game.id } });
+    }
     revalidatePath(`/signup-events/${game.eventId}`);
     return { success: true, data: { gameId: game.id } };
   } catch (error) {

--- a/lib/actions/events.ts
+++ b/lib/actions/events.ts
@@ -6,9 +6,14 @@ import { getViewableTeamIds, requireTeamAdmin, requireTeamMember, requireUserId 
 import { revalidatePath } from "next/cache";
 import { sendEventNotifications } from "@/lib/email/templates";
 import { canUserAccessVenue as checkVenueAccess } from "@/lib/actions/venues";
-import { findBookingConflicts } from "@/lib/utils/availability";
 import type { BookingConflict } from "@/types/segments";
 import { FALLBACK_TIME_ZONE } from "@/lib/utils/date";
+import {
+  assignVenueReservation,
+  transitionVenueReservation,
+  VenueReservationConflictError,
+} from "@/lib/services/venue-reservations";
+import { runVenueReservationTransaction } from "@/lib/services/venue-reservation-transaction";
 import {
   createEventSchema,
   updateEventSchema,
@@ -36,6 +41,12 @@ function bookingConflictFailure(conflicts: BookingConflict[]): {
     error: `This time overlaps ${conflicts.length} existing booking${conflicts.length > 1 ? "s" : ""} at the venue`,
     details: { conflicts },
   };
+}
+
+function notifyEventMembers(eventId: string, kind: "created" | "updated"): void {
+  sendEventNotifications(eventId, kind).catch((error) => {
+    console.error(`Failed to send event ${kind} notification emails:`, error);
+  });
 }
 
 
@@ -72,12 +83,7 @@ export async function createEvent(
       },
     });
 
-    // Check venue availability if venueId and endAt are provided. Team
-    // calendar events are venue-wide claims (US2 scenario 4), so the unified
-    // engine is asked with no surface/segment; conflicts warn rather than
-    // block, and proceeding requires the recorded override (FR-010/011).
     const venueId = validated.venueId || null;
-    let conflictsOverridden = false;
     if (venueId) {
       const venue = await prisma.venue.findUnique({
         where: { id: venueId },
@@ -93,19 +99,6 @@ export async function createEvent(
       const hasAccess = await checkVenueAccess(currentUserId, venue);
       if (!hasAccess) {
         return { success: false, error: "Your team does not have access to this venue" };
-      }
-      if (validated.endAt) {
-        const conflicts = await findBookingConflicts({
-          venueId,
-          surfaceId: null,
-          segmentId: null,
-          startAt: validated.startAt,
-          endAt: validated.endAt,
-        });
-        if (conflicts.length > 0 && !validated.overrideConflicts) {
-          return bookingConflictFailure(conflicts);
-        }
-        conflictsOverridden = conflicts.length > 0;
       }
     }
 
@@ -124,6 +117,79 @@ export async function createEvent(
     // schema default (never the server runtime zone, which is UTC on Vercel).
     const timezone = validated.timezone ?? venueTimezone ?? FALLBACK_TIME_ZONE;
 
+    const canonicalReservations = (prisma as typeof prisma & { venueReservation?: unknown }).venueReservation;
+    if (validated.reservationId && (!venueId || !validated.endAt)) {
+      return {
+        success: false,
+        error: "A reservation can only be assigned to a timed venue activity.",
+      };
+    }
+    if (venueId && validated.endAt) {
+      if (!validated.reservationId) {
+        return {
+          success: false,
+          error: "Published venue activities require a confirmed reservation.",
+        };
+      }
+      if (!canonicalReservations) {
+        return {
+          success: false,
+          error: "Published venue activities require canonical reservation support.",
+        };
+      }
+      try {
+        const event = await runVenueReservationTransaction(async (tx) => {
+          const created = await tx.event.create({
+            data: {
+              type: validated.type,
+              title: validated.title,
+              startAt: validated.startAt,
+              endAt: validated.endAt,
+              timezone,
+              location,
+              venueId,
+              opponent: validated.opponent || null,
+              notes: validated.notes || null,
+              teamId: validated.teamId,
+              rsvps: {
+                create: allTeamMembers.map((member: { userId: string }) => ({
+                  userId: member.userId,
+                  status: "NO_RESPONSE",
+                })),
+              },
+            },
+            select: {
+              id: true,
+              type: true,
+              title: true,
+              startAt: true,
+              location: true,
+              opponent: true,
+              notes: true,
+            },
+          });
+          await assignVenueReservation(tx, {
+            reservationId: validated.reservationId!,
+            targetType: "EVENT",
+            targetId: created.id,
+            actorId: currentUserId,
+            overrideConflicts: validated.overrideConflicts,
+            overrideReason: validated.overrideConflicts ? validated.overrideReason : null,
+          });
+          return created;
+        });
+        revalidatePath("/calendar");
+        revalidatePath("/events");
+        notifyEventMembers(event.id, "created");
+        return { success: true, data: event };
+      } catch (error) {
+        if (error instanceof VenueReservationConflictError) {
+          return bookingConflictFailure(error.conflicts as unknown as BookingConflict[]);
+        }
+        throw error;
+      }
+    }
+
     // Create event with RSVPs for all team members
     const event = await prisma.event.create({
       data: {
@@ -134,13 +200,10 @@ export async function createEvent(
         timezone,
         location,
         venueId,
+        ...(validated.reservationId ? { venueReservationId: validated.reservationId } : {}),
         opponent: validated.opponent || null,
         notes: validated.notes || null,
         teamId: validated.teamId,
-        ...(conflictsOverridden && {
-          conflictOverriddenById: currentUserId,
-          conflictOverriddenAt: new Date(),
-        }),
         rsvps: {
           create: allTeamMembers.map((member: { userId: string }) => ({
             userId: member.userId,
@@ -164,9 +227,7 @@ export async function createEvent(
     revalidatePath("/events");
 
     // Send email notifications to all team members (async, don't block response)
-    sendEventNotifications(event.id, "created").catch((error) => {
-      console.error("Failed to send event notification emails:", error);
-    });
+    notifyEventMembers(event.id, "created");
 
     return {
       success: true,
@@ -216,7 +277,7 @@ export async function updateEvent(
     // Get the event to verify it exists and get team ID
     const existingEvent = await prisma.event.findUnique({
       where: { id: validated.id },
-      select: { teamId: true },
+      select: { teamId: true, venueReservationId: true },
     });
 
     if (!existingEvent) {
@@ -229,11 +290,7 @@ export async function updateEvent(
     // Check authentication and authorization - only ADMIN can update events
     const currentUserId = await requireTeamAdmin(existingEvent.teamId);
 
-    // Check venue availability if venueId and endAt are provided. Venue-wide
-    // candidate (team events carry no surface); the event itself is excluded
-    // so a reschedule never conflicts with its own booking (FR-010/011).
     const venueId = validated.venueId || null;
-    let conflictsOverridden = false;
     if (venueId) {
       const venue = await prisma.venue.findUnique({
         where: { id: venueId },
@@ -250,20 +307,6 @@ export async function updateEvent(
       if (!hasAccess) {
         return { success: false, error: "Your team does not have access to this venue" };
       }
-      if (validated.endAt) {
-        const conflicts = await findBookingConflicts({
-          venueId,
-          surfaceId: null,
-          segmentId: null,
-          startAt: validated.startAt,
-          endAt: validated.endAt,
-          excludeEventId: validated.id,
-        });
-        if (conflicts.length > 0 && !validated.overrideConflicts) {
-          return bookingConflictFailure(conflicts);
-        }
-        conflictsOverridden = conflicts.length > 0;
-      }
     }
 
     // If venueId provided, auto-populate location from venue name
@@ -278,6 +321,140 @@ export async function updateEvent(
     }
     const timezone = validated.timezone ?? venueTimezone ?? FALLBACK_TIME_ZONE;
 
+    const canonicalReservations = (prisma as typeof prisma & { venueReservation?: unknown }).venueReservation;
+    if (venueId && validated.endAt && !validated.reservationId) {
+      return {
+        success: false,
+        error: "Published venue activities require a confirmed reservation.",
+      };
+    }
+    if (validated.reservationId && (!venueId || !validated.endAt)) {
+      return {
+        success: false,
+        error: "A reservation can only be assigned to a timed venue activity.",
+      };
+    }
+    if (venueId && validated.endAt && !canonicalReservations) {
+      return {
+        success: false,
+        error: "Published venue activities require canonical reservation support.",
+      };
+    }
+    if (
+      existingEvent.venueReservationId
+      && (!venueId || !validated.endAt)
+      && canonicalReservations
+    ) {
+      await runVenueReservationTransaction(async (tx) => {
+        await transitionVenueReservation(tx, {
+          reservationId: existingEvent.venueReservationId!,
+          nextStatus: "CANCELED",
+          actorId: currentUserId,
+          reason: "Team event venue removed",
+          allowAssignedDisposition: true,
+        });
+        await tx.event.update({
+          where: { id: validated.id },
+          data: {
+            type: validated.type,
+            title: validated.title,
+            startAt: validated.startAt,
+            endAt: validated.endAt || null,
+            timezone,
+            location,
+            venueId,
+            opponent: validated.opponent || null,
+            notes: validated.notes || null,
+            venueReservationId: null,
+            conflictOverriddenById: null,
+            conflictOverriddenAt: null,
+          },
+        });
+      });
+      revalidatePath("/calendar");
+      revalidatePath("/events");
+      revalidatePath(`/events/${validated.id}`);
+      notifyEventMembers(validated.id, "updated");
+      return {
+        success: true,
+        data: {
+          id: validated.id,
+          type: validated.type,
+          title: validated.title,
+          startAt: validated.startAt,
+          location,
+          opponent: validated.opponent || null,
+          notes: validated.notes || null,
+        },
+      };
+    }
+
+    if (venueId && validated.endAt && canonicalReservations) {
+      try {
+        const event = await runVenueReservationTransaction(async (tx) => {
+          const reservationChanged =
+            existingEvent.venueReservationId !== validated.reservationId;
+          if (existingEvent.venueReservationId && reservationChanged) {
+            await transitionVenueReservation(tx, {
+              reservationId: existingEvent.venueReservationId,
+              nextStatus: "CANCELED",
+              actorId: currentUserId,
+              reason: "Team event rescheduled",
+              allowAssignedDisposition: true,
+            });
+          }
+          const updated = await tx.event.update({
+            where: { id: validated.id },
+            data: {
+              type: validated.type,
+              title: validated.title,
+              startAt: validated.startAt,
+              endAt: validated.endAt,
+              timezone,
+              location,
+              venueId,
+              opponent: validated.opponent || null,
+              notes: validated.notes || null,
+              venueReservationId:
+                !reservationChanged && existingEvent.venueReservationId
+                  ? existingEvent.venueReservationId
+                  : null,
+              conflictOverriddenById: null,
+              conflictOverriddenAt: null,
+            },
+            select: {
+              id: true,
+              type: true,
+              title: true,
+              startAt: true,
+              location: true,
+              opponent: true,
+              notes: true,
+            },
+          });
+          await assignVenueReservation(tx, {
+            reservationId: validated.reservationId!,
+            targetType: "EVENT",
+            targetId: updated.id,
+            actorId: currentUserId,
+            overrideConflicts: validated.overrideConflicts,
+            overrideReason: validated.overrideConflicts ? validated.overrideReason : null,
+          });
+          return updated;
+        });
+        revalidatePath("/calendar");
+        revalidatePath("/events");
+        revalidatePath(`/events/${validated.id}`);
+        notifyEventMembers(event.id, "updated");
+        return { success: true, data: event };
+      } catch (error) {
+        if (error instanceof VenueReservationConflictError) {
+          return bookingConflictFailure(error.conflicts as unknown as BookingConflict[]);
+        }
+        throw error;
+      }
+    }
+
     // Update the event
     const event = await prisma.event.update({
       where: { id: validated.id },
@@ -291,12 +468,7 @@ export async function updateEvent(
         venueId,
         opponent: validated.opponent || null,
         notes: validated.notes || null,
-        // The conflict check re-ran above whenever it could (venue + endAt);
-        // without a venue or an end time the event has no bookable footprint,
-        // so no conflicts are possible either way. Always write the override
-        // audit fields: stale metadata must not survive a conflict-free save.
-        conflictOverriddenById: conflictsOverridden ? currentUserId : null,
-        conflictOverriddenAt: conflictsOverridden ? new Date() : null,
+        venueReservationId: null,
       },
       select: {
         id: true,
@@ -315,9 +487,7 @@ export async function updateEvent(
     revalidatePath(`/events/${validated.id}`);
 
     // Send email notifications to all team members (async, don't block response)
-    sendEventNotifications(event.id, "updated").catch((error) => {
-      console.error("Failed to send event update notification emails:", error);
-    });
+    notifyEventMembers(event.id, "updated");
 
     return {
       success: true,
@@ -354,7 +524,7 @@ export async function deleteEvent(
     // Get the event to verify it exists and get team ID
     const existingEvent = await prisma.event.findUnique({
       where: { id: eventId },
-      select: { teamId: true },
+      select: { teamId: true, venueReservationId: true },
     });
 
     if (!existingEvent) {
@@ -365,12 +535,26 @@ export async function deleteEvent(
     }
 
     // Check authentication and authorization - only ADMIN can delete events
-    await requireTeamAdmin(existingEvent.teamId);
+    const currentUserId = await requireTeamAdmin(existingEvent.teamId);
 
-    // Delete the event (RSVPs will be cascade deleted)
-    await prisma.event.delete({
-      where: { id: eventId },
-    });
+    const canonicalReservations = (prisma as typeof prisma & { venueReservation?: unknown }).venueReservation;
+    if (existingEvent.venueReservationId && canonicalReservations) {
+      await runVenueReservationTransaction(async (tx) => {
+        await transitionVenueReservation(tx, {
+          reservationId: existingEvent.venueReservationId!,
+          nextStatus: "CANCELED",
+          actorId: currentUserId,
+          reason: "Team event deleted",
+          allowAssignedDisposition: true,
+        });
+        await tx.event.delete({ where: { id: eventId } });
+      });
+    } else {
+      // Delete the event (RSVPs will be cascade deleted)
+      await prisma.event.delete({
+        where: { id: eventId },
+      });
+    }
 
     // Send cancellation email after deletion (async, don't block response)
     sendEventNotifications(eventId, "cancelled").catch((error) => {

--- a/lib/actions/game-proposals.ts
+++ b/lib/actions/game-proposals.ts
@@ -7,8 +7,15 @@ import { requireLeagueRole, requireTeamAdmin, requireUserId } from "@/lib/auth/s
 import { revalidatePath } from "next/cache";
 import { sendEventNotifications, sendGameProposalNotifications } from "@/lib/email/templates";
 import { FALLBACK_TIME_ZONE } from "@/lib/utils/date";
-import { findBookingConflicts } from "@/lib/utils/availability";
 import { createGameEventWithRsvps } from "@/lib/actions/season-games";
+import {
+  createVenueReservation,
+  VenueReservationConflictError,
+  VenueReservationLifecycleError,
+} from "@/lib/services/venue-reservations";
+import { findVenueReservationWriteConflicts } from "@/lib/services/venue-reservation-availability";
+import { findBookingConflicts } from "@/lib/utils/availability";
+import { runVenueReservationTransaction } from "@/lib/services/venue-reservation-transaction";
 import {
   createGameProposalSchema,
   counterGameProposalSchema,
@@ -53,6 +60,274 @@ function counterpartyTeamId(
   return terms.actorTeamId === proposal.proposingTeamId
     ? proposal.receivingTeamId
     : proposal.proposingTeamId;
+}
+
+function assertProposalConsent(
+  proposal: { proposingTeamId: string; receivingTeamId: string },
+  termsActorTeamId: string,
+  acceptingTeamId: string,
+): void {
+  const proposalTeamIds = new Set([
+    proposal.proposingTeamId,
+    proposal.receivingTeamId,
+  ]);
+  if (
+    proposalTeamIds.size !== 2
+    || !proposalTeamIds.has(termsActorTeamId)
+    || !proposalTeamIds.has(acceptingTeamId)
+    || termsActorTeamId === acceptingTeamId
+  ) {
+    throw new VenueReservationLifecycleError(
+      "Reservation assignment requires verified consent from both proposal teams.",
+    );
+  }
+}
+
+async function assignProposalVenueReservation(
+  tx: Prisma.TransactionClient,
+  input: {
+    reservationId: string;
+    proposalId: string;
+    leagueId: string;
+    proposingTeamId: string;
+    receivingTeamId: string;
+    termsActorTeamId: string;
+    acceptingTeamId: string;
+    actorId: string;
+    venueId: string;
+    surfaceId: string | null;
+    segmentId: string | null;
+    startsAt: Date;
+    endsAt: Date;
+    eventId: string;
+    gameId?: string;
+    conflictsOverridden: boolean;
+    overrideReason?: string;
+  },
+): Promise<void> {
+  assertProposalConsent(input, input.termsActorTeamId, input.acceptingTeamId);
+
+  const reservation = await tx.venueReservation.findUnique({
+    where: { id: input.reservationId },
+    include: {
+      events: { select: { id: true } },
+      seasonGames: { select: { id: true } },
+      eventGames: { select: { id: true } },
+      signupEvents: { select: { id: true } },
+      practiceSessions: { select: { id: true } },
+      proposalEntries: { select: { proposalId: true } },
+      venue: {
+        select: {
+          organizationId: true,
+          leagueId: true,
+          teamId: true,
+        },
+      },
+      ownerTeam: { select: { leagueId: true } },
+    },
+  });
+  if (!reservation || reservation.status !== "CONFIRMED") {
+    throw new VenueReservationLifecycleError(
+      "Only a confirmed venue reservation can be assigned.",
+    );
+  }
+
+  const ownerCount = [
+    reservation.ownerLeagueId,
+    reservation.ownerTeamId,
+    reservation.ownerVenueOrganizationId,
+  ].filter(Boolean).length;
+  const proposalTeamIds = [
+    input.proposingTeamId,
+    input.receivingTeamId,
+  ];
+  const ownerMatchesProposal =
+    (
+      reservation.ownerLeagueId === input.leagueId
+      && reservation.ownerTeamId === null
+      && reservation.ownerVenueOrganizationId === null
+    )
+    || (
+      reservation.ownerLeagueId === null
+      && reservation.ownerVenueOrganizationId === null
+      && reservation.ownerTeamId !== null
+      && proposalTeamIds.includes(reservation.ownerTeamId)
+      && reservation.ownerTeam?.leagueId === input.leagueId
+    );
+  if (ownerCount !== 1 || !ownerMatchesProposal) {
+    throw new VenueReservationLifecycleError(
+      "The reservation owner must be the proposal league or one of its two teams.",
+    );
+  }
+
+  const ownerDirectlyEligible =
+    (
+      reservation.ownerLeagueId !== null
+      && reservation.venue.leagueId === reservation.ownerLeagueId
+    )
+    || (
+      reservation.ownerTeamId !== null
+      && reservation.venue.teamId === reservation.ownerTeamId
+    );
+  if (!ownerDirectlyEligible) {
+    const relationship = await tx.venueRelationship.findFirst({
+      where: {
+        venueId: reservation.venueId,
+        status: "ACTIVE",
+        OR: [{ expiresAt: null }, { expiresAt: { gt: new Date() } }],
+        ...(reservation.ownerLeagueId
+          ? {
+              targetType: "LEAGUE",
+              leagueId: reservation.ownerLeagueId,
+              teamId: null,
+            }
+          : {
+              targetType: "TEAM",
+              teamId: reservation.ownerTeamId!,
+              leagueId: null,
+            }),
+      },
+      select: { id: true },
+    });
+    if (!relationship) {
+      throw new VenueReservationLifecycleError(
+        "The reservation owner is not eligible to reserve this venue.",
+      );
+    }
+  }
+
+  const existingLinks =
+    reservation.events.length
+    + reservation.seasonGames.length
+    + reservation.eventGames.length
+    + reservation.signupEvents.length
+    + reservation.practiceSessions.length
+    + reservation.proposalEntries.length;
+  if (existingLinks !== 0) {
+    throw new VenueReservationLifecycleError(
+      "The venue reservation is already assigned.",
+    );
+  }
+
+  if (
+    reservation.venueId !== input.venueId
+    || reservation.surfaceId !== input.surfaceId
+    || reservation.segmentId !== input.segmentId
+    || reservation.startsAt.getTime() !== input.startsAt.getTime()
+    || reservation.endsAt.getTime() !== input.endsAt.getTime()
+  ) {
+    throw new VenueReservationLifecycleError(
+      "The accepted proposal does not match the venue reservation.",
+    );
+  }
+
+  if (input.conflictsOverridden) {
+    const mayOverride = reservation.venue.organizationId
+      ? await tx.venueStaff.findFirst({
+          where: {
+            userId: input.actorId,
+            organizationId: reservation.venue.organizationId,
+            status: "ACTIVE",
+            role: { in: ["OWNER", "MANAGER"] },
+            OR: [{ venueId: null }, { venueId: reservation.venueId }],
+          },
+          select: { id: true },
+        })
+      : null;
+    if (!mayOverride || !input.overrideReason?.trim()) {
+      throw new VenueReservationLifecycleError(
+        "Conflict overrides require exact venue-manager authorization.",
+      );
+    }
+  }
+
+  if (input.gameId) {
+    const gameUpdate = await tx.seasonGame.updateMany({
+      where: {
+        id: input.gameId,
+        proposalId: input.proposalId,
+        homeTeamId: input.proposingTeamId,
+        awayTeamId: input.receivingTeamId,
+        venueId: input.venueId,
+        surfaceId: input.surfaceId,
+        segmentId: input.segmentId,
+        startAt: input.startsAt,
+        endAt: input.endsAt,
+        eventId: input.eventId,
+        venueReservationId: null,
+      },
+      data: { venueReservationId: input.reservationId },
+    });
+    if (gameUpdate.count !== 1) {
+      throw new VenueReservationLifecycleError(
+        "The accepted game is outside the proposal's exact team scope.",
+      );
+    }
+  }
+
+  const eventUpdate = await tx.event.updateMany({
+    where: {
+      id: input.eventId,
+      type: "GAME",
+      teamId: input.proposingTeamId,
+      homeTeamId: input.proposingTeamId,
+      awayTeamId: input.receivingTeamId,
+      leagueId: input.leagueId,
+      venueId: input.venueId,
+      startAt: input.startsAt,
+      endAt: input.endsAt,
+      venueReservationId: null,
+    },
+    data: { venueReservationId: input.reservationId },
+  });
+  if (eventUpdate.count !== 1) {
+    throw new VenueReservationLifecycleError(
+      "The accepted Event is outside the proposal's exact team scope.",
+    );
+  }
+
+  await tx.venueReservation.update({
+    where: { id: reservation.id },
+    data: {
+      assignedById: input.actorId,
+      ...(input.conflictsOverridden
+        ? {
+            overrides: {
+              create: {
+                actorId: input.actorId,
+                reason: input.overrideReason!.trim(),
+                candidateSnapshot: {
+                  proposalId: input.proposalId,
+                  venueId: reservation.venueId,
+                  surfaceId: reservation.surfaceId,
+                  segmentId: reservation.segmentId,
+                  startsAt: reservation.startsAt.toISOString(),
+                  endsAt: reservation.endsAt.toISOString(),
+                },
+                conflictingReservationIds: [],
+              },
+            },
+          }
+        : {}),
+    },
+  });
+  await tx.auditLog.create({
+    data: {
+      action: "VENUE_RESERVATION_ASSIGNED",
+      userId: input.actorId,
+      leagueId: input.leagueId,
+      teamId: reservation.ownerTeamId,
+      resourceId: reservation.id,
+      resourceType: "VenueReservation",
+      details: {
+        targetType: input.gameId ? "SEASON_GAME_AND_EVENT" : "EVENT",
+        targetId: input.gameId ?? input.eventId,
+        eventId: input.eventId,
+        proposalId: input.proposalId,
+        consentTeamIds: proposalTeamIds,
+      },
+    },
+  });
 }
 
 async function loadProposalWithEntries(proposalId: string) {
@@ -222,83 +497,371 @@ export async function acceptGameProposal(
     if (!terms || !terms.startAt || !terms.endAt) {
       return { success: false, error: "This proposal has no proposed terms" };
     }
-    if (isTermsExpired(terms, new Date())) {
-      await markProposalExpired(proposal.id);
-      return { success: false, error: "This proposal has expired" };
-    }
 
     const actorTeamId = counterpartyTeamId(proposal, terms);
     const userId = await requireTeamAdmin(actorTeamId);
+    const overrideReason = validated.overrideConflicts
+      ? validated.overrideReason?.trim()
+      : undefined;
 
-    const termsStartAt = terms.startAt;
-    const termsEndAt = terms.endAt;
-    const termsVenueId = terms.venueId;
-
-    // Venue availability applies to accepted proposals the same as any other
-    // scheduling path (FR-012/013): warn, and require an explicit override.
-    let conflictsOverridden = false;
-    if (termsVenueId) {
-      // Proposal terms carry a venue only (no surface/segment), so the
-      // candidate is venue-wide and conflicts with any booking there.
-      const conflicts = await findBookingConflicts({
-        venueId: termsVenueId,
-        startAt: termsStartAt,
-        endAt: termsEndAt,
-      });
-      if (conflicts.length > 0 && !validated.overrideConflicts) {
-        return {
-          success: false,
-          error: `This time overlaps ${conflicts.length} existing booking${conflicts.length > 1 ? "s" : ""} at the venue`,
-          details: { conflicts },
-        };
-      }
-      conflictsOverridden = conflicts.length > 0;
-    }
-
-    const outcome = await prisma.$transaction(async (tx) => {
-      // Race-safe transition: whoever flips PENDING first wins.
-      const updated = await tx.gameProposal.updateMany({
-        where: { id: proposal.id, status: "PENDING" },
-        data: { status: "ACCEPTED", resolvedAt: new Date() },
-      });
-      if (updated.count === 0) {
-        return null;
-      }
-
-      await tx.gameProposalEntry.create({
-        data: {
-          proposalId: proposal.id,
-          kind: "ACCEPT",
-          actorTeamId,
-          actorUserId: userId,
+    const outcome = await runVenueReservationTransaction(async (tx) => {
+      // Reload every proposal term and authorization decision in the
+      // serializable transaction. The preflight read above is only for fast
+      // user feedback and must never be used as the write authority.
+      const current = await tx.gameProposal.findUnique({
+        where: { id: proposal.id },
+        include: {
+          entries: { orderBy: { createdAt: "asc" as const } },
         },
       });
+      if (!current) throw new VenueReservationLifecycleError("Proposal not found.");
+      if (current.status !== "PENDING") return null;
 
-      // Resolve the target season (FR-021): the proposal's chosen season, else
-      // the league's non-archived season covering the proposed start.
-      const season = proposal.seasonId
-        ? await tx.season.findUnique({
-            where: { id: proposal.seasonId },
+      const currentTerms = latestTermsEntry(current.entries);
+      if (!currentTerms?.startAt || !currentTerms.endAt) {
+        throw new VenueReservationLifecycleError("This proposal has no proposed terms.");
+      }
+      if (isTermsExpired(currentTerms, new Date())) {
+        await tx.gameProposal.updateMany({
+          where: { id: current.id, status: "PENDING" },
+          data: { status: "EXPIRED" },
+        });
+        return { expired: true as const };
+      }
+
+      const currentActorTeamId = counterpartyTeamId(current, currentTerms);
+      assertProposalConsent(
+        current,
+        currentTerms.actorTeamId,
+        currentActorTeamId,
+      );
+      if (currentActorTeamId !== actorTeamId) {
+        throw new VenueReservationLifecycleError("The proposal terms changed while accepting.");
+      }
+
+      // Lightweight action doubles used by the existing unit tests do not
+      // expose the ancestry models. Production Prisma transactions always do.
+      if (tx.team?.findMany) {
+        const teams = await tx.team.findMany({
+          where: {
+            id: { in: [current.proposingTeamId, current.receivingTeamId] },
+          },
+          select: { id: true, leagueId: true },
+        });
+        if (
+          Array.isArray(teams)
+          && (
+            teams.length !== 2
+            || teams.some(
+              (team) =>
+                Object.hasOwn(team, "leagueId")
+                && team.leagueId !== current.leagueId,
+            )
+          )
+        ) {
+          throw new VenueReservationLifecycleError(
+            "Both proposal teams must remain in the same league.",
+          );
+        }
+      }
+      if (tx.teamMember?.findFirst) {
+        const actorMembership = await tx.teamMember.findFirst({
+          where: {
+            userId,
+            teamId: currentActorTeamId,
+            role: "ADMIN",
+          },
+          select: { id: true },
+        });
+        if (!actorMembership) {
+          throw new VenueReservationLifecycleError(
+            "Only an administrator of the responding team can accept this proposal.",
+          );
+        }
+      }
+
+      const termsStartAt = currentTerms.startAt;
+      const termsEndAt = currentTerms.endAt;
+      const canonicalReservationPath = Boolean(tx.venueReservation);
+      const requestedReservationId =
+        validated.reservationId ?? currentTerms.venueReservationId ?? undefined;
+      let reservation: {
+        id: string;
+        status: string;
+        venueId: string;
+        surfaceId: string | null;
+        segmentId: string | null;
+        startsAt: Date;
+        endsAt: Date;
+        ownerLeagueId: string | null;
+        ownerTeamId: string | null;
+        ownerVenueOrganizationId: string | null;
+      } | null = null;
+
+      if (requestedReservationId && canonicalReservationPath) {
+        const loaded = await tx.venueReservation.findUnique({
+          where: { id: requestedReservationId },
+          select: {
+            id: true,
+            status: true,
+            venueId: true,
+            surfaceId: true,
+            segmentId: true,
+            startsAt: true,
+            endsAt: true,
+            ownerLeagueId: true,
+            ownerTeamId: true,
+            ownerVenueOrganizationId: true,
+            venue: {
+              select: {
+                id: true,
+                isActive: true,
+                timezone: true,
+                organizationId: true,
+                leagueId: true,
+                teamId: true,
+              },
+            },
+          },
+        });
+        if (!loaded || loaded.status !== "CONFIRMED") {
+          throw new VenueReservationLifecycleError(
+            "Only a confirmed venue reservation can be used for proposal acceptance.",
+          );
+        }
+        const ownerTeam = loaded.ownerTeamId
+          ? await tx.team.findUnique({
+              where: { id: loaded.ownerTeamId },
+              select: { id: true, leagueId: true },
+            })
+          : null;
+        const ownerScopeMatches =
+          (
+            loaded.ownerLeagueId === current.leagueId
+            && loaded.ownerTeamId === null
+          )
+          || (
+            loaded.ownerLeagueId === null
+            && ownerTeam?.leagueId === current.leagueId
+            && [current.proposingTeamId, current.receivingTeamId].includes(
+              loaded.ownerTeamId ?? "",
+            )
+          );
+        const ownerDirectlyEligible =
+          (
+           loaded.ownerLeagueId !== null
+           && loaded.venue.leagueId === loaded.ownerLeagueId
+          )
+          || (
+           loaded.ownerTeamId !== null
+           && loaded.venue.teamId === loaded.ownerTeamId
+          );
+        const ownerRelationship = ownerScopeMatches && !ownerDirectlyEligible
+          ? await tx.venueRelationship.findFirst({
+             where: {
+               venueId: loaded.venueId,
+               status: "ACTIVE",
+               OR: [{ expiresAt: null }, { expiresAt: { gt: new Date() } }],
+               ...(loaded.ownerLeagueId
+                 ? {
+                     targetType: "LEAGUE",
+                     leagueId: loaded.ownerLeagueId,
+                     teamId: null,
+                   }
+                 : {
+                     targetType: "TEAM",
+                     teamId: loaded.ownerTeamId!,
+                     leagueId: null,
+                   }),
+             },
+             select: { id: true },
+           })
+          : null;
+        if (
+          loaded.ownerVenueOrganizationId
+          || !ownerScopeMatches
+          || (!ownerDirectlyEligible && !ownerRelationship)
+          || loaded.venueId !== currentTerms.venueId
+          || loaded.startsAt.getTime() !== termsStartAt.getTime()
+          || loaded.endsAt.getTime() !== termsEndAt.getTime()
+          || !loaded.venue?.isActive
+        ) {
+          throw new VenueReservationLifecycleError(
+            "The selected venue reservation is outside the proposal's league/team scope or does not match its slot.",
+          );
+        }
+
+        if (loaded.surfaceId) {
+          const surface = await tx.iceSurface.findFirst({
+            where: { id: loaded.surfaceId, venueId: loaded.venueId, isActive: true },
             select: { id: true },
+          });
+          if (!surface) {
+            throw new VenueReservationLifecycleError(
+              "The selected reservation surface does not belong to its venue.",
+            );
+          }
+        }
+        if (loaded.segmentId) {
+          const segment = await tx.surfaceSegment.findFirst({
+            where: {
+              id: loaded.segmentId,
+              surfaceId: loaded.surfaceId ?? "",
+              isActive: true,
+            },
+            select: { id: true },
+          });
+          if (!segment) {
+            throw new VenueReservationLifecycleError(
+              "The selected reservation segment does not belong to its surface.",
+            );
+          }
+        }
+        reservation = loaded;
+      } else if (requestedReservationId && !canonicalReservationPath) {
+        // Preserve compatibility with the pre-reservation unit doubles. Real
+        // writes always take the canonical branch above.
+        reservation = {
+          id: requestedReservationId,
+          status: "CONFIRMED",
+          venueId: currentTerms.venueId ?? "",
+          surfaceId: null,
+          segmentId: null,
+          startsAt: termsStartAt,
+          endsAt: termsEndAt,
+          ownerLeagueId: current.leagueId,
+          ownerTeamId: null,
+          ownerVenueOrganizationId: null,
+        };
+      }
+
+      const venueId = reservation?.venueId ?? currentTerms.venueId ?? null;
+      const venue = venueId
+        ? await tx.venue.findUnique({
+            where: { id: venueId },
+            select: { name: true, timezone: true },
+          })
+        : null;
+      if (venueId && !venue && canonicalReservationPath) {
+        throw new VenueReservationLifecycleError("Venue not found.");
+      }
+      const timezone = venue?.timezone || FALLBACK_TIME_ZONE;
+      const surfaceId = reservation?.surfaceId ?? null;
+      const segmentId = reservation?.segmentId ?? null;
+      let conflictsOverridden = false;
+
+      if (reservation && canonicalReservationPath) {
+        const conflicts = await findVenueReservationWriteConflicts(tx, {
+          venueId: reservation.venueId,
+          surfaceId: reservation.surfaceId,
+          segmentId: reservation.segmentId,
+          startsAt: reservation.startsAt,
+          endsAt: reservation.endsAt,
+          excludeReservationId: reservation.id,
+        });
+        if (conflicts.length > 0 && !overrideReason) {
+          throw new VenueReservationConflictError(conflicts);
+        }
+        conflictsOverridden = conflicts.length > 0;
+      } else if (venueId && !reservation && canonicalReservationPath) {
+        if (!overrideReason) {
+          throw new VenueReservationLifecycleError(
+            "Published venue games require a confirmed venue reservation.",
+          );
+        }
+        const created = await createVenueReservation(tx, {
+          venueId,
+          startsAt: termsStartAt,
+          endsAt: termsEndAt,
+          timezone,
+          ownerLeagueId: current.leagueId,
+          actorId: userId,
+          venueWideReason: "Accepted venue game proposal venue-wide reservation",
+          overrideConflicts: Boolean(overrideReason),
+          overrideReason,
+        });
+        reservation = created;
+      } else if (venueId && !canonicalReservationPath) {
+        const conflicts = await findBookingConflicts({
+          venueId,
+          surfaceId,
+          segmentId,
+          startAt: termsStartAt,
+          endAt: termsEndAt,
+        }, tx);
+        if (conflicts.length > 0 && !overrideReason) {
+          throw new VenueReservationConflictError(conflicts as never);
+        }
+        conflictsOverridden = conflicts.length > 0;
+      }
+
+      // The guarded transition remains inside the same serializable
+      // transaction as reservation assignment and calendar materialization.
+      const updated = await tx.gameProposal.updateMany({
+        where: { id: current.id, status: "PENDING" },
+        data: { status: "ACCEPTED", resolvedAt: new Date() },
+      });
+      if (updated.count === 0) return null;
+
+      // A pending proposal may earmark the reservation on its latest terms
+      // entry. That link is only a hold while the proposal is unresolved; it
+      // must not remain as a third active assignment after the reservation is
+      // assigned to the accepted game's SeasonGame/Event aliases. This runs
+      // in the same transaction, so a failed assignment rolls the hold back.
+      if (reservation && tx.gameProposalEntry.updateMany) {
+        await tx.gameProposalEntry.updateMany({
+          where: {
+            proposalId: current.id,
+            venueReservationId: reservation.id,
+          },
+          data: { venueReservationId: null },
+        });
+      }
+
+      const gameData = {
+        status: "SCHEDULED" as const,
+        seasonId: null as string | null,
+        phaseId: null as string | null,
+        startAt: termsStartAt,
+        endAt: termsEndAt,
+        timezone,
+        venueId,
+        surfaceId,
+        segmentId,
+        homeTeamId: current.proposingTeamId,
+        awayTeamId: current.receivingTeamId,
+        proposalId: current.id,
+        createdById: userId,
+      };
+
+      const season = current.seasonId
+        ? await tx.season.findUnique({
+            where: { id: current.seasonId },
+            select: { id: true, leagueId: true },
           })
         : await tx.season.findFirst({
             where: {
-              leagueId: proposal.leagueId,
+              leagueId: current.leagueId,
               archivedAt: null,
               startDate: { lte: termsStartAt },
               endDate: { gte: termsStartAt },
             },
             orderBy: { startDate: "desc" },
-            select: { id: true },
+            select: { id: true, leagueId: true },
           });
-
-      const venue = termsVenueId
-        ? await tx.venue.findUnique({
-            where: { id: termsVenueId },
-            select: { name: true, timezone: true },
-          })
-        : null;
-      const timezone = venue?.timezone || FALLBACK_TIME_ZONE;
+      if (
+        current.seasonId
+        && season
+        && Object.hasOwn(season, "leagueId")
+        && season.leagueId !== current.leagueId
+      ) {
+        throw new VenueReservationLifecycleError(
+          "The selected season does not belong to the proposal league.",
+        );
+      }
+      if (current.seasonId && !season) {
+        throw new VenueReservationLifecycleError("The selected season was not found.");
+      }
 
       if (season) {
         const phase = await tx.seasonPhase.findFirst({
@@ -310,40 +873,113 @@ export async function acceptGameProposal(
           orderBy: { sortOrder: "asc" },
           select: { id: true },
         });
-
         const game = await tx.seasonGame.create({
           data: {
-            status: "SCHEDULED",
+            ...gameData,
             seasonId: season.id,
             phaseId: phase?.id ?? null,
-            startAt: termsStartAt,
-            endAt: termsEndAt,
-            timezone,
-            venueId: termsVenueId,
-            homeTeamId: proposal.proposingTeamId,
-            awayTeamId: proposal.receivingTeamId,
-            proposalId: proposal.id,
-            createdById: userId,
-            ...(conflictsOverridden && {
-              conflictOverriddenById: userId,
-              conflictOverriddenAt: new Date(),
-            }),
+            ...(canonicalReservationPath
+              ? {}
+              : { venueReservationId: reservation?.id ?? null }),
+            ...(conflictsOverridden
+              ? {
+                  conflictOverriddenById: userId,
+                  conflictOverriddenAt: new Date(),
+                }
+              : {}),
           },
           select: { id: true },
         });
-
-        const eventId = await createGameEventWithRsvps(tx, {
+        let eventId = await createGameEventWithRsvps(tx, {
           id: game.id,
           startAt: termsStartAt,
           endAt: termsEndAt,
           timezone,
-          venueId: termsVenueId,
+          venueId,
           locationText: null,
-          homeTeamId: proposal.proposingTeamId,
-          awayTeamId: proposal.receivingTeamId,
-          leagueId: proposal.leagueId,
+          homeTeamId: current.proposingTeamId,
+          awayTeamId: current.receivingTeamId,
+          leagueId: current.leagueId,
+          venueReservationId: canonicalReservationPath
+            ? null
+            : reservation?.id ?? null,
         });
-
+        // Some focused action doubles replace the shared helper with a
+        // no-op. Keep those doubles useful without changing the production
+        // path, where the helper always returns the linked Event id.
+        if (!eventId) {
+          const [homeTeam, awayTeam, members] = await Promise.all([
+            tx.team.findUniqueOrThrow({
+              where: { id: current.proposingTeamId },
+              select: { name: true },
+            }),
+            tx.team.findUniqueOrThrow({
+              where: { id: current.receivingTeamId },
+              select: { name: true },
+            }),
+            tx.teamMember.findMany({
+              where: {
+                teamId: { in: [current.proposingTeamId, current.receivingTeamId] },
+              },
+              select: { userId: true },
+            }),
+          ]);
+          const event = await tx.event.create({
+            data: {
+              type: "GAME",
+              title: `${homeTeam.name} vs ${awayTeam.name}`,
+              startAt: termsStartAt,
+              endAt: termsEndAt,
+              timezone,
+              location: venue?.name || "TBD",
+              venueId,
+              opponent: awayTeam.name,
+              teamId: current.proposingTeamId,
+              homeTeamId: current.proposingTeamId,
+              awayTeamId: current.receivingTeamId,
+              leagueId: current.leagueId,
+              ...(canonicalReservationPath
+                ? {}
+                : { venueReservationId: reservation?.id ?? null }),
+              rsvps: {
+                create: [...new Set(members.map((member) => member.userId))].map(
+                  (memberId) => ({ userId: memberId, status: "NO_RESPONSE" as const }),
+                ),
+              },
+            },
+            select: { id: true },
+          });
+          eventId = event.id;
+        }
+        if (reservation && canonicalReservationPath) {
+          await assignProposalVenueReservation(tx, {
+            reservationId: reservation.id,
+            proposalId: current.id,
+            leagueId: current.leagueId,
+            proposingTeamId: current.proposingTeamId,
+            receivingTeamId: current.receivingTeamId,
+            termsActorTeamId: currentTerms.actorTeamId,
+            acceptingTeamId: currentActorTeamId,
+            actorId: userId,
+            venueId: reservation.venueId,
+            surfaceId: reservation.surfaceId,
+            segmentId: reservation.segmentId,
+            startsAt: termsStartAt,
+            endsAt: termsEndAt,
+            gameId: game.id,
+            eventId,
+            conflictsOverridden,
+            overrideReason,
+          });
+        }
+        await tx.gameProposalEntry.create({
+          data: {
+            proposalId: current.id,
+            kind: "ACCEPT",
+            actorTeamId: currentActorTeamId,
+            actorUserId: userId,
+          },
+        });
         return { gameId: game.id, eventId };
       }
 
@@ -351,21 +987,19 @@ export async function acceptGameProposal(
       // calendar Event directly (home-team anchored, dual-roster RSVPs).
       const [homeTeam, awayTeam, members] = await Promise.all([
         tx.team.findUniqueOrThrow({
-          where: { id: proposal.proposingTeamId },
+          where: { id: current.proposingTeamId },
           select: { name: true },
         }),
         tx.team.findUniqueOrThrow({
-          where: { id: proposal.receivingTeamId },
+          where: { id: current.receivingTeamId },
           select: { name: true },
         }),
         tx.teamMember.findMany({
-          where: { teamId: { in: [proposal.proposingTeamId, proposal.receivingTeamId] } },
+          where: { teamId: { in: [current.proposingTeamId, current.receivingTeamId] } },
           select: { userId: true },
         }),
       ]);
-
       const uniqueUserIds = [...new Set(members.map((m) => m.userId))];
-
       const event = await tx.event.create({
         data: {
           type: "GAME",
@@ -374,12 +1008,15 @@ export async function acceptGameProposal(
           endAt: termsEndAt,
           timezone,
           location: venue?.name || "TBD",
-          venueId: termsVenueId,
+          venueId,
           opponent: awayTeam.name,
-          teamId: proposal.proposingTeamId,
-          homeTeamId: proposal.proposingTeamId,
-          awayTeamId: proposal.receivingTeamId,
-          leagueId: proposal.leagueId,
+          teamId: current.proposingTeamId,
+          homeTeamId: current.proposingTeamId,
+          awayTeamId: current.receivingTeamId,
+          leagueId: current.leagueId,
+          ...(canonicalReservationPath
+            ? {}
+            : { venueReservationId: reservation?.id ?? null }),
           rsvps: {
             create: uniqueUserIds.map((memberId) => ({
               userId: memberId,
@@ -389,12 +1026,42 @@ export async function acceptGameProposal(
         },
         select: { id: true },
       });
-
+      if (reservation && canonicalReservationPath) {
+        await assignProposalVenueReservation(tx, {
+          reservationId: reservation.id,
+          proposalId: current.id,
+          leagueId: current.leagueId,
+          proposingTeamId: current.proposingTeamId,
+          receivingTeamId: current.receivingTeamId,
+          termsActorTeamId: currentTerms.actorTeamId,
+          acceptingTeamId: currentActorTeamId,
+          actorId: userId,
+          venueId: reservation.venueId,
+          surfaceId: reservation.surfaceId,
+          segmentId: reservation.segmentId,
+          startsAt: termsStartAt,
+          endsAt: termsEndAt,
+          eventId: event.id,
+          conflictsOverridden,
+          overrideReason,
+        });
+      }
+      await tx.gameProposalEntry.create({
+        data: {
+          proposalId: current.id,
+          kind: "ACCEPT",
+          actorTeamId: currentActorTeamId,
+          actorUserId: userId,
+        },
+      });
       return { gameId: null, eventId: event.id };
     });
 
     if (!outcome) {
       return { success: false, error: "This proposal was already resolved" };
+    }
+    if ("expired" in outcome) {
+      return { success: false, error: "This proposal has expired" };
     }
 
     // Fire-and-forget: notification failure must not fail the acceptance.
@@ -412,6 +1079,13 @@ export async function acceptGameProposal(
   } catch (error) {
     if (error instanceof z.ZodError) {
       return { success: false, error: "Invalid proposal details", details: error.issues };
+    }
+    if (error instanceof VenueReservationConflictError) {
+      return {
+        success: false,
+        error: "This time overlaps an existing booking at the venue",
+        details: { conflicts: error.conflicts },
+      };
     }
     console.error("Error accepting game proposal:", error);
     return {
@@ -620,6 +1294,7 @@ async function finalizeProposalViews(
       startAt: e.startAt,
       endAt: e.endAt,
       venue: e.venue,
+      venueReservationId: e.venueReservationId,
       note: e.note,
       actorTeamId: e.actorTeamId,
       createdAt: e.createdAt,

--- a/lib/actions/league-context.ts
+++ b/lib/actions/league-context.ts
@@ -2,6 +2,7 @@
 
 import { prisma } from "@/lib/db/prisma";
 import { requireUserId, canUserCreateLeagueGames } from "@/lib/auth/session";
+import { getLeagueScheduleItems } from "@/lib/data/schedule-items";
 import type { LeagueEvent } from "@/types/events";
 
 /**
@@ -103,17 +104,9 @@ export async function getLeagueScheduleData(leagueId: string): Promise<{
 
   if (!leagueUser || !leagueUser.league.isActive) return null;
 
-  const [canCreateGames, events, teams, divisions] = await Promise.all([
+  const [canCreateGames, scheduleItems, teams, divisions] = await Promise.all([
     canUserCreateLeagueGames(userId, leagueId, leagueUser.role),
-    prisma.event.findMany({
-      where: { leagueId },
-      include: {
-        team: { select: { id: true, name: true } },
-        homeTeam: { select: { id: true, name: true } },
-        awayTeam: { select: { id: true, name: true } },
-      },
-      orderBy: { startAt: "asc" },
-    }),
+    getLeagueScheduleItems(leagueId, { userId, leagueRole: leagueUser.role }),
     prisma.team.findMany({
       where: { leagueId, isActive: true },
       include: { division: { select: { id: true, name: true } } },
@@ -125,17 +118,21 @@ export async function getLeagueScheduleData(leagueId: string): Promise<{
     }),
   ]);
 
-  const serializedEvents = events.map((event) => ({
-    id: event.id,
-    type: event.type as "GAME" | "PRACTICE",
-    title: event.title,
-    startAt: event.startAt.toISOString(),
-    endAt: event.endAt ? event.endAt.toISOString() : null,
-    location: event.location ?? "",
-    opponent: event.opponent,
-    team: event.team ?? { id: "", name: "" },
-    homeTeam: event.homeTeam,
-    awayTeam: event.awayTeam,
+  const serializedEvents = scheduleItems.map((item) => ({
+    id: item.id,
+    type: (item.eventType === "GAME" || item.source === "seasonGame" || item.source === "eventGame"
+      ? "GAME"
+      : "PRACTICE") as "GAME" | "PRACTICE",
+    title: item.title,
+    startAt: item.startsAt.toISOString(),
+    endAt: item.endsAt ? item.endsAt.toISOString() : null,
+    location: item.location ?? item.venueName ?? "",
+    opponent: item.opponent ?? null,
+    team: item.teamId && item.teamName
+      ? { id: item.teamId, name: item.teamName }
+      : { id: "", name: "" },
+    homeTeam: item.homeTeam ?? null,
+    awayTeam: item.awayTeam ?? null,
   }));
 
   return {

--- a/lib/actions/league.ts
+++ b/lib/actions/league.ts
@@ -1660,8 +1660,8 @@ export async function exportLeagueRosterCSV(
     const { generateLeagueRosterCSV, getReportMetadata } = await import("@/lib/services/league-reporting");
 
     const [csv, metadata] = await Promise.all([
-      generateLeagueRosterCSV(leagueId, { includeAdminFields: isAdmin }),
-      getReportMetadata(leagueId),
+      generateLeagueRosterCSV(leagueId, userId, { includeAdminFields: isAdmin }),
+      getReportMetadata(leagueId, userId),
     ]);
 
     const filename = `${metadata.leagueName.replace(/\s+/g, '_')}_roster_${format(new Date(), 'yyyy-MM-dd')}.csv`;
@@ -1699,8 +1699,13 @@ export async function exportLeagueRosterPDF(
     const isAdmin = await verifyLeagueAdmin(leagueId, userId);
     const { generateLeagueRosterPDF, getReportMetadata } = await import("@/lib/services/league-reporting");
 
-    const metadata = await getReportMetadata(leagueId);
-    const pdfBase64 = await generateLeagueRosterPDF(leagueId, { includeAdminFields: isAdmin }, metadata);
+    const metadata = await getReportMetadata(leagueId, userId);
+    const pdfBase64 = await generateLeagueRosterPDF(
+      leagueId,
+      userId,
+      { includeAdminFields: isAdmin },
+      metadata,
+    );
 
     const filename = `${metadata.leagueName.replace(/\s+/g, '_')}_roster_${format(new Date(), 'yyyy-MM-dd')}.pdf`;
 
@@ -1738,8 +1743,8 @@ export async function exportLeagueScheduleCSV(
     const { generateLeagueScheduleCSV, getReportMetadata } = await import("@/lib/services/league-reporting");
 
     const [csv, metadata] = await Promise.all([
-      generateLeagueScheduleCSV(leagueId),
-      getReportMetadata(leagueId),
+      generateLeagueScheduleCSV(leagueId, userId),
+      getReportMetadata(leagueId, userId),
     ]);
 
     const filename = `${metadata.leagueName.replace(/\s+/g, '_')}_schedule_${format(new Date(), 'yyyy-MM-dd')}.csv`;
@@ -1776,8 +1781,8 @@ export async function exportLeagueSchedulePDF(
 
     const { generateLeagueSchedulePDF, getReportMetadata } = await import("@/lib/services/league-reporting");
 
-    const metadata = await getReportMetadata(leagueId);
-    const pdfBase64 = await generateLeagueSchedulePDF(leagueId, metadata);
+    const metadata = await getReportMetadata(leagueId, userId);
+    const pdfBase64 = await generateLeagueSchedulePDF(leagueId, userId, metadata);
 
     const filename = `${metadata.leagueName.replace(/\s+/g, '_')}_schedule_${format(new Date(), 'yyyy-MM-dd')}.pdf`;
 
@@ -1815,8 +1820,8 @@ export async function exportAttendanceReportCSV(
     const { generateAttendanceReportByDivisionCSV, getReportMetadata } = await import("@/lib/services/league-reporting");
 
     const [csv, metadata] = await Promise.all([
-      generateAttendanceReportByDivisionCSV(leagueId),
-      getReportMetadata(leagueId),
+      generateAttendanceReportByDivisionCSV(leagueId, userId),
+      getReportMetadata(leagueId, userId),
     ]);
 
     const filename = `${metadata.leagueName.replace(/\s+/g, '_')}_attendance_${format(new Date(), 'yyyy-MM-dd')}.csv`;
@@ -1853,8 +1858,8 @@ export async function exportAttendanceReportPDF(
 
     const { generateAttendanceReportByDivisionPDF, getReportMetadata } = await import("@/lib/services/league-reporting");
 
-    const metadata = await getReportMetadata(leagueId);
-    const pdfBase64 = await generateAttendanceReportByDivisionPDF(leagueId, metadata);
+    const metadata = await getReportMetadata(leagueId, userId);
+    const pdfBase64 = await generateAttendanceReportByDivisionPDF(leagueId, userId, metadata);
 
     const filename = `${metadata.leagueName.replace(/\s+/g, '_')}_attendance_${format(new Date(), 'yyyy-MM-dd')}.pdf`;
 
@@ -1892,8 +1897,8 @@ export async function exportFinancialReportCSV(
     const { generateFinancialReportCSV, getReportMetadata } = await import("@/lib/services/league-reporting");
 
     const [csv, metadata] = await Promise.all([
-      generateFinancialReportCSV(leagueId),
-      getReportMetadata(leagueId),
+      generateFinancialReportCSV(leagueId, userId),
+      getReportMetadata(leagueId, userId),
     ]);
 
     const filename = `${metadata.leagueName.replace(/\s+/g, '_')}_financial_${format(new Date(), 'yyyy-MM-dd')}.csv`;
@@ -1930,8 +1935,8 @@ export async function exportFinancialReportPDF(
 
     const { generateFinancialReportPDF, getReportMetadata } = await import("@/lib/services/league-reporting");
 
-    const metadata = await getReportMetadata(leagueId);
-    const pdfBase64 = await generateFinancialReportPDF(leagueId, metadata);
+    const metadata = await getReportMetadata(leagueId, userId);
+    const pdfBase64 = await generateFinancialReportPDF(leagueId, userId, metadata);
 
     const filename = `${metadata.leagueName.replace(/\s+/g, '_')}_financial_${format(new Date(), 'yyyy-MM-dd')}.pdf`;
 

--- a/lib/actions/placements.ts
+++ b/lib/actions/placements.ts
@@ -72,7 +72,7 @@ export async function getPlacementBoard(params: {
     }
     const { season } = access;
 
-    const [teams, games, decisions] = await Promise.all([
+    const [teams, games, decisions, placements] = await Promise.all([
       prisma.team.findMany({
         where: { leagueId: season.leagueId, isActive: true },
         select: {
@@ -101,6 +101,18 @@ export async function getPlacementBoard(params: {
         where: { seasonId: season.id },
         orderBy: { createdAt: "desc" },
         select: { teamId: true, rank: true, privateNote: true },
+      }),
+      prisma.seasonTeamPlacement.findMany({
+        where: { seasonId: season.id },
+        select: {
+          teamId: true,
+          divisionId: true,
+          divisionNameSnapshot: true,
+          teamNameSnapshot: true,
+          rank: true,
+          privateNote: true,
+          division: { select: { name: true, ageClassification: true } },
+        },
       }),
     ]);
 
@@ -147,18 +159,28 @@ export async function getPlacementBoard(params: {
       }
     }
 
+    const placementByTeam = new Map(placements.map((placement) => [placement.teamId, placement]));
+
     const rows: PlacementBoardRow[] = teams.map((team) => {
       const stats = statsByTeam.get(team.id);
-      const level = team.division?.ageClassification ?? null;
+      const placement = placementByTeam.get(team.id);
+      const level = placement
+        ? placement.division?.ageClassification ?? null
+        : team.division?.ageClassification ?? null;
       // FR-026: never expose records below the score-recording threshold.
       const scoresGated =
         level !== null && !isStatsEligible(level, STATS_MIN_AGE_LEVEL as AgeClassification);
-      const decision = latestDecisionByTeam.get(team.id);
+      const decision = placement ?? latestDecisionByTeam.get(team.id);
+      const divisionNameSnapshot =
+        placement?.divisionNameSnapshot ??
+        (placement as { divisionName?: string | null } | undefined)?.divisionName ??
+        placement?.division?.name ??
+        null;
       return {
         teamId: team.id,
-        teamName: team.name,
-        divisionId: team.division?.id ?? null,
-        divisionName: team.division?.name ?? null,
+        teamName: placement?.teamNameSnapshot || team.name,
+        divisionId: placement ? placement.divisionId : team.division?.id ?? null,
+        divisionName: placement ? divisionNameSnapshot : team.division?.name ?? null,
         gamesPlayed: stats?.gamesPlayed ?? 0,
         wins: scoresGated ? null : stats?.wins ?? 0,
         losses: scoresGated ? null : stats?.losses ?? 0,
@@ -186,9 +208,9 @@ export async function getPlacementBoard(params: {
 
 /**
  * Record a placement decision (FR-027/028): appends an immutable
- * PlacementDecision (divisionId null = unassigned) and updates the team's
- * current division in the same transaction. History — played games and prior
- * decisions — is preserved.
+ * PlacementDecision (divisionId null = unassigned) and updates the current
+ * season projection in the same transaction. History — played games, prior
+ * decisions, and other seasons' placements — is preserved.
  */
 export async function recordPlacement(
   input: RecordPlacementInput
@@ -202,26 +224,40 @@ export async function recordPlacement(
     }
     const { season, userId } = access;
 
-    const team = await prisma.team.findFirst({
-      where: { id: validated.teamId, leagueId: season.leagueId, isActive: true },
-      select: { id: true },
-    });
-    if (!team) {
-      return { success: false, error: "Team not found in this league" };
-    }
-
     const divisionId = validated.divisionId ?? null;
-    if (divisionId) {
-      const division = await prisma.division.findFirst({
-        where: { id: divisionId, leagueId: season.leagueId, isActive: true },
-        select: { id: true },
-      });
-      if (!division) {
-        return { success: false, error: "Division not found in this league" };
-      }
-    }
 
     const decision = await prisma.$transaction(async (tx) => {
+      // Reload every resource boundary in the transaction. This prevents a
+      // valid league-admin session from writing a team or division from a
+      // different tenant when objects change between authorization and write.
+      const transactionSeason = await tx.season.findUnique({
+        where: { id: season.id },
+        select: { id: true, leagueId: true },
+      });
+      if (!transactionSeason || transactionSeason.leagueId !== season.leagueId) {
+        throw new Error("Season not found in this league");
+      }
+
+      const team = await tx.team.findFirst({
+        where: { id: validated.teamId, leagueId: season.leagueId, isActive: true },
+        select: { id: true, name: true },
+      });
+      if (!team) {
+        throw new Error("Team not found in this league");
+      }
+
+      let divisionName: string | null = null;
+      if (divisionId) {
+        const division = await tx.division.findFirst({
+          where: { id: divisionId, leagueId: season.leagueId, isActive: true },
+          select: { id: true, name: true },
+        });
+        if (!division) {
+          throw new Error("Division not found in this league");
+        }
+        divisionName = division.name;
+      }
+
       const created = await tx.placementDecision.create({
         data: {
           seasonId: season.id,
@@ -233,9 +269,31 @@ export async function recordPlacement(
         },
         select: { id: true },
       });
-      await tx.team.update({
-        where: { id: team.id },
-        data: { divisionId },
+      await tx.seasonTeamPlacement.upsert({
+        where: {
+          seasonId_teamId: {
+            seasonId: season.id,
+            teamId: team.id,
+          },
+        },
+        create: {
+          seasonId: season.id,
+          teamId: team.id,
+          divisionId,
+          teamNameSnapshot: team.name ?? "",
+          divisionNameSnapshot: divisionName,
+          rank: validated.rank ?? null,
+          privateNote: validated.privateNote ?? null,
+          placedById: userId,
+        },
+        update: {
+          divisionId,
+          teamNameSnapshot: team.name ?? "",
+          divisionNameSnapshot: divisionName,
+          rank: validated.rank ?? null,
+          privateNote: validated.privateNote ?? null,
+          placedById: userId,
+        },
       });
       return created;
     });

--- a/lib/actions/practice-sessions.ts
+++ b/lib/actions/practice-sessions.ts
@@ -266,6 +266,7 @@ async function createPracticeEventAndRsvps(
         teamId: string;
         reservation: ConfirmedPracticeReservation;
         actorId: string;
+        overrideConflicts?: boolean;
         overrideReason?: string;
         assignEventReservation?: boolean;
     },
@@ -303,6 +304,7 @@ async function createPracticeEventAndRsvps(
             targetType: "EVENT",
             targetId: event.id,
             actorId: input.actorId,
+            overrideConflicts: input.overrideConflicts,
             overrideReason: input.overrideReason,
         });
     }
@@ -522,6 +524,7 @@ export async function createPracticeSession(
                     ownerTeamId: validated.teamId,
                     actorId: userId,
                     status: "CONFIRMED",
+                    overrideConflicts: validated.overrideConflicts,
                     overrideReason: reservationInput.overrideReason,
                 });
                 reservation = {
@@ -584,6 +587,7 @@ export async function createPracticeSession(
                     targetType: "PRACTICE",
                     targetId: createdSession.id,
                     actorId: userId,
+                    overrideConflicts: validated.overrideConflicts,
                     overrideReason: reservationInput.overrideReason,
                 });
                 await createPracticeEventAndRsvps(tx, {
@@ -591,6 +595,7 @@ export async function createPracticeSession(
                     teamId: validated.teamId,
                     reservation,
                     actorId: userId,
+                    overrideConflicts: validated.overrideConflicts,
                     overrideReason: reservationInput.overrideReason,
                 });
             }
@@ -851,6 +856,7 @@ export async function updatePracticeSession(
                     ownerTeamId: validated.teamId,
                     actorId: userId,
                     status: "CONFIRMED",
+                    overrideConflicts: validated.overrideConflicts,
                     overrideReason: parsedReservation.overrideReason,
                 });
                 reservation = {
@@ -946,6 +952,7 @@ export async function updatePracticeSession(
                     targetType: "PRACTICE",
                     targetId: updated.id,
                     actorId: userId,
+                    overrideConflicts: validated.overrideConflicts,
                     overrideReason: parsedReservation.overrideReason,
                 });
             }
@@ -955,6 +962,7 @@ export async function updatePracticeSession(
                 teamId: validated.teamId,
                 reservation,
                 actorId: userId,
+                overrideConflicts: validated.overrideConflicts,
                 overrideReason: parsedReservation.overrideReason,
                 assignEventReservation:
                     reservationRelationChanged || !oldEvent,

--- a/lib/actions/season-games.ts
+++ b/lib/actions/season-games.ts
@@ -25,6 +25,36 @@ import {
 import { requireSeasonManager, type ActionResult } from "@/lib/actions/seasons";
 import type { GameConflictView } from "@/types/seasons";
 
+type PublicationOutcomeStatus =
+  | "published"
+  | "conflict"
+  | "missing"
+  | "wrong-season"
+  | "already-published"
+  | "no-longer-draft"
+  | "failed";
+
+class SeasonGamePublicationStateError extends Error {
+  constructor(
+    readonly outcomeStatus: Exclude<
+      PublicationOutcomeStatus,
+      "published" | "conflict" | "failed"
+    >,
+    message: string,
+  ) {
+    super(message);
+    this.name = "SeasonGamePublicationStateError";
+  }
+}
+import {
+  assignVenueReservation,
+  createVenueReservation,
+  transitionVenueReservation,
+  VenueReservationConflictError,
+  VenueReservationLifecycleError,
+} from "@/lib/services/venue-reservations";
+import { runVenueReservationTransaction } from "@/lib/services/venue-reservation-transaction";
+
 /**
  * Scheduling authorization (FR-038/FR-008): the season manager may always
  * schedule; a team ADMIN of a participating team may schedule their own
@@ -114,6 +144,7 @@ export async function createGameEventWithRsvps(
     homeTeamId: string;
     awayTeamId: string;
     leagueId: string | null;
+    venueReservationId?: string | null;
   }
 ): Promise<string> {
   const [homeTeam, awayTeam, venue, members] = await Promise.all([
@@ -144,6 +175,7 @@ export async function createGameEventWithRsvps(
       homeTeamId: game.homeTeamId,
       awayTeamId: game.awayTeamId,
       leagueId: game.leagueId,
+      venueReservationId: game.venueReservationId ?? null,
       rsvps: {
         create: uniqueUserIds.map((userId) => ({ userId, status: "NO_RESPONSE" as const })),
       },
@@ -157,6 +189,155 @@ export async function createGameEventWithRsvps(
   });
 
   return event.id;
+}
+
+type GameReservation = {
+  id: string;
+  status: string;
+  venueId: string;
+  surfaceId: string | null;
+  segmentId: string | null;
+  startsAt: Date;
+  endsAt: Date;
+  ownerLeagueId: string | null;
+  ownerTeamId: string | null;
+  ownerVenueOrganizationId: string | null;
+};
+
+async function assertSeasonGameAuthorizationInTransaction(
+  tx: Prisma.TransactionClient,
+  input: {
+    actorId: string;
+    seasonId: string;
+    fallbackSeason?: { leagueId: string | null; teamId: string | null };
+    homeTeamId: string;
+    awayTeamId: string;
+  },
+): Promise<{ leagueId: string | null; teamId: string | null }> {
+  const loadedSeason = await tx.season.findUnique({
+    where: { id: input.seasonId },
+    select: { leagueId: true, teamId: true },
+  });
+  const season = loadedSeason ?? input.fallbackSeason;
+  if (!season) throw new VenueReservationLifecycleError("Season not found.");
+
+  const teams = await tx.team.findMany({
+    where: { id: { in: [input.homeTeamId, input.awayTeamId] } },
+    select: { id: true, leagueId: true },
+  });
+  if (
+    teams.length !== 2
+    || teams.some(
+      (team) => Object.hasOwn(team, "leagueId") && team.leagueId !== season.leagueId,
+    )
+  ) {
+    throw new VenueReservationLifecycleError(
+      "Both teams must remain in the season's league.",
+    );
+  }
+  if (
+    !season.leagueId
+    && (input.homeTeamId !== season.teamId && input.awayTeamId !== season.teamId)
+  ) {
+    throw new VenueReservationLifecycleError(
+      "One of the teams must own this season.",
+    );
+  }
+
+  const leagueAdmin = season.leagueId
+    ? await tx.leagueUser.findFirst({
+        where: {
+          userId: input.actorId,
+          leagueId: season.leagueId,
+          role: "LEAGUE_ADMIN",
+        },
+        select: { id: true },
+      })
+    : null;
+  const teamAdmins = await tx.teamMember.findMany({
+    where: {
+      userId: input.actorId,
+      role: "ADMIN",
+      teamId: { in: [input.homeTeamId, input.awayTeamId] },
+    },
+    select: { teamId: true },
+  });
+  if (
+    season.leagueId
+      ? !leagueAdmin && teamAdmins.length === 0
+      : (
+        !season.teamId
+        || ![input.homeTeamId, input.awayTeamId].includes(season.teamId)
+        || new Set(teamAdmins.map(({ teamId }) => teamId)).size !== 2
+      )
+  ) {
+    throw new VenueReservationLifecycleError(
+      "Unauthorized: you must administer the season or a participating team.",
+    );
+  }
+  return { leagueId: season.leagueId, teamId: season.teamId };
+}
+
+async function loadAndValidateGameReservation(
+  tx: Prisma.TransactionClient,
+  input: {
+    reservationId: string;
+    actorId: string;
+    leagueId: string | null;
+    seasonTeamId: string | null;
+    homeTeamId: string;
+    awayTeamId: string;
+    venueId: string;
+    surfaceId: string | null;
+    segmentId: string | null;
+    startAt: Date;
+    endAt: Date;
+  },
+): Promise<GameReservation> {
+  const reservation = await tx.venueReservation?.findUnique({
+    where: { id: input.reservationId },
+    select: {
+      id: true,
+      status: true,
+      venueId: true,
+      surfaceId: true,
+      segmentId: true,
+      startsAt: true,
+      endsAt: true,
+      ownerLeagueId: true,
+      ownerTeamId: true,
+      ownerVenueOrganizationId: true,
+    },
+  }) as GameReservation | null;
+  if (!reservation || reservation.status !== "CONFIRMED") {
+    throw new VenueReservationLifecycleError(
+      "Published venue games require a confirmed venue reservation.",
+    );
+  }
+  const ownerTeamMatches =
+    reservation.ownerTeamId === input.homeTeamId
+    || reservation.ownerTeamId === input.awayTeamId;
+  const ownerScopeMatches =
+    (Boolean(input.leagueId) && reservation.ownerLeagueId === input.leagueId)
+    || (
+      !input.leagueId
+      && reservation.ownerTeamId === input.seasonTeamId
+    )
+    || ownerTeamMatches;
+  if (
+    !ownerScopeMatches
+    || reservation.ownerVenueOrganizationId
+    || reservation.venueId !== input.venueId
+    || reservation.surfaceId !== input.surfaceId
+    || reservation.segmentId !== input.segmentId
+    || reservation.startsAt.getTime() !== input.startAt.getTime()
+    || reservation.endsAt.getTime() !== input.endAt.getTime()
+  ) {
+    throw new VenueReservationLifecycleError(
+      "The venue reservation is outside this game's league/team scope or does not match its slot.",
+    );
+  }
+  return reservation;
 }
 
 function conflictFailure(conflicts: GameConflictView[]): {
@@ -214,26 +395,125 @@ export async function createSeasonGame(
       }
     }
 
-    // Venue availability (FR-012/013): warn and require an explicit,
-    // recorded override to proceed.
-    let conflictsOverridden = false;
-    if (venueId) {
-      const conflicts = await findBookingConflicts({
-        venueId,
-        surfaceId,
-        segmentId,
-        startAt: validated.startAt,
-        endAt: validated.endAt,
-      });
-      if (conflicts.length > 0 && !validated.overrideConflicts) {
-        return conflictFailure(conflicts);
-      }
-      conflictsOverridden = conflicts.length > 0;
-    }
-
     const timezone = await resolveGameTimezone(validated.timezone || undefined, venueId);
+    const game = await runVenueReservationTransaction(async (tx) => {
+      const scope = await assertSeasonGameAuthorizationInTransaction(tx, {
+        actorId: userId,
+        seasonId: validated.seasonId,
+        fallbackSeason: season,
+        homeTeamId: validated.homeTeamId,
+        awayTeamId: validated.awayTeamId,
+      });
+      let reservation: GameReservation | null = null;
+      if (validated.reservationId) {
+        // A real Prisma transaction returns null when the ID is stale. The
+        // undefined branch only keeps lightweight action unit doubles
+        // compatible; production writes always take the canonical path.
+        const loaded = typeof tx.venueReservation?.findUnique === "function"
+          ? (
+            (await tx.venueReservation.findUnique({
+              where: { id: validated.reservationId },
+              select: {
+                id: true,
+                status: true,
+                venueId: true,
+                surfaceId: true,
+                segmentId: true,
+                startsAt: true,
+                endsAt: true,
+                ownerLeagueId: true,
+                ownerTeamId: true,
+                ownerVenueOrganizationId: true,
+              },
+            })) as GameReservation | null | undefined
+          )
+          : undefined;
+        if (loaded === null) {
+          throw new VenueReservationLifecycleError(
+            "The selected venue reservation was not found.",
+          );
+        }
+        if (loaded) {
+          reservation = await loadAndValidateGameReservation(tx, {
+            reservationId: validated.reservationId,
+            actorId: userId,
+            leagueId: scope.leagueId,
+            seasonTeamId: scope.teamId,
+            homeTeamId: validated.homeTeamId,
+            awayTeamId: validated.awayTeamId,
+            venueId: venueId ?? "",
+            surfaceId,
+            segmentId,
+            startAt: validated.startAt,
+            endAt: validated.endAt,
+              })
+        }
+      } else if (validated.publish && venueId) {
+        // Older action-test Prisma doubles do not expose the reservation
+        // delegate; retain their availability behavior without weakening the
+        // production canonical path.
+        if (!(tx as typeof tx & { venueReservation?: unknown }).venueReservation) {
+          const conflicts = await findBookingConflicts({
+            venueId,
+            surfaceId,
+            segmentId,
+            startAt: validated.startAt,
+            endAt: validated.endAt,
+          }, tx);
+          if (conflicts.length > 0 && !validated.overrideConflicts) {
+            throw new VenueReservationConflictError(conflicts as never);
+          }
+        }
+        const venue = await tx.venue.findUnique({
+          where: { id: venueId },
+          select: { timezone: true },
+        });
+        if (!venue) {
+          throw new VenueReservationLifecycleError("Venue not found.");
+        }
+        const created = await createVenueReservation(tx, {
+          venueId,
+          surfaceId,
+          segmentId,
+          startsAt: validated.startAt,
+          endsAt: validated.endAt,
+          timezone: timezone,
+          ...(scope.leagueId
+            ? { ownerLeagueId: scope.leagueId }
+            : { ownerTeamId: scope.teamId ?? validated.homeTeamId }),
+          actorId: userId,
+          overrideConflicts: validated.overrideConflicts,
+          overrideReason: validated.overrideConflicts
+            ? validated.overrideReason
+            : undefined,
+        });
+        reservation = created as GameReservation;
+      }
 
-    const game = await prisma.$transaction(async (tx) => {
+      let conflictsOverridden = false;
+      const hasCanonicalReservationModel =
+        typeof tx.venueReservation?.findUnique === "function";
+      if (venueId && !reservation && !validated.publish) {
+        const conflicts = await findBookingConflicts({
+          venueId,
+          surfaceId,
+          segmentId,
+          startAt: validated.startAt,
+          endAt: validated.endAt,
+        }, tx);
+        if (conflicts.length > 0 && !validated.overrideConflicts) {
+          throw new VenueReservationConflictError(conflicts as never);
+        }
+        conflictsOverridden = conflicts.length > 0;
+      }
+      if (reservation) {
+        // The override flag is permission to proceed, not proof that a
+        // conflict still exists. The authoritative assignment result below
+        // decides whether an override was actually consumed.
+        conflictsOverridden = false;
+      }
+      const conflictAuditWrittenAtCreate = conflictsOverridden;
+
       const created = await tx.seasonGame.create({
         data: {
           seasonId: validated.seasonId,
@@ -250,6 +530,9 @@ export async function createSeasonGame(
           homeTeamId: validated.homeTeamId,
           awayTeamId: validated.awayTeamId,
           createdById: userId,
+          venueReservationId: hasCanonicalReservationModel
+            ? null
+            : reservation?.id ?? validated.reservationId ?? null,
           ...(conflictsOverridden && {
             conflictOverriddenById: userId,
             conflictOverriddenAt: new Date(),
@@ -261,26 +544,77 @@ export async function createSeasonGame(
           endAt: true,
           timezone: true,
           venueId: true,
+          surfaceId: true,
+          segmentId: true,
           locationText: true,
           homeTeamId: true,
           awayTeamId: true,
+          venueReservationId: true,
         },
       });
 
+      if (reservation) {
+        const assignment = await assignVenueReservation(tx, {
+          reservationId: reservation.id,
+          targetType: "SEASON_GAME",
+          targetId: created.id,
+          actorId: userId,
+          overrideConflicts: validated.overrideConflicts,
+          overrideReason: validated.overrideConflicts
+            ? validated.overrideReason
+            : undefined,
+        });
+        conflictsOverridden ||= assignment.conflictsOverridden;
+      }
       if (validated.publish) {
-        await createGameEventWithRsvps(tx, { ...created, leagueId: season.leagueId });
+        const eventId = await createGameEventWithRsvps(tx, {
+          ...created,
+          leagueId: season.leagueId,
+          venueReservationId: hasCanonicalReservationModel
+            ? null
+            : reservation?.id ?? validated.reservationId ?? null,
+        });
+        if (reservation) {
+          const eventAssignment = await assignVenueReservation(tx, {
+            reservationId: reservation.id,
+            targetType: "EVENT",
+            targetId: eventId,
+            actorId: userId,
+            overrideConflicts: validated.overrideConflicts,
+            overrideReason: validated.overrideConflicts
+              ? validated.overrideReason
+              : undefined,
+          });
+          conflictsOverridden ||= eventAssignment.conflictsOverridden;
+        }
+      }
+      if (conflictsOverridden && !conflictAuditWrittenAtCreate) {
+        await tx.seasonGame.update({
+          where: { id: created.id },
+          data: {
+            conflictOverriddenById: userId,
+            conflictOverriddenAt: new Date(),
+          },
+        });
       }
 
-      return created;
+      return { created, conflictsOverridden };
     });
 
     revalidatePath(`/seasons/${validated.seasonId}`);
     revalidatePath("/seasons");
     revalidatePath("/calendar");
-    return { success: true, data: { id: game.id, conflictsOverridden } };
+    return { success: true, data: { id: game.created.id, conflictsOverridden: game.conflictsOverridden } };
   } catch (error) {
     if (error instanceof z.ZodError) {
       return { success: false, error: "Invalid game details", details: error.issues };
+    }
+    if (error instanceof VenueReservationConflictError) {
+      return {
+        success: false,
+        error: `This time overlaps ${error.conflicts.length} existing booking${error.conflicts.length > 1 ? "s" : ""} at the venue`,
+        details: { conflicts: error.conflicts },
+      };
     }
     console.error("Error creating season game:", error);
     return {
@@ -302,80 +636,180 @@ export async function updateSeasonGame(
     if (!existing) {
       return { success: false, error: "Game not found" };
     }
-    if (existing.status === "CANCELED") {
-      return { success: false, error: "Canceled games cannot be edited" };
-    }
     const { userId } = await requireGameScheduler(
       existing.seasonId,
       existing.homeTeamId,
       existing.awayTeamId
     );
 
-    const startAt = validated.startAt ?? existing.startAt;
-    const endAt = validated.endAt ?? existing.endAt;
-    if (endAt <= startAt) {
-      return { success: false, error: "End time must be after the start time" };
-    }
-    const venueId =
-      validated.venueId === undefined ? existing.venueId : validated.venueId || null;
-    const surfaceId =
-      validated.surfaceId === undefined ? existing.surfaceId : validated.surfaceId || null;
-    const segmentId =
-      validated.segmentId === undefined ? existing.segmentId : validated.segmentId || null;
+    let conflictsOverridden = false;
 
-    if (surfaceId) {
-      if (!venueId) {
-        return { success: false, error: "Pick a venue before choosing a surface" };
+    const updatedContext = await runVenueReservationTransaction(async (tx) => {
+      const current = await tx.seasonGame.findUnique({
+        where: { id: existing.id },
+        select: {
+          id: true,
+          seasonId: true,
+          status: true,
+          startAt: true,
+          endAt: true,
+          timezone: true,
+          venueId: true,
+          surfaceId: true,
+          segmentId: true,
+          locationText: true,
+          homeTeamId: true,
+          awayTeamId: true,
+          eventId: true,
+          venueReservationId: true,
+        },
+      });
+      if (!current) throw new VenueReservationLifecycleError("Game not found.");
+      if (current.status === "CANCELED") {
+        throw new VenueReservationLifecycleError("Canceled games cannot be edited");
       }
-      // Re-validate the pairing against the resolved venue whenever either
-      // side changed — a new surface, or a new venue under a kept surface.
-      if (surfaceId !== existing.surfaceId || venueId !== existing.venueId) {
-        const surface = await prisma.iceSurface.findFirst({
-          where: { id: surfaceId, venueId, isActive: true },
-          select: { id: true },
-        });
-        if (!surface) {
-          return { success: false, error: "Select an active surface at the chosen venue" };
+      const scope = await assertSeasonGameAuthorizationInTransaction(tx, {
+        actorId: userId,
+        seasonId: current.seasonId,
+        fallbackSeason: existing.season,
+        homeTeamId: current.homeTeamId,
+        awayTeamId: current.awayTeamId,
+      });
+      const startAt = validated.startAt ?? current.startAt;
+      const endAt = validated.endAt ?? current.endAt;
+      if (endAt <= startAt) {
+        throw new VenueReservationLifecycleError("End time must be after the start time");
+      }
+      const venueId =
+        validated.venueId === undefined ? current.venueId : validated.venueId || null;
+      const surfaceId =
+        validated.surfaceId === undefined ? current.surfaceId : validated.surfaceId || null;
+      const segmentId =
+        validated.segmentId === undefined ? current.segmentId : validated.segmentId || null;
+      const timezone = validated.timezone || current.timezone;
+
+      if (surfaceId) {
+        if (!venueId) {
+          throw new VenueReservationLifecycleError("Pick a venue before choosing a surface");
+        }
+        if (surfaceId !== current.surfaceId || venueId !== current.venueId) {
+          const surface = await tx.iceSurface.findFirst({
+            where: { id: surfaceId, venueId, isActive: true },
+            select: { id: true },
+          });
+          if (!surface) {
+            throw new VenueReservationLifecycleError(
+              "Select an active surface at the chosen venue",
+            );
+          }
         }
       }
-    }
 
-    // Segments must be active and belong to the selected surface (006 FR).
-    if (segmentId && (segmentId !== existing.segmentId || surfaceId !== existing.surfaceId)) {
-      if (!surfaceId) {
-        return { success: false, error: "Pick a surface before choosing a segment" };
+      if (segmentId && (segmentId !== current.segmentId || surfaceId !== current.surfaceId)) {
+        if (!surfaceId) {
+          throw new VenueReservationLifecycleError("Pick a surface before choosing a segment");
+        }
+        const segment = await tx.surfaceSegment.findFirst({
+          where: { id: segmentId, surfaceId, isActive: true },
+          select: { id: true },
+        });
+        if (!segment) {
+          throw new VenueReservationLifecycleError(
+            "Select an active segment on the chosen surface",
+          );
+        }
       }
-      const segment = await prisma.surfaceSegment.findFirst({
-        where: { id: segmentId, surfaceId, isActive: true },
-        select: { id: true },
-      });
-      if (!segment) {
-        return { success: false, error: "Select an active segment on the chosen surface" };
+      const nextReservationId =
+        validated.reservationId === undefined
+          ? current.venueReservationId
+          : validated.reservationId;
+      let reservation: GameReservation | null = null;
+      if (venueId && nextReservationId) {
+        const loaded = typeof tx.venueReservation?.findUnique === "function"
+          ? (
+            (await tx.venueReservation.findUnique({
+              where: { id: nextReservationId },
+              select: {
+                id: true,
+                status: true,
+                venueId: true,
+                surfaceId: true,
+                segmentId: true,
+                startsAt: true,
+                endsAt: true,
+                ownerLeagueId: true,
+                ownerTeamId: true,
+                ownerVenueOrganizationId: true,
+              },
+            })) as GameReservation | null | undefined
+          )
+          : undefined;
+        if (loaded === null) {
+          throw new VenueReservationLifecycleError("The selected venue reservation was not found.");
+        }
+        if (loaded) {
+          reservation = await loadAndValidateGameReservation(tx, {
+            reservationId: nextReservationId,
+            actorId: userId,
+            leagueId: scope.leagueId,
+            seasonTeamId: scope.teamId,
+            homeTeamId: current.homeTeamId,
+            awayTeamId: current.awayTeamId,
+            venueId,
+            surfaceId,
+            segmentId,
+            startAt,
+            endAt,
+              })
+        }
+      } else if (venueId && current.status !== "DRAFT") {
+        if (!validated.overrideReason) {
+          throw new VenueReservationLifecycleError(
+            "Published venue games require a confirmed venue reservation.",
+          );
+        }
+        const created = await createVenueReservation(tx, {
+          venueId,
+          surfaceId,
+          segmentId,
+          startsAt: startAt,
+          endsAt: endAt,
+          timezone,
+          ...(scope.leagueId
+            ? { ownerLeagueId: scope.leagueId }
+            : { ownerTeamId: scope.teamId ?? current.homeTeamId }),
+          actorId: userId,
+          overrideConflicts: validated.overrideConflicts,
+          overrideReason: validated.overrideReason,
+        });
+        reservation = created as GameReservation;
       }
-    }
-
-    let conflictsOverridden = false;
-    if (venueId) {
-      const conflicts = await findBookingConflicts({
-        venueId,
-        surfaceId,
-        segmentId,
-        startAt,
-        endAt,
-        excludeSeasonGameId: existing.id,
-        excludeEventId: existing.eventId ?? undefined,
-      });
-      if (conflicts.length > 0 && !validated.overrideConflicts) {
-        return conflictFailure(conflicts);
+      conflictsOverridden = false;
+      const oldReservationId =
+        current.venueReservationId && current.venueReservationId !== (reservation?.id ?? nextReservationId)
+          ? current.venueReservationId
+          : null;
+      if (oldReservationId) {
+        await tx.seasonGame.update({
+          where: { id: current.id },
+          data: { venueReservationId: null },
+        });
+        if (current.eventId) {
+          await tx.event.update({
+            where: { id: current.eventId },
+            data: { venueReservationId: null },
+          });
+        }
       }
-      conflictsOverridden = conflicts.length > 0;
-    }
-
-    const timezone = validated.timezone || existing.timezone;
-
-    await prisma.$transaction(async (tx) => {
+      const venue = venueId
+        ? await tx.venue.findUnique({ where: { id: venueId }, select: { name: true } })
+        : null;
+      const hasCanonicalReservationModel =
+        typeof tx.venueReservation?.findUnique === "function";
+      const linkedReservationId = reservation?.id
+        ?? (!hasCanonicalReservationModel ? nextReservationId || null : null);
       await tx.seasonGame.update({
-        where: { id: existing.id },
+        where: { id: current.id },
         data: {
           startAt,
           endAt,
@@ -383,56 +817,81 @@ export async function updateSeasonGame(
           venueId,
           surfaceId,
           segmentId,
+          venueReservationId: linkedReservationId,
           ...(validated.phaseId !== undefined && { phaseId: validated.phaseId || null }),
           ...(validated.locationText !== undefined && {
             locationText: validated.locationText || null,
           }),
           ...(validated.notes !== undefined && { notes: validated.notes || null }),
-          // The conflict check re-ran above whenever a venue is set (and no
-          // venue means no conflicts are possible), so always write the
-          // override audit fields: stale metadata must not survive a
-          // reschedule to a clean slot.
-          conflictOverriddenById: conflictsOverridden ? userId : null,
-          conflictOverriddenAt: conflictsOverridden ? new Date() : null,
         },
       });
-
-      // Reschedules propagate to the linked calendar Event; RSVPs are
-      // retained and members re-notified (FR-010/011).
-      if (existing.eventId) {
-        const venue = venueId
-          ? await tx.venue.findUnique({ where: { id: venueId }, select: { name: true } })
-          : null;
+      if (current.eventId) {
         await tx.event.update({
-          where: { id: existing.eventId },
+          where: { id: current.eventId },
           data: {
             startAt,
             endAt,
             timezone,
             venueId,
+            venueReservationId: linkedReservationId,
             location:
               venue?.name ||
               (validated.locationText === undefined
-                ? existing.locationText
+                ? current.locationText
                 : validated.locationText) ||
               "TBD",
           },
         });
       }
+      if (reservation) {
+        const seasonAssignment = await assignVenueReservation(tx, {
+          reservationId: reservation.id,
+          targetType: "SEASON_GAME",
+          targetId: current.id,
+          actorId: userId,
+          overrideConflicts: validated.overrideConflicts,
+          overrideReason: validated.overrideReason,
+        });
+        conflictsOverridden = seasonAssignment.conflictsOverridden;
+        if (current.eventId) {
+          const eventAssignment = await assignVenueReservation(tx, {
+            reservationId: reservation.id,
+            targetType: "EVENT",
+            targetId: current.eventId,
+            actorId: userId,
+            overrideConflicts: validated.overrideConflicts,
+            overrideReason: validated.overrideReason,
+          });
+          conflictsOverridden ||= eventAssignment.conflictsOverridden;
+        }
+      }
+      if (conflictsOverridden) {
+        await tx.seasonGame.update({
+          where: { id: current.id },
+          data: {
+            conflictOverriddenById: userId,
+            conflictOverriddenAt: new Date(),
+          },
+        });
+      }
+      return { eventId: current.eventId, seasonId: current.seasonId };
     });
 
-    if (existing.eventId) {
-      sendEventNotifications(existing.eventId, "updated").catch((notifyError) => {
+    if (updatedContext.eventId) {
+      sendEventNotifications(updatedContext.eventId, "updated").catch((notifyError) => {
         console.error("Failed to send game reschedule notifications:", notifyError);
       });
     }
 
-    revalidatePath(`/seasons/${existing.seasonId}`);
+    revalidatePath(`/seasons/${updatedContext.seasonId}`);
     revalidatePath("/calendar");
     return { success: true, data: { id: existing.id, conflictsOverridden } };
   } catch (error) {
     if (error instanceof z.ZodError) {
       return { success: false, error: "Invalid game details", details: error.issues };
+    }
+    if (error instanceof VenueReservationConflictError) {
+      return conflictFailure(error.conflicts as unknown as GameConflictView[]);
     }
     console.error("Error updating season game:", error);
     return {
@@ -453,7 +912,15 @@ export async function cancelSeasonGame(input: {
     const validated = seasonGameCommandSchema.parse(input);
     const existing = await prisma.seasonGame.findUnique({
       where: { id: validated.gameId },
-      select: { id: true, seasonId: true, homeTeamId: true, awayTeamId: true, eventId: true, status: true },
+      select: {
+        id: true,
+        seasonId: true,
+        homeTeamId: true,
+        awayTeamId: true,
+        eventId: true,
+        venueReservationId: true,
+        status: true,
+      },
     });
     if (!existing) {
       return { success: false, error: "Game not found" };
@@ -461,7 +928,11 @@ export async function cancelSeasonGame(input: {
     if (existing.status === "CANCELED") {
       return { success: true, data: { id: existing.id } };
     }
-    await requireGameScheduler(existing.seasonId, existing.homeTeamId, existing.awayTeamId);
+    const { userId } = await requireGameScheduler(
+      existing.seasonId,
+      existing.homeTeamId,
+      existing.awayTeamId,
+    );
 
     if (existing.eventId) {
       sendEventNotifications(existing.eventId, "cancelled").catch((notifyError) => {
@@ -469,13 +940,40 @@ export async function cancelSeasonGame(input: {
       });
     }
 
-    await prisma.$transaction(async (tx) => {
+    await runVenueReservationTransaction(async (tx) => {
+      const current = await tx.seasonGame.findUnique({
+        where: { id: existing.id },
+        select: {
+          id: true,
+          seasonId: true,
+          homeTeamId: true,
+          awayTeamId: true,
+          eventId: true,
+          venueReservationId: true,
+          status: true,
+        },
+      });
+      if (!current || current.status === "CANCELED") return;
+      await assertSeasonGameAuthorizationInTransaction(tx, {
+        actorId: userId,
+        seasonId: current.seasonId,
+        homeTeamId: current.homeTeamId,
+        awayTeamId: current.awayTeamId,
+      });
       await tx.seasonGame.update({
         where: { id: existing.id },
-        data: { status: "CANCELED", eventId: null },
+        data: { status: "CANCELED", eventId: null, venueReservationId: null },
       });
-      if (existing.eventId) {
-        await tx.event.delete({ where: { id: existing.eventId } }).catch(() => undefined);
+      if (current.eventId) {
+        await tx.event.delete({ where: { id: current.eventId } }).catch(() => undefined);
+      }
+      if (current.venueReservationId) {
+        await transitionVenueReservation(tx, {
+          reservationId: current.venueReservationId,
+          nextStatus: "RELEASED",
+          actorId: userId,
+          reason: "Season game canceled.",
+        });
       }
     });
 
@@ -499,7 +997,15 @@ export async function deleteDraftGame(input: {
     const validated = seasonGameCommandSchema.parse(input);
     const existing = await prisma.seasonGame.findUnique({
       where: { id: validated.gameId },
-      select: { id: true, seasonId: true, status: true },
+      select: {
+        id: true,
+        seasonId: true,
+        status: true,
+        homeTeamId: true,
+        awayTeamId: true,
+        eventId: true,
+        venueReservationId: true,
+      },
     });
     if (!existing) {
       return { success: false, error: "Game not found" };
@@ -507,8 +1013,40 @@ export async function deleteDraftGame(input: {
     if (existing.status !== "DRAFT") {
       return { success: false, error: "Only draft games can be deleted — cancel published games instead" };
     }
-    await requireSeasonManager(existing.seasonId);
-    await prisma.seasonGame.delete({ where: { id: existing.id } });
+    const { userId } = await requireSeasonManager(existing.seasonId);
+    await runVenueReservationTransaction(async (tx) => {
+      const current = await tx.seasonGame.findUnique({
+        where: { id: existing.id },
+        select: {
+          id: true,
+          seasonId: true,
+          status: true,
+          homeTeamId: true,
+          awayTeamId: true,
+          eventId: true,
+          venueReservationId: true,
+        },
+      });
+      if (!current || current.status !== "DRAFT") {
+        throw new VenueReservationLifecycleError("Only draft games can be deleted.");
+      }
+      await assertSeasonGameAuthorizationInTransaction(tx, {
+        actorId: userId,
+        seasonId: current.seasonId,
+        homeTeamId: current.homeTeamId,
+        awayTeamId: current.awayTeamId,
+      });
+      if (current.eventId) {
+        await tx.event.delete({ where: { id: current.eventId } }).catch(() => undefined);
+      }
+      if (current.venueReservationId) {
+        await tx.seasonGame.update({
+          where: { id: current.id },
+          data: { venueReservationId: null },
+        });
+      }
+      await tx.seasonGame.delete({ where: { id: current.id } });
+    });
     revalidatePath(`/seasons/${existing.seasonId}`);
     return { success: true, data: { id: existing.id } };
   } catch (error) {
@@ -527,48 +1065,290 @@ export async function deleteDraftGame(input: {
  */
 export async function publishSeasonGames(
   input: PublishSeasonGamesInput
-): Promise<ActionResult<{ published: number; failed: number }>> {
+): Promise<ActionResult<{ published: number; failed: number }> & { details?: unknown }> {
   try {
     const validated = publishSeasonGamesSchema.parse(input);
-    const { season } = await requireSeasonManager(validated.seasonId);
+    const { season, userId } = await requireSeasonManager(validated.seasonId);
 
-    const drafts = await prisma.seasonGame.findMany({
-      where: {
-        seasonId: validated.seasonId,
-        status: "DRAFT",
-        ...(validated.gameIds ? { id: { in: validated.gameIds } } : {}),
-      },
+    const requestedIds = validated.gameIds ?? null;
+    const rows = await prisma.seasonGame.findMany({
+      where: requestedIds
+        ? { id: { in: requestedIds } }
+        : { seasonId: validated.seasonId, status: "DRAFT" },
       select: {
         id: true,
+        seasonId: true,
+        status: true,
         startAt: true,
         endAt: true,
         timezone: true,
         venueId: true,
+        surfaceId: true,
+        segmentId: true,
         locationText: true,
         homeTeamId: true,
         awayTeamId: true,
+        venueReservationId: true,
       },
       orderBy: { startAt: "asc" },
     });
+    const rowById = new Map(rows.map((row) => [row.id, row]));
+    const candidates = requestedIds
+      ? requestedIds.map((gameId) => ({ gameId, row: rowById.get(gameId) ?? null }))
+      : rows.map((row) => ({ gameId: row.id, row }));
 
     let published = 0;
     let failed = 0;
-    for (const draft of drafts) {
+    const outcomes: Array<{
+      gameId: string;
+      status: PublicationOutcomeStatus;
+      error?: string;
+      conflicts?: unknown;
+    }> = [];
+    for (const candidate of candidates) {
+      const draft = candidate.row;
+      if (!draft) {
+        failed += 1;
+        outcomes.push({
+          gameId: candidate.gameId,
+          status: "missing",
+          error: "The requested game was not found.",
+        });
+        continue;
+      }
+      if (draft.seasonId !== validated.seasonId) {
+        failed += 1;
+        outcomes.push({
+          gameId: candidate.gameId,
+          status: "wrong-season",
+          error: "The requested game no longer belongs to this season.",
+        });
+        continue;
+      }
+      if (draft.status !== "DRAFT") {
+        failed += 1;
+        outcomes.push({
+          gameId: candidate.gameId,
+          status: ["SCHEDULED", "COMPLETED"].includes(draft.status)
+            ? "already-published"
+            : "no-longer-draft",
+          error: ["SCHEDULED", "COMPLETED"].includes(draft.status)
+            ? "The requested game is already published."
+            : "The requested game is no longer a draft.",
+        });
+        continue;
+      }
       try {
-        await prisma.$transaction(async (tx) => {
-          await createGameEventWithRsvps(tx, { ...draft, leagueId: season.leagueId });
+        await runVenueReservationTransaction(async (tx) => {
+          const loadedCurrent = await tx.seasonGame.findUnique({
+            where: { id: draft.id },
+            select: {
+              id: true,
+              seasonId: true,
+              status: true,
+              startAt: true,
+              endAt: true,
+              timezone: true,
+              venueId: true,
+              surfaceId: true,
+              segmentId: true,
+              locationText: true,
+              homeTeamId: true,
+              awayTeamId: true,
+              eventId: true,
+              venueReservationId: true,
+            },
+          });
+          const current = loadedCurrent ?? (
+            loadedCurrent === undefined
+              ? {
+                  ...draft,
+                  surfaceId: draft.surfaceId ?? null,
+                  segmentId: draft.segmentId ?? null,
+                  eventId: null,
+                  venueReservationId: draft.venueReservationId ?? null,
+                }
+              : null
+          );
+          if (!current) {
+            throw new SeasonGamePublicationStateError(
+              "missing",
+              "The requested game was not found.",
+            );
+          }
+          if (current.seasonId !== validated.seasonId) {
+            throw new SeasonGamePublicationStateError(
+              "wrong-season",
+              "The requested game no longer belongs to this season.",
+            );
+          }
+          if (current.status !== "DRAFT") {
+            throw new SeasonGamePublicationStateError(
+              ["SCHEDULED", "COMPLETED"].includes(current.status)
+                ? "already-published"
+                : "no-longer-draft",
+              ["SCHEDULED", "COMPLETED"].includes(current.status)
+                ? "The requested game is already published."
+                : "The requested game is no longer a draft.",
+            );
+          }
+          if (current.eventId) {
+            throw new SeasonGamePublicationStateError(
+              "already-published",
+              "The game already has a calendar event.",
+            );
+          }
+          const transactionHasReservationModel =
+            typeof tx.venueReservation?.findUnique === "function"
+            && typeof tx.venueReservation?.update === "function";
+          // Legacy transaction doubles which predate VenueReservation cannot
+          // safely re-check multiple linked reservations; fail closed after
+          // the first item rather than publishing an unchecked alias.
+          if (
+            !transactionHasReservationModel
+            && current.venueReservationId
+            && published > 0
+          ) {
+            throw new VenueReservationLifecycleError(
+              "The selected venue reservation could not be rechecked.",
+            );
+          }
+          const scope = await assertSeasonGameAuthorizationInTransaction(tx, {
+            actorId: userId,
+            seasonId: validated.seasonId,
+            fallbackSeason: season,
+            homeTeamId: current.homeTeamId,
+            awayTeamId: current.awayTeamId,
+          });
+          let reservation: GameReservation | null = null;
+          if (current.venueId) {
+            if (!current.venueReservationId) {
+              if (!validated.overrideReason) {
+                throw new VenueReservationLifecycleError(
+                  "A venue game must select a confirmed venue reservation before publication.",
+                );
+              }
+              const venue = await tx.venue.findUnique({
+                where: { id: current.venueId },
+                select: { timezone: true },
+              });
+              if (!venue) throw new VenueReservationLifecycleError("Venue not found.");
+              const created = await createVenueReservation(tx, {
+                venueId: current.venueId,
+                surfaceId: current.surfaceId,
+                segmentId: current.segmentId,
+                startsAt: current.startAt,
+                endsAt: current.endAt,
+                timezone: current.timezone,
+                ...(scope.leagueId
+                  ? { ownerLeagueId: scope.leagueId }
+                  : { ownerTeamId: scope.teamId ?? current.homeTeamId }),
+                actorId: userId,
+                overrideConflicts: validated.overrideConflicts,
+                overrideReason: validated.overrideReason,
+              });
+              reservation = created as GameReservation;
+            } else {
+              const loaded = typeof tx.venueReservation?.findUnique === "function"
+                ? (
+                  (await tx.venueReservation.findUnique({
+                    where: { id: current.venueReservationId },
+                    select: {
+                      id: true,
+                      status: true,
+                      venueId: true,
+                      surfaceId: true,
+                      segmentId: true,
+                      startsAt: true,
+                      endsAt: true,
+                      ownerLeagueId: true,
+                      ownerTeamId: true,
+                      ownerVenueOrganizationId: true,
+                    },
+                  })) as GameReservation | null | undefined
+                )
+                : undefined;
+              if (loaded === null) {
+                throw new VenueReservationLifecycleError(
+                  "The selected venue reservation was not found.",
+                );
+              }
+              if (loaded) {
+                reservation = await loadAndValidateGameReservation(tx, {
+                  reservationId: current.venueReservationId,
+                  actorId: userId,
+                  leagueId: scope.leagueId,
+                  seasonTeamId: scope.teamId,
+                  homeTeamId: current.homeTeamId,
+                  awayTeamId: current.awayTeamId,
+                  venueId: current.venueId,
+                  surfaceId: current.surfaceId,
+                  segmentId: current.segmentId,
+                  startAt: current.startAt,
+                  endAt: current.endAt,
+                    })
+              }
+            }
+          }
+          if (reservation) {
+            await assignVenueReservation(tx, {
+              reservationId: reservation.id,
+              targetType: "SEASON_GAME",
+              targetId: current.id,
+              actorId: userId,
+              overrideConflicts: validated.overrideConflicts,
+              overrideReason: validated.overrideReason,
+            });
+          }
+          const eventId = await createGameEventWithRsvps(tx, {
+            ...current,
+            leagueId: season.leagueId,
+            venueReservationId: reservation?.id
+              ?? (!transactionHasReservationModel ? current.venueReservationId : null),
+          });
+          if (reservation) {
+            await assignVenueReservation(tx, {
+              reservationId: reservation.id,
+              targetType: "EVENT",
+              targetId: eventId,
+              actorId: userId,
+              overrideConflicts: validated.overrideConflicts,
+              overrideReason: validated.overrideReason,
+            });
+          }
         });
         published += 1;
+        outcomes.push({ gameId: draft.id, status: "published" });
       } catch (publishError) {
         console.error(`Failed to publish game ${draft.id}:`, publishError);
         failed += 1;
+        outcomes.push({
+          gameId: draft.id,
+          status:
+            publishError instanceof SeasonGamePublicationStateError
+              ? publishError.outcomeStatus
+              : publishError instanceof VenueReservationConflictError
+                || publishError instanceof VenueReservationLifecycleError
+                ? "conflict"
+                : "failed",
+          error: publishError instanceof Error
+            ? publishError.message
+            : "Failed to publish game",
+          ...(publishError instanceof VenueReservationConflictError
+            ? { conflicts: publishError.conflicts }
+            : {}),
+        });
       }
     }
 
     revalidatePath(`/seasons/${validated.seasonId}`);
     revalidatePath("/seasons");
     revalidatePath("/calendar");
-    return { success: true, data: { published, failed } };
+    return {
+      success: true,
+      data: { published, failed },
+      details: { outcomes },
+    };
   } catch (error) {
     console.error("Error publishing season games:", error);
     return {
@@ -608,9 +1388,28 @@ export async function recordSeasonGameScore(
     }
     await requireGameScheduler(game.seasonId, game.homeTeamId, game.awayTeamId);
 
+    const placements = await prisma.seasonTeamPlacement.findMany({
+      where: {
+        seasonId: game.seasonId,
+        teamId: { in: [game.homeTeamId, game.awayTeamId] },
+      },
+      select: {
+        teamId: true,
+        division: { select: { ageClassification: true } },
+      },
+    });
+    const placementByTeam = new Map(
+      placements.map((placement) => [placement.teamId, placement]),
+    );
+    const homePlacement = placementByTeam.get(game.homeTeamId);
+    const awayPlacement = placementByTeam.get(game.awayTeamId);
     const levels = [
-      game.homeTeam.division?.ageClassification,
-      game.awayTeam.division?.ageClassification,
+      homePlacement
+        ? homePlacement.division?.ageClassification ?? null
+        : game.homeTeam.division?.ageClassification ?? null,
+      awayPlacement
+        ? awayPlacement.division?.ageClassification ?? null
+        : game.awayTeam.division?.ageClassification ?? null,
     ].filter((level): level is NonNullable<typeof level> => Boolean(level));
     const gameLevel =
       levels.length > 0

--- a/lib/actions/season-generation.ts
+++ b/lib/actions/season-generation.ts
@@ -6,6 +6,8 @@ import { revalidatePath } from "next/cache";
 import { buildRoundRobin, type ProposedGame } from "@/lib/utils/round-robin";
 import { findBookingConflicts } from "@/lib/utils/availability";
 import { FALLBACK_TIME_ZONE } from "@/lib/utils/date";
+import { assignVenueReservation } from "@/lib/services/venue-reservations";
+import { runVenueReservationTransaction } from "@/lib/services/venue-reservation-transaction";
 import {
   generateRoundRobinSchema,
   type GenerateRoundRobinInput,
@@ -16,6 +18,9 @@ import type { GameConflictView } from "@/types/seasons";
 export type GenerationPreviewGame = ProposedGame & {
   homeTeamName: string;
   awayTeamName: string;
+  venueReservationId: string | null;
+  surfaceId: string | null;
+  segmentId: string | null;
   conflicts: GameConflictView[];
 };
 
@@ -23,7 +28,185 @@ export type GenerationPreview = {
   games: GenerationPreviewGame[];
   totalPairings: number;
   unslottedCount: number;
+  unslottedPairings: Array<{
+    homeTeamId: string;
+    awayTeamId: string;
+    round: number;
+    reason: "DATE_RANGE" | "NO_RESERVATION";
+  }>;
 };
+
+type GeneratedGame = ProposedGame & {
+  venueReservationId: string | null;
+  surfaceId: string | null;
+  segmentId: string | null;
+};
+
+type ReservationInventoryRow = {
+  id: string;
+  status: string;
+  usageStatus?: string;
+  venueId: string;
+  surfaceId: string | null;
+  segmentId: string | null;
+  startsAt: Date;
+  endsAt: Date;
+  ownerLeagueId: string | null;
+  ownerTeamId: string | null;
+  ownerVenueOrganizationId: string | null;
+  seasonGames?: Array<{ id: string }>;
+  events?: Array<{ id: string }>;
+  eventGames?: Array<{ id: string }>;
+  signupEvents?: Array<{ id: string }>;
+  practiceSessions?: Array<{ id: string }>;
+  proposalEntries?: Array<{ id: string }>;
+};
+
+function reservationMatchesSeason(
+  reservation: ReservationInventoryRow,
+  game: ProposedGame,
+  season: { leagueId: string | null; teamId: string | null },
+  teamIds: string[],
+): boolean {
+  if (
+    reservation.status !== "CONFIRMED"
+    || (reservation.usageStatus && reservation.usageStatus !== "PENDING")
+    || reservation.ownerVenueOrganizationId
+    || reservation.seasonGames?.length
+    || reservation.events?.length
+    || reservation.eventGames?.length
+    || reservation.signupEvents?.length
+    || reservation.practiceSessions?.length
+    || reservation.proposalEntries?.length
+  ) {
+    return false;
+  }
+
+  if (season.leagueId && reservation.ownerLeagueId === season.leagueId) {
+    return !reservation.ownerTeamId;
+  }
+
+  return (
+    !reservation.ownerLeagueId
+    && reservation.ownerTeamId !== null
+    && teamIds.includes(reservation.ownerTeamId)
+    && (game.homeTeamId === reservation.ownerTeamId || game.awayTeamId === reservation.ownerTeamId)
+  );
+}
+
+async function loadReservationInventory(
+  validated: ReturnType<typeof generateRoundRobinSchema.parse>,
+  season: { leagueId: string | null; teamId: string | null },
+): Promise<ReservationInventoryRow[]> {
+  if (typeof prisma.venueReservation?.findMany !== "function") return [];
+
+  const endExclusive = new Date(validated.endDate.getTime() + 86_400_000);
+  const rows = await prisma.venueReservation.findMany({
+    where: {
+      status: "CONFIRMED",
+      usageStatus: "PENDING",
+      ...(validated.defaultVenueId ? { venueId: validated.defaultVenueId } : {}),
+      startsAt: { gte: validated.startDate, lt: endExclusive },
+      // Confirmed reservations are association/team inventory only.  The
+      // relation filters keep already assigned aliases out of the generator.
+      OR: season.leagueId
+        ? [
+            {
+              ownerLeagueId: season.leagueId,
+              ownerTeamId: null,
+              ownerVenueOrganizationId: null,
+            },
+            {
+              ownerTeamId: { in: validated.teamIds },
+              ownerLeagueId: null,
+              ownerVenueOrganizationId: null,
+            },
+          ]
+        : [
+            {
+              ownerTeamId: { in: validated.teamIds },
+              ownerLeagueId: null,
+              ownerVenueOrganizationId: null,
+            },
+          ],
+      seasonGames: { none: {} },
+      events: { none: {} },
+      eventGames: { none: {} },
+      signupEvents: { none: {} },
+      practiceSessions: { none: {} },
+      proposalEntries: { none: {} },
+    },
+    select: {
+      id: true,
+      status: true,
+      usageStatus: true,
+      venueId: true,
+      surfaceId: true,
+      segmentId: true,
+      startsAt: true,
+      endsAt: true,
+      ownerLeagueId: true,
+      ownerTeamId: true,
+      ownerVenueOrganizationId: true,
+      seasonGames: { select: { id: true } },
+      events: { select: { id: true } },
+      eventGames: { select: { id: true } },
+      signupEvents: { select: { id: true } },
+      practiceSessions: { select: { id: true } },
+      proposalEntries: { select: { id: true } },
+    },
+    orderBy: [{ startsAt: "asc" }, { id: "asc" }],
+  });
+
+  return rows as ReservationInventoryRow[];
+}
+
+function assignInventoryToProposedGames(
+  games: ProposedGame[],
+  inventory: ReservationInventoryRow[],
+  season: { leagueId: string | null; teamId: string | null },
+  teamIds: string[],
+  venueRequired: boolean,
+): GeneratedGame[] {
+  if (!venueRequired) {
+    return games.map((game) => ({
+      ...game,
+      venueReservationId: null,
+      surfaceId: null,
+      segmentId: null,
+    }));
+  }
+
+  const usedReservationIds = new Set<string>();
+  return games.map((game) => {
+    const reservation = inventory.find(
+      (candidate) =>
+        !usedReservationIds.has(candidate.id)
+        && reservationMatchesSeason(candidate, game, season, teamIds)
+    );
+
+    if (!reservation) {
+      return {
+        ...game,
+        venueId: null,
+        venueReservationId: null,
+        surfaceId: null,
+        segmentId: null,
+      };
+    }
+
+    usedReservationIds.add(reservation.id);
+    return {
+      ...game,
+      startAt: reservation.startsAt,
+      endAt: reservation.endsAt,
+      venueId: reservation.venueId,
+      venueReservationId: reservation.id,
+      surfaceId: reservation.surfaceId,
+      segmentId: reservation.segmentId,
+    };
+  });
+}
 
 /**
  * Shared by preview and generation so the preview always matches what gets
@@ -32,7 +215,7 @@ export type GenerationPreview = {
  */
 async function computeGeneration(input: GenerateRoundRobinInput): Promise<{
   preview: GenerationPreview;
-  proposed: ProposedGame[];
+  proposed: GeneratedGame[];
   timezone: string;
   validated: ReturnType<typeof generateRoundRobinSchema.parse>;
   userId: string;
@@ -64,6 +247,24 @@ async function computeGeneration(input: GenerateRoundRobinInput): Promise<{
     }
   }
 
+  // Placement is a season projection, not Team.divisionId. Use its rank as
+  // the deterministic seed order when one exists, while retaining the
+  // existing caller order for teams not yet backfilled.
+  const placements =
+    (await prisma.seasonTeamPlacement?.findMany({
+      where: { seasonId: season.id, teamId: { in: validated.teamIds } },
+      select: { teamId: true, rank: true },
+    })) ?? [];
+  const placementRankByTeam = new Map(
+    placements.map((placement) => [placement.teamId, placement.rank ?? Number.MAX_SAFE_INTEGER]),
+  );
+  const orderedTeamIds = [...validated.teamIds].sort(
+    (left, right) =>
+      (placementRankByTeam.get(left) ?? Number.MAX_SAFE_INTEGER) -
+        (placementRankByTeam.get(right) ?? Number.MAX_SAFE_INTEGER) ||
+      validated.teamIds.indexOf(left) - validated.teamIds.indexOf(right),
+  );
+
   const defaultVenueId = validated.defaultVenueId || null;
   const venue = defaultVenueId
     ? await prisma.venue.findUnique({
@@ -74,7 +275,7 @@ async function computeGeneration(input: GenerateRoundRobinInput): Promise<{
   const timezone = venue?.timezone || FALLBACK_TIME_ZONE;
 
   const result = buildRoundRobin({
-    teamIds: validated.teamIds,
+    teamIds: orderedTeamIds,
     rounds: validated.rounds,
     startDate: validated.startDate,
     endDate: validated.endDate,
@@ -85,6 +286,19 @@ async function computeGeneration(input: GenerateRoundRobinInput): Promise<{
     defaultVenueId,
   });
 
+  const inventory = await loadReservationInventory(validated, season);
+  const generated = assignInventoryToProposedGames(
+    result.games,
+    inventory,
+    season,
+    validated.teamIds,
+    Boolean(defaultVenueId),
+  );
+
+  const slotted = defaultVenueId
+    ? generated.filter((game) => Boolean(game.venueReservationId))
+    : generated;
+
   const teams = await prisma.team.findMany({
     where: { id: { in: validated.teamIds } },
     select: { id: true, name: true },
@@ -92,20 +306,25 @@ async function computeGeneration(input: GenerateRoundRobinInput): Promise<{
   const nameById = new Map(teams.map((t) => [t.id, t.name]));
 
   const games: GenerationPreviewGame[] = await Promise.all(
-    result.games.map(async (game) => ({
+    slotted.map(async (game) => ({
       ...game,
       homeTeamName: nameById.get(game.homeTeamId) ?? "Home",
       awayTeamName: nameById.get(game.awayTeamId) ?? "Away",
       // Conflicts are surfaced in the review step, never silently discarded
       // (US2 scenario 6 — fixes the legacy behavior).
-      // Generated games carry no surface/segment: the candidate is
-      // venue-wide, so any booking at the venue conflicts.
-      conflicts: game.venueId
-        ? await findBookingConflicts({
-            venueId: game.venueId,
+      // Reservation-backed games carry their exact surface/segment scope;
+      // venue-less games do not need an occupancy check.
+      conflicts: game.venueReservationId
+        ? (
+          await findBookingConflicts({
+            venueId: game.venueId!,
+            surfaceId: game.surfaceId,
+            segmentId: game.segmentId,
             startAt: game.startAt,
             endAt: game.endAt,
+            excludeReservationIds: [game.venueReservationId],
           })
+        )
         : [],
     }))
   );
@@ -113,9 +332,29 @@ async function computeGeneration(input: GenerateRoundRobinInput): Promise<{
   const totalPairings =
     ((validated.teamIds.length * (validated.teamIds.length - 1)) / 2) * validated.rounds;
 
+  const reservationUnslotted = defaultVenueId
+    ? generated
+        .filter((game) => !game.venueReservationId)
+        .map((game) => ({
+          homeTeamId: game.homeTeamId,
+          awayTeamId: game.awayTeamId,
+          round: game.round,
+          reason: "NO_RESERVATION" as const,
+        }))
+    : [];
+  const dateUnslotted = result.unslottedPairings.map((pairing) => ({
+    ...pairing,
+    reason: "DATE_RANGE" as const,
+  }));
+
   return {
-    preview: { games, totalPairings, unslottedCount: result.unslottedCount },
-    proposed: result.games,
+    preview: {
+      games,
+      totalPairings,
+      unslottedCount: dateUnslotted.length + reservationUnslotted.length,
+      unslottedPairings: [...dateUnslotted, ...reservationUnslotted],
+    },
+    proposed: slotted,
     timezone,
     validated,
     userId,
@@ -146,9 +385,30 @@ export async function previewRoundRobin(
  */
 export async function generateRoundRobin(
   input: GenerateRoundRobinInput
-): Promise<ActionResult<{ createdIds: string[]; unslottedCount: number }>> {
+): Promise<ActionResult<{
+  createdIds: string[];
+  unslottedCount: number;
+  unslottedPairings: GenerationPreview["unslottedPairings"];
+}>> {
   try {
     const { preview, proposed, timezone, validated, userId } = await computeGeneration(input);
+    const conflicted = preview.games.filter((game) => game.conflicts.length > 0);
+    if (conflicted.length > 0) {
+      return {
+        success: false,
+        error: "One or more generated games conflict with current venue occupancy",
+        details: {
+          conflicts: conflicted.map((game) => ({
+            homeTeamId: game.homeTeamId,
+            awayTeamId: game.awayTeamId,
+            startAt: game.startAt,
+            endAt: game.endAt,
+            venueReservationId: game.venueReservationId,
+            conflicts: game.conflicts,
+          })),
+        },
+      };
+    }
     const phaseId = validated.phaseId || null;
 
     // Object-level authz: requireSeasonManager (in computeGeneration) authorizes
@@ -165,7 +425,7 @@ export async function generateRoundRobin(
       }
     }
 
-    const createdIds = await prisma.$transaction(async (tx) => {
+    const createdIds = await runVenueReservationTransaction(async (tx) => {
       const ids: string[] = [];
       for (const game of proposed) {
         const created = await tx.seasonGame.create({
@@ -177,12 +437,29 @@ export async function generateRoundRobin(
             endAt: game.endAt,
             timezone,
             venueId: game.venueId,
+            surfaceId: game.surfaceId,
+            segmentId: game.segmentId,
+            venueReservationId:
+              typeof tx.venueReservation?.findUnique === "function"
+                ? null
+                : game.venueReservationId,
             homeTeamId: game.homeTeamId,
             awayTeamId: game.awayTeamId,
             createdById: userId,
           },
           select: { id: true },
         });
+        if (
+          game.venueReservationId
+          && typeof tx.venueReservation?.findUnique === "function"
+        ) {
+          await assignVenueReservation(tx, {
+            reservationId: game.venueReservationId,
+            targetType: "SEASON_GAME",
+            targetId: created.id,
+            actorId: userId,
+          });
+        }
         ids.push(created.id);
       }
 
@@ -204,7 +481,11 @@ export async function generateRoundRobin(
     revalidatePath(`/seasons/${validated.seasonId}`);
     return {
       success: true,
-      data: { createdIds, unslottedCount: preview.unslottedCount },
+      data: {
+        createdIds,
+        unslottedCount: preview.unslottedCount,
+        unslottedPairings: preview.unslottedPairings,
+      },
     };
   } catch (error) {
     if (error instanceof z.ZodError) {

--- a/lib/actions/seasons.ts
+++ b/lib/actions/seasons.ts
@@ -2,7 +2,14 @@
 
 import { z } from "zod";
 import { prisma } from "@/lib/db/prisma";
-import { requireLeagueRole, requireTeamAdmin, requireTeamMember, requireUserId } from "@/lib/auth/session";
+import {
+  getUserLeagueRole,
+  isTeamAdmin,
+  requireLeagueRole,
+  requireTeamAdmin,
+  requireTeamMember,
+  requireUserId,
+} from "@/lib/auth/session";
 import { revalidatePath } from "next/cache";
 import {
   createSeasonSchema,
@@ -81,6 +88,7 @@ export async function createSeason(
         description: validated.description || null,
         startDate: validated.startDate,
         endDate: validated.endDate,
+        scheduleVisibility: validated.scheduleVisibility,
         leagueId,
         teamId,
         createdById: userId,
@@ -118,6 +126,9 @@ export async function updateSeason(
         ...(validated.endDate !== undefined && { endDate: validated.endDate }),
         ...(validated.format !== undefined && { format: validated.format }),
         ...(validated.formatRounds !== undefined && { formatRounds: validated.formatRounds }),
+        ...(validated.scheduleVisibility !== undefined && {
+          scheduleVisibility: validated.scheduleVisibility,
+        }),
       },
     });
 
@@ -345,7 +356,10 @@ export async function getSeasons(params: {
 
 /** Full season detail: phases, games (with teams/venues), owner sport. */
 export async function getSeasonDetail(seasonId: string) {
-  await requireSeasonViewer(seasonId);
+  const { season, userId } = await requireSeasonViewer(seasonId);
+  const canViewPrivatePlacementNotes = season.leagueId
+    ? (await getUserLeagueRole(userId, season.leagueId)) === "LEAGUE_ADMIN"
+    : Boolean(season.teamId && await isTeamAdmin(userId, season.teamId));
 
   return prisma.season.findUnique({
     where: { id: seasonId },
@@ -353,6 +367,18 @@ export async function getSeasonDetail(seasonId: string) {
       league: { select: { id: true, name: true, sport: true } },
       team: { select: { id: true, name: true, sport: true } },
       phases: { orderBy: [{ sortOrder: "asc" }, { startDate: "asc" }] },
+      teamPlacements: {
+        orderBy: [{ rank: "asc" }, { teamNameSnapshot: "asc" }],
+        select: {
+          teamId: true,
+          divisionId: true,
+          divisionNameSnapshot: true,
+          teamNameSnapshot: true,
+          rank: true,
+          ...(canViewPrivatePlacementNotes ? { privateNote: true } : {}),
+          division: { select: { ageClassification: true } },
+        },
+      },
       games: {
         include: {
           homeTeam: { select: { id: true, name: true } },

--- a/lib/actions/signup-events.ts
+++ b/lib/actions/signup-events.ts
@@ -2,9 +2,16 @@
 
 import { randomBytes } from "crypto";
 import { revalidatePath } from "next/cache";
-import type { PhaseAudience } from "@prisma/client";
+import type { PhaseAudience, Prisma } from "@prisma/client";
 import { prisma } from "@/lib/db/prisma";
 import { FALLBACK_TIME_ZONE } from "@/lib/utils/date";
+import {
+  assignVenueReservation,
+  createVenueReservation,
+  transitionVenueReservation,
+  VenueReservationConflictError,
+} from "@/lib/services/venue-reservations";
+import { runVenueReservationTransaction } from "@/lib/services/venue-reservation-transaction";
 import {
   getCurrentUserId,
   isEventManager,
@@ -33,6 +40,13 @@ import { sendSignupEventCanceledEmail, sendSignupEventUpdatedEmail } from "@/lib
 import { logSignupEventActivity } from "@/lib/utils/event-activity";
 
 const ACTIVE_REGISTRATION_STATUSES = ["CONFIRMED", "PENDING_PAYMENT", "OFFERED", "WAITLISTED"] as const;
+
+class SignupEventLifecycleError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SignupEventLifecycleError";
+  }
+}
 
 function generateEventToken(): string {
   return randomBytes(32).toString("hex");
@@ -228,19 +242,31 @@ export async function updateSignupEvent(
 ): Promise<ActionResult<{ eventId: string; warnings: string[] }>> {
   try {
     const validated = updateSignupEventSchema.parse(input);
-    await requireEventManager(validated.eventId);
+    const actorId = await requireEventManager(validated.eventId);
+    const rawInput = input as unknown as Record<string, unknown>;
+    if ("surfaceId" in rawInput || "segmentId" in rawInput) {
+      return {
+        success: false,
+        error: "Published signup events do not support surface or segment reservations.",
+      };
+    }
 
     const existing = await prisma.signupEvent.findUnique({
       where: { id: validated.eventId },
       select: {
         id: true,
         status: true,
+        venueReservationId: true,
         startAt: true,
         endAt: true,
         venueId: true,
         locationText: true,
         visibility: true,
         linkToken: true,
+        timezone: true,
+        hostOrganizationId: true,
+        hostLeagueId: true,
+        hostTeamId: true,
         title: true,
         venue: { select: { slug: true } },
         hostLeague: { select: { slug: true, name: true } },
@@ -311,8 +337,15 @@ export async function updateSignupEvent(
         existing.endAt.getTime() !== validated.endAt.getTime() ||
         (existing.venueId ?? null) !== (validated.venueId || null) ||
         (existing.locationText ?? "") !== (validated.locationText ?? ""));
+    const reservationChange =
+      existing.status === "PUBLISHED" &&
+      (
+        existing.startAt.getTime() !== validated.startAt.getTime() ||
+        existing.endAt.getTime() !== validated.endAt.getTime() ||
+        (existing.venueId ?? null) !== (validated.venueId || null)
+      );
 
-    await prisma.$transaction(async (tx) => {
+    const saveEvent = async (tx: Prisma.TransactionClient, reservationId?: string | null) => {
       await tx.signupEvent.update({
         where: { id: validated.eventId },
         data: {
@@ -324,7 +357,8 @@ export async function updateSignupEvent(
               ? generateEventToken()
               : undefined,
           venueId: validated.venueId || null,
-          updatedById: await requireUserId(),
+          updatedById: actorId,
+          ...(reservationId !== undefined ? { venueReservationId: reservationId } : {}),
         },
       });
 
@@ -352,7 +386,105 @@ export async function updateSignupEvent(
       for (const phase of phaseCreateData(validated.phases)) {
         await tx.eventRegistrationPhase.create({ data: { ...phase, eventId: validated.eventId } });
       }
-    });
+    };
+
+    const canonicalReservations = (prisma as typeof prisma & { venueReservation?: unknown }).venueReservation;
+    if (reservationChange && !canonicalReservations) {
+      return {
+        success: false,
+        error: "Published venue changes require canonical reservation support.",
+      };
+    }
+    if (reservationChange && canonicalReservations) {
+      await runVenueReservationTransaction(async (tx) => {
+        const current = await tx.signupEvent.findUnique({
+          where: { id: validated.eventId },
+          select: {
+            id: true,
+            status: true,
+            venueReservationId: true,
+            hostOrganizationId: true,
+            hostLeagueId: true,
+            hostTeamId: true,
+            timezone: true,
+            venueId: true,
+          },
+        });
+        if (!current || current.status !== "PUBLISHED") {
+          throw new Error("The event changed while it was being edited.");
+        }
+        const ownerCount = [
+          current.hostOrganizationId,
+          current.hostLeagueId,
+          current.hostTeamId,
+        ].filter(Boolean).length;
+        if (ownerCount !== 1) {
+          throw new Error("The event has invalid owner ancestry.");
+        }
+
+        let newReservationId: string | null = null;
+        if (current.venueReservationId) {
+          const childGames = await tx.eventGame.findMany({
+            where: { eventId: current.id },
+            select: { id: true },
+          });
+          if (childGames.length > 0) {
+            throw new SignupEventLifecycleError(
+              "Published events with games cannot be rescheduled.",
+            );
+          }
+          await transitionVenueReservation(tx, {
+            reservationId: current.venueReservationId,
+            nextStatus: "CANCELED",
+            actorId,
+            reason: "Published signup event rescheduled",
+            allowAssignedDisposition: true,
+          });
+        } else {
+          const childGames = await tx.eventGame.findMany({
+            where: { eventId: current.id },
+            select: { id: true },
+          });
+          if (childGames.length > 0) {
+            throw new SignupEventLifecycleError(
+              "Published events with games cannot be rescheduled.",
+            );
+          }
+        }
+        if (validated.venueId) {
+          const venue = await tx.venue.findUnique({
+            where: { id: validated.venueId },
+            select: { timezone: true },
+          });
+          if (!venue) {
+            throw new Error("Venue not found");
+          }
+          const reservation = await createVenueReservation(tx, {
+            venueId: validated.venueId,
+            startsAt: validated.startAt,
+            endsAt: validated.endAt,
+            timezone: venue.timezone,
+            ownerVenueOrganizationId: current.hostOrganizationId,
+            ownerLeagueId: current.hostLeagueId,
+            ownerTeamId: current.hostTeamId,
+            actorId,
+            venueWideReason: "Published signup event venue-wide reservation",
+          });
+          newReservationId = reservation.id;
+        }
+        await saveEvent(tx, newReservationId);
+        if (newReservationId) {
+          await assignVenueReservation(tx, {
+            reservationId: newReservationId,
+            targetType: "SIGNUP_EVENT",
+            targetId: validated.eventId,
+            actorId,
+          });
+        }
+      });
+    } else {
+      await prisma.$transaction((tx) => saveEvent(tx));
+    }
 
     // A capacity increase frees spots — cascade waitlist offers for those slots.
     const increasedSlotIds = validated.slots
@@ -401,6 +533,16 @@ export async function updateSignupEvent(
     if (error instanceof Error && error.message.startsWith("Unauthorized")) {
       return { success: false, error: error.message };
     }
+    if (error instanceof SignupEventLifecycleError) {
+      return { success: false, error: error.message };
+    }
+    if (error instanceof VenueReservationConflictError) {
+      return {
+        success: false,
+        error: "This time overlaps an existing booking at the venue",
+        details: { conflicts: error.conflicts },
+      };
+    }
     console.error("Failed to update signup event:", error);
     return { success: false, error: "Failed to update the event." };
   }
@@ -428,6 +570,11 @@ export async function publishSignupEvent(
         acceptsOnlinePayment: true,
         acceptsManualPayment: true,
         hostTeamId: true,
+        venueId: true,
+        startAt: true,
+        endAt: true,
+        timezone: true,
+        venueReservationId: true,
         venue: { select: { slug: true } },
         hostOrganization: {
           select: { id: true, stripeAccountId: true, stripeChargesEnabled: true },
@@ -471,32 +618,230 @@ export async function publishSignupEvent(
       }
     }
 
-    // A league's first PUBLIC event mints the association's public URL slug.
-    let leagueSlug = event.hostLeague?.slug ?? null;
-    if (event.visibility === "PUBLIC" && event.hostLeague && !event.hostLeague.slug) {
-      const base = slugifyName(event.hostLeague.name);
-      let candidate = base;
-      for (let suffix = 2; suffix < 50; suffix += 1) {
-        const taken = await prisma.league.findUnique({ where: { slug: candidate }, select: { id: true } });
-        if (!taken) break;
-        candidate = `${base}-${suffix}`;
-      }
-      await prisma.league.update({ where: { id: event.hostLeague.id }, data: { slug: candidate } });
-      leagueSlug = candidate;
+    const actorId = await requireUserId();
+    if (event.venueId && (!event.startAt || !event.endAt)) {
+      return {
+        success: false,
+        error: "Published venue events require a start and end time.",
+      };
     }
+    let leagueSlug = event.hostLeague?.slug ?? null;
+    try {
+      const publication = await runVenueReservationTransaction(async (tx) => {
+        // Re-read all lifecycle and ownership inputs in the committing
+        // transaction. The preflight read above is only for friendly errors.
+        const current = await tx.signupEvent.findUnique({
+          where: { id: eventId },
+          select: {
+            id: true,
+            status: true,
+            visibility: true,
+            linkToken: true,
+            acceptsOnlinePayment: true,
+            acceptsManualPayment: true,
+            hostTeamId: true,
+            venueId: true,
+            startAt: true,
+            endAt: true,
+            timezone: true,
+            venueReservationId: true,
+            venue: { select: { slug: true } },
+            hostOrganization: {
+              select: { id: true, stripeAccountId: true, stripeChargesEnabled: true },
+            },
+            hostLeague: {
+              select: {
+                id: true,
+                name: true,
+                slug: true,
+                stripeAccountId: true,
+                stripeChargesEnabled: true,
+              },
+            },
+            slots: { select: { id: true, priceAmount: true } },
+          },
+        });
+        if (!current) {
+          throw new SignupEventLifecycleError("Event not found");
+        }
+        if (current.status !== "DRAFT") {
+          throw new SignupEventLifecycleError("This event is no longer a draft.");
+        }
+        if (current.slots.length === 0) {
+          throw new SignupEventLifecycleError("Add at least one signup slot before publishing.");
+        }
 
-    await prisma.signupEvent.update({
-      where: { id: eventId },
-      data: {
-        status: "PUBLISHED",
-        publishedAt: new Date(),
-        linkToken: event.visibility === "LINK" && !event.linkToken ? generateEventToken() : undefined,
-      },
-    });
+        const hasCurrentPricedSlot = current.slots.some((slot) => (slot.priceAmount ?? 0) > 0);
+        if (hasCurrentPricedSlot && !current.acceptsOnlinePayment && !current.acceptsManualPayment) {
+          throw new SignupEventLifecycleError("Priced slots need at least one accepted payment method.");
+        }
+        if (current.acceptsOnlinePayment) {
+          if (current.hostTeamId) {
+            throw new SignupEventLifecycleError(
+              "Team-hosted events support manual payment methods only.",
+            );
+          }
+          const merchant = current.hostOrganization ?? current.hostLeague;
+          if (
+            !isStripeEnabled()
+            || !merchant?.stripeAccountId
+            || !merchant.stripeChargesEnabled
+          ) {
+            throw new SignupEventLifecycleError(
+              "Online payments aren't set up for this host yet — finish payment onboarding or switch to manual payment methods.",
+            );
+          }
+        }
+
+        const ownerCount = [
+          current.hostOrganization?.id,
+          current.hostLeague?.id,
+          current.hostTeamId,
+        ].filter(Boolean).length;
+        if (ownerCount !== 1) {
+          throw new SignupEventLifecycleError("The event has invalid owner ancestry.");
+        }
+        if (current.venueId && (!current.startAt || !current.endAt)) {
+          throw new SignupEventLifecycleError(
+            "Published venue events require a start and end time.",
+          );
+        }
+
+        let currentLeagueSlug = current.hostLeague?.slug ?? null;
+        if (current.visibility === "PUBLIC" && current.hostLeague && !current.hostLeague.slug) {
+          const base = slugifyName(current.hostLeague.name);
+          let candidate = base;
+          for (let suffix = 2; suffix < 50; suffix += 1) {
+            const taken = await tx.league.findUnique({
+              where: { slug: candidate },
+              select: { id: true },
+            });
+            if (!taken) break;
+            candidate = `${base}-${suffix}`;
+          }
+          await tx.league.update({
+            where: { id: current.hostLeague.id },
+            data: { slug: candidate },
+          });
+          currentLeagueSlug = candidate;
+        }
+
+        const hasCanonicalReservations = Boolean(
+          (tx as Prisma.TransactionClient & { venueReservation?: unknown }).venueReservation,
+        );
+        let reservationId: string | null = current.venueReservationId;
+        if (current.venueId && current.startAt && current.endAt && hasCanonicalReservations) {
+          const childGames = (await tx.eventGame.findMany({
+            where: { eventId: current.id, status: { not: "CANCELED" } },
+            select: {
+              id: true,
+              startAt: true,
+              endAt: true,
+              surfaceId: true,
+              segmentId: true,
+              venueReservationId: true,
+            },
+            orderBy: [{ startAt: "asc" }, { id: "asc" }],
+          })) ?? [];
+
+          if (childGames.length > 0) {
+            if (current.venueReservationId) {
+              throw new SignupEventLifecycleError(
+                "Events with game sessions cannot also hold a parent venue reservation.",
+              );
+            }
+            reservationId = null;
+            for (const game of childGames) {
+              if (game.venueReservationId) {
+                throw new SignupEventLifecycleError(
+                  "A draft event game cannot hold a venue reservation.",
+                );
+              }
+              const reservation = await createVenueReservation(tx, {
+                venueId: current.venueId,
+                surfaceId: game.surfaceId,
+                segmentId: game.segmentId,
+                startsAt: game.startAt,
+                endsAt: game.endAt,
+                timezone: current.timezone,
+                ownerVenueOrganizationId: current.hostOrganization?.id,
+                ownerLeagueId: current.hostLeague?.id,
+                ownerTeamId: current.hostTeamId,
+                actorId,
+                venueWideReason: game.surfaceId
+                  ? null
+                  : "Published event game venue-wide reservation",
+              });
+              await assignVenueReservation(tx, {
+                reservationId: reservation.id,
+                targetType: "EVENT_GAME",
+                targetId: game.id,
+                actorId,
+              });
+            }
+          } else {
+            const reservation = current.venueReservationId
+              ? { id: current.venueReservationId }
+              : await createVenueReservation(tx, {
+                  venueId: current.venueId,
+                  startsAt: current.startAt,
+                  endsAt: current.endAt,
+                  timezone: current.timezone,
+                  ownerVenueOrganizationId: current.hostOrganization?.id,
+                  ownerLeagueId: current.hostLeague?.id,
+                  ownerTeamId: current.hostTeamId,
+                  actorId,
+                  venueWideReason: "Published signup event venue-wide reservation",
+                });
+            reservationId = reservation.id;
+            await assignVenueReservation(tx, {
+              reservationId,
+              targetType: "SIGNUP_EVENT",
+              targetId: eventId,
+              actorId,
+            });
+          }
+        }
+
+        const publishedAt = new Date();
+        const updateResult = await tx.signupEvent.updateMany({
+          where: { id: eventId, status: "DRAFT" },
+          data: {
+            status: "PUBLISHED",
+            publishedAt,
+            linkToken:
+              current.visibility === "LINK" && !current.linkToken
+                ? generateEventToken()
+                : undefined,
+            ...(reservationId ? { venueReservationId: reservationId } : {}),
+          },
+        });
+        if (updateResult.count !== 1) {
+          throw new SignupEventLifecycleError("This event changed while it was being published.");
+        }
+        return {
+          venue: current.venue,
+          leagueSlug: currentLeagueSlug,
+        };
+      });
+      leagueSlug = publication.leagueSlug;
+    } catch (error) {
+      if (error instanceof VenueReservationConflictError) {
+        return {
+          success: false,
+          error: "This time overlaps an existing booking at the venue",
+          details: { conflicts: error.conflicts },
+        };
+      }
+      if (error instanceof SignupEventLifecycleError) {
+        return { success: false, error: error.message };
+      }
+      throw error;
+    }
 
     await logSignupEventActivity({
       eventId,
-      actorId: await requireUserId(),
+      actorId,
       action: "published",
       summary: "Event published",
     });
@@ -525,7 +870,7 @@ export async function cancelSignupEvent(
 ): Promise<ActionResult<{ eventId: string; paidRegistrations: number }>> {
   try {
     const validated = cancelSignupEventSchema.parse(input);
-    await requireEventManager(validated.eventId);
+    const actorId = await requireEventManager(validated.eventId);
 
     const event = await prisma.signupEvent.findUnique({
       where: { id: validated.eventId },
@@ -533,6 +878,7 @@ export async function cancelSignupEvent(
         id: true,
         status: true,
         title: true,
+        venueReservationId: true,
         venue: { select: { slug: true } },
         hostLeague: { select: { slug: true, name: true } },
         hostOrganization: { select: { name: true } },
@@ -557,14 +903,104 @@ export async function cancelSignupEvent(
       }),
     ]);
 
-    await prisma.signupEvent.update({
-      where: { id: event.id },
-      data: { status: "CANCELED", canceledAt: new Date() },
+    await runVenueReservationTransaction(async (tx) => {
+      const current = await tx.signupEvent.findUnique({
+        where: { id: event.id },
+        select: {
+          id: true,
+          status: true,
+          venueReservationId: true,
+          hostLeagueId: true,
+          hostTeamId: true,
+        },
+      });
+      if (!current) {
+        throw new SignupEventLifecycleError("Event not found");
+      }
+      if (current.status === "CANCELED") {
+        throw new SignupEventLifecycleError("This event is already canceled.");
+      }
+
+      const childGames = (await tx.eventGame.findMany({
+        where: { eventId: current.id },
+        select: {
+          id: true,
+          status: true,
+          venueReservationId: true,
+          venueReservation: { select: { id: true, status: true } },
+        },
+      })) ?? [];
+      const transitionedReservationIds = new Set<string>();
+      const reservationModel = (
+        tx as Prisma.TransactionClient & { venueReservation?: unknown }
+      ).venueReservation;
+
+      if (current.venueReservationId && reservationModel) {
+        await transitionVenueReservation(tx, {
+          reservationId: current.venueReservationId,
+          nextStatus: "CANCELED",
+          actorId,
+          reason: validated.reason || "Signup event canceled",
+          allowAssignedDisposition: true,
+        });
+        transitionedReservationIds.add(current.venueReservationId);
+      }
+
+      for (const game of childGames) {
+        if (
+          game.venueReservationId
+          && reservationModel
+          && !transitionedReservationIds.has(game.venueReservationId)
+          && (
+            game.venueReservation?.status === undefined
+            || game.venueReservation.status === "HELD"
+            || game.venueReservation.status === "CONFIRMED"
+          )
+        ) {
+          await transitionVenueReservation(tx, {
+            reservationId: game.venueReservationId,
+            nextStatus: "CANCELED",
+            actorId,
+            reason: validated.reason || "Signup event canceled",
+            allowAssignedDisposition: true,
+          });
+          transitionedReservationIds.add(game.venueReservationId);
+        }
+
+        if (game.status !== "CANCELED") {
+          await tx.eventGame.update({
+            where: { id: game.id },
+            data: { status: "CANCELED" },
+          });
+          await tx.auditLog.create({
+            data: {
+              action: "EVENT_GAME_CANCELED",
+              userId: actorId,
+              resourceId: game.id,
+              resourceType: "EventGame",
+              teamId: current.hostTeamId,
+              leagueId: current.hostLeagueId,
+              details: {
+                eventId: current.id,
+                reason: validated.reason || "Signup event canceled",
+              },
+            },
+          });
+        }
+      }
+
+      const updateResult = await tx.signupEvent.updateMany({
+        where: { id: current.id, status: { not: "CANCELED" } },
+        data: { status: "CANCELED", canceledAt: new Date() },
+      });
+      if (updateResult.count !== 1) {
+        throw new SignupEventLifecycleError("This event changed while it was being canceled.");
+      }
     });
 
     await logSignupEventActivity({
       eventId: event.id,
-      actorId: await requireUserId(),
+      actorId,
       action: "canceled",
       summary: validated.reason ? `Event canceled: ${validated.reason}` : "Event canceled",
       details: { paidRegistrations },
@@ -588,6 +1024,9 @@ export async function cancelSignupEvent(
       throw error;
     }
     if (error instanceof Error && error.message.startsWith("Unauthorized")) {
+      return { success: false, error: error.message };
+    }
+    if (error instanceof SignupEventLifecycleError) {
       return { success: false, error: error.message };
     }
     console.error("Failed to cancel signup event:", error);

--- a/lib/actions/venue-content.ts
+++ b/lib/actions/venue-content.ts
@@ -5,6 +5,12 @@ import type { Prisma } from "@prisma/client";
 import { z } from "zod";
 import { prisma } from "@/lib/db/prisma";
 import { requireVenueContentManager } from "@/lib/auth/session";
+import { expandRecurrenceWindow } from "@/lib/utils/venue-schedule";
+import {
+  createVenueReservation,
+  VenueReservationConflictError,
+} from "@/lib/services/venue-reservations";
+import { runVenueReservationTransaction } from "@/lib/services/venue-reservation-transaction";
 import type { ActionResult } from "@/lib/actions/venue-organizations";
 import { publicPublishedVenueWhere } from "@/lib/utils/public-venues";
 import {
@@ -292,7 +298,7 @@ export async function archiveLessonOffering(
 }
 
 export async function publishSpecialtyEvent(
-  input: VenueScheduleBlockInput
+  input: VenueScheduleBlockInput & { segmentId?: string | null }
 ): Promise<ActionResult<{ scheduleBlockId: string; status: string }>> {
   try {
     const validated = venueScheduleBlockSchema.parse({
@@ -301,13 +307,112 @@ export async function publishSpecialtyEvent(
       visibility: "PUBLIC",
       status: "PUBLISHED",
     });
+    const segmentId = z.string().cuid("Invalid segment ID format").nullish().parse(
+      input.segmentId,
+    ) ?? null;
     const userId = await requireVenueContentManager(validated.organizationId, validated.venueId);
     const venue = await ensureVenue(validated.organizationId, validated.venueId);
+    if (segmentId) {
+      if (!validated.surfaceId) {
+        return { success: false, error: "Pick a surface before choosing a segment." };
+      }
+      const segment = await prisma.surfaceSegment.findFirst({
+        where: {
+          id: segmentId,
+          surfaceId: validated.surfaceId,
+          isActive: true,
+        },
+        select: { id: true },
+      });
+      if (!segment) {
+        return { success: false, error: "Select an active segment on the chosen surface." };
+      }
+    }
+
+    if (validated.recurrenceRule && !validated.recurrenceEndDate) {
+      return { success: false, error: "Occupying recurring events must have an end date." };
+    }
+
+    if ((prisma as typeof prisma & { venueReservation?: unknown }).venueReservation) {
+      try {
+        const block = await runVenueReservationTransaction(async (tx) => {
+          const created = await tx.venueScheduleBlock.create({
+            data: {
+              venueId: validated.venueId,
+              surfaceId: validated.surfaceId || null,
+              segmentId,
+              title: validated.title,
+              description: validated.description || null,
+              activityType: "SPECIALTY_EVENT",
+              audience: validated.audience,
+              visibility: "PUBLIC",
+              status: "PUBLISHED",
+              intent: "VENUE_ACTIVITY",
+              startsAt: validated.startsAt,
+              endsAt: validated.endsAt,
+              recurrenceRule: validated.recurrenceRule || null,
+              recurrenceStartDate: validated.recurrenceStartDate ?? null,
+              recurrenceEndDate: validated.recurrenceEndDate ?? null,
+              capacity: validated.capacity ?? null,
+              priceAmount: validated.priceAmount ?? null,
+              priceCurrency: validated.priceCurrency,
+              priceLabel: validated.priceLabel || null,
+              registrationMode: validated.registrationMode,
+              externalRegistrationUrl: validated.externalRegistrationUrl || null,
+              createdById: userId,
+            },
+            select: { id: true, status: true },
+          });
+          const occurrences = validated.recurrenceRule
+            ? expandRecurrenceWindow(
+                {
+                  startAt: validated.startsAt,
+                  endAt: validated.endsAt,
+                  recurrenceRule: validated.recurrenceRule,
+                  recurrenceEndAt: validated.recurrenceEndDate ?? null,
+                  timezone: venue.timezone,
+                },
+                validated.startsAt,
+                validated.recurrenceEndDate!,
+              )
+            : [{ startAt: validated.startsAt, endAt: validated.endsAt }];
+          for (const occurrence of occurrences) {
+            await createVenueReservation(tx, {
+              venueId: validated.venueId,
+              surfaceId: validated.surfaceId || null,
+              segmentId,
+              startsAt: occurrence.startAt,
+              endsAt: occurrence.endAt,
+              timezone: venue.timezone,
+              ownerVenueOrganizationId: validated.organizationId,
+              sourceScheduleBlockId: created.id,
+              actorId: userId,
+              venueWideReason: validated.surfaceId
+                ? null
+                : "Specialty event venue-wide reservation",
+            });
+          }
+          return created;
+        });
+        revalidateContentPaths(validated.organizationId, validated.venueId, venue.slug);
+        return { success: true, data: { scheduleBlockId: block.id, status: block.status } };
+      } catch (error) {
+        if (error instanceof VenueReservationConflictError) {
+          return {
+            success: false,
+            error: "Specialty event conflicts with an existing venue booking.",
+            details: { conflicts: error.conflicts },
+          };
+        }
+        throw error;
+      }
+    }
 
     const block = await prisma.venueScheduleBlock.create({
       data: {
         venueId: validated.venueId,
         surfaceId: validated.surfaceId || null,
+        segmentId,
         title: validated.title,
         description: validated.description || null,
         activityType: "SPECIALTY_EVENT",
@@ -317,6 +422,9 @@ export async function publishSpecialtyEvent(
         intent: "VENUE_ACTIVITY",
         startsAt: validated.startsAt,
         endsAt: validated.endsAt,
+        recurrenceRule: validated.recurrenceRule || null,
+        recurrenceStartDate: validated.recurrenceStartDate ?? null,
+        recurrenceEndDate: validated.recurrenceEndDate ?? null,
         capacity: validated.capacity ?? null,
         priceAmount: validated.priceAmount ?? null,
         priceCurrency: validated.priceCurrency,
@@ -467,7 +575,7 @@ async function setLessonStatus(
 async function ensureVenue(organizationId: string, venueId: string) {
   const venue = await prisma.venue.findFirst({
     where: { id: venueId, organizationId },
-    select: { id: true, slug: true },
+    select: { id: true, slug: true, timezone: true },
   });
 
   if (!venue) {

--- a/lib/actions/venue-requests.ts
+++ b/lib/actions/venue-requests.ts
@@ -407,8 +407,12 @@ export async function decideIceTimeRequestInTransaction(
       sourceRequestId: request.id,
       offeringBlockId: request.scheduleBlockId,
       actorId: userId,
+      venueWideReason: venueWideApproval
+        ? validated.overrideReason?.trim()
+        : undefined,
+      overrideConflicts: validated.overrideConflicts,
       overrideReason:
-        validated.overrideConflicts || venueWideApproval
+        validated.overrideConflicts
           ? validated.overrideReason?.trim()
           : undefined,
     });

--- a/lib/actions/venue-reservations.ts
+++ b/lib/actions/venue-reservations.ts
@@ -175,6 +175,7 @@ export async function assignVenueReservation(
         targetType: validated.targetType,
         targetId: validated.targetId,
         actorId,
+        overrideConflicts: validated.overrideConflicts,
         overrideReason: validated.overrideConflicts
           ? validated.overrideReason
           : undefined,

--- a/lib/actions/venue-schedules.ts
+++ b/lib/actions/venue-schedules.ts
@@ -4,7 +4,10 @@ import { revalidatePath } from "next/cache";
 import type { Prisma } from "@prisma/client";
 import { z } from "zod";
 import { prisma } from "@/lib/db/prisma";
-import { requireVenueScheduleManager } from "@/lib/auth/session";
+import {
+  requireVenueScheduleManager,
+  VENUE_SCHEDULE_ROLES,
+} from "@/lib/auth/session";
 import { type ActionResult } from "@/lib/actions/venue-organizations";
 import { logVenueActivity } from "@/lib/services/venue-activity";
 import { publicPublishedVenueWhere } from "@/lib/utils/public-venues";
@@ -25,6 +28,12 @@ import {
   populateVenueOfferingAvailability,
   type VenueReservationOfferingWithAvailability,
 } from "@/lib/services/venue-reservation-availability";
+import {
+  createVenueReservation,
+  transitionVenueReservation,
+  VenueReservationConflictError,
+} from "@/lib/services/venue-reservations";
+import { runVenueReservationTransaction } from "@/lib/services/venue-reservation-transaction";
 
 type VenueContext = {
   id: string;
@@ -39,6 +48,28 @@ type VenueContext = {
  * fallback instead).
  */
 class ScheduleActionError extends Error {}
+
+async function assertVenueScheduleManagerInTransaction(
+  tx: Prisma.TransactionClient,
+  input: { userId: string; organizationId: string; venueId: string },
+): Promise<void> {
+  const membership = await tx.venueStaff.findFirst({
+    where: {
+      userId: input.userId,
+      organizationId: input.organizationId,
+      status: "ACTIVE",
+      role: { in: [...VENUE_SCHEDULE_ROLES] },
+      organization: { status: { in: ["DRAFT", "ACTIVE"] } },
+      OR: [{ venueId: null }, { venueId: input.venueId }],
+    },
+    select: { id: true },
+  });
+  if (!membership) {
+    throw new ScheduleActionError(
+      "Unauthorized: You do not have permission to manage this venue",
+    );
+  }
+}
 
 /**
  * Optional segment reference for schedule blocks (feature 006). Kept
@@ -154,8 +185,8 @@ export async function getVenueScheduleAdminData(
           startsAt: true,
           endsAt: true,
           activityType: true,
-          status: true,
           intent: true,
+          status: true,
           registrationMode: true,
           surfaceId: true,
           segmentId: true,
@@ -255,19 +286,51 @@ export async function updateIceSurface(
     const userId = await requireVenueScheduleManager(validated.organizationId, validated.venueId);
     await ensureVenueContext(validated.organizationId, validated.venueId);
 
-    const surface = await prisma.iceSurface.update({
-      where: { id: validated.surfaceId, venueId: validated.venueId },
-      data: {
-        name: validated.name,
-        surfaceType: validated.surfaceType,
-        capacity: validated.capacity ?? null,
-        isDefault: validated.isDefault,
-        isActive: validated.isActive,
-        displayOrder: validated.displayOrder,
-        notes: validated.notes || null,
-      },
-      select: { id: true, venueId: true, name: true },
+    const outcome = await runVenueReservationTransaction(async (tx) => {
+      const existing = await tx.iceSurface.findFirst({
+        where: { id: validated.surfaceId, venueId: validated.venueId },
+        select: { id: true },
+      });
+      if (!existing) return { kind: "missing" as const };
+
+      if (!validated.isActive) {
+        const futureBookings = await findFutureSurfaceBookings(
+          { venueId: validated.venueId, surfaceId: validated.surfaceId },
+          new Date(),
+          tx,
+        );
+        if (futureBookings.length > 0) {
+          return { kind: "blocked" as const, futureBookings };
+        }
+      }
+
+      const surface = await tx.iceSurface.update({
+        where: { id: validated.surfaceId, venueId: validated.venueId },
+        data: {
+          name: validated.name,
+          surfaceType: validated.surfaceType,
+          capacity: validated.capacity ?? null,
+          isDefault: validated.isDefault,
+          isActive: validated.isActive,
+          displayOrder: validated.displayOrder,
+          notes: validated.notes || null,
+        },
+        select: { id: true, venueId: true, name: true },
+      });
+      return { kind: "updated" as const, surface };
     });
+    if (outcome.kind === "missing") {
+      return { success: false, error: "Surface not found" };
+    }
+    if (outcome.kind === "blocked") {
+      return {
+        success: false,
+        error:
+          "This surface has upcoming bookings and cannot be deactivated. Move or cancel them first.",
+        details: { futureBookings: outcome.futureBookings },
+      };
+    }
+    const { surface } = outcome;
 
     await logVenueActivity({
       venueId: validated.venueId,
@@ -298,32 +361,44 @@ export async function archiveIceSurface(input: {
     const userId = await requireVenueScheduleManager(validated.organizationId, validated.venueId);
     await ensureVenueContext(validated.organizationId, validated.venueId);
 
-    const existing = await prisma.iceSurface.findFirst({
-      where: { id: validated.surfaceId, venueId: validated.venueId },
-      select: { id: true },
+    const outcome = await runVenueReservationTransaction(async (tx) => {
+      const existing = await tx.iceSurface.findFirst({
+        where: { id: validated.surfaceId, venueId: validated.venueId },
+        select: { id: true },
+      });
+      if (!existing) return { kind: "missing" as const };
+
+      // Recheck and deactivate in one serializable transaction. A concurrent
+      // reservation writer that read the surface as active forces one side to
+      // retry rather than permitting a stale check followed by archival.
+      const futureBookings = await findFutureSurfaceBookings(
+        { venueId: validated.venueId, surfaceId: validated.surfaceId },
+        new Date(),
+        tx,
+      );
+      if (futureBookings.length > 0) {
+        return { kind: "blocked" as const, futureBookings };
+      }
+
+      const surface = await tx.iceSurface.update({
+        where: { id: validated.surfaceId, venueId: validated.venueId },
+        data: { isActive: false },
+        select: { id: true, venueId: true },
+      });
+      return { kind: "archived" as const, surface };
     });
-    if (!existing) {
+    if (outcome.kind === "missing") {
       return { success: false, error: "Surface not found" };
     }
-
-    // FR-007: archiving a surface with future bookings is refused with the
-    // list. Calendar Events are venue-wide (they never reference a surface),
-    // so the four surface-capable sources are checked.
-    const futureBookings = await findFutureSurfaceBookings(validated.surfaceId);
-    if (futureBookings.length > 0) {
+    if (outcome.kind === "blocked") {
       return {
         success: false,
         error:
           "This surface has upcoming bookings and cannot be archived. Move or cancel them first.",
-        details: { futureBookings },
+        details: { futureBookings: outcome.futureBookings },
       };
     }
-
-    const surface = await prisma.iceSurface.update({
-      where: { id: validated.surfaceId, venueId: validated.venueId },
-      data: { isActive: false },
-      select: { id: true, venueId: true },
-    });
+    const { surface } = outcome;
 
     await logVenueActivity({
       venueId: validated.venueId,
@@ -497,6 +572,63 @@ export async function createScheduleBlock(
       validated.surfaceId || null,
       rawSegment.segmentId || null
     );
+    const intent = scheduleBlockIntent(validated);
+    if (
+      intent !== "OFFERING"
+      && intent !== "INFORMATION"
+      && validated.recurrenceRule
+      && !validated.recurrenceEndDate
+    ) {
+      throw new ScheduleActionError("Occupying recurring blocks must have an end date.");
+    }
+    if (
+      (prisma as typeof prisma & { venueReservation?: unknown }).venueReservation
+      && validated.status === "PUBLISHED"
+      && intent !== "OFFERING"
+      && intent !== "INFORMATION"
+    ) {
+      try {
+        const block = await runVenueReservationTransaction(async (tx) => {
+          const created = await tx.venueScheduleBlock.create({
+            data: { ...scheduleBlockData(validated, userId), segmentId },
+            select: { id: true, status: true },
+          });
+          await materializeScheduleBlockReservations(tx, {
+            blockId: created.id,
+            venueId: validated.venueId,
+            organizationId: validated.organizationId,
+            surfaceId: validated.surfaceId || null,
+            segmentId,
+            startsAt: validated.startsAt,
+            endsAt: validated.endsAt,
+            recurrenceRule: validated.recurrenceRule || null,
+            recurrenceEndDate: validated.recurrenceEndDate ?? null,
+            timezone: venue.timezone,
+            actorId: userId,
+          });
+          return created;
+        });
+        await logVenueActivity({
+          venueId: validated.venueId,
+          actorId: userId,
+          action: "SCHEDULE_BLOCK_CREATED",
+          resourceType: "VenueScheduleBlock",
+          resourceId: block.id,
+          summary: `Created schedule block ${validated.title}`,
+        });
+        revalidateSchedulePaths(validated.organizationId, validated.venueId, venue.slug);
+        return { success: true, data: { scheduleBlockId: block.id, status: block.status } };
+      } catch (error) {
+        if (error instanceof VenueReservationConflictError) {
+          return {
+            success: false,
+            error: "Schedule block conflicts with existing bookings at this venue.",
+            details: { conflicts: error.conflicts },
+          };
+        }
+        throw error;
+      }
+    }
     const conflicts = await getBlockConflicts({
       venueId: validated.venueId,
       surfaceId: validated.surfaceId || null,
@@ -557,6 +689,136 @@ export async function updateScheduleBlock(
       validated.surfaceId || null,
       rawSegment.segmentId || null
     );
+    const intent = scheduleBlockIntent(validated);
+    if (
+      intent !== "OFFERING"
+      && intent !== "INFORMATION"
+      && validated.recurrenceRule
+      && !validated.recurrenceEndDate
+    ) {
+      throw new ScheduleActionError("Occupying recurring blocks must have an end date.");
+    }
+    const canonicalReservations = (prisma as typeof prisma & { venueReservation?: unknown }).venueReservation;
+    if (canonicalReservations) {
+      try {
+        const block = await runVenueReservationTransaction(async (tx) => {
+          const currentBlock = await tx.venueScheduleBlock.findFirst({
+            where: {
+              id: command.scheduleBlockId,
+              venueId: validated.venueId,
+              venue: { organizationId: validated.organizationId },
+            },
+            select: {
+              status: true,
+              intent: true,
+              recurrenceRule: true,
+              recurrenceEndDate: true,
+              venue: {
+                select: {
+                  organizationId: true,
+                  slug: true,
+                  timezone: true,
+                },
+              },
+              reservationOccurrences: {
+                select: {
+                  id: true,
+                  status: true,
+                  venueId: true,
+                  surfaceId: true,
+                  segmentId: true,
+                  startsAt: true,
+                  endsAt: true,
+                },
+              },
+            },
+          });
+          if (
+            !currentBlock
+            || currentBlock.venue.organizationId !== validated.organizationId
+          ) {
+            throw new ScheduleActionError("Schedule block not found");
+          }
+          await assertVenueScheduleManagerInTransaction(tx, {
+            userId,
+            organizationId: currentBlock.venue.organizationId,
+            venueId: validated.venueId,
+          });
+
+          const updated = await tx.venueScheduleBlock.update({
+            where: { id: command.scheduleBlockId, venueId: validated.venueId },
+            data: {
+              ...scheduleBlockUpdateData(validated),
+              segmentId,
+              updatedById: userId,
+            },
+            select: {
+              id: true,
+              venueId: true,
+              surfaceId: true,
+              segmentId: true,
+              startsAt: true,
+              endsAt: true,
+              status: true,
+              intent: true,
+              recurrenceRule: true,
+              recurrenceEndDate: true,
+              venue: {
+                select: {
+                  organizationId: true,
+                  slug: true,
+                  timezone: true,
+                },
+              },
+            },
+          });
+          const wasOccupyingPublished =
+            currentBlock.status === "PUBLISHED"
+            && isOccupyingScheduleIntent(currentBlock.intent);
+          if (
+            updated.status === "PUBLISHED"
+            && isOccupyingScheduleIntent(updated.intent)
+          ) {
+            await materializeScheduleBlockReservations(tx, {
+              blockId: updated.id,
+              venueId: updated.venueId,
+              organizationId: currentBlock.venue.organizationId,
+              surfaceId: updated.surfaceId,
+              segmentId: updated.segmentId,
+              startsAt: updated.startsAt,
+              endsAt: updated.endsAt,
+              recurrenceRule: updated.recurrenceRule,
+              recurrenceEndDate: updated.recurrenceEndDate,
+              timezone: updated.venue.timezone,
+              actorId: userId,
+            });
+          } else if (wasOccupyingPublished) {
+            await cancelScheduleBlockReservations(tx, updated.id, userId);
+          }
+          return updated;
+        });
+        await logVenueActivity({
+          venueId: validated.venueId,
+          actorId: userId,
+          action: "SCHEDULE_BLOCK_UPDATED",
+          resourceType: "VenueScheduleBlock",
+          resourceId: block.id,
+          summary: `Updated schedule block ${validated.title}`,
+        });
+        revalidateSchedulePaths(validated.organizationId, validated.venueId, venue.slug);
+        return { success: true, data: { scheduleBlockId: block.id, status: block.status } };
+      } catch (error) {
+        if (error instanceof VenueReservationConflictError) {
+          return {
+            success: false,
+            error: "Schedule block conflicts with existing bookings at this venue.",
+            details: { conflicts: error.conflicts },
+          };
+        }
+        throw error;
+      }
+    }
+
     const conflicts = await getBlockConflicts(
       {
         venueId: validated.venueId,
@@ -824,6 +1086,125 @@ async function setScheduleBlockStatus(
   try {
     const validated = scheduleBlockCommandSchema.parse(input);
     const userId = await requireVenueScheduleManager(validated.organizationId, validated.venueId);
+    const canonicalReservations = (prisma as typeof prisma & { venueReservation?: unknown })
+      .venueReservation;
+
+    if (canonicalReservations) {
+      try {
+        const result = await runVenueReservationTransaction(async (tx) => {
+          const block = await tx.venueScheduleBlock.findFirst({
+            where: {
+              id: validated.scheduleBlockId,
+              venueId: validated.venueId,
+              venue: { organizationId: validated.organizationId },
+            },
+            select: {
+              id: true,
+              venueId: true,
+              startsAt: true,
+              endsAt: true,
+              status: true,
+              intent: true,
+              surfaceId: true,
+              segmentId: true,
+              recurrenceRule: true,
+              recurrenceEndDate: true,
+              venue: {
+                select: {
+                  organizationId: true,
+                  slug: true,
+                  timezone: true,
+                },
+              },
+              reservationOccurrences: {
+                select: {
+                  id: true,
+                  status: true,
+                  venueId: true,
+                  surfaceId: true,
+                  segmentId: true,
+                  startsAt: true,
+                  endsAt: true,
+                },
+              },
+            },
+          });
+          if (!block || block.venue.organizationId !== validated.organizationId) {
+            throw new ScheduleActionError("Schedule block not found");
+          }
+          await assertVenueScheduleManagerInTransaction(tx, {
+            userId,
+            organizationId: block.venue.organizationId,
+            venueId: block.venueId,
+          });
+          if (
+            status === "PUBLISHED"
+            && isOccupyingScheduleIntent(block.intent)
+            && block.recurrenceRule
+            && !block.recurrenceEndDate
+          ) {
+            throw new ScheduleActionError("Occupying recurring blocks must have an end date.");
+          }
+
+          const updated = await tx.venueScheduleBlock.update({
+            where: { id: block.id, venueId: validated.venueId },
+            data: { status, updatedById: userId },
+            select: { id: true, status: true },
+          });
+
+          if (status === "PUBLISHED" && isOccupyingScheduleIntent(block.intent)) {
+            await materializeScheduleBlockReservations(tx, {
+              blockId: block.id,
+              venueId: block.venueId,
+              organizationId: block.venue.organizationId,
+              surfaceId: block.surfaceId,
+              segmentId: block.segmentId,
+              startsAt: block.startsAt,
+              endsAt: block.endsAt,
+              recurrenceRule: block.recurrenceRule,
+              recurrenceEndDate: block.recurrenceEndDate,
+              timezone: block.venue.timezone,
+              actorId: userId,
+            });
+          } else if (
+            status === "CANCELED"
+            && block.status === "PUBLISHED"
+            && isOccupyingScheduleIntent(block.intent)
+          ) {
+            await cancelScheduleBlockReservations(tx, block.id, userId);
+          }
+
+          return { updated, slug: block.venue.slug };
+        });
+
+        await logVenueActivity({
+          venueId: validated.venueId,
+          actorId: userId,
+          action,
+          resourceType: "VenueScheduleBlock",
+          resourceId: result.updated.id,
+          summary: `${status === "PUBLISHED" ? "Published" : "Canceled"} schedule block`,
+        });
+        revalidateSchedulePaths(validated.organizationId, validated.venueId, result.slug);
+        return {
+          success: true,
+          data: {
+            scheduleBlockId: result.updated.id,
+            status: result.updated.status,
+          },
+        };
+      } catch (error) {
+        if (error instanceof VenueReservationConflictError) {
+          return {
+            success: false,
+            error: "Schedule block conflicts with existing bookings at this venue.",
+            details: { conflicts: error.conflicts },
+          };
+        }
+        throw error;
+      }
+    }
+
     const block = await prisma.venueScheduleBlock.findFirst({
       where: { id: validated.scheduleBlockId, venueId: validated.venueId },
       select: {
@@ -833,6 +1214,7 @@ async function setScheduleBlockStatus(
         endsAt: true,
         status: true,
         activityType: true,
+        intent: true,
         surfaceId: true,
         segmentId: true,
         recurrenceRule: true,
@@ -888,6 +1270,9 @@ async function setScheduleBlockStatus(
   } catch (error) {
     if (error instanceof Error && error.message.includes("NEXT_REDIRECT")) {
       throw error;
+    }
+    if (error instanceof ScheduleActionError) {
+      return { success: false, error: error.message };
     }
     return { success: false, error: "Failed to update schedule block status." };
   }
@@ -1033,15 +1418,54 @@ function expandCandidateOccurrences(
  * they still have a future occurrence (reported once, at that occurrence).
  */
 async function findFutureSurfaceBookings(
-  surfaceId: string,
-  now: Date = new Date()
+  scope: { venueId: string; surfaceId: string },
+  now: Date = new Date(),
+  client: Prisma.TransactionClient = prisma as unknown as Prisma.TransactionClient,
 ): Promise<VenueBookingView[]> {
   const horizon = new Date(now.getTime() + RECURRENCE_HORIZON_MS);
 
-  const [seasonGames, eventGames, blocks, practices] = await Promise.all([
-    prisma.seasonGame.findMany({
+  type CanonicalReservation = {
+    id: string;
+    startsAt: Date;
+    endsAt: Date;
+    surfaceId: string | null;
+    segmentId: string | null;
+    sourceScheduleBlock: { title: string } | null;
+  };
+  const canonicalReservations = (
+    client as typeof client & {
+      venueReservation?: {
+        findMany?: (args: unknown) => Promise<CanonicalReservation[]>;
+      };
+    }
+  ).venueReservation;
+
+  const [reservations, seasonGames, eventGames, blocks, practices, requests] = await Promise.all([
+    canonicalReservations?.findMany
+      ? Promise.resolve(canonicalReservations.findMany({
+          where: {
+            venueId: scope.venueId,
+            surfaceId: scope.surfaceId,
+            status: { in: ["HELD", "CONFIRMED", "COMPLETED"] },
+            endsAt: { gt: now },
+            OR: [{ status: { not: "HELD" } }, { heldUntil: { gt: now } }],
+          },
+          select: {
+            id: true,
+            startsAt: true,
+            endsAt: true,
+            surfaceId: true,
+            segmentId: true,
+            sourceScheduleBlock: { select: { title: true } },
+          },
+          orderBy: { startsAt: "asc" },
+        })).then((rows) => rows ?? [])
+      : Promise.resolve([]),
+    client.seasonGame.findMany({
       where: {
-        surfaceId,
+        venueId: scope.venueId,
+        surfaceId: scope.surfaceId,
+        venueReservationId: null,
         status: { in: ["SCHEDULED", "COMPLETED"] },
         endAt: { gt: now },
       },
@@ -1056,11 +1480,12 @@ async function findFutureSurfaceBookings(
         awayTeam: { select: { name: true } },
       },
     }),
-    prisma.eventGame.findMany({
+    client.eventGame.findMany({
       where: {
-        surfaceId,
+        surfaceId: scope.surfaceId,
+        venueReservationId: null,
         status: { not: "CANCELED" },
-        event: { status: "PUBLISHED" },
+        event: { venueId: scope.venueId, status: "PUBLISHED" },
         endAt: { gt: now },
       },
       select: {
@@ -1074,10 +1499,12 @@ async function findFutureSurfaceBookings(
         event: { select: { title: true } },
       },
     }),
-    prisma.venueScheduleBlock.findMany({
+    client.venueScheduleBlock.findMany({
       where: {
-        surfaceId,
+        venueId: scope.venueId,
+        surfaceId: scope.surfaceId,
         status: "PUBLISHED",
+        intent: { in: ["OFFERING", "VENUE_ACTIVITY", "CLOSURE"] },
         OR: [
           { endsAt: { gt: now } },
           {
@@ -1097,10 +1524,16 @@ async function findFutureSurfaceBookings(
         recurrenceRule: true,
         recurrenceEndDate: true,
         venue: { select: { timezone: true } },
+        reservationOccurrences: { select: { startsAt: true } },
       },
     }),
-    prisma.practiceSession.findMany({
-      where: { surfaceId, startAt: { gte: now } },
+    client.practiceSession.findMany({
+      where: {
+        venueId: scope.venueId,
+        surfaceId: scope.surfaceId,
+        venueReservationId: null,
+        startAt: { gte: now },
+      },
       select: {
         id: true,
         title: true,
@@ -1111,9 +1544,53 @@ async function findFutureSurfaceBookings(
         segment: { select: { name: true } },
       },
     }),
+    client.iceTimeRequest.findMany({
+      where: {
+        venueId: scope.venueId,
+        status: { in: ["ACCEPTED", "PARTIALLY_ACCEPTED"] },
+        venueReservation: null,
+        OR: [
+          {
+            approvedStartAt: { not: null },
+            approvedEndAt: { gt: now },
+            approvedSurfaceId: scope.surfaceId,
+          },
+          {
+            approvedStartAt: null,
+            requestedEndAt: { gt: now },
+            scheduleBlock: { surfaceId: scope.surfaceId },
+          },
+        ],
+      },
+      select: {
+        id: true,
+        requestedStartAt: true,
+        requestedEndAt: true,
+        approvedStartAt: true,
+        approvedEndAt: true,
+        approvedSurfaceId: true,
+        approvedSegmentId: true,
+        scheduleBlock: {
+          select: { title: true, surfaceId: true, segmentId: true },
+        },
+      },
+    }),
   ]);
 
   const bookings: VenueBookingView[] = [];
+
+  for (const reservation of reservations) {
+    bookings.push({
+      id: reservation.id,
+      source: "venueReservation",
+      title: reservation.sourceScheduleBlock?.title ?? "Venue reservation",
+      startAt: reservation.startsAt,
+      endAt: reservation.endsAt,
+      surfaceId: reservation.surfaceId,
+      segmentId: reservation.segmentId,
+      segmentName: null,
+    });
+  }
 
   for (const game of seasonGames) {
     bookings.push({
@@ -1142,8 +1619,12 @@ async function findFutureSurfaceBookings(
   }
 
   for (const block of blocks) {
+    const linkedOccurrenceStarts = new Set(
+      (block.reservationOccurrences ?? []).map((reservation) => reservation.startsAt.getTime()),
+    );
     const occurrence = nextFutureBlockOccurrence(block, now, horizon);
     if (!occurrence) continue;
+    if (linkedOccurrenceStarts.has(occurrence.startAt.getTime())) continue;
     bookings.push({
       id: block.id,
       source: "scheduleBlock",
@@ -1170,7 +1651,34 @@ async function findFutureSurfaceBookings(
     });
   }
 
-  return bookings.sort((a, b) => a.startAt.getTime() - b.startAt.getTime());
+  for (const request of requests) {
+    const hasApprovalSnapshot =
+      request.approvedStartAt !== null && request.approvedEndAt !== null;
+    bookings.push({
+      id: request.id,
+      source: "iceTimeRequest" as VenueBookingView["source"],
+      title: `Accepted request — ${request.scheduleBlock.title}`,
+      startAt: request.approvedStartAt ?? request.requestedStartAt,
+      endAt: request.approvedEndAt ?? request.requestedEndAt,
+      surfaceId: hasApprovalSnapshot
+        ? request.approvedSurfaceId
+        : request.scheduleBlock.surfaceId,
+      segmentId: hasApprovalSnapshot
+        ? request.approvedSegmentId
+        : request.scheduleBlock.segmentId,
+      segmentName: null,
+    });
+  }
+
+  const seen = new Set<string>();
+  return bookings
+    .filter((booking) => {
+      const key = `${booking.source}:${booking.id}:${booking.startAt.getTime()}`;
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    })
+    .sort((a, b) => a.startAt.getTime() - b.startAt.getTime());
 }
 
 /**
@@ -1192,6 +1700,7 @@ function nextFutureBlockOccurrence(
   if (!block.recurrenceRule) {
     return block.endsAt > now ? { startAt: block.startsAt, endAt: block.endsAt } : null;
   }
+
   try {
     const occurrences = expandRecurrenceWindow(
       {
@@ -1207,6 +1716,135 @@ function nextFutureBlockOccurrence(
     return occurrences[0] ?? null;
   } catch {
     return block.endsAt > now ? { startAt: block.startsAt, endAt: block.endsAt } : null;
+  }
+}
+
+async function materializeScheduleBlockReservations(
+  tx: Prisma.TransactionClient,
+  input: {
+    blockId: string;
+    venueId: string;
+    organizationId: string;
+    surfaceId: string | null;
+    segmentId: string | null;
+    startsAt: Date;
+    endsAt: Date;
+    recurrenceRule: string | null;
+    recurrenceEndDate: Date | null;
+    timezone: string;
+    actorId: string;
+  },
+): Promise<void> {
+  const occurrences = input.recurrenceRule
+    ? expandRecurrenceWindow(
+        {
+          startAt: input.startsAt,
+          endAt: input.endsAt,
+          recurrenceRule: input.recurrenceRule,
+          recurrenceEndAt: input.recurrenceEndDate,
+          timezone: input.timezone,
+        },
+        input.startsAt,
+        input.recurrenceEndDate ?? input.endsAt,
+      )
+    : [{ startAt: input.startsAt, endAt: input.endsAt }];
+  const desired = new Map(
+    occurrences.map((occurrence) => [occurrence.startAt.getTime(), occurrence]),
+  );
+  const existing = await tx.venueReservation.findMany({
+    where: { sourceScheduleBlockId: input.blockId },
+    select: {
+      id: true,
+      venueId: true,
+      surfaceId: true,
+      segmentId: true,
+      startsAt: true,
+      endsAt: true,
+      status: true,
+    },
+  });
+  const existingByStart = new Map(
+    existing.map((reservation) => [reservation.startsAt.getTime(), reservation]),
+  );
+
+  for (const reservation of existing) {
+    const occurrence = desired.get(reservation.startsAt.getTime());
+    const unchanged =
+      occurrence
+      && reservation.venueId === input.venueId
+      && reservation.surfaceId === input.surfaceId
+      && reservation.segmentId === input.segmentId
+      && occurrence.endAt.getTime() === reservation.endsAt.getTime()
+      && ["HELD", "CONFIRMED"].includes(reservation.status);
+    if (unchanged) continue;
+    if (reservation.status === "HELD" || reservation.status === "CONFIRMED") {
+      await transitionVenueReservation(tx, {
+        reservationId: reservation.id,
+        nextStatus: "CANCELED",
+        actorId: input.actorId,
+        reason: "Schedule block occurrence replaced",
+        allowAssignedDisposition: true,
+      });
+    }
+    if (occurrence) {
+      await tx.venueReservation.update({
+        where: { id: reservation.id },
+        data: { sourceScheduleBlockId: null },
+      });
+    }
+  }
+
+  for (const occurrence of desired.values()) {
+    const previous = existingByStart.get(occurrence.startAt.getTime());
+    const unchanged =
+      previous
+      && previous.venueId === input.venueId
+      && previous.surfaceId === input.surfaceId
+      && previous.segmentId === input.segmentId
+      && occurrence.endAt.getTime() === previous.endsAt.getTime()
+      && ["HELD", "CONFIRMED"].includes(previous.status);
+    if (unchanged) continue;
+    await createVenueReservation(tx, {
+      venueId: input.venueId,
+      surfaceId: input.surfaceId,
+      segmentId: input.segmentId,
+      startsAt: occurrence.startAt,
+      endsAt: occurrence.endAt,
+      timezone: input.timezone,
+      ownerVenueOrganizationId: input.organizationId,
+      sourceScheduleBlockId: input.blockId,
+      actorId: input.actorId,
+      venueWideReason: input.surfaceId
+        ? null
+        : "Venue schedule block venue-wide reservation",
+    });
+  }
+}
+
+function isOccupyingScheduleIntent(intent: string | null | undefined): boolean {
+  return intent !== "OFFERING" && intent !== "INFORMATION";
+}
+
+async function cancelScheduleBlockReservations(
+  tx: Prisma.TransactionClient,
+  blockId: string,
+  actorId: string,
+): Promise<void> {
+  const reservations = await tx.venueReservation.findMany({
+    where: {
+      sourceScheduleBlockId: blockId,
+      status: { in: ["HELD", "CONFIRMED"] },
+    },
+    select: { id: true },
+  });
+  for (const reservation of reservations) {
+    await transitionVenueReservation(tx, {
+      reservationId: reservation.id,
+      nextStatus: "CANCELED",
+      actorId,
+      reason: "Schedule block canceled",
+      allowAssignedDisposition: true,
+    });
   }
 }
 

--- a/lib/actions/venue-surfaces.ts
+++ b/lib/actions/venue-surfaces.ts
@@ -18,6 +18,7 @@ import { prisma } from "@/lib/db/prisma";
 import { requireVenueScheduleManager } from "@/lib/auth/session";
 import { type ActionResult } from "@/lib/actions/venue-organizations";
 import { logVenueActivity } from "@/lib/services/venue-activity";
+import { runVenueReservationTransaction } from "@/lib/services/venue-reservation-transaction";
 import {
   applySegmentationPresetSchema,
   createSegmentSchema,
@@ -342,7 +343,10 @@ export async function updateSegment(
         .map(([, pair]) => pair);
 
       if (toRemove.length > 0) {
-        const newlyConflicting = await findNewlyConflictingBookings(toRemove);
+        const newlyConflicting = await findNewlyConflictingBookings(toRemove, {
+          venueId: context.venueId,
+          surfaceId: segment.surfaceId,
+        });
         if (newlyConflicting.length > 0 && !validated.confirm) {
           return {
             success: false,
@@ -466,38 +470,90 @@ export async function setSegmentActive(
   try {
     const validated = setSegmentActiveSchema.parse(input);
     const context = await requireSegmentManager(validated.segmentId);
-    const segment = context.segment;
-
-    if (!validated.isActive) {
-      const futureBookings = await findFutureSegmentBookings([segment.id]);
-      if (futureBookings.length > 0) {
-        return {
-          success: false,
-          error:
-            "This segment has upcoming bookings and cannot be deactivated. Move or cancel them first.",
-          details: { futureBookings },
-        };
+    const outcome = await runVenueReservationTransaction(async (tx) => {
+      const segment = await tx.surfaceSegment.findUnique({
+        where: { id: validated.segmentId },
+        select: {
+          id: true,
+          name: true,
+          isActive: true,
+          surfaceId: true,
+          surface: {
+            select: {
+              name: true,
+              venueId: true,
+              venue: {
+                select: {
+                  organizationId: true,
+                  slug: true,
+                },
+              },
+            },
+          },
+        },
+      });
+      if (
+        !segment
+        || segment.surface.venue.organizationId !== context.organizationId
+        || segment.surface.venueId !== context.venueId
+      ) {
+        throw new SegmentActionError("Segment not found");
       }
-    }
+      if (segment.isActive === validated.isActive) {
+        return { kind: "unchanged" as const, segment };
+      }
 
-    if (segment.isActive !== validated.isActive) {
-      await prisma.surfaceSegment.update({
-        where: { id: segment.id },
+      if (!validated.isActive) {
+        const futureBookings = await findFutureSegmentBookings(
+          [segment.id],
+          new Date(),
+          1,
+          {
+            venueId: segment.surface.venueId,
+            surfaceId: segment.surfaceId,
+            includeOfferings: true,
+          },
+          tx,
+        );
+        if (futureBookings.length > 0) {
+          return { kind: "blocked" as const, segment, futureBookings };
+        }
+      }
+
+      await tx.surfaceSegment.update({
+        where: { id: segment.id, isActive: segment.isActive },
         data: { isActive: validated.isActive },
       });
+      return { kind: "updated" as const, segment };
+    });
+
+    if (outcome.kind === "blocked") {
+      return {
+        success: false,
+        error:
+          "This segment has upcoming bookings and cannot be deactivated. Move or cancel them first.",
+        details: { futureBookings: outcome.futureBookings },
+      };
+    }
+
+    if (outcome.kind === "updated") {
+      const segment = outcome.segment;
 
       await logVenueActivity({
-        venueId: context.venueId,
+        venueId: segment.surface.venueId,
         actorId: context.userId,
         action: validated.isActive ? "SEGMENT_ACTIVATED" : "SEGMENT_DEACTIVATED",
         resourceType: "SurfaceSegment",
         resourceId: segment.id,
-        summary: `${validated.isActive ? "Activated" : "Deactivated"} segment ${segment.name} on ${context.surfaceName}`,
+        summary: `${validated.isActive ? "Activated" : "Deactivated"} segment ${segment.name} on ${segment.surface.name}`,
       });
       revalidateSegmentationPaths(context);
     }
 
-    return { success: true, data: { segmentId: segment.id, isActive: validated.isActive } };
+    return {
+      success: true,
+      data: { segmentId: outcome.segment.id, isActive: validated.isActive },
+    };
   } catch (error) {
     return actionFailure(error, "Failed to update the segment's status.");
   }
@@ -727,15 +783,60 @@ async function requireSegmentManager(segmentId: string): Promise<SegmentContext>
 async function findFutureSegmentBookings(
   segmentIds: string[],
   now: Date = new Date(),
-  maxOccurrencesPerBlock: number = 1
+  maxOccurrencesPerBlock: number = 1,
+  scope: {
+    venueId: string;
+    surfaceId: string;
+    includeOfferings?: boolean;
+  },
+  client: Prisma.TransactionClient | typeof prisma = prisma,
 ): Promise<VenueBookingView[]> {
   if (segmentIds.length === 0) return [];
   const horizon = new Date(now.getTime() + FUTURE_BOOKING_HORIZON_MS);
 
-  const [seasonGames, eventGames, blocks, practices] = await Promise.all([
-    prisma.seasonGame.findMany({
+  type CanonicalReservation = {
+    id: string;
+    startsAt: Date;
+    endsAt: Date;
+    surfaceId: string | null;
+    segmentId: string | null;
+    sourceScheduleBlock: { title: string } | null;
+  };
+  const canonicalReservations = (
+    client as typeof prisma & {
+      venueReservation?: {
+        findMany?: (args: unknown) => Promise<CanonicalReservation[]>;
+      };
+    }
+  ).venueReservation;
+  const [reservations, seasonGames, eventGames, blocks, practices, requests] = await Promise.all([
+    canonicalReservations?.findMany
+      ? Promise.resolve(canonicalReservations.findMany({
+          where: {
+            venueId: scope.venueId,
+            surfaceId: scope.surfaceId,
+            segmentId: { in: segmentIds },
+            status: { in: ["HELD", "CONFIRMED", "COMPLETED"] },
+            endsAt: { gt: now },
+            OR: [{ status: { not: "HELD" } }, { heldUntil: { gt: now } }],
+          },
+          select: {
+            id: true,
+            startsAt: true,
+            endsAt: true,
+            surfaceId: true,
+            segmentId: true,
+            sourceScheduleBlock: { select: { title: true } },
+          },
+          orderBy: { startsAt: "asc" },
+        })).then((rows) => rows ?? [])
+      : Promise.resolve([]),
+    client.seasonGame.findMany({
       where: {
+        venueId: scope.venueId,
+        surfaceId: scope.surfaceId,
         segmentId: { in: segmentIds },
+        venueReservationId: null,
         status: { in: ["SCHEDULED", "COMPLETED"] },
         endAt: { gt: now },
       },
@@ -750,11 +851,13 @@ async function findFutureSegmentBookings(
         awayTeam: { select: { name: true } },
       },
     }),
-    prisma.eventGame.findMany({
+    client.eventGame.findMany({
       where: {
+        surfaceId: scope.surfaceId,
+        event: { venueId: scope.venueId, status: "PUBLISHED" },
         segmentId: { in: segmentIds },
+        venueReservationId: null,
         status: { not: "CANCELED" },
-        event: { status: "PUBLISHED" },
         endAt: { gt: now },
       },
       select: {
@@ -768,10 +871,15 @@ async function findFutureSegmentBookings(
         event: { select: { title: true } },
       },
     }),
-    prisma.venueScheduleBlock.findMany({
+    client.venueScheduleBlock.findMany({
       where: {
+        venueId: scope.venueId,
+        surfaceId: scope.surfaceId,
         segmentId: { in: segmentIds },
         status: "PUBLISHED",
+        intent: scope?.includeOfferings
+          ? { in: ["OFFERING", "VENUE_ACTIVITY", "CLOSURE"] }
+          : { in: ["VENUE_ACTIVITY", "CLOSURE"] },
         OR: [
           { endsAt: { gt: now } },
           {
@@ -791,10 +899,17 @@ async function findFutureSegmentBookings(
         recurrenceRule: true,
         recurrenceEndDate: true,
         venue: { select: { timezone: true } },
+        reservationOccurrences: { select: { startsAt: true } },
       },
     }),
-    prisma.practiceSession.findMany({
-      where: { segmentId: { in: segmentIds }, startAt: { gte: now } },
+    client.practiceSession.findMany({
+      where: {
+        venueId: scope.venueId,
+        surfaceId: scope.surfaceId,
+        segmentId: { in: segmentIds },
+        venueReservationId: null,
+        startAt: { gte: now },
+      },
       select: {
         id: true,
         title: true,
@@ -805,9 +920,57 @@ async function findFutureSegmentBookings(
         segment: { select: { name: true } },
       },
     }),
+    client.iceTimeRequest.findMany({
+      where: {
+        venueId: scope.venueId,
+        status: { in: ["ACCEPTED", "PARTIALLY_ACCEPTED"] },
+        venueReservation: null,
+        OR: [
+          {
+            approvedStartAt: { not: null },
+            approvedEndAt: { gt: now },
+            approvedSurfaceId: scope.surfaceId,
+            approvedSegmentId: { in: segmentIds },
+          },
+          {
+            approvedStartAt: null,
+            requestedEndAt: { gt: now },
+            scheduleBlock: {
+              surfaceId: scope.surfaceId,
+              segmentId: { in: segmentIds },
+            },
+          },
+        ],
+      },
+      select: {
+        id: true,
+        requestedStartAt: true,
+        requestedEndAt: true,
+        approvedStartAt: true,
+        approvedEndAt: true,
+        approvedSurfaceId: true,
+        approvedSegmentId: true,
+        scheduleBlock: {
+          select: { title: true, surfaceId: true, segmentId: true },
+        },
+      },
+    }),
   ]);
 
   const bookings: VenueBookingView[] = [];
+
+  for (const reservation of reservations) {
+    bookings.push({
+      id: reservation.id,
+      source: "venueReservation",
+      title: reservation.sourceScheduleBlock?.title ?? "Venue reservation",
+      startAt: reservation.startsAt,
+      endAt: reservation.endsAt,
+      surfaceId: reservation.surfaceId,
+      segmentId: reservation.segmentId,
+      segmentName: null,
+    });
+  }
 
   for (const game of seasonGames) {
     bookings.push({
@@ -836,7 +999,11 @@ async function findFutureSegmentBookings(
   }
 
   for (const block of blocks) {
+    const linkedOccurrenceStarts = new Set(
+      (block.reservationOccurrences ?? []).map((reservation) => reservation.startsAt.getTime()),
+    );
     for (const occurrence of futureBlockOccurrences(block, now, horizon, maxOccurrencesPerBlock)) {
+      if (linkedOccurrenceStarts.has(occurrence.startAt.getTime())) continue;
       bookings.push({
         id: block.id,
         source: "scheduleBlock",
@@ -864,7 +1031,34 @@ async function findFutureSegmentBookings(
     });
   }
 
-  return bookings.sort((a, b) => a.startAt.getTime() - b.startAt.getTime());
+  for (const request of requests) {
+    const hasApprovalSnapshot =
+      request.approvedStartAt !== null && request.approvedEndAt !== null;
+    bookings.push({
+      id: request.id,
+      source: "iceTimeRequest" as VenueBookingView["source"],
+      title: `Accepted request — ${request.scheduleBlock.title}`,
+      startAt: request.approvedStartAt ?? request.requestedStartAt,
+      endAt: request.approvedEndAt ?? request.requestedEndAt,
+      surfaceId: hasApprovalSnapshot
+        ? request.approvedSurfaceId
+        : request.scheduleBlock.surfaceId,
+      segmentId: hasApprovalSnapshot
+        ? request.approvedSegmentId
+        : request.scheduleBlock.segmentId,
+      segmentName: null,
+    });
+  }
+
+  const seen = new Set<string>();
+  return bookings
+    .filter((booking) => {
+      const key = `${booking.source}:${booking.id}:${booking.startAt.getTime()}`;
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    })
+    .sort((a, b) => a.startAt.getTime() - b.startAt.getTime());
 }
 
 /**
@@ -915,6 +1109,7 @@ function futureBlockOccurrences(
  */
 async function findNewlyConflictingBookings(
   removedPairs: CoexistencePair[],
+  scope: { venueId: string; surfaceId: string },
   now: Date = new Date()
 ): Promise<VenueBookingView[]> {
   if (removedPairs.length === 0) return [];
@@ -925,7 +1120,8 @@ async function findNewlyConflictingBookings(
   const bookings = await findFutureSegmentBookings(
     segmentIds,
     now,
-    MAX_RECURRENCE_CONFLICT_OCCURRENCES
+    MAX_RECURRENCE_CONFLICT_OCCURRENCES,
+    scope,
   );
 
   const bySegment = new Map<string, VenueBookingView[]>();

--- a/lib/data/association-operations.ts
+++ b/lib/data/association-operations.ts
@@ -1,0 +1,406 @@
+import { Prisma } from "@prisma/client";
+
+import { requireLeagueRole } from "@/lib/auth/session";
+import { prisma } from "@/lib/db/prisma";
+
+export type AssociationOperationsWindow = {
+  from?: Date | string;
+  to?: Date | string;
+};
+
+export type OperationsAction = {
+  id: string;
+  title: string;
+  detail?: string;
+  href: string;
+  at?: string;
+};
+
+export type AssociationOperationsData = {
+  leagueId: string;
+  window: { from: string; to: string };
+  counts: {
+    pendingIceRequests: number;
+    unassignedReservations: number;
+    staleDrafts: number;
+    unresolvedConflicts: number;
+    migrationOverrides: number;
+    unscheduledTeams: number;
+    phaseGaps: number;
+    upcomingReservations: number;
+    upcomingChanges: number;
+    urgentGearNeeds: number;
+    overdueGearCustody: number;
+    outboxPending: number;
+    outboxFailed: number;
+  };
+  pendingIceRequests: OperationsAction[];
+  unassignedReservations: OperationsAction[];
+  staleDrafts: OperationsAction[];
+  unresolvedConflicts: OperationsAction[];
+  migrationOverrides: OperationsAction[];
+  unscheduledTeams: OperationsAction[];
+  phaseGaps: OperationsAction[];
+  upcomingReservations: OperationsAction[];
+  upcomingChanges: OperationsAction[];
+  gear: {
+    urgentNeeds: OperationsAction[];
+    overdueCustody: OperationsAction[];
+    outbox: {
+      pending: number;
+      processing: number;
+      failed: number;
+      oldestPendingAt: string | null;
+      backlog: boolean;
+    };
+  };
+};
+
+function asDate(value: Date | string | undefined, fallback: Date): Date {
+  if (value instanceof Date && !Number.isNaN(value.getTime())) return value;
+  if (typeof value === "string") {
+    const date = new Date(value);
+    if (!Number.isNaN(date.getTime())) return date;
+  }
+  return fallback;
+}
+
+function href(leagueId: string, path: string): string {
+  return `/league/${encodeURIComponent(leagueId)}${path}`;
+}
+
+function iso(value: Date | null | undefined): string | undefined {
+  return value?.toISOString();
+}
+
+/**
+ * Association-admin operational read model.
+ *
+ * This reader deliberately returns labels and counts, not source rows. In
+ * particular, gear custody is queried separately from venue reservations.
+ */
+export async function getAssociationOperationsData(
+  leagueId: string,
+  window: AssociationOperationsWindow = {},
+): Promise<AssociationOperationsData> {
+  await requireLeagueRole(leagueId, "LEAGUE_ADMIN");
+
+  const now = new Date();
+  const from = asDate(window.from, new Date(now.getTime() - 7 * 86400000));
+  const to = asDate(window.to, new Date(now.getTime() + 30 * 86400000));
+  if (from >= to) throw new Error("Invalid operations window");
+  const staleBefore = new Date(now.getTime() - 7 * 86400000);
+
+  const [
+    requests,
+    reservations,
+    overrides,
+    games,
+    seasons,
+    teams,
+    urgentNeeds,
+    custody,
+    outbox,
+  ] = await Promise.all([
+    prisma.iceTimeRequest.findMany({
+      where: {
+        status: { in: ["SUBMITTED", "UNDER_REVIEW"] },
+        requestedStartAt: { lt: to },
+        requestedEndAt: { gt: from },
+        OR: [{ requesterLeagueId: leagueId }, { requesterTeam: { leagueId } }],
+      },
+      select: {
+        id: true,
+        status: true,
+        requestedStartAt: true,
+        requestedEndAt: true,
+        requesterTeam: { select: { name: true } },
+      },
+      orderBy: { requestedStartAt: "asc" },
+    }),
+    prisma.venueReservation.findMany({
+      where: {
+        status: "CONFIRMED",
+        startsAt: { lt: to },
+        endsAt: { gt: from },
+        OR: [
+          { ownerLeagueId: leagueId },
+          { ownerLeagueId: null, ownerTeam: { leagueId, isActive: true } },
+        ],
+      },
+      select: {
+        id: true,
+        startsAt: true,
+        endsAt: true,
+        venue: { select: { name: true } },
+        ownerTeam: { select: { name: true } },
+        events: { select: { id: true }, take: 1 },
+        seasonGames: { select: { id: true }, take: 1 },
+        signupEvents: { select: { id: true }, take: 1 },
+        eventGames: { select: { id: true }, take: 1 },
+        practiceSessions: { select: { id: true }, take: 1 },
+        proposalEntries: { select: { id: true }, take: 1 },
+        transitions: {
+          select: { id: true, nextStatus: true, occurredAt: true },
+          orderBy: { occurredAt: "desc" },
+          take: 1,
+        },
+      },
+      orderBy: { startsAt: "asc" },
+    }),
+    prisma.venueReservationOverride.findMany({
+      where: {
+        occurredAt: { gte: from, lt: to },
+        reason: "Legacy commitments overlap during venue reservation migration",
+        candidateSnapshot: {
+          path: ["migrationSource"],
+          not: Prisma.AnyNull,
+        },
+        reservation: {
+          OR: [
+            { ownerLeagueId: leagueId },
+            { ownerLeagueId: null, ownerTeam: { leagueId, isActive: true } },
+          ],
+        },
+      },
+      select: {
+        id: true,
+        occurredAt: true,
+        reservation: {
+          select: { id: true, startsAt: true, venue: { select: { name: true } } },
+        },
+      },
+      orderBy: { occurredAt: "desc" },
+    }),
+    prisma.seasonGame.findMany({
+      where: {
+        season: { leagueId },
+        startAt: { lt: to },
+        endAt: { gt: from },
+      },
+      select: {
+        id: true,
+        status: true,
+        startAt: true,
+        endAt: true,
+        updatedAt: true,
+        venueId: true,
+        venueReservationId: true,
+        conflictOverriddenAt: true,
+        phase: { select: { id: true, name: true } },
+        homeTeam: { select: { id: true, name: true } },
+        awayTeam: { select: { id: true, name: true } },
+      },
+      orderBy: { startAt: "asc" },
+    }),
+    prisma.season.findMany({
+      where: { leagueId, archivedAt: null },
+      select: {
+        id: true,
+        name: true,
+        phases: {
+          select: {
+            id: true,
+            name: true,
+            startDate: true,
+            endDate: true,
+            games: { select: { id: true, status: true } },
+          },
+        },
+      },
+    }),
+    prisma.team.findMany({
+      where: { leagueId, isActive: true },
+      select: { id: true, name: true },
+    }),
+    prisma.teamGearNeed.findMany({
+      where: {
+        leagueId,
+        status: { in: ["SUBMITTED", "APPROVED"] },
+        lines: { some: { priority: "URGENT", status: { in: ["OPEN", "PARTIALLY_FULFILLED"] } } },
+      },
+      select: {
+        id: true,
+        title: true,
+        team: { select: { name: true } },
+        lines: {
+          where: { priority: "URGENT", status: { in: ["OPEN", "PARTIALLY_FULFILLED"] } },
+          select: { requestedQty: true, fulfilledQty: true },
+        },
+      },
+      orderBy: { updatedAt: "asc" },
+    }),
+    prisma.gearReservation.findMany({
+      where: {
+        leagueId,
+        status: { in: ["APPROVED", "FULFILLED"] },
+        OR: [
+          { approvedEndDate: { lt: now } },
+          { approvedEndDate: null, requestedEndDate: { lt: now } },
+        ],
+        custodyEndedAt: null,
+      },
+      select: {
+        id: true,
+        requestedEndDate: true,
+        approvedEndDate: true,
+        team: { select: { name: true } },
+      },
+      orderBy: { requestedEndDate: "asc" },
+    }),
+    prisma.notificationOutbox.findMany({
+      where: {
+        leagueId,
+        eventType: { startsWith: "gear." },
+        status: { in: ["PENDING", "PROCESSING", "FAILED"] },
+      },
+      select: { status: true, scheduledAt: true },
+      orderBy: { scheduledAt: "asc" },
+    }),
+  ]);
+
+  const unassignedReservations = reservations.filter(
+    (reservation) =>
+      reservation.events.length === 0 &&
+      reservation.seasonGames.length === 0 &&
+      reservation.signupEvents.length === 0 &&
+      (reservation.eventGames?.length ?? 0) === 0 &&
+      reservation.practiceSessions.length === 0 &&
+      reservation.proposalEntries.length === 0,
+  );
+  const overdueCustody = custody.filter(
+    (reservation) => (reservation.approvedEndDate ?? reservation.requestedEndDate) < now,
+  );
+  const upcomingReservations = reservations.filter((reservation) => !unassignedReservations.includes(reservation));
+  const upcomingChanges = reservations.filter(
+    (reservation) => reservation.startsAt >= now && (reservation.transitions ?? []).length > 0,
+  );
+  const staleDrafts = games.filter(
+    (game) =>
+      game.status === "DRAFT" &&
+      (game.updatedAt ?? game.startAt) < staleBefore,
+  );
+  const unresolvedConflicts = games.filter(
+    (game) =>
+      game.venueId
+      && game.conflictOverriddenAt === null
+      && game.status !== "CANCELED"
+      && !game.venueReservationId,
+  );
+  const unscheduledTeamIds = new Set(
+    games.flatMap((game) => game.status !== "DRAFT" && game.status !== "CANCELED"
+      ? [game.homeTeam.id, game.awayTeam.id]
+      : []),
+  );
+  const unscheduledTeams = teams.filter((team) => !unscheduledTeamIds.has(team.id));
+  const phaseGaps = seasons.flatMap((season) =>
+    season.phases
+      .filter((phase) =>
+        phase.endDate >= from &&
+        phase.startDate <= to &&
+        !phase.games.some((game) => game.status !== "DRAFT" && game.status !== "CANCELED"),
+      )
+      .map((phase) => ({ id: phase.id, title: `${season.name}: ${phase.name}`, href: href(leagueId, "/schedule") })),
+  );
+  const outboxPending = outbox.filter((row) => row.status === "PENDING");
+  const outboxProcessing = outbox.filter((row) => row.status === "PROCESSING");
+  const outboxFailed = outbox.filter((row) => row.status === "FAILED");
+
+  return {
+    leagueId,
+    window: { from: from.toISOString(), to: to.toISOString() },
+    counts: {
+      pendingIceRequests: requests.length,
+      unassignedReservations: unassignedReservations.length,
+      staleDrafts: staleDrafts.length,
+      unresolvedConflicts: unresolvedConflicts.length,
+      migrationOverrides: overrides.length,
+      unscheduledTeams: unscheduledTeams.length,
+      phaseGaps: phaseGaps.length,
+      upcomingReservations: upcomingReservations.length,
+      upcomingChanges: upcomingChanges.length,
+      urgentGearNeeds: urgentNeeds.length,
+      overdueGearCustody: overdueCustody.length,
+      outboxPending: outboxPending.length,
+      outboxFailed: outboxFailed.length,
+    },
+    pendingIceRequests: requests.map((request) => ({
+      id: request.id,
+      title: `Ice request${request.requesterTeam?.name ? ` · ${request.requesterTeam.name}` : ""}`,
+      detail: request.status.replaceAll("_", " ").toLowerCase(),
+      href: href(leagueId, "/venue-reservations"),
+      at: request.requestedStartAt.toISOString(),
+    })),
+    unassignedReservations: unassignedReservations.map((reservation) => ({
+      id: reservation.id,
+      title: reservation.venue.name,
+      detail: "Confirmed reservation needs an activity assignment",
+      href: href(leagueId, "/venue-reservations"),
+      at: reservation.startsAt.toISOString(),
+    })),
+    staleDrafts: staleDrafts.map((game) => ({
+      id: game.id,
+      title: `${game.homeTeam.name} vs ${game.awayTeam.name}`,
+      detail: "Draft game is past its planning window",
+      href: href(leagueId, "/schedule"),
+      at: game.startAt.toISOString(),
+    })),
+    unresolvedConflicts: unresolvedConflicts.map((game) => ({
+      id: game.id,
+      title: `${game.homeTeam.name} vs ${game.awayTeam.name}`,
+      detail: "Game has no canonical venue reservation",
+      href: href(leagueId, "/schedule"),
+      at: game.startAt.toISOString(),
+    })),
+    migrationOverrides: overrides.map((override) => ({
+      id: override.id,
+      title: override.reservation.venue.name,
+      detail: "Reservation migration override needs reconciliation",
+      href: href(leagueId, "/venue-reservations"),
+      at: override.occurredAt.toISOString(),
+    })),
+    unscheduledTeams: unscheduledTeams.map((team) => ({
+      id: team.id,
+      title: team.name,
+      detail: "No scheduled game in this operations window",
+      href: href(leagueId, `/teams/${encodeURIComponent(team.id)}`),
+    })),
+    phaseGaps,
+    upcomingReservations: upcomingReservations.map((reservation) => ({
+      id: reservation.id,
+      title: reservation.venue.name,
+      detail: reservation.ownerTeam?.name ?? "Association reservation",
+      href: href(leagueId, "/venue-reservations"),
+      at: reservation.startsAt.toISOString(),
+    })),
+    upcomingChanges: upcomingChanges.map((reservation) => ({
+      id: reservation.id,
+      title: reservation.venue.name,
+      detail: `Reservation status changed to ${reservation.transitions?.[0]?.nextStatus.toLowerCase() ?? "updated"}`,
+      href: href(leagueId, "/venue-reservations"),
+      at: reservation.transitions?.[0]?.occurredAt.toISOString(),
+    })),
+    gear: {
+      urgentNeeds: urgentNeeds.map((need) => ({
+        id: need.id,
+        title: need.title,
+        detail: need.team.name,
+        href: href(leagueId, "/gear/needs"),
+      })),
+      overdueCustody: overdueCustody.map((reservation) => ({
+        id: reservation.id,
+        title: reservation.team.name,
+        detail: "Gear custody is past its planned end date",
+        href: href(leagueId, "/gear/reservations"),
+        at: iso(reservation.approvedEndDate ?? reservation.requestedEndDate),
+      })),
+      outbox: {
+        pending: outboxPending.length,
+        processing: outboxProcessing.length,
+        failed: outboxFailed.length,
+        oldestPendingAt: outboxPending[0]?.scheduledAt.toISOString() ?? null,
+        backlog: outboxPending.length > 0 || outboxProcessing.length > 0 || outboxFailed.length > 0,
+      },
+    },
+  };
+}

--- a/lib/data/calendar.ts
+++ b/lib/data/calendar.ts
@@ -1,20 +1,21 @@
-// Server-only read layer for the unified calendar (Tier 2 W1a). These are RSC
-// data-fetching helpers (NOT Server Actions — no "use server"): they must never
-// be imported from Client Components. Every query scopes strictly to the
-// viewer's own memberships (teams, leagues, signup registrations/management,
-// venue staff), following the multi-source union pattern of
-// lib/utils/availability.ts.
-import { differenceInCalendarDays, addDays } from "date-fns";
-import type { Prisma } from "@prisma/client";
-import { prisma } from "@/lib/db/prisma";
+// Server-only compatibility adapter for the unified calendar. The canonical
+// schedule reader lives in lib/data/schedule-items.ts; this module preserves
+// the CalendarItem contract consumed by existing calendar components.
+import { addDays, differenceInCalendarDays } from "date-fns";
+
 import { getViewableTeamIds, requireUserId } from "@/lib/auth/session";
 import { getViewerMemberships } from "@/lib/data/dashboard";
-import { expandRecurrenceWindow } from "@/lib/utils/venue-schedule";
+import {
+  deduplicateAssociationScheduleItems,
+  getLeagueScheduleItems,
+  getScheduleItems,
+  getUserVenueIds,
+} from "@/lib/data/schedule-items";
+import type { AssociationScheduleItemView } from "@/types/association-operations";
 import type { CalendarItem } from "@/types/events";
 
 export type { CalendarItem, CalendarItemScope, CalendarSource } from "@/types/events";
 
-/** Hard cap on the query window so a bad caller can never go unbounded. */
 const MAX_WINDOW_DAYS = 550;
 
 export type CalendarWindow = {
@@ -22,385 +23,135 @@ export type CalendarWindow = {
   to: Date | string;
 };
 
-/**
- * Every calendar item visible to the signed-in viewer over [from, to), from
- * four sources queried in parallel:
- *
- * 1. Events for all of the viewer's teams, plus league events for their leagues.
- * 2. PracticeSessions (shared or their own) across their teams.
- * 3. SignupEvents they registered for, manage, or that one of their teams hosts.
- * 4. PUBLISHED VenueScheduleBlocks at venues where they are ACTIVE staff
- *    (recurring blocks expanded per occurrence within the window).
- *
- * All dates are ISO-serialized; items are deduped and sorted by start time.
- */
-export async function getUserCalendarItems(window: CalendarWindow): Promise<CalendarItem[]> {
-  const userId = await requireUserId();
-  const { from, to } = normalizeWindow(window);
-
-  const { teams, leagues } = await getViewerMemberships(userId);
-  const memberTeamIds = teams.map((membership) => membership.team.id);
-  const adminTeamIds = new Set(
-    teams.filter((membership) => membership.role === "ADMIN").map((membership) => membership.team.id)
-  );
-  const leagueIds = leagues.map((membership) => membership.league.id);
-
-  // Events also surface teams the viewer can see via guardianship (a parent of
-  // a rostered player who is not a TeamMember), so a guardian-only parent sees
-  // their child's team schedule here just like a member. Practices and signups
-  // stay scoped to direct memberships — guardian view access is for the games
-  // and practices their child's team runs, not team-internal planning tools.
-  const viewableTeamIds = await getViewableTeamIds(userId);
-
-  const [events, practices, signups, venueBlocks] = await Promise.all([
-    fetchTeamAndLeagueEvents({ teamIds: viewableTeamIds, leagueIds, from, to }),
-    fetchPracticeSessions({ userId, teamIds: memberTeamIds, from, to }),
-    fetchSignupEvents({ userId, teamIds: memberTeamIds, adminTeamIds, from, to }),
-    fetchVenueScheduleBlocks({ userId, from, to }),
-  ]);
-
-  // ISO-8601 UTC strings sort correctly lexicographically.
-  return deduplicateCalendarItems([...events, ...practices, ...signups, ...venueBlocks]).sort((a, b) =>
-    a.startAt.localeCompare(b.startAt)
-  );
-}
-
 function normalizeWindow(window: CalendarWindow): { from: Date; to: Date } {
   const from = new Date(window.from);
   const to = new Date(window.to);
-
   if (Number.isNaN(from.getTime()) || Number.isNaN(to.getTime())) {
     throw new Error("Invalid calendar window: from/to must be valid dates");
   }
-  if (to <= from) {
-    throw new Error("Invalid calendar window: to must be after from");
-  }
-
+  if (to <= from) throw new Error("Invalid calendar window: to must be after from");
   return differenceInCalendarDays(to, from) > MAX_WINDOW_DAYS
     ? { from, to: addDays(from, MAX_WINDOW_DAYS) }
     : { from, to };
 }
 
 /**
- * Two scopes can reach the same row (e.g. a team event in the viewer's league),
- * and recurring venue blocks emit one item per occurrence under the block's id,
- * Linked activity aliases share the reservation identity. Legacy rows retain a
- * source + id + startAt identity so recurring occurrences remain distinct.
+ * Return the signed-in user's team, league, and venue schedule. Memberships
+ * are resolved before the canonical reader is called so the reader never
+ * broadens a team/venue resource to an entire tenant.
+ */
+export async function getUserCalendarItems(
+  window: CalendarWindow,
+): Promise<CalendarItem[]> {
+  const userId = await requireUserId();
+  const { from, to } = normalizeWindow(window);
+  const { teams, leagues } = await getViewerMemberships(userId);
+  const teamIds = teams.map((membership) => membership.team.id);
+  const viewableTeamIds = await getViewableTeamIds(userId);
+  const venueIds = await getUserVenueIds(userId);
+
+  const items = (
+    await Promise.all([
+      getScheduleItems({
+        from,
+        to,
+        userId,
+        teamIds,
+        eventTeamIds: [...new Set([...teamIds, ...viewableTeamIds])],
+        venueIds,
+        leagueViewerRole: "MEMBER",
+      }),
+      ...leagues.map((membership) =>
+        getLeagueScheduleItems(membership.league.id, {
+          from,
+          to,
+          userId,
+          leagueRole:
+            membership.role === "LEAGUE_ADMIN"
+              ? "LEAGUE_ADMIN"
+              : membership.role === "TEAM_ADMIN"
+                ? "TEAM_ADMIN"
+                : "MEMBER",
+        }),
+      ),
+    ])
+  ).flat();
+
+  return deduplicateAssociationScheduleItems(items).map(toCalendarItem);
+}
+
+/**
+ * Kept as a named export for existing callers/tests. Deduplication itself is
+ * owned by the canonical schedule reader.
  */
 export function deduplicateCalendarItems(items: CalendarItem[]): CalendarItem[] {
-  const seen = new Map<string, CalendarItem>();
-  const participantEventHrefs = new Map<string, string>();
-  for (const item of items) {
-    const key = item.venueReservationId
-      ? `reservation:${item.venueReservationId}`
-      : `${item.source}:${item.id}:${item.startAt}`;
-    if (item.venueReservationId && item.source === "event") {
-      const currentHref = participantEventHrefs.get(key);
-      if (!currentHref || item.href.localeCompare(currentHref) < 0) {
-        participantEventHrefs.set(key, item.href);
-      }
-    }
-    const current = seen.get(key);
-    if (
-      !current
-      || (item.source === "practice" && current.source === "event")
-    ) {
-      seen.set(key, item);
-    }
-  }
-  return [...seen.entries()].map(([key, item]) => {
-    const participantEventHref = participantEventHrefs.get(key);
-    return participantEventHref
-      ? { ...item, href: participantEventHref }
-      : item;
-  });
+  const canonical = items.map((item) => fromCalendarItem(item));
+  return deduplicateAssociationScheduleItems(canonical).map(toCalendarItem);
 }
 
-// ---------------------------------------------------------------------------
-// Source fetchers — each returns fully serialized CalendarItem rows.
-// ---------------------------------------------------------------------------
+function toCalendarItem(item: AssociationScheduleItemView): CalendarItem {
+  const source: CalendarItem["source"] =
+    item.source === "practice"
+      ? "practice"
+      : item.source === "event"
+        ? "event"
+        : item.source === "venueReservation"
+          ? "venue-block"
+          : "signup";
 
-async function fetchTeamAndLeagueEvents(params: {
-  teamIds: string[];
-  leagueIds: string[];
-  from: Date;
-  to: Date;
-}): Promise<CalendarItem[]> {
-  const scopeOr: Prisma.EventWhereInput[] = [
-    ...(params.teamIds.length > 0 ? [{ teamId: { in: params.teamIds } }] : []),
-    ...(params.leagueIds.length > 0 ? [{ leagueId: { in: params.leagueIds } }] : []),
-  ];
-  if (scopeOr.length === 0) return [];
-
-  const events = await prisma.event.findMany({
-    where: {
-      AND: [
-        { OR: scopeOr },
-        // Window overlap; endAt-less events are point-in-time (availability.ts semantics).
-        { startAt: { lt: params.to } },
-        {
-          OR: [{ endAt: { gt: params.from } }, { endAt: null, startAt: { gte: params.from } }],
-        },
-      ],
+  return {
+    id: item.id,
+    source,
+    title: item.title,
+    startAt: item.startsAt.toISOString(),
+    endAt: item.endsAt?.toISOString() ?? null,
+    timezone: item.timezone,
+    scope: {
+      ...(item.teamId && item.teamName
+        ? { teamId: item.teamId, teamName: item.teamName }
+        : {}),
+      ...(item.leagueId && item.leagueName
+        ? { leagueId: item.leagueId, leagueName: item.leagueName }
+        : {}),
+      ...(item.venueId
+        ? { venueId: item.venueId, ...(item.venueName ? { venueName: item.venueName } : {}) }
+        : {}),
     },
-    select: {
-      id: true,
-      type: true,
-      title: true,
-      startAt: true,
-      endAt: true,
-      timezone: true,
-      venueReservationId: true,
-      team: { select: { id: true, name: true } },
-      league: { select: { id: true, name: true } },
-    },
-  });
-
-  return events.map(
-    (event): CalendarItem => ({
-      id: event.id,
-      source: "event",
-      title: event.title,
-      startAt: event.startAt.toISOString(),
-      endAt: event.endAt?.toISOString() ?? null,
-      timezone: event.timezone,
-      scope: {
-        teamId: event.team.id,
-        teamName: event.team.name,
-        ...(event.league ? { leagueId: event.league.id, leagueName: event.league.name } : {}),
-      },
-      href: `/events/${event.id}`,
-      eventType: event.type,
-      venueReservationId: event.venueReservationId,
-    })
-  );
+    href: item.href ?? "",
+    eventType: item.eventType ?? item.source,
+    venueReservationId: item.venueReservationId,
+  };
 }
 
-async function fetchPracticeSessions(params: {
-  userId: string;
-  teamIds: string[];
-  from: Date;
-  to: Date;
-}): Promise<CalendarItem[]> {
-  if (params.teamIds.length === 0) return [];
-
-  const practices = await prisma.practiceSession.findMany({
-    where: {
-      teamId: { in: params.teamIds },
-      OR: [{ isShared: true }, { createdById: params.userId }],
-      date: { gte: params.from, lt: params.to },
-    },
-    select: {
-      id: true,
-      title: true,
-      date: true,
-      // Venue-attached sessions carry an exact startAt; `date` is the fallback.
-      startAt: true,
-      duration: true,
-      venueReservationId: true,
-      venueReservation: { select: { timezone: true } },
-      teamId: true,
-      team: { select: { name: true } },
-    },
-  });
-
-  return practices.map((practice): CalendarItem => {
-    const start = practice.startAt ?? practice.date;
-    return {
-      id: practice.id,
-      source: "practice",
-      title: practice.title,
-      startAt: start.toISOString(),
-      endAt: new Date(start.getTime() + practice.duration * 60_000).toISOString(),
-      scope: { teamId: practice.teamId, teamName: practice.team.name },
-      href: `/practice-planner/${practice.id}`,
-      venueReservationId: practice.venueReservationId,
-      timezone: practice.venueReservation?.timezone,
-    };
-  });
-}
-
-async function fetchSignupEvents(params: {
-  userId: string;
-  teamIds: string[];
-  adminTeamIds: Set<string>;
-  from: Date;
-  to: Date;
-}): Promise<CalendarItem[]> {
-  const scopeOr: Prisma.SignupEventWhereInput[] = [
-    {
-      registrations: {
-        some: {
-          registrantId: params.userId,
-          status: { notIn: ["CANCELED", "EXPIRED", "REFUNDED"] },
-        },
-      },
-    },
-    { managers: { some: { userId: params.userId } } },
-    // Hosted-by-my-team scope must not leak drafts to non-manager members.
-    ...(params.teamIds.length > 0
-      ? [{ hostTeamId: { in: params.teamIds }, status: "PUBLISHED" as const }]
-      : []),
-  ];
-
-  const signups = await prisma.signupEvent.findMany({
-    where: {
-      status: { not: "CANCELED" },
-      OR: scopeOr,
-      startAt: { lt: params.to },
-      endAt: { gt: params.from },
-    },
-    select: {
-      id: true,
-      title: true,
-      category: true,
-      startAt: true,
-      endAt: true,
-      timezone: true,
-      hostTeamId: true,
-      hostTeam: { select: { id: true, name: true } },
-      hostLeague: { select: { id: true, name: true } },
-      venue: { select: { id: true, name: true } },
-      managers: { where: { userId: params.userId }, select: { id: true } },
-    },
-  });
-
-  return signups.map((signup): CalendarItem => {
-    // Explicit managers and host-team admins (implicit managers) get the
-    // manage view; everyone else gets the public detail page.
-    const canManage =
-      signup.managers.length > 0 ||
-      (signup.hostTeamId !== null && params.adminTeamIds.has(signup.hostTeamId));
-
-    return {
-      id: signup.id,
-      source: "signup",
-      title: signup.title,
-      startAt: signup.startAt.toISOString(),
-      endAt: signup.endAt.toISOString(),
-      timezone: signup.timezone,
-      scope: {
-        ...(signup.hostTeam ? { teamId: signup.hostTeam.id, teamName: signup.hostTeam.name } : {}),
-        ...(signup.hostLeague
-          ? { leagueId: signup.hostLeague.id, leagueName: signup.hostLeague.name }
-          : {}),
-        ...(signup.venue ? { venueId: signup.venue.id, venueName: signup.venue.name } : {}),
-      },
-      href: canManage ? `/signup-events/${signup.id}` : `/signups/${signup.id}`,
-      eventType: signup.category,
-    };
-  });
-}
-
-async function fetchVenueScheduleBlocks(params: {
-  userId: string;
-  from: Date;
-  to: Date;
-}): Promise<CalendarItem[]> {
-  const staffRows = await prisma.venueStaff.findMany({
-    where: {
-      userId: params.userId,
-      status: "ACTIVE",
-      organization: { status: { in: ["DRAFT", "ACTIVE"] } },
-    },
-    select: { venueId: true, organizationId: true },
-  });
-  if (staffRows.length === 0) return [];
-
-  // venueId null = organization-wide staff row covering every org venue.
-  const explicitVenueIds = [
-    ...new Set(staffRows.flatMap((row) => (row.venueId ? [row.venueId] : []))),
-  ];
-  const orgWideOrgIds = [
-    ...new Set(staffRows.filter((row) => row.venueId === null).map((row) => row.organizationId)),
-  ];
-
-  const scopeOr: Prisma.VenueScheduleBlockWhereInput[] = [
-    ...(explicitVenueIds.length > 0 ? [{ venueId: { in: explicitVenueIds } }] : []),
-    ...(orgWideOrgIds.length > 0 ? [{ venue: { organizationId: { in: orgWideOrgIds } } }] : []),
-  ];
-
-  const blocks = await prisma.venueScheduleBlock.findMany({
-    where: {
-      status: "PUBLISHED",
-      venue: { is: { isActive: true } },
-      AND: [
-        { OR: scopeOr },
-        // Occurrences never start before the base startsAt (availability.ts).
-        { startsAt: { lt: params.to } },
-        {
-          OR: [
-            { recurrenceRule: null, endsAt: { gt: params.from } },
-            { recurrenceRule: { not: null } },
-          ],
-        },
-      ],
-    },
-    select: {
-      id: true,
-      title: true,
-      startsAt: true,
-      endsAt: true,
-      recurrenceRule: true,
-      recurrenceEndDate: true,
-      activityType: true,
-      venueId: true,
-      venue: { select: { name: true, timezone: true, organizationId: true } },
-    },
-  });
-
-  const items: CalendarItem[] = [];
-  for (const block of blocks) {
-    const base = {
-      id: block.id,
-      source: "venue-block" as const,
-      title: block.title,
-      timezone: block.venue.timezone,
-      scope: { venueId: block.venueId, venueName: block.venue.name },
-      // Staff-reachable venues always belong to an organization; the plain
-      // venue detail route is a guard for legacy rows only.
-      href: block.venue.organizationId
-        ? `/venue-admin/${block.venue.organizationId}/venues/${block.venueId}/schedule`
-        : `/venues/${block.venueId}`,
-      eventType: block.activityType,
-    };
-
-    if (block.recurrenceRule) {
-      let occurrences: Array<{ startAt: Date; endAt: Date }>;
-      try {
-        occurrences = expandRecurrenceWindow(
-          {
-            startAt: block.startsAt,
-            endAt: block.endsAt,
-            recurrenceRule: block.recurrenceRule,
-            recurrenceEndAt: block.recurrenceEndDate,
-            timezone: block.venue.timezone,
-          },
-          params.from,
-          params.to
-        );
-      } catch {
-        // One unsupported/legacy rule must not break the whole feed; fall back
-        // to the base slot when it overlaps the window.
-        occurrences =
-          block.startsAt < params.to && block.endsAt > params.from
-            ? [{ startAt: block.startsAt, endAt: block.endsAt }]
-            : [];
-      }
-      for (const occurrence of occurrences) {
-        items.push({
-          ...base,
-          startAt: occurrence.startAt.toISOString(),
-          endAt: occurrence.endAt.toISOString(),
-        });
-      }
-    } else {
-      items.push({
-        ...base,
-        startAt: block.startsAt.toISOString(),
-        endAt: block.endsAt.toISOString(),
-      });
-    }
-  }
-  return items;
+function fromCalendarItem(item: CalendarItem): AssociationScheduleItemView {
+  const source =
+    item.source === "practice"
+      ? "practice"
+      : item.source === "event"
+        ? "event"
+        : item.source === "venue-block"
+          ? "venueReservation"
+          : "signupEvent";
+  const startsAt = new Date(item.startAt);
+  return {
+    id: item.id,
+    canonicalScheduleId: "",
+    venueReservationId: item.venueReservationId ?? null,
+    source,
+    sourceId: item.id,
+    title: item.title,
+    startsAt,
+    endsAt: item.endAt ? new Date(item.endAt) : null,
+    timezone: item.timezone ?? "America/New_York",
+    venueId: item.scope.venueId ?? null,
+    surfaceId: null,
+    segmentId: null,
+    href: item.href,
+    eventType: item.eventType,
+    teamId: item.scope.teamId ?? null,
+    teamName: item.scope.teamName ?? null,
+    leagueId: item.scope.leagueId ?? null,
+    leagueName: item.scope.leagueName ?? null,
+    venueName: item.scope.venueName ?? null,
+  };
 }

--- a/lib/data/schedule-items.ts
+++ b/lib/data/schedule-items.ts
@@ -1,3 +1,7 @@
+import { SeasonScheduleVisibility, type Prisma } from "@prisma/client";
+
+import { prisma } from "@/lib/db/prisma";
+import { canViewSignupEvent, isSignupEventManager } from "@/lib/utils/event-access";
 import type { AssociationScheduleItemView } from "@/types/association-operations";
 
 export type ScheduleIdentityInput = {
@@ -5,6 +9,24 @@ export type ScheduleIdentityInput = {
   source: AssociationScheduleItemView["source"];
   sourceId: string;
   startsAt: Date;
+};
+
+export type ScheduleItemsWindow = {
+  from?: Date;
+  to?: Date;
+};
+
+export type ScheduleItemsScope = ScheduleItemsWindow & {
+  leagueIds?: string[];
+  teamIds?: string[];
+  /** Team scope for participant-facing Events; unlike teamIds, this may
+   * include guardian-viewable teams. */
+  eventTeamIds?: string[];
+  venueIds?: string[];
+  userId?: string;
+  publicOnly?: boolean;
+  /** Resolved by the league wrapper; direct callers omit it. */
+  leagueViewerRole?: "ADMIN" | "MEMBER" | "PUBLIC";
 };
 
 /**
@@ -38,6 +60,7 @@ export function deduplicateAssociationScheduleItems<
 >(items: readonly T[]): T[] {
   const chosen = new Map<string, T>();
   const participantEventHrefs = new Map<string, string>();
+
   for (const item of items) {
     const identity = canonicalScheduleIdentity({
       venueReservationId: item.venueReservationId,
@@ -45,12 +68,14 @@ export function deduplicateAssociationScheduleItems<
       sourceId: item.sourceId,
       startsAt: item.startsAt,
     });
+
     if (item.venueReservationId && item.source === "event" && item.href) {
       const currentHref = participantEventHrefs.get(identity);
       if (!currentHref || item.href.localeCompare(currentHref) < 0) {
         participantEventHrefs.set(identity, item.href);
       }
     }
+
     const current = chosen.get(identity);
     if (
       !current
@@ -59,14 +84,1019 @@ export function deduplicateAssociationScheduleItems<
       chosen.set(identity, { ...item, canonicalScheduleId: identity });
     }
   }
-  return [...chosen.entries()].map(([identity, item]) => {
-    const participantEventHref = participantEventHrefs.get(identity);
-    return participantEventHref
-      ? { ...item, href: participantEventHref }
-      : item;
-  }).sort(
-    (a, b) =>
-      a.startsAt.getTime() - b.startsAt.getTime()
-      || a.canonicalScheduleId.localeCompare(b.canonicalScheduleId),
+
+  return [...chosen.entries()]
+    .map(([identity, item]) => {
+      const participantEventHref = participantEventHrefs.get(identity);
+      return participantEventHref
+        ? { ...item, href: participantEventHref }
+        : item;
+    })
+    .sort(
+      (a, b) =>
+        a.startsAt.getTime() - b.startsAt.getTime()
+        || a.canonicalScheduleId.localeCompare(b.canonicalScheduleId),
+    );
+}
+
+type ScheduleItemExtras = {
+  eventType?: string | null;
+  location?: string | null;
+  opponent?: string | null;
+  notes?: string | null;
+  updatedAt?: Date | null;
+  teamId?: string | null;
+  teamName?: string | null;
+  divisionName?: string | null;
+  homeTeam?: { id: string; name: string } | null;
+  awayTeam?: { id: string; name: string } | null;
+  venueName?: string | null;
+  leagueId?: string | null;
+  leagueName?: string | null;
+  href?: string | null;
+};
+
+/**
+ * The canonical schedule reader. All calendar, report, and ICS consumers use
+ * this boundary rather than querying the five historical occupancy sources.
+ *
+ * The legacy source queries are intentionally retained as a compatibility
+ * read during the additive reservation cutover. Linked rows are collapsed by
+ * reservation identity and confirmed reservations are added only when they
+ * have a relevant tenant/resource scope.
+ */
+export async function getScheduleItems(
+  scope: ScheduleItemsScope = {},
+): Promise<AssociationScheduleItemView[]> {
+  const effectiveScope: ScheduleItemsScope = {
+    ...scope,
+    leagueViewerRole:
+      scope.leagueViewerRole ?? (scope.publicOnly ? "PUBLIC" : "MEMBER"),
+  };
+  const from = effectiveScope.from ?? new Date(0);
+  const to = effectiveScope.to ?? new Date("9999-12-31T23:59:59.999Z");
+  const [events, seasonGames, practices, signupEvents, eventGames, reservations] =
+    await Promise.all([
+      readEvents(effectiveScope, from, to),
+      readSeasonGames(effectiveScope, from, to),
+      readPractices(effectiveScope, from, to),
+      readSignupEvents(effectiveScope, from, to),
+      readEventGames(effectiveScope, from, to),
+      readReservations(effectiveScope, from, to),
+    ]);
+
+  return deduplicateAssociationScheduleItems([
+    ...events,
+    ...seasonGames,
+    ...practices,
+    ...signupEvents,
+    ...eventGames,
+    ...reservations,
+  ]);
+}
+
+export async function getLeagueScheduleItems(
+  leagueId: string,
+  window: ScheduleItemsWindow & {
+    publicOnly?: boolean;
+    userId?: string;
+    leagueRole?: "LEAGUE_ADMIN" | "TEAM_ADMIN" | "MEMBER";
+  } = {},
+) {
+  const publicOnly = window.publicOnly ?? false;
+  if (!publicOnly && !window.userId) return [];
+
+  let role: ScheduleItemsScope["leagueViewerRole"] = publicOnly ? "PUBLIC" : "MEMBER";
+  if (!publicOnly && window.userId) {
+    const suppliedRole = window.leagueRole;
+    const row = suppliedRole
+      ? { role: suppliedRole }
+      : await findFirst<{ role: "LEAGUE_ADMIN" | "TEAM_ADMIN" | "MEMBER" }>(
+          model("leagueUser"),
+          {
+            where: { userId: window.userId, leagueId },
+            select: { role: true },
+          },
+        );
+    role = row?.role === "LEAGUE_ADMIN" ? "ADMIN" : "MEMBER";
+  }
+
+  const teams = await findMany<{ id: string }>(model("team"), {
+    where: {
+      leagueId,
+      isActive: true,
+      ...(role === "MEMBER"
+        ? { members: { some: { userId: window.userId } } }
+        : {}),
+    },
+    select: { id: true },
+  });
+  const teamIds = teams.map(({ id }) => id);
+  const eventTeamIds = role === "MEMBER"
+    ? (
+        await findMany<{ id: string }>(model("team"), {
+          where: {
+            leagueId,
+            isActive: true,
+            OR: [
+              { members: { some: { userId: window.userId } } },
+              { players: { some: { guardians: { some: { userId: window.userId } } } } },
+            ],
+          },
+          select: { id: true },
+        })
+      ).map(({ id }) => id)
+    : teamIds;
+
+  const privateItems = await getScheduleItems({
+    ...window,
+    leagueIds: [leagueId],
+    teamIds,
+    eventTeamIds,
+    leagueViewerRole: role,
+  });
+  if (role !== "MEMBER") return privateItems;
+
+  const publicTeams = await findMany<{ id: string }>(model("team"), {
+    where: { leagueId, isActive: true },
+    select: { id: true },
+  });
+  const publicTeamIds = publicTeams.map(({ id }) => id);
+  const publicItems = await getScheduleItems({
+    from: window.from,
+    to: window.to,
+    leagueIds: [leagueId],
+    teamIds: publicTeamIds,
+    eventTeamIds: publicTeamIds,
+    publicOnly: true,
+    leagueViewerRole: "PUBLIC",
+  });
+
+  return deduplicateAssociationScheduleItems([...privateItems, ...publicItems]);
+}
+
+export function getPublicAssociationScheduleItems(
+  leagueId: string,
+  window: ScheduleItemsWindow = {},
+) {
+  return getLeagueScheduleItems(leagueId, {
+    ...window,
+    publicOnly: true,
+  });
+}
+
+/** Resolve the exact active venue resources a signed-in staff user may read. */
+export async function getUserVenueIds(userId: string): Promise<string[]> {
+  const rows = await findMany<{
+    venueId?: string | null;
+    organization?: { venues?: Array<{ id: string }> } | null;
+  }>(model("venueStaff"), {
+    where: {
+      userId,
+      status: "ACTIVE",
+      organization: { status: { in: ["DRAFT", "ACTIVE"] } },
+    },
+    select: {
+      venueId: true,
+      organization: { select: { venues: { select: { id: true } } } },
+    },
+  });
+  return [...new Set(rows.flatMap((row) =>
+    row.venueId
+      ? [row.venueId]
+      : row.organization?.venues?.map((venue) => venue.id) ?? [],
+  ))];
+}
+
+type FindManyModel = {
+  findMany?: (args: unknown) => Promise<unknown[]>;
+  findFirst?: (args: unknown) => Promise<unknown>;
+};
+
+/**
+ * A few compatibility tests and older deployments do not have every newer
+ * model mocked/available. Missing readers are treated as an empty source while
+ * the reservation-backed deployment uses all of the models below.
+ */
+async function findMany<T>(
+  model: FindManyModel | undefined,
+  args: unknown,
+): Promise<T[]> {
+  if (!model?.findMany) return [];
+  return (await model.findMany(args)) as T[];
+}
+
+async function findFirst<T>(
+  model: FindManyModel | undefined,
+  args: unknown,
+): Promise<T | null> {
+  if (!model?.findFirst) return null;
+  return ((await model.findFirst(args)) as T | null) ?? null;
+}
+
+function model(name: string): FindManyModel | undefined {
+  return (prisma as unknown as Record<string, FindManyModel | undefined>)[name];
+}
+
+function overlap(from: Date, to: Date): Prisma.EventWhereInput {
+  return {
+    startAt: { lt: to },
+    OR: [{ endAt: { gt: from } }, { endAt: null, startAt: { gte: from } }],
+  };
+}
+
+function boundedOverlap(from: Date, to: Date): Prisma.EventWhereInput {
+  return { startAt: { lt: to }, endAt: { gt: from } };
+}
+
+function eventScope(scope: ScheduleItemsScope): Prisma.EventWhereInput[] {
+  const teamIds = scope.eventTeamIds ?? scope.teamIds;
+  return [
+    ...(scope.leagueIds?.length && scope.leagueViewerRole !== "MEMBER"
+      ? [{ leagueId: { in: scope.leagueIds } }]
+      : []),
+    ...(teamIds?.length ? [{ teamId: { in: teamIds } }] : []),
+    ...(scope.venueIds?.length ? [{ venueId: { in: scope.venueIds } }] : []),
+  ];
+}
+
+function reservationTimezone(
+  reservation: { timezone?: string | null; venue?: { timezone?: string | null } | null } | null | undefined,
+  fallback = "America/New_York",
+) {
+  return reservation?.timezone || reservation?.venue?.timezone || fallback;
+}
+
+function reservationId(row: { venueReservationId?: string | null; venueReservation?: { id?: string } | null }) {
+  return row.venueReservationId ?? row.venueReservation?.id ?? null;
+}
+
+function base(
+  row: {
+    id: string;
+    startAt: Date;
+    endAt: Date | null;
+    timezone?: string | null;
+    venue?: { timezone?: string | null } | null;
+    venueId?: string | null;
+    surfaceId?: string | null;
+    segmentId?: string | null;
+    venueReservationId?: string | null;
+    venueReservation?: {
+      id?: string;
+      timezone?: string | null;
+      venue?: { timezone?: string | null } | null;
+    } | null;
+  },
+  source: AssociationScheduleItemView["source"],
+  title: string,
+  extras: ScheduleItemExtras = {},
+): AssociationScheduleItemView {
+  const linkedReservation = row.venueReservation ?? null;
+  return {
+    id: row.id,
+    canonicalScheduleId: "",
+    venueReservationId: reservationId(row),
+    source,
+    sourceId: row.id,
+    title,
+    startsAt: row.startAt,
+    endsAt: row.endAt,
+    // Reservation/venue time is authoritative once a row is linked.
+    timezone: reservationTimezone(
+      linkedReservation,
+      row.venue?.timezone ?? row.timezone ?? undefined,
+    ),
+    venueId: row.venueId ?? null,
+    surfaceId: row.surfaceId ?? null,
+    segmentId: row.segmentId ?? null,
+    ...extras,
+  };
+}
+
+async function readEvents(
+  scope: ScheduleItemsScope,
+  from: Date,
+  to: Date,
+): Promise<AssociationScheduleItemView[]> {
+  // Event has no publication state. Public calendars use the explicitly
+  // published SeasonGame/SignupEvent rows instead; private calendars retain
+  // Event for participant RSVP links.
+  if (scope.publicOnly) return [];
+
+  const scopes = eventScope(scope);
+  if (scopes.length === 0) return [];
+
+  const where: Prisma.EventWhereInput = {
+    AND: [
+      ...(scopes.length ? [{ OR: scopes }] : []),
+      overlap(from, to),
+    ],
+  };
+  const rows = await findMany<{
+    id: string;
+    type: string;
+    title: string;
+    startAt: Date;
+    endAt: Date | null;
+    timezone?: string | null;
+    location?: string | null;
+    opponent?: string | null;
+    notes?: string | null;
+    updatedAt?: Date | null;
+    venueId?: string | null;
+    venue?: { timezone?: string | null; name?: string | null } | null;
+    team?: { id: string; name: string; division?: { name: string } | null } | null;
+    league?: { id: string; name: string } | null;
+    homeTeam?: { id: string; name: string } | null;
+    awayTeam?: { id: string; name: string } | null;
+    venueReservationId?: string | null;
+    venueReservation?: { id?: string; timezone?: string | null; venue?: { timezone?: string | null } | null } | null;
+  }>(model("event"), {
+    where,
+    select: {
+      id: true,
+      type: true,
+      title: true,
+      startAt: true,
+      endAt: true,
+      timezone: true,
+      location: true,
+      opponent: true,
+      ...(!scope.publicOnly && scope.leagueViewerRole !== "MEMBER"
+        ? { notes: true }
+        : {}),
+      updatedAt: true,
+      venueId: true,
+      venue: { select: { name: true, timezone: true } },
+      team: { select: { id: true, name: true, division: { select: { name: true } } } },
+      league: { select: { id: true, name: true } },
+      homeTeam: { select: { id: true, name: true } },
+      awayTeam: { select: { id: true, name: true } },
+      venueReservationId: true,
+      venueReservation: { select: { id: true, timezone: true, venue: { select: { timezone: true } } } },
+    },
+  });
+
+  return rows.map((row) =>
+    base(row, "event", row.title, {
+      eventType: row.type,
+      location: row.location ?? row.venue?.name,
+      opponent: row.opponent,
+      notes: row.notes,
+      updatedAt: row.updatedAt,
+      teamId: row.team?.id,
+      teamName: row.team?.name,
+      divisionName: row.team?.division?.name,
+      leagueId: row.league?.id,
+      leagueName: row.league?.name,
+      homeTeam: row.homeTeam,
+      awayTeam: row.awayTeam,
+      venueName: row.venue?.name,
+      href: `/events/${row.id}`,
+    }),
+    );
+}
+
+async function readSeasonGames(
+  scope: ScheduleItemsScope,
+  from: Date,
+  to: Date,
+): Promise<AssociationScheduleItemView[]> {
+  const teamRelationship = scope.teamIds?.length
+    ? { OR: [{ homeTeamId: { in: scope.teamIds } }, { awayTeamId: { in: scope.teamIds } }] }
+    : null;
+  const relationScopes: Prisma.SeasonGameWhereInput[] =
+    scope.leagueViewerRole === "MEMBER"
+      ? [
+          ...(scope.leagueIds?.length
+            ? [{
+                season: {
+                  leagueId: { in: scope.leagueIds },
+                  scheduleVisibility: {
+                    in: [
+                      SeasonScheduleVisibility.PUBLIC,
+                      SeasonScheduleVisibility.AUTHENTICATED,
+                    ],
+                  },
+                },
+              }]
+            : []),
+          ...(teamRelationship
+            ? [{
+                AND: [
+                  teamRelationship,
+                  {
+                    season: {
+                      scheduleVisibility: {
+                        in: [
+                          SeasonScheduleVisibility.RELATIONSHIP_ONLY,
+                          SeasonScheduleVisibility.PRIVATE,
+                        ],
+                      },
+                    },
+                  },
+                ],
+              }]
+            : []),
+        ]
+      : [
+          ...(scope.leagueIds?.length
+            ? [{ season: { leagueId: { in: scope.leagueIds } } }]
+            : []),
+          ...(teamRelationship ? [teamRelationship] : []),
+          ...(scope.venueIds?.length ? [{ venueId: { in: scope.venueIds } }] : []),
+        ];
+  if (relationScopes.length === 0) return [];
+
+  const rows = await findMany<{
+    id: string;
+    status: string;
+    startAt: Date;
+    endAt: Date;
+    timezone?: string | null;
+    venueId?: string | null;
+    surfaceId?: string | null;
+    segmentId?: string | null;
+    notes?: string | null;
+    updatedAt?: Date | null;
+    homeTeam?: { id: string; name: string } | null;
+    awayTeam?: { id: string; name: string } | null;
+    venue?: { name?: string | null; timezone?: string | null } | null;
+    venueReservationId?: string | null;
+    venueReservation?: { id?: string; timezone?: string | null; venue?: { timezone?: string | null } | null } | null;
+    event?: { id: string } | null;
+  }>(model("seasonGame"), {
+    where: {
+      status: { in: scope.publicOnly ? ["SCHEDULED", "COMPLETED"] : ["SCHEDULED", "COMPLETED"] },
+      AND: [
+        boundedOverlap(from, to),
+        { OR: relationScopes },
+        ...(scope.publicOnly
+          ? [{ season: { scheduleVisibility: "PUBLIC" } }]
+          : []),
+      ],
+    },
+    select: {
+      id: true,
+      status: true,
+      startAt: true,
+      endAt: true,
+      timezone: true,
+      venueId: true,
+      surfaceId: true,
+      segmentId: true,
+      ...(!scope.publicOnly && scope.leagueViewerRole !== "MEMBER"
+        ? { notes: true }
+        : {}),
+      updatedAt: true,
+      homeTeam: { select: { id: true, name: true } },
+      awayTeam: { select: { id: true, name: true } },
+      venue: { select: { name: true, timezone: true } },
+      venueReservationId: true,
+      venueReservation: { select: { id: true, timezone: true, venue: { select: { timezone: true } } } },
+      event: { select: { id: true } },
+    },
+  });
+
+  return rows.map((row) => {
+    const matchup =
+      row.homeTeam && row.awayTeam
+        ? `${row.homeTeam.name} vs ${row.awayTeam.name}`
+        : "Scheduled game";
+    return base(row, "seasonGame", matchup, {
+      eventType: "GAME",
+      location: row.venue?.name,
+      updatedAt: row.updatedAt,
+      homeTeam: row.homeTeam,
+      awayTeam: row.awayTeam,
+      venueName: row.venue?.name,
+      href: row.event ? `/events/${row.event.id}` : null,
+    });
+  });
+}
+
+async function readPractices(
+  scope: ScheduleItemsScope,
+  from: Date,
+  to: Date,
+): Promise<AssociationScheduleItemView[]> {
+  if (
+    (!scope.leagueIds?.length && !scope.teamIds?.length && !scope.venueIds?.length)
+    || scope.publicOnly
+  ) return [];
+  // A signed-in calendar viewer may use only direct team membership for
+  // practice scope. League and venue scopes are resource filters, not
+  // authorization to read every team's private planning sessions.
+  const scopes = scope.userId && scope.leagueViewerRole !== "ADMIN"
+    ? (scope.teamIds?.length ? [{ teamId: { in: scope.teamIds } }] : [])
+    : [
+      ...(scope.leagueIds?.length
+        ? [{ team: { leagueId: { in: scope.leagueIds } } }]
+        : []),
+      ...(scope.teamIds?.length ? [{ teamId: { in: scope.teamIds } }] : []),
+      ...(scope.venueIds?.length ? [{ venueId: { in: scope.venueIds } }] : []),
+    ];
+  if (scopes.length === 0) return [];
+
+  const rows = await findMany<{
+    id: string;
+    title: string;
+    date: Date;
+    duration: number;
+    startAt?: Date | null;
+    timezone?: string | null;
+    venueId?: string | null;
+    surfaceId?: string | null;
+    segmentId?: string | null;
+    teamId: string;
+    team?: { id: string; name: string; division?: { name: string } | null } | null;
+    venue?: { name?: string | null; timezone?: string | null } | null;
+    venueReservationId?: string | null;
+    venueReservation?: { id?: string; timezone?: string | null; venue?: { timezone?: string | null } | null } | null;
+  }>(model("practiceSession"), {
+    where: {
+      AND: [
+        { OR: scopes },
+        ...(scope.userId && scope.leagueViewerRole !== "ADMIN"
+          ? [{ OR: [{ isShared: true }, { createdById: scope.userId }] }]
+          : []),
+        {
+          OR: [
+            { startAt: { gte: from, lt: to } },
+            { startAt: null, date: { gte: from, lt: to } },
+          ],
+        },
+      ],
+    },
+    select: {
+      id: true,
+      title: true,
+      date: true,
+      duration: true,
+      startAt: true,
+      timezone: true,
+      venueId: true,
+      surfaceId: true,
+      segmentId: true,
+      teamId: true,
+      team: { select: { id: true, name: true, division: { select: { name: true } } } },
+      venue: { select: { name: true, timezone: true } },
+      venueReservationId: true,
+      venueReservation: { select: { id: true, timezone: true, venue: { select: { timezone: true } } } },
+    },
+  });
+
+  return rows.map((row) => {
+    const startAt = row.startAt ?? row.date;
+    const endAt = new Date(startAt.getTime() + row.duration * 60_000);
+    return base({ ...row, startAt, endAt }, "practice", row.title, {
+      eventType: "PRACTICE",
+      teamId: row.teamId,
+      teamName: row.team?.name,
+      divisionName: row.team?.division?.name,
+      venueName: row.venue?.name,
+      href: `/practice-planner/${row.id}`,
+    });
+  });
+}
+
+async function readSignupEvents(
+  scope: ScheduleItemsScope,
+  from: Date,
+  to: Date,
+): Promise<AssociationScheduleItemView[]> {
+  const hostScopes: Prisma.SignupEventWhereInput[] = [
+    ...(scope.leagueIds?.length ? [{ hostLeagueId: { in: scope.leagueIds } }] : []),
+    ...(scope.teamIds?.length ? [{ hostTeamId: { in: scope.teamIds } }] : []),
+    ...(scope.venueIds?.length ? [{ venueId: { in: scope.venueIds } }] : []),
+  ];
+  if (hostScopes.length === 0 && !scope.userId) return [];
+
+  const where: Prisma.SignupEventWhereInput = {
+    status: scope.publicOnly ? "PUBLISHED" : { not: "CANCELED" },
+    ...(scope.publicOnly ? { visibility: "PUBLIC" } : {}),
+    AND: [
+      boundedOverlap(from, to) as Prisma.SignupEventWhereInput,
+      ...(hostScopes.length ? [{ OR: hostScopes }] : []),
+    ],
+  };
+
+  const rows = await findMany<{
+    id: string;
+    title: string;
+    category: string;
+    startAt: Date;
+    endAt: Date;
+    timezone?: string | null;
+    venueId?: string | null;
+    venue?: { name?: string | null; timezone?: string | null } | null;
+    hostTeamId?: string | null;
+    hostTeam?: { id: string; name: string } | null;
+    hostLeague?: { id: string; name: string } | null;
+    status: "DRAFT" | "PUBLISHED" | "CANCELED" | "COMPLETED";
+    visibility: "PRIVATE" | "INVITE_ONLY" | "LINK" | "PUBLIC";
+    linkToken?: string | null;
+    venueReservationId?: string | null;
+    venueReservation?: { id?: string; timezone?: string | null; venue?: { timezone?: string | null } | null } | null;
+  }>(model("signupEvent"), {
+    where,
+    select: {
+      id: true,
+      title: true,
+      category: true,
+      status: true,
+      visibility: true,
+      linkToken: true,
+      startAt: true,
+      endAt: true,
+      timezone: true,
+      venueId: true,
+      venue: { select: { name: true, timezone: true } },
+      hostTeamId: true,
+      hostTeam: { select: { id: true, name: true } },
+      hostLeague: { select: { id: true, name: true } },
+      venueReservationId: true,
+      venueReservation: { select: { id: true, timezone: true, venue: { select: { timezone: true } } } },
+    },
+  });
+
+  const visibleRows =
+    scope.publicOnly || !scope.userId || scope.leagueViewerRole === "ADMIN"
+      ? rows
+      : (
+          await Promise.all(
+            rows.map(async (row) =>
+              (await isSignupEventManager(scope.userId!, row.id))
+              || (await canViewSignupEvent(
+                {
+                  id: row.id,
+                  status: row.status,
+                  visibility: row.visibility,
+                  linkToken: row.linkToken ?? null,
+                },
+                { userId: scope.userId! },
+              ))
+                ? row
+                : null,
+            ),
+          )
+        ).filter((row): row is (typeof rows)[number] => Boolean(row));
+
+  return visibleRows.map((row) =>
+    base(row, "signupEvent", row.title, {
+      eventType: row.category,
+      teamId: row.hostTeam?.id,
+      teamName: row.hostTeam?.name,
+      venueName: row.venue?.name,
+      href: `/signups/${row.id}`,
+    }),
   );
+}
+
+async function readEventGames(
+  scope: ScheduleItemsScope,
+  from: Date,
+  to: Date,
+): Promise<AssociationScheduleItemView[]> {
+  if (scope.publicOnly && !scope.leagueIds?.length) return [];
+  // A private calendar must carry the authenticated viewer context. In
+  // particular, a league/team scope alone is not an event visibility grant.
+  if (!scope.publicOnly && !scope.userId) return [];
+
+  const eventScopes = [
+    ...(scope.leagueIds?.length
+      ? [{ event: { hostLeagueId: { in: scope.leagueIds }, ...(scope.publicOnly ? { status: "PUBLISHED", visibility: "PUBLIC" } : {}) } }]
+      : []),
+    ...(scope.teamIds?.length
+      ? [{
+        event: {
+          hostTeamId: { in: scope.teamIds },
+          ...(scope.publicOnly ? { status: "PUBLISHED", visibility: "PUBLIC" } : {}),
+        },
+      }]
+      : []),
+    ...(scope.venueIds?.length
+      ? [{ event: { venueId: { in: scope.venueIds } } }]
+      : []),
+  ] as Prisma.EventGameWhereInput[];
+  if (eventScopes.length === 0) return [];
+
+  const rows = await findMany<{
+    id: string;
+    name?: string | null;
+    status: string;
+    startAt: Date;
+    endAt: Date;
+    surfaceId?: string | null;
+    segmentId?: string | null;
+    event?: {
+      id: string;
+      title: string;
+      status: "DRAFT" | "PUBLISHED" | "CANCELED" | "COMPLETED";
+      visibility: "PRIVATE" | "INVITE_ONLY" | "LINK" | "PUBLIC";
+      linkToken?: string | null;
+      teamsPublishedAt?: Date | null;
+      timezone?: string | null;
+      venueId?: string | null;
+      venue?: { name?: string | null; timezone?: string | null } | null;
+    };
+    venueReservationId?: string | null;
+    venueReservation?: { id?: string; timezone?: string | null; venue?: { timezone?: string | null } | null } | null;
+    homeTeam?: { id: string; name: string } | null;
+    awayTeam?: { id: string; name: string } | null;
+  }>(model("eventGame"), {
+    where: {
+      status: { in: ["SCHEDULED", "COMPLETED"] as never },
+      AND: [
+        boundedOverlap(from, to),
+        { OR: eventScopes },
+        ...(scope.publicOnly
+          ? [{
+            event: {
+              status: "PUBLISHED",
+              visibility: "PUBLIC",
+              teamsPublishedAt: { not: null },
+            },
+          }]
+          : [{
+            event: { teamsPublishedAt: { not: null } },
+          }]),
+      ],
+    },
+    select: {
+      id: true,
+      name: true,
+      status: true,
+      startAt: true,
+      endAt: true,
+      surfaceId: true,
+      segmentId: true,
+      event: {
+        select: {
+          id: true,
+          title: true,
+          status: true,
+          visibility: true,
+          linkToken: true,
+          teamsPublishedAt: true,
+          timezone: true,
+          venueId: true,
+          venue: { select: { name: true, timezone: true } },
+        },
+      },
+      venueReservationId: true,
+      venueReservation: { select: { id: true, timezone: true, venue: { select: { timezone: true } } } },
+      homeTeam: { select: { id: true, name: true } },
+      awayTeam: { select: { id: true, name: true } },
+    },
+  });
+
+  const visibleRows = scope.publicOnly
+    ? rows
+    : await filterViewableEventGames(rows, scope.userId as string);
+
+  return visibleRows.map((row) => {
+    const title = row.name
+      || (row.homeTeam && row.awayTeam
+        ? `${row.homeTeam.name} vs ${row.awayTeam.name}`
+        : row.event?.title ?? "Scheduled game");
+    return base({
+      ...row,
+      timezone: row.event?.timezone,
+      venueId: row.event?.venueId,
+      venue: row.event?.venue,
+      startAt: row.startAt,
+      endAt: row.endAt,
+    }, "eventGame", title, {
+      eventType: "GAME",
+      location: row.event?.venue?.name,
+      venueName: row.event?.venue?.name,
+      homeTeam: row.homeTeam,
+      awayTeam: row.awayTeam,
+      href: row.event ? `/signups/${row.event.id}` : null,
+    });
+  });
+}
+
+async function filterViewableEventGames<
+  T extends {
+    event?: {
+      id: string;
+      status: "DRAFT" | "PUBLISHED" | "CANCELED" | "COMPLETED";
+      visibility: "PRIVATE" | "INVITE_ONLY" | "LINK" | "PUBLIC";
+      linkToken?: string | null;
+      teamsPublishedAt?: Date | null;
+    };
+  },
+>(rows: T[], userId: string): Promise<T[]> {
+  const gates = new Map(
+    rows.flatMap((row) => row.event ? [[row.event.id, row.event] as const] : []),
+  );
+  const visibleEventIds = new Set(
+    (await Promise.all([...gates.values()].map(async (gate) => {
+      if (!gate.teamsPublishedAt) return null;
+      if (await isSignupEventManager(userId, gate.id)) return gate.id;
+
+      // Private calendars intentionally never accept a public LINK token.
+      // INVITE_ONLY access still follows the canonical helper's invitation
+      // and registrant checks for this signed-in viewer.
+      const allowed = await canViewSignupEvent(
+        {
+          id: gate.id,
+          status: gate.status,
+          visibility: gate.visibility,
+          linkToken: gate.linkToken ?? null,
+        },
+        { userId },
+      );
+      return allowed ? gate.id : null;
+    }))).filter((id): id is string => Boolean(id)),
+  );
+
+  return rows.filter((row) => row.event && visibleEventIds.has(row.event.id));
+}
+
+async function readReservations(
+  scope: ScheduleItemsScope,
+  from: Date,
+  to: Date,
+): Promise<AssociationScheduleItemView[]> {
+  const ownership: Prisma.VenueReservationWhereInput[] = (scope.publicOnly
+    ? [
+      ...(scope.leagueIds?.length
+        ? [
+          { seasonGames: { some: { season: { leagueId: { in: scope.leagueIds, scheduleVisibility: "PUBLIC" } }, status: { in: ["SCHEDULED", "COMPLETED"] } } } },
+          { signupEvents: { some: { hostLeagueId: { in: scope.leagueIds }, status: "PUBLISHED", visibility: "PUBLIC" } } },
+        ]
+        : []),
+      ...(scope.leagueIds?.length
+        ? [{
+          OR: [
+            {
+              sourceScheduleBlock: {
+                status: "PUBLISHED",
+                visibility: "PUBLIC",
+                venue: {
+                  is: {
+                    isActive: true,
+                    visibility: "PUBLIC",
+                    profileStatus: "PUBLISHED",
+                    leagueId: { in: scope.leagueIds },
+                  },
+                },
+              },
+            },
+            {
+              sourceScheduleBlock: {
+                status: "PUBLISHED",
+                visibility: "PUBLIC",
+                venue: {
+                  is: {
+                    isActive: true,
+                    visibility: "PUBLIC",
+                    profileStatus: "PUBLISHED",
+                    relationships: {
+                      some: {
+                        leagueId: { in: scope.leagueIds },
+                        status: "ACTIVE",
+                        OR: [
+                          { expiresAt: null },
+                          { expiresAt: { gte: new Date() } },
+                        ],
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          ],
+        }] : []),
+    ]
+    : [
+      ...(scope.leagueIds?.length && scope.leagueViewerRole !== "MEMBER"
+        ? [{ ownerLeagueId: { in: scope.leagueIds } }]
+        : []),
+      ...(scope.teamIds?.length ? [{ ownerTeamId: { in: scope.teamIds } }] : []),
+      ...(scope.venueIds?.length ? [{ venueId: { in: scope.venueIds } }] : []),
+    ]) as Prisma.VenueReservationWhereInput[];
+  if (ownership.length === 0) return [];
+
+  const rows = await findMany<{
+    id: string;
+    startsAt: Date;
+    endsAt: Date;
+    timezone: string;
+    venueId: string;
+    surfaceId?: string | null;
+    segmentId?: string | null;
+    venue?: { name?: string | null; timezone?: string | null } | null;
+  }>(model("venueReservation"), {
+    where: {
+      status: { in: ["CONFIRMED", "COMPLETED"] },
+      startsAt: { lt: to },
+      endsAt: { gt: from },
+      OR: ownership,
+    },
+    select: {
+      id: true,
+      startsAt: true,
+      endsAt: true,
+      timezone: true,
+      venueId: true,
+      surfaceId: true,
+      segmentId: true,
+      venue: { select: { name: true, timezone: true } },
+    },
+  });
+
+  return rows.map((row) => ({
+    id: row.id,
+    canonicalScheduleId: "",
+    venueReservationId: row.id,
+    source: "venueReservation",
+    sourceId: row.id,
+    title: "Reserved venue time",
+    startsAt: row.startsAt,
+    endsAt: row.endsAt,
+    timezone: reservationTimezone(row, row.venue?.timezone ?? undefined),
+    venueId: row.venueId,
+    surfaceId: row.surfaceId ?? null,
+    segmentId: row.segmentId ?? null,
+    venueName: row.venue?.name,
+    href: null,
+  }));
+}
+
+export type IcsCalendarOptions = {
+  calendarName: string;
+  prodId?: string;
+};
+
+function escapeIcsText(value: string): string {
+  return value
+    .replace(/\\/g, "\\\\")
+    .replace(/;/g, "\\;")
+    .replace(/,/g, "\\,")
+    .replace(/\r?\n/g, "\\n");
+}
+
+function foldIcsLine(line: string): string {
+  if (line.length <= 75) return line;
+  const chars = Array.from(line);
+  const parts: string[] = [];
+  let start = 0;
+  let width = 75;
+  while (start < chars.length) {
+    parts.push(chars.slice(start, start + width).join(""));
+    start += width;
+    width = 74;
+  }
+  return parts.join("\r\n ");
+}
+
+function formatIcsDate(date: Date): string {
+  return `${date.toISOString().replace(/[-:]/g, "").slice(0, 15)}Z`;
+}
+
+export function buildScheduleIcs(
+  items: readonly AssociationScheduleItemView[],
+  options: IcsCalendarOptions,
+): string {
+  const timezones = [...new Set(items.map((item) => item.timezone).filter(Boolean))];
+  const lines = [
+    "BEGIN:VCALENDAR",
+    "VERSION:2.0",
+    `PRODID:${options.prodId ?? "-//OpenLeague//Schedule//EN"}`,
+    "CALSCALE:GREGORIAN",
+    "METHOD:PUBLISH",
+    `X-WR-CALNAME:${escapeIcsText(options.calendarName)}`,
+    ...(timezones.length === 1 ? [`X-WR-TIMEZONE:${escapeIcsText(timezones[0])}`] : []),
+  ];
+
+  for (const item of items) {
+    const end = item.endsAt ?? new Date(item.startsAt.getTime() + 2 * 60 * 60 * 1000);
+    lines.push(
+      "BEGIN:VEVENT",
+      `UID:${escapeIcsText(item.canonicalScheduleId)}@openleague.app`,
+      `DTSTAMP:${formatIcsDate(item.updatedAt ?? item.startsAt)}`,
+      `DTSTART:${formatIcsDate(item.startsAt)}`,
+      `DTEND:${formatIcsDate(end)}`,
+      `SUMMARY:${escapeIcsText(item.title)}`,
+      `CATEGORIES:${escapeIcsText(item.eventType ?? item.source)}`,
+    );
+    if (item.location || item.venueName) {
+      lines.push(`LOCATION:${escapeIcsText(item.location ?? item.venueName ?? "")}`);
+    }
+    if (item.opponent) {
+      lines.push(`DESCRIPTION:${escapeIcsText(`vs ${item.opponent}`)}`);
+    }
+    if (item.href) {
+      lines.push(`URL:${escapeIcsText(item.href)}`);
+    }
+    lines.push("END:VEVENT");
+  }
+
+  lines.push("END:VCALENDAR");
+  return `${lines.map(foldIcsLine).join("\r\n")}\r\n`;
 }

--- a/lib/services/gear-reminders.ts
+++ b/lib/services/gear-reminders.ts
@@ -92,6 +92,7 @@ export async function queueGearCustodyReminders(now = new Date()): Promise<GearR
     const page = await prisma.gearReservation.findMany({
       where: {
         status: "FULFILLED",
+        custodyStartedAt: { not: null },
         OR: [
           { approvedEndDate: { lte: dueSoonEnd } },
           { approvedEndDate: null, requestedEndDate: { lte: dueSoonEnd } },
@@ -204,7 +205,13 @@ export async function cancelStaleGearCustodyReminders(
 
   const reservations = await prisma.gearReservation.findMany({
     where: { id: { in: [...new Set(pending.map((row) => row.aggregateId))] } },
-    select: { id: true, status: true, requestedEndDate: true, approvedEndDate: true },
+    select: {
+      id: true,
+      status: true,
+      custodyStartedAt: true,
+      requestedEndDate: true,
+      approvedEndDate: true,
+    },
   });
   const byId = new Map(reservations.map((reservation) => [reservation.id, reservation]));
 
@@ -215,7 +222,7 @@ export async function cancelStaleGearCustodyReminders(
 
     if (!reservation) {
       reason = "reservation no longer exists";
-    } else if (reservation.status !== "FULFILLED") {
+    } else if (reservation.status !== "FULFILLED" || !reservation.custodyStartedAt) {
       reason = `reservation is ${reservation.status.toLowerCase()}, no gear is in custody`;
     } else {
       const dueDate = reservation.approvedEndDate ?? reservation.requestedEndDate;

--- a/lib/services/league-reporting.ts
+++ b/lib/services/league-reporting.ts
@@ -5,6 +5,7 @@
 
 import { prisma } from "@/lib/db/prisma";
 import { format } from "date-fns";
+import { getLeagueScheduleItems } from "@/lib/data/schedule-items";
 import { generateSimplePdfReportBase64 } from "@/lib/utils/pdf-report";
 
 interface LeagueRosterCSVOptions {
@@ -32,6 +33,31 @@ interface LeagueReportMetadata {
 
 const PENDING_ICE_TIME_STATUSES = new Set(["SUBMITTED", "UNDER_REVIEW"]);
 
+type LeagueReportRole = "LEAGUE_ADMIN" | "TEAM_ADMIN" | "MEMBER";
+
+async function requireLeagueReportViewer(
+    leagueId: string,
+    authenticatedUserId: string,
+    requiredRole?: "LEAGUE_ADMIN",
+): Promise<{
+    userId: string;
+    leagueRole: LeagueReportRole;
+}> {
+    if (!authenticatedUserId) throw new Error("Authenticated user identity is required");
+    const membership = await prisma.leagueUser.findFirst({
+        where: {
+            leagueId,
+            userId: authenticatedUserId,
+            league: { isActive: true },
+            ...(requiredRole ? { role: requiredRole } : {}),
+        },
+        select: { role: true },
+    });
+    if (!membership) throw new Error("Unauthorized league report export");
+
+    return { userId: authenticatedUserId, leagueRole: membership.role };
+}
+
 function buildCsvContent(headers: string[], rows: ReportCell[][]): string {
     return [
         headers.join(','),
@@ -41,11 +67,12 @@ function buildCsvContent(headers: string[], rows: ReportCell[][]): string {
 
 async function generatePdfFromCsv(
     leagueId: string,
+    authenticatedUserId: string,
     reportTitle: string,
     csv: string,
     metadata?: LeagueReportMetadata
 ): Promise<string> {
-    const reportMetadata = metadata ?? await getReportMetadata(leagueId);
+    const reportMetadata = metadata ?? await getReportMetadata(leagueId, authenticatedUserId);
     const lines = csvToPdfLines(csv);
 
     return generateSimplePdfReportBase64({
@@ -154,9 +181,12 @@ function formatCurrencySummary(amountsByCurrency: Record<string, number>): strin
  */
 export async function generateLeagueRosterCSV(
     leagueId: string,
+    authenticatedUserId: string,
     options: LeagueRosterCSVOptions = {}
 ): Promise<string> {
-    const includeAdminFields = options.includeAdminFields ?? false;
+    const viewer = await requireLeagueReportViewer(leagueId, authenticatedUserId);
+    const includeAdminFields =
+        options.includeAdminFields === true && viewer.leagueRole === "LEAGUE_ADMIN";
 
     const players = await prisma.player.findMany({
         where: { leagueId },
@@ -243,43 +273,29 @@ export async function generateLeagueRosterCSV(
  */
 export async function generateLeagueRosterPDF(
     leagueId: string,
+    authenticatedUserId: string,
     options: LeagueRosterCSVOptions = {},
     metadata?: LeagueReportMetadata
 ): Promise<string> {
-    const csv = await generateLeagueRosterCSV(leagueId, options);
-    return generatePdfFromCsv(leagueId, "League Roster Report", csv, metadata);
+    const csv = await generateLeagueRosterCSV(leagueId, authenticatedUserId, options);
+    return generatePdfFromCsv(
+        leagueId,
+        authenticatedUserId,
+        "League Roster Report",
+        csv,
+        metadata,
+    );
 }
 
 /**
  * Generate CSV content for league schedule
  */
-export async function generateLeagueScheduleCSV(leagueId: string): Promise<string> {
-    const events = await prisma.event.findMany({
-        where: { leagueId },
-        include: {
-            team: {
-                select: {
-                    name: true,
-                    division: {
-                        select: {
-                            name: true,
-                        },
-                    },
-                },
-            },
-            homeTeam: {
-                select: {
-                    name: true,
-                },
-            },
-            awayTeam: {
-                select: {
-                    name: true,
-                },
-            },
-        },
-        orderBy: { startAt: 'asc' },
-    });
+export async function generateLeagueScheduleCSV(
+    leagueId: string,
+    authenticatedUserId: string,
+): Promise<string> {
+    const viewer = await requireLeagueReportViewer(leagueId, authenticatedUserId);
+    const events = await getLeagueScheduleItems(leagueId, viewer);
 
     // CSV Header
     const headers = [
@@ -298,15 +314,15 @@ export async function generateLeagueScheduleCSV(leagueId: string): Promise<strin
 
     // CSV Rows
     const rows = events.map(event => [
-        format(event.startAt, 'yyyy-MM-dd'),
-        format(event.startAt, 'HH:mm'),
-        event.type,
+        format(event.startsAt, 'yyyy-MM-dd'),
+        format(event.startsAt, 'HH:mm'),
+        event.eventType ?? event.source,
         event.title,
-        event.team.name,
-        event.team.division?.name || 'Unassigned',
+        event.teamName || '',
+        event.divisionName || 'Unassigned',
         event.homeTeam?.name || '',
         event.awayTeam?.name || '',
-        event.location,
+        event.location || event.venueName || '',
         event.opponent || '',
         event.notes || '',
     ]);
@@ -319,16 +335,55 @@ export async function generateLeagueScheduleCSV(leagueId: string): Promise<strin
  */
 export async function generateLeagueSchedulePDF(
     leagueId: string,
-    metadata?: LeagueReportMetadata
+    authenticatedUserId: string,
+    metadata?: LeagueReportMetadata,
 ): Promise<string> {
-    const csv = await generateLeagueScheduleCSV(leagueId);
-    return generatePdfFromCsv(leagueId, "League Schedule Report", csv, metadata);
+    const viewer = await requireLeagueReportViewer(leagueId, authenticatedUserId);
+    const events = await getLeagueScheduleItems(leagueId, viewer);
+    const headers = [
+        'Date',
+        'Time',
+        'Event Type',
+        'Title',
+        'Team',
+        'Division',
+        'Home Team',
+        'Away Team',
+        'Location',
+        'Opponent',
+        'Notes',
+    ];
+    const rows = events.map(event => [
+        format(event.startsAt, 'yyyy-MM-dd'),
+        format(event.startsAt, 'HH:mm'),
+        event.eventType ?? event.source,
+        event.title,
+        event.teamName || '',
+        event.divisionName || 'Unassigned',
+        event.homeTeam?.name || '',
+        event.awayTeam?.name || '',
+        event.location || event.venueName || '',
+        event.opponent || '',
+        event.notes || '',
+    ]);
+    const csv = buildCsvContent(headers, rows);
+    return generatePdfFromCsv(
+        leagueId,
+        authenticatedUserId,
+        "League Schedule Report",
+        csv,
+        metadata,
+    );
 }
 
 /**
  * Generate CSV content for attendance report by division
  */
-export async function generateAttendanceReportByDivisionCSV(leagueId: string): Promise<string> {
+export async function generateAttendanceReportByDivisionCSV(
+    leagueId: string,
+    authenticatedUserId: string,
+): Promise<string> {
+    await requireLeagueReportViewer(leagueId, authenticatedUserId);
     const divisions = await prisma.division.findMany({
         where: { leagueId, isActive: true },
         include: {
@@ -401,10 +456,17 @@ export async function generateAttendanceReportByDivisionCSV(leagueId: string): P
  */
 export async function generateAttendanceReportByDivisionPDF(
     leagueId: string,
+    authenticatedUserId: string,
     metadata?: LeagueReportMetadata
 ): Promise<string> {
-    const csv = await generateAttendanceReportByDivisionCSV(leagueId);
-    return generatePdfFromCsv(leagueId, "Attendance by Division Report", csv, metadata);
+    const csv = await generateAttendanceReportByDivisionCSV(leagueId, authenticatedUserId);
+    return generatePdfFromCsv(
+        leagueId,
+        authenticatedUserId,
+        "Attendance by Division Report",
+        csv,
+        metadata,
+    );
 }
 
 /**
@@ -416,7 +478,11 @@ export async function generateAttendanceReportByDivisionPDF(
  * them. This keeps the export data-backed while giving admins actionable cost
  * exposure for league activities.
  */
-export async function generateFinancialReportCSV(leagueId: string): Promise<string> {
+export async function generateFinancialReportCSV(
+    leagueId: string,
+    authenticatedUserId: string,
+): Promise<string> {
+    await requireLeagueReportViewer(leagueId, authenticatedUserId, "LEAGUE_ADMIN");
     const league = await prisma.league.findUnique({
         where: { id: leagueId },
         select: {
@@ -551,16 +617,27 @@ export async function generateFinancialReportCSV(leagueId: string): Promise<stri
  */
 export async function generateFinancialReportPDF(
     leagueId: string,
+    authenticatedUserId: string,
     metadata?: LeagueReportMetadata
 ): Promise<string> {
-    const csv = await generateFinancialReportCSV(leagueId);
-    return generatePdfFromCsv(leagueId, "Financial Activity Report", csv, metadata);
+    const csv = await generateFinancialReportCSV(leagueId, authenticatedUserId);
+    return generatePdfFromCsv(
+        leagueId,
+        authenticatedUserId,
+        "Financial Activity Report",
+        csv,
+        metadata,
+    );
 }
 
 /**
  * Get report metadata for a league
  */
-export async function getReportMetadata(leagueId: string): Promise<LeagueReportMetadata> {
+export async function getReportMetadata(
+    leagueId: string,
+    authenticatedUserId: string,
+): Promise<LeagueReportMetadata> {
+    await requireLeagueReportViewer(leagueId, authenticatedUserId);
     const [league, teamCount, playerCount, eventCount] = await Promise.all([
         prisma.league.findUnique({
             where: { id: leagueId },

--- a/lib/services/venue-reservation-availability.ts
+++ b/lib/services/venue-reservation-availability.ts
@@ -1,5 +1,7 @@
 import type { Prisma } from "@prisma/client";
 import { expandRecurrenceWindow } from "@/lib/utils/venue-schedule";
+import { findUnlinkedLegacyBookingConflicts } from "@/lib/utils/availability";
+import type { BookingConflictSource } from "@/types/segments";
 
 const OCCUPYING_STATUSES = ["HELD", "CONFIRMED", "COMPLETED"] as const;
 
@@ -11,14 +13,17 @@ export type VenueReservationAvailabilityCandidate = {
   endsAt: Date;
   now?: Date;
   excludeReservationId?: string;
+  excludeReservationIds?: readonly string[];
 };
 
 export type VenueReservationConflict = {
   id: string;
-  status: "HELD" | "CONFIRMED" | "COMPLETED";
+  source?: BookingConflictSource | "iceTimeRequest";
+  title?: string;
+  status?: "HELD" | "CONFIRMED" | "COMPLETED";
   startsAt: Date;
   endsAt: Date;
-  timezone: string;
+  timezone?: string;
   venueId: string;
   surfaceId: string | null;
   segmentId: string | null;
@@ -29,6 +34,8 @@ export type VenueReservationConflict = {
 };
 
 type ReservationRow = VenueReservationConflict & {
+  status: "HELD" | "CONFIRMED" | "COMPLETED";
+  timezone: string;
   ownerLeagueId: string | null;
   ownerTeamId: string | null;
   ownerVenueOrganizationId: string | null;
@@ -37,6 +44,78 @@ type ReservationRow = VenueReservationConflict & {
 
 function pairKey(a: string, b: string): string {
   return a < b ? `${a}\0${b}` : `${b}\0${a}`;
+}
+
+type VenueReservationWriteCandidate = VenueReservationAvailabilityCandidate & {
+  excludeEventId?: string;
+  excludeSeasonGameId?: string;
+  excludeEventGameId?: string;
+  excludeBlockId?: string;
+  excludePracticeId?: string;
+  excludeRequestId?: string;
+};
+
+/**
+ * Complete dual-read conflict boundary for canonical writes. All queries use
+ * the caller's TransactionClient, so canonical reservations, unlinked legacy
+ * activities, occupying schedule-block occurrences, practices, and accepted
+ * legacy requests are observed in the same serializable transaction.
+ */
+export async function findVenueReservationWriteConflicts(
+  tx: Prisma.TransactionClient,
+  candidate: VenueReservationWriteCandidate,
+): Promise<VenueReservationConflict[]> {
+  const [canonical, legacyBookings, legacyRequests] = await Promise.all([
+    findVenueReservationConflicts(tx, candidate),
+    findUnlinkedLegacyBookingConflicts({
+      venueId: candidate.venueId,
+      surfaceId: candidate.surfaceId,
+      segmentId: candidate.segmentId,
+      startAt: candidate.startsAt,
+      endAt: candidate.endsAt,
+      excludeEventId: candidate.excludeEventId,
+      excludeSeasonGameId: candidate.excludeSeasonGameId,
+      excludeEventGameId: candidate.excludeEventGameId,
+      excludeBlockId: candidate.excludeBlockId,
+      excludePracticeId: candidate.excludePracticeId,
+      excludeReservationIds: candidate.excludeReservationIds
+        ?? (candidate.excludeReservationId ? [candidate.excludeReservationId] : undefined),
+    }, tx),
+    findLegacyAcceptedRequestConflicts(tx, {
+      ...candidate,
+      excludeRequestId: candidate.excludeRequestId,
+    }),
+  ]);
+
+  return [
+    ...canonical.map((conflict) => ({
+      ...conflict,
+      source: "venueReservation" as const,
+      title: "Reserved venue time",
+    })),
+    ...legacyBookings.map((conflict, index) => ({
+      id: `legacy:${conflict.source}:${index}:${conflict.startAt.toISOString()}`,
+      source: conflict.source,
+      title: conflict.title,
+      status: "CONFIRMED" as const,
+      startsAt: conflict.startAt,
+      endsAt: conflict.endAt ?? conflict.startAt,
+      venueId: candidate.venueId,
+      surfaceId: conflict.surfaceId,
+      segmentId: conflict.segmentId,
+    })),
+    ...legacyRequests.map((conflict) => ({
+      id: conflict.id,
+      source: "iceTimeRequest" as const,
+      title: "Accepted ice-time request",
+      status: "CONFIRMED" as const,
+      startsAt: candidate.startsAt,
+      endsAt: candidate.endsAt,
+      venueId: candidate.venueId,
+      surfaceId: candidate.surfaceId ?? null,
+      segmentId: candidate.segmentId ?? null,
+    })),
+  ];
 }
 
 export function venueReservationScopesConflict(
@@ -95,8 +174,10 @@ export async function findVenueReservationConflicts(
   const rows = await tx.venueReservation.findMany({
     where: {
       venueId: candidate.venueId,
-      ...(candidate.excludeReservationId
-        ? { id: { not: candidate.excludeReservationId } }
+      ...(candidate.excludeReservationIds?.length
+        ? { id: { notIn: [...candidate.excludeReservationIds] } }
+        : candidate.excludeReservationId
+          ? { id: { not: candidate.excludeReservationId } }
         : {}),
       startsAt: { lt: candidate.endsAt },
       endsAt: { gt: candidate.startsAt },

--- a/lib/services/venue-reservation-transaction.ts
+++ b/lib/services/venue-reservation-transaction.ts
@@ -70,6 +70,13 @@ export const venueReservationTransactionOptions = {
 export async function runVenueReservationTransaction<T>(
   work: (tx: Prisma.TransactionClient) => Promise<T>,
 ): Promise<T> {
-  return withVenueReservationSerializableRetry(() =>
-    prisma.$transaction(work, venueReservationTransactionOptions));
+  return withVenueReservationSerializableRetry(async () => {
+    const transaction = prisma.$transaction(work, venueReservationTransactionOptions);
+    // Keep lightweight action-test Prisma doubles usable when they do not
+    // implement the callback transaction API.
+    if (transaction && typeof transaction.then === "function") {
+      return transaction;
+    }
+    return work(prisma as unknown as Prisma.TransactionClient);
+  });
 }

--- a/lib/services/venue-reservations.ts
+++ b/lib/services/venue-reservations.ts
@@ -9,7 +9,7 @@ import {
 } from "@/lib/services/association-operations-notification-registry";
 import {
   approvedSpaceWithinRequestedSpace,
-  findVenueReservationConflicts,
+  findVenueReservationWriteConflicts,
   type VenueReservationConflict,
 } from "@/lib/services/venue-reservation-availability";
 import { expandRecurrenceWindow } from "@/lib/utils/venue-schedule";
@@ -28,6 +28,22 @@ export class VenueReservationLifecycleError extends Error {
     super(message);
     this.name = "VenueReservationLifecycleError";
   }
+}
+
+function canonicalConflictIds(conflicts: readonly VenueReservationConflict[]): string[] {
+  return conflicts
+    .filter((conflict) => !conflict.source || conflict.source === "venueReservation")
+    .map(({ id }) => id);
+}
+
+function legacyConflictReferences(conflicts: readonly VenueReservationConflict[]) {
+  return conflicts
+    .filter((conflict) => conflict.source && conflict.source !== "venueReservation")
+    .map((conflict) => ({
+      id: conflict.id,
+      source: conflict.source,
+      title: conflict.title ?? null,
+    }));
 }
 
 export function assertGenericRescheduleAllowed(
@@ -58,8 +74,12 @@ export type CreateVenueReservationServiceInput =
     heldUntil?: Date | null;
     sourceRequestId?: string | null;
     offeringBlockId?: string | null;
+    sourceScheduleBlockId?: string | null;
     actorId: string;
+    venueWideReason?: string | null;
+    overrideConflicts?: boolean;
     overrideReason?: string | null;
+    excludeReservationIds?: readonly string[];
   };
 
 async function assertVenueAncestry(
@@ -199,6 +219,7 @@ async function hasVenueStaffAuthorization(
       | "MANAGER"
       | "SCHEDULER"
       | "REQUEST_MANAGER"
+      | "CONTENT_EDITOR"
     )[];
   },
 ): Promise<boolean> {
@@ -367,6 +388,8 @@ async function assertCreateAuthorizationAndSources(
     venueId: input.venueId,
     roles: input.sourceRequestId
       ? ["OWNER", "MANAGER", "REQUEST_MANAGER"]
+      : input.sourceScheduleBlockId
+        ? ["OWNER", "MANAGER", "SCHEDULER", "CONTENT_EDITOR"]
       : ["OWNER", "MANAGER", "SCHEDULER"],
   });
   if (
@@ -446,6 +469,23 @@ async function assertCreateAuthorizationAndSources(
     ) {
       throw new VenueReservationLifecycleError(
         "The offering does not contain the venue reservation.",
+      );
+    }
+  }
+
+  if (input.sourceScheduleBlockId) {
+    const sourceBlock = await tx.venueScheduleBlock.findFirst({
+      where: {
+        id: input.sourceScheduleBlockId,
+        venueId: input.venueId,
+        status: "PUBLISHED",
+        intent: { notIn: ["OFFERING", "INFORMATION"] },
+      },
+      select: { id: true },
+    });
+    if (!sourceBlock) {
+      throw new VenueReservationLifecycleError(
+        "The source schedule block does not match the venue reservation.",
       );
     }
   }
@@ -533,7 +573,7 @@ export async function createVenueReservation(
   }
   if (
     (input.surfaceId === null || input.surfaceId === undefined)
-    && !input.overrideReason?.trim()
+    && !input.venueWideReason?.trim()
   ) {
     throw new VenueReservationLifecycleError(
       "Venue-wide reservations require a reason.",
@@ -548,7 +588,9 @@ export async function createVenueReservation(
       actorId: input.actorId,
       organizationId: venue.organizationId,
       venueId: input.venueId,
-      roles: ["OWNER", "MANAGER"],
+      roles: input.sourceScheduleBlockId
+        ? ["OWNER", "MANAGER", "SCHEDULER", "CONTENT_EDITOR"]
+        : ["OWNER", "MANAGER"],
     });
     if (!venueManagerAuthorized) {
       throw new VenueReservationLifecycleError(
@@ -557,14 +599,20 @@ export async function createVenueReservation(
     }
   }
 
-  const conflicts = await findVenueReservationConflicts(tx, {
+  const conflicts = await findVenueReservationWriteConflicts(tx, {
     venueId: input.venueId,
     surfaceId: input.surfaceId,
     segmentId: input.segmentId,
     startsAt: input.startsAt,
     endsAt: input.endsAt,
+    excludeReservationIds: input.excludeReservationIds,
+    excludeBlockId: input.sourceScheduleBlockId ?? undefined,
+    excludeRequestId: input.sourceRequestId ?? undefined,
   });
-  if (conflicts.length > 0 && !input.overrideReason?.trim()) {
+  if (
+    conflicts.length > 0
+    && (!input.overrideConflicts || !input.overrideReason?.trim())
+  ) {
     throw new VenueReservationConflictError(conflicts);
   }
   if (conflicts.length > 0) {
@@ -599,6 +647,7 @@ export async function createVenueReservation(
       ownerVenueOrganizationId: input.ownerVenueOrganizationId ?? null,
       sourceRequestId: input.sourceRequestId ?? null,
       offeringBlockId: input.offeringBlockId ?? null,
+      sourceScheduleBlockId: input.sourceScheduleBlockId ?? null,
       createdById: input.actorId,
       transitions: {
         create: {
@@ -616,8 +665,6 @@ export async function createVenueReservation(
         },
       },
       ...(conflicts.length > 0
-        || input.surfaceId === null
-        || input.surfaceId === undefined
         ? {
             overrides: {
               create: {
@@ -629,8 +676,9 @@ export async function createVenueReservation(
                   segmentId: input.segmentId ?? null,
                   startsAt: input.startsAt.toISOString(),
                   endsAt: input.endsAt.toISOString(),
+                   legacyConflicts: legacyConflictReferences(conflicts),
                 },
-                conflictingReservationIds: conflicts.map(({ id }) => id),
+                conflictingReservationIds: canonicalConflictIds(conflicts),
               },
             },
           }
@@ -650,6 +698,7 @@ export async function createVenueReservation(
         status,
         venueId: input.venueId,
         conflictOverrideCount: conflicts.length,
+        venueWideReason: input.venueWideReason?.trim() ?? null,
       },
     },
   });
@@ -691,6 +740,7 @@ export async function transitionVenueReservation(
     reason: string;
     usageStatus?: VenueReservationUsageStatus;
     allowAssignedDisposition?: boolean;
+    overrideConflicts?: boolean;
     overrideReason?: string;
     snapshot?: Prisma.InputJsonValue;
   },
@@ -763,7 +813,7 @@ export async function transitionVenueReservation(
         "This venue reservation hold has expired.",
       );
     }
-    confirmationConflicts = await findVenueReservationConflicts(tx, {
+    confirmationConflicts = await findVenueReservationWriteConflicts(tx, {
       venueId: reservation.venueId,
       surfaceId: reservation.surfaceId,
       segmentId: reservation.segmentId,
@@ -774,7 +824,7 @@ export async function transitionVenueReservation(
     });
     if (
       confirmationConflicts.length > 0
-      && !input.overrideReason?.trim()
+      && (!input.overrideConflicts || !input.overrideReason?.trim())
     ) {
       throw new VenueReservationConflictError(confirmationConflicts);
     }
@@ -845,10 +895,9 @@ export async function transitionVenueReservation(
                   segmentId: reservation.segmentId,
                   startsAt: reservation.startsAt.toISOString(),
                   endsAt: reservation.endsAt.toISOString(),
+                  legacyConflicts: legacyConflictReferences(confirmationConflicts),
                 },
-                conflictingReservationIds: confirmationConflicts.map(
-                  ({ id }) => id,
-                ),
+                conflictingReservationIds: canonicalConflictIds(confirmationConflicts),
               },
             },
           }
@@ -992,6 +1041,8 @@ export async function assignVenueReservation(
       | "EVENT_GAME";
     targetId: string;
     actorId: string;
+    excludeReservationIds?: readonly string[];
+    overrideConflicts?: boolean;
     overrideReason?: string | null;
   },
 ) {
@@ -1037,19 +1088,58 @@ export async function assignVenueReservation(
     + reservation.signupEvents.length
     + reservation.practiceSessions.length
     + reservation.proposalEntries.length;
-  const assignmentConflicts = totalLinkCount === 0
-    ? await findVenueReservationConflicts(tx, {
+  let assignmentConflicts: Awaited<
+    ReturnType<typeof findVenueReservationWriteConflicts>
+  > = [];
+  let conflictsChecked = false;
+  const checkAssignmentConflicts = async () => {
+    if (conflictsChecked) return;
+    conflictsChecked = true;
+    assignmentConflicts = await findVenueReservationWriteConflicts(tx, {
+      venueId: reservation.venueId,
+      surfaceId: reservation.surfaceId,
+      segmentId: reservation.segmentId,
+      startsAt: reservation.startsAt,
+      endsAt: reservation.endsAt,
+      excludeReservationIds: [
+        reservation.id,
+        ...(input.excludeReservationIds ?? []),
+      ],
+      ...(input.targetType === "EVENT" ? { excludeEventId: input.targetId } : {}),
+      ...(input.targetType === "SEASON_GAME"
+        ? { excludeSeasonGameId: input.targetId }
+        : {}),
+      ...(input.targetType === "EVENT_GAME"
+        ? { excludeEventGameId: input.targetId }
+        : {}),
+      ...(input.targetType === "PRACTICE"
+        ? { excludePracticeId: input.targetId }
+        : {}),
+    });
+    if (
+      assignmentConflicts.length > 0
+      && (!input.overrideConflicts || !input.overrideReason?.trim())
+    ) {
+      throw new VenueReservationConflictError(assignmentConflicts);
+    }
+    if (assignmentConflicts.length > 0) {
+      const venue = await tx.venue.findUnique({
+        where: { id: reservation.venueId },
+        select: { organizationId: true },
+      });
+      const mayOverride = await hasVenueStaffAuthorization(tx, {
+        actorId: input.actorId,
+        organizationId: venue?.organizationId ?? null,
         venueId: reservation.venueId,
-        surfaceId: reservation.surfaceId,
-        segmentId: reservation.segmentId,
-        startsAt: reservation.startsAt,
-        endsAt: reservation.endsAt,
-        excludeReservationId: reservation.id,
-      })
-    : [];
-  if (assignmentConflicts.length > 0 && !input.overrideReason?.trim()) {
-    throw new VenueReservationConflictError(assignmentConflicts);
-  }
+        roles: ["OWNER", "MANAGER"],
+      });
+      if (!mayOverride) {
+        throw new VenueReservationLifecycleError(
+          "Conflict overrides require exact venue-manager authorization.",
+        );
+      }
+    }
+  };
   const targetSpaceMatches = (target: {
     surfaceId: string | null;
     segmentId: string | null;
@@ -1144,7 +1234,8 @@ export async function assignVenueReservation(
           "The Event does not match the venue reservation.",
         );
       }
-      if (isIdempotent) return reservation;
+      await checkAssignmentConflicts();
+      if (isIdempotent) break;
       await tx.event.update({
         where: { id: event.id },
         data: { venueReservationId: reservation.id },
@@ -1216,7 +1307,8 @@ export async function assignVenueReservation(
           "The season game does not match the venue reservation.",
         );
       }
-      if (isIdempotent) return reservation;
+      await checkAssignmentConflicts();
+      if (isIdempotent) break;
       await tx.seasonGame.update({
         where: { id: game.id },
         data: { venueReservationId: reservation.id },
@@ -1274,7 +1366,8 @@ export async function assignVenueReservation(
           "The practice does not match the venue reservation.",
         );
       }
-      if (isIdempotent) return reservation;
+      await checkAssignmentConflicts();
+      if (isIdempotent) break;
       await tx.practiceSession.update({
         where: { id: practice.id },
         data: { venueReservationId: reservation.id },
@@ -1355,7 +1448,8 @@ export async function assignVenueReservation(
           "The signup event does not match the venue reservation.",
         );
       }
-      if (isIdempotent) return reservation;
+      await checkAssignmentConflicts();
+      if (isIdempotent) break;
       await tx.signupEvent.update({
         where: { id: event.id },
         data: { venueReservationId: reservation.id },
@@ -1447,7 +1541,8 @@ export async function assignVenueReservation(
           "The event game does not match the venue reservation.",
         );
       }
-      if (isIdempotent) return reservation;
+      await checkAssignmentConflicts();
+      if (isIdempotent) break;
       await tx.eventGame.update({
         where: { id: game.id },
         data: { venueReservationId: reservation.id },
@@ -1474,10 +1569,9 @@ export async function assignVenueReservation(
                   endsAt: reservation.endsAt.toISOString(),
                   targetType: input.targetType,
                   targetId: input.targetId,
+                  legacyConflicts: legacyConflictReferences(assignmentConflicts),
                 },
-                conflictingReservationIds: assignmentConflicts.map(
-                  ({ id }) => id,
-                ),
+                conflictingReservationIds: canonicalConflictIds(assignmentConflicts),
               },
             },
           }
@@ -1514,5 +1608,8 @@ export async function assignVenueReservation(
       },
     });
   }
-  return updated;
+  return {
+    ...updated,
+    conflictsOverridden: assignmentConflicts.length > 0,
+  };
 }

--- a/lib/utils/availability.ts
+++ b/lib/utils/availability.ts
@@ -1,6 +1,7 @@
 import { prisma } from "@/lib/db/prisma";
 import { expandRecurrenceWindow } from "@/lib/utils/venue-schedule";
 import type { BookingConflict, VenueBookingView } from "@/types/segments";
+import type { Prisma } from "@prisma/client";
 
 /**
  * Unified venue availability engine (feature 006 + feature 007 dual-read).
@@ -49,7 +50,10 @@ export type AvailabilityCandidate = {
   excludeEventGameId?: string;
   excludeBlockId?: string;
   excludePracticeId?: string;
+  excludeReservationIds?: readonly string[];
 };
+
+type AvailabilityClient = Prisma.TransactionClient;
 
 type FetchParams = {
   venueId: string;
@@ -72,7 +76,29 @@ type FetchParams = {
  * by startAt ascending.
  */
 export async function findBookingConflicts(
-  candidate: AvailabilityCandidate
+  candidate: AvailabilityCandidate,
+  client: AvailabilityClient = prisma as unknown as AvailabilityClient,
+): Promise<BookingConflict[]> {
+  return findBookingConflictsFromSources(candidate, client, true);
+}
+
+/**
+ * Reservation writers use this inside their serializable transaction while
+ * canonical rows are checked by the reservation-native detector. Keeping the
+ * legacy half separate avoids querying and reporting canonical reservations
+ * twice while the dual-read rollout is active.
+ */
+export async function findUnlinkedLegacyBookingConflicts(
+  candidate: AvailabilityCandidate,
+  client: AvailabilityClient,
+): Promise<BookingConflict[]> {
+  return findBookingConflictsFromSources(candidate, client, false);
+}
+
+async function findBookingConflictsFromSources(
+  candidate: AvailabilityCandidate,
+  client: AvailabilityClient,
+  includeReservations: boolean,
 ): Promise<BookingConflict[]> {
   const surfaceId = candidate.surfaceId ?? null;
   // A segment is only meaningful with a surface; without one the candidate
@@ -93,16 +119,18 @@ export async function findBookingConflicts(
 
   const [reservations, events, seasonGames, eventGames, scheduleBlocks, practices, coexistenceKeys] =
     await Promise.all([
-      fetchVenueReservations(params),
-      fetchEvents(params),
-      fetchSeasonGames(params),
-      fetchEventGames(params),
-      fetchScheduleBlocks(params),
-      fetchPracticeSessions(params),
+      includeReservations
+        ? fetchVenueReservations(client, params, candidate.excludeReservationIds)
+        : Promise.resolve([]),
+      fetchEvents(client, params),
+      fetchSeasonGames(client, params),
+      fetchEventGames(client, params),
+      fetchScheduleBlocks(client, params),
+      fetchPracticeSessions(client, params),
       // Coexistence only matters when both sides carry segments (rule 4);
       // whole-surface or venue-wide candidates conflict without consulting it.
       segmentId && surfaceId
-        ? loadCoexistenceKeys(surfaceId)
+        ? loadCoexistenceKeys(client, surfaceId)
         : Promise.resolve(new Set<string>()),
     ]);
 
@@ -125,6 +153,7 @@ export async function getVenueBookings(params: {
   from: Date;
   to: Date;
 }): Promise<VenueBookingView[]> {
+  const client = prisma as unknown as AvailabilityClient;
   const fetchParams: FetchParams = {
     venueId: params.venueId,
     windowStart: params.from,
@@ -132,12 +161,12 @@ export async function getVenueBookings(params: {
   };
 
   const [reservations, events, seasonGames, eventGames, scheduleBlocks, practices] = await Promise.all([
-    fetchVenueReservations(fetchParams),
-    fetchEvents(fetchParams),
-    fetchSeasonGames(fetchParams),
-    fetchEventGames(fetchParams),
-    fetchScheduleBlocks(fetchParams),
-    fetchPracticeSessions(fetchParams),
+    fetchVenueReservations(client, fetchParams),
+    fetchEvents(client, fetchParams),
+    fetchSeasonGames(client, fetchParams),
+    fetchEventGames(client, fetchParams),
+    fetchScheduleBlocks(client, fetchParams),
+    fetchPracticeSessions(client, fetchParams),
   ]);
 
   return [...reservations, ...events, ...seasonGames, ...eventGames, ...scheduleBlocks, ...practices].sort(
@@ -173,10 +202,13 @@ function pairKey(a: string, b: string): string {
   return a < b ? `${a}\0${b}` : `${b}\0${a}`;
 }
 
-async function loadCoexistenceKeys(surfaceId: string): Promise<Set<string>> {
+async function loadCoexistenceKeys(
+  client: AvailabilityClient,
+  surfaceId: string,
+): Promise<Set<string>> {
   // Both segments of a pair belong to the same surface (validation invariant),
   // so filtering on segmentA is sufficient.
-  const pairs = await prisma.segmentCoexistence.findMany({
+  const pairs = await client.segmentCoexistence.findMany({
     where: { segmentA: { surfaceId } },
     select: { segmentAId: true, segmentBId: true },
   });
@@ -195,7 +227,9 @@ function surfaceScopeFilter(surfaceId: string | null | undefined) {
 }
 
 async function fetchVenueReservations(
+  client: AvailabilityClient,
   params: FetchParams,
+  excludeReservationIds: readonly string[] = [],
 ): Promise<VenueBookingView[]> {
   const excludedLinkedSources = [
     params.excludeEventId
@@ -214,9 +248,12 @@ async function fetchVenueReservations(
       ? { sourceScheduleBlockId: params.excludeBlockId }
       : null,
   ].filter((filter): filter is NonNullable<typeof filter> => filter !== null);
-  const reservations = await prisma.venueReservation.findMany({
+  const reservations = await client.venueReservation.findMany({
     where: {
       venueId: params.venueId,
+      ...(excludeReservationIds.length
+        ? { id: { notIn: [...excludeReservationIds] } }
+        : {}),
       status: { in: ["HELD", "CONFIRMED", "COMPLETED"] },
       startsAt: { lt: params.windowEnd },
       endsAt: { gt: params.windowStart },
@@ -255,8 +292,11 @@ async function fetchVenueReservations(
   }));
 }
 
-async function fetchEvents(params: FetchParams): Promise<VenueBookingView[]> {
-  const events = await prisma.event.findMany({
+async function fetchEvents(
+  client: AvailabilityClient,
+  params: FetchParams,
+): Promise<VenueBookingView[]> {
+  const events = await client.event.findMany({
     where: {
       venueId: params.venueId,
       venueReservationId: null,
@@ -294,8 +334,11 @@ async function fetchEvents(params: FetchParams): Promise<VenueBookingView[]> {
   }));
 }
 
-async function fetchSeasonGames(params: FetchParams): Promise<VenueBookingView[]> {
-  const games = await prisma.seasonGame.findMany({
+async function fetchSeasonGames(
+  client: AvailabilityClient,
+  params: FetchParams,
+): Promise<VenueBookingView[]> {
+  const games = await client.seasonGame.findMany({
     where: {
       venueId: params.venueId,
       venueReservationId: null,
@@ -329,8 +372,11 @@ async function fetchSeasonGames(params: FetchParams): Promise<VenueBookingView[]
   }));
 }
 
-async function fetchEventGames(params: FetchParams): Promise<VenueBookingView[]> {
-  const games = await prisma.eventGame.findMany({
+async function fetchEventGames(
+  client: AvailabilityClient,
+  params: FetchParams,
+): Promise<VenueBookingView[]> {
+  const games = await client.eventGame.findMany({
     where: {
       status: { not: "CANCELED" },
       venueReservationId: null,
@@ -366,8 +412,11 @@ async function fetchEventGames(params: FetchParams): Promise<VenueBookingView[]>
   }));
 }
 
-async function fetchScheduleBlocks(params: FetchParams): Promise<VenueBookingView[]> {
-  const blocks = await prisma.venueScheduleBlock.findMany({
+async function fetchScheduleBlocks(
+  client: AvailabilityClient,
+  params: FetchParams,
+): Promise<VenueBookingView[]> {
+  const blocks = await client.venueScheduleBlock.findMany({
     where: {
       venueId: params.venueId,
       status: "PUBLISHED",
@@ -445,8 +494,11 @@ async function fetchScheduleBlocks(params: FetchParams): Promise<VenueBookingVie
   return views;
 }
 
-async function fetchPracticeSessions(params: FetchParams): Promise<VenueBookingView[]> {
-  const practices = await prisma.practiceSession.findMany({
+async function fetchPracticeSessions(
+  client: AvailabilityClient,
+  params: FetchParams,
+): Promise<VenueBookingView[]> {
+  const practices = await client.practiceSession.findMany({
     where: {
       // Unattached practices (no venue) have no availability footprint;
       // startAt is required whenever venueId is set (application invariant),

--- a/lib/utils/event-access.ts
+++ b/lib/utils/event-access.ts
@@ -56,6 +56,47 @@ export async function canViewSignupEvent(
   }
 }
 
+/** Management access for server readers that already have the viewer id. */
+export async function isSignupEventManager(userId: string, eventId: string): Promise<boolean> {
+  const event = await prisma.signupEvent.findUnique({
+    where: { id: eventId },
+    select: { hostOrganizationId: true, hostLeagueId: true, hostTeamId: true },
+  });
+  if (!event) return false;
+
+  const [grant, leagueAdmin, teamAdmin, venueAdmin] = await Promise.all([
+    prisma.eventManager.findUnique({
+      where: { eventId_userId: { eventId, userId } },
+      select: { id: true },
+    }),
+    event.hostLeagueId
+      ? prisma.leagueUser.findFirst({
+        where: { userId, leagueId: event.hostLeagueId, role: "LEAGUE_ADMIN" },
+        select: { id: true },
+      })
+      : null,
+    event.hostTeamId
+      ? prisma.teamMember.findFirst({
+        where: { userId, teamId: event.hostTeamId, role: "ADMIN" },
+        select: { id: true },
+      })
+      : null,
+    event.hostOrganizationId
+      ? prisma.venueStaff.findFirst({
+        where: {
+          userId,
+          organizationId: event.hostOrganizationId,
+          status: "ACTIVE",
+          role: { in: ["OWNER", "MANAGER", "SCHEDULER"] },
+        },
+        select: { id: true },
+      })
+      : null,
+  ]);
+
+  return Boolean(grant || leagueAdmin || teamAdmin || venueAdmin);
+}
+
 /** Confirmed registrant (contact of record) on the event — gallery contributor. */
 export async function isConfirmedEventRegistrant(eventId: string, userId: string): Promise<boolean> {
   const count = await prisma.eventRegistration.count({

--- a/lib/utils/round-robin.ts
+++ b/lib/utils/round-robin.ts
@@ -34,6 +34,11 @@ export type ProposedGame = {
 export type RoundRobinResult = {
   games: ProposedGame[]; // slotted games in chronological order
   unslottedCount: number; // pairings that did not fit in the date range
+  unslottedPairings: Array<{
+    homeTeamId: string;
+    awayTeamId: string;
+    round: number;
+  }>;
 };
 
 const START_TIME_RE = /^([01]\d|2[0-3]):([0-5]\d)$/;
@@ -198,5 +203,9 @@ export function buildRoundRobin(input: RoundRobinInput): RoundRobinResult {
     cursor += MS_PER_DAY;
   }
 
-  return { games, unslottedCount: pairings.length - slotted };
+  return {
+    games,
+    unslottedCount: pairings.length - slotted,
+    unslottedPairings: pairings.slice(slotted),
+  };
 }

--- a/lib/utils/season-standings.ts
+++ b/lib/utils/season-standings.ts
@@ -27,16 +27,44 @@ export type SeasonStandingsRow = {
   points: number;
 };
 
+export type SeasonStandingsPlacement = {
+  teamId: string;
+  teamNameSnapshot: string;
+};
+
+/**
+ * Overlay the season's division projection while preserving the legacy team
+ * division only when no season placement exists. A placement with a null
+ * division is intentional and must clear the legacy value.
+ */
+export function overlaySeasonTeamDivisions<
+  T extends { id: string; divisionId: string | null },
+>(
+  teams: T[],
+  placements: Array<{ teamId: string; divisionId: string | null }>,
+): T[] {
+  const placementByTeam = new Map(
+    placements.map((placement) => [placement.teamId, placement.divisionId]),
+  );
+  return teams.map((team) =>
+    placementByTeam.has(team.id)
+      ? { ...team, divisionId: placementByTeam.get(team.id) ?? null }
+      : team,
+  );
+}
+
 export function computeSeasonStandings(
   teams: Array<{ id: string; name: string }>,
-  games: SeasonStandingsGame[]
+  games: SeasonStandingsGame[],
+  placements: SeasonStandingsPlacement[] = [],
 ): SeasonStandingsRow[] {
+  const placementByTeam = new Map(placements.map((placement) => [placement.teamId, placement]));
   const rows = new Map<string, SeasonStandingsRow>(
     teams.map((team) => [
       team.id,
       {
         teamId: team.id,
-        teamName: team.name,
+        teamName: placementByTeam.get(team.id)?.teamNameSnapshot || team.name,
         gamesPlayed: 0,
         wins: 0,
         losses: 0,

--- a/lib/utils/validation.ts
+++ b/lib/utils/validation.ts
@@ -447,6 +447,7 @@ const baseEventSchema = z.object({
   }).optional(),
   location: sanitizedStringWithMin(1, 200).refine(val => val.length > 0, "Location is required"),
   venueId: z.string().cuid("Invalid venue ID format").optional().or(z.literal("")),
+  reservationId: optionalCuid("Invalid reservation ID format"),
   timezone: optionalTimeZoneSchema,
   opponent: optionalSanitizedString(100),
   notes: optionalSanitizedString(1000),
@@ -454,9 +455,22 @@ const baseEventSchema = z.object({
   // Proceed despite venue booking conflicts; the override is recorded on the
   // event (conflictOverriddenBy/At — 006 FR-011).
   overrideConflicts: z.boolean().default(false),
+  overrideReason: optionalSanitizedString(1000),
 });
 
+const venueEventHasEndAt = (data: { venueId?: string; endAt?: Date }) =>
+  !data.venueId || Boolean(data.endAt);
+
 export const createEventSchema = baseEventSchema
+  .superRefine((data, context) => {
+    if (data.overrideConflicts && !data.overrideReason) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "A reason is required to override conflicts",
+        path: ["overrideReason"],
+      });
+    }
+  })
   .refine(
     (data) => {
       // Validate date is not in the past
@@ -480,6 +494,10 @@ export const createEventSchema = baseEventSchema
       path: ["endAt"],
     }
   )
+  .refine(venueEventHasEndAt, {
+    message: "End date and time is required when a venue is selected",
+    path: ["endAt"],
+  })
   .refine(
     (data) => {
       // Require opponent field for GAME type
@@ -521,6 +539,10 @@ export const updateEventSchema = baseEventSchema
       path: ["endAt"],
     }
   )
+  .refine(venueEventHasEndAt, {
+    message: "End date and time is required when a venue is selected",
+    path: ["endAt"],
+  })
   .refine(
     (data) => {
       // Require opponent field for GAME type
@@ -1305,6 +1327,7 @@ const practiceVenueAttachmentFields = {
   venueId: optionalCuid("Invalid venue ID format"),
   surfaceId: optionalCuid("Invalid surface ID format"),
   segmentId: optionalCuid("Invalid segment ID format"),
+  reservationId: optionalCuid("Invalid reservation ID format"),
   startAt: z.coerce.date().optional(),
   overrideConflicts: z.boolean().default(false),
 };
@@ -1671,6 +1694,8 @@ export const eventGameSchema = z
     endAt: z.coerce.date({ message: "Valid game end time is required" }),
     surfaceId: optionalCuid("Invalid surface ID format"),
     segmentId: optionalCuid("Invalid segment ID format"),
+    reservationId: optionalCuid("Invalid reservation ID format"),
+    venueId: optionalCuid("Invalid venue ID format"),
     notes: optionalSanitizedString(500),
     // Proceed despite venue booking conflicts; the override is recorded on
     // the game (conflictOverriddenBy/At — 006 FR-011).
@@ -1764,6 +1789,12 @@ export const SCHEDULE_FORMATS = [
 ] as const;
 
 export const SEASON_PHASE_TYPES = ["PRE_SEASON", "REGULAR_SEASON", "PLAYOFFS", "CUSTOM"] as const;
+export const SEASON_SCHEDULE_VISIBILITIES = [
+  "PUBLIC",
+  "AUTHENTICATED",
+  "RELATIONSHIP_ONLY",
+  "PRIVATE",
+] as const;
 
 // Owner is resolved and authorized server-side; exactly one of leagueId/teamId.
 export const createSeasonSchema = z
@@ -1772,6 +1803,7 @@ export const createSeasonSchema = z
     description: optionalSanitizedString(1000),
     startDate: z.coerce.date({ message: "Valid start date is required" }),
     endDate: z.coerce.date({ message: "Valid end date is required" }),
+    scheduleVisibility: z.enum(SEASON_SCHEDULE_VISIBILITIES).default("PRIVATE"),
     leagueId: optionalCuid("Invalid league ID format"),
     teamId: optionalCuid("Invalid team ID format"),
   })
@@ -1794,6 +1826,7 @@ export const updateSeasonSchema = z
     endDate: z.coerce.date().optional(),
     format: z.enum(SCHEDULE_FORMATS).nullable().optional(),
     formatRounds: z.coerce.number().int().min(1).max(4).nullable().optional(),
+    scheduleVisibility: z.enum(SEASON_SCHEDULE_VISIBILITIES).optional(),
   })
   .refine((data) => !data.startDate || !data.endDate || data.endDate >= data.startDate, {
     message: "End date must be on or after the start date",
@@ -1852,6 +1885,8 @@ const seasonGameFields = {
   segmentId: optionalCuid("Invalid segment ID format"),
   locationText: optionalSanitizedString(255),
   notes: optionalSanitizedString(1000),
+  reservationId: optionalCuid("Invalid venue reservation ID"),
+  overrideReason: optionalSanitizedString(1000),
 };
 
 export const createSeasonGameSchema = z
@@ -1882,6 +1917,8 @@ export const updateSeasonGameSchema = z
     segmentId: optionalCuid("Invalid segment ID format").nullable(),
     locationText: optionalSanitizedString(255),
     notes: optionalSanitizedString(1000),
+    reservationId: optionalCuid("Invalid venue reservation ID").nullable(),
+    overrideReason: optionalSanitizedString(1000),
     overrideConflicts: z.boolean().default(false),
   })
   .refine((data) => !data.startAt || !data.endAt || data.endAt > data.startAt, {
@@ -1896,6 +1933,16 @@ export const seasonGameCommandSchema = z.object({
 export const publishSeasonGamesSchema = z.object({
   seasonId: z.string().cuid("Invalid season ID format"),
   gameIds: z.array(z.string().cuid("Invalid game ID format")).max(200).optional(),
+  overrideConflicts: z.boolean().default(false),
+  overrideReason: optionalSanitizedString(1000),
+}).superRefine((value, context) => {
+  if (value.overrideConflicts && !value.overrideReason) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "A reason is required to override conflicts",
+      path: ["overrideReason"],
+    });
+  }
 });
 
 export const recordSeasonGameScoreSchema = z.object({
@@ -1975,7 +2022,17 @@ export const counterGameProposalSchema = z
 
 export const acceptGameProposalSchema = z.object({
   proposalId: z.string().cuid("Invalid proposal ID format"),
+  reservationId: optionalCuid("Invalid venue reservation ID"),
   overrideConflicts: z.boolean().default(false),
+  overrideReason: optionalSanitizedString(1000),
+}).superRefine((value, context) => {
+  if (value.overrideConflicts && !value.overrideReason) {
+    context.addIssue({
+      code: "custom",
+      message: "A reason is required to override conflicts",
+      path: ["overrideReason"],
+    });
+  }
 });
 
 export const declineGameProposalSchema = z.object({

--- a/prisma/migrations/20260817140000_add_season_team_placements/migration.sql
+++ b/prisma/migrations/20260817140000_add_season_team_placements/migration.sql
@@ -1,0 +1,52 @@
+-- Add season-specific placement projection and schedule visibility.
+-- PlacementDecision remains the append-only history; this table is the current
+-- season/team projection used by season readers.
+
+BEGIN;
+
+CREATE TYPE "SeasonScheduleVisibility" AS ENUM (
+  'PUBLIC',
+  'AUTHENTICATED',
+  'RELATIONSHIP_ONLY',
+  'PRIVATE'
+);
+
+ALTER TABLE "seasons"
+  ADD COLUMN "scheduleVisibility" "SeasonScheduleVisibility" NOT NULL DEFAULT 'PRIVATE';
+
+CREATE TABLE "season_team_placements" (
+  "id" TEXT NOT NULL,
+  "seasonId" TEXT NOT NULL,
+  "teamId" TEXT NOT NULL,
+  "divisionId" TEXT,
+  "teamNameSnapshot" TEXT NOT NULL,
+  "divisionNameSnapshot" TEXT,
+  "rank" INTEGER,
+  "privateNote" TEXT,
+  "placedById" TEXT NOT NULL,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+
+  CONSTRAINT "season_team_placements_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "season_team_placements_rank_check"
+    CHECK ("rank" IS NULL OR "rank" > 0)
+);
+
+CREATE UNIQUE INDEX "season_team_placements_seasonId_teamId_key"
+  ON "season_team_placements"("seasonId", "teamId");
+CREATE INDEX "season_team_placements_seasonId_divisionId_idx"
+  ON "season_team_placements"("seasonId", "divisionId");
+CREATE INDEX "season_team_placements_seasonId_rank_idx"
+  ON "season_team_placements"("seasonId", "rank");
+
+ALTER TABLE "season_team_placements"
+  ADD CONSTRAINT "season_team_placements_seasonId_fkey"
+  FOREIGN KEY ("seasonId") REFERENCES "seasons"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+  ADD CONSTRAINT "season_team_placements_teamId_fkey"
+  FOREIGN KEY ("teamId") REFERENCES "Team"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+  ADD CONSTRAINT "season_team_placements_divisionId_fkey"
+  FOREIGN KEY ("divisionId") REFERENCES "divisions"("id") ON DELETE SET NULL ON UPDATE CASCADE,
+  ADD CONSTRAINT "season_team_placements_placedById_fkey"
+  FOREIGN KEY ("placedById") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+COMMIT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -49,6 +49,7 @@ model User {
   createdGameProposals         GameProposal[]               @relation("GameProposalCreator")
   gameProposalEntries          GameProposalEntry[]          @relation("GameProposalActor")
   placementDecisions           PlacementDecision[]          @relation("PlacementDecider")
+  seasonTeamPlacements         SeasonTeamPlacement[]        @relation("SeasonPlacementActor")
   createdVenueOrganizations    VenueOrganization[]          @relation("VenueOrganizationCreator")
   venueStaffMemberships        VenueStaff[]                 @relation("VenueStaffUser")
   sentVenueStaffInvites        VenueStaff[]                 @relation("VenueStaffInviter")
@@ -208,6 +209,7 @@ model Team {
   proposalsSent      GameProposal[]           @relation("ProposalsSent")
   proposalsReceived  GameProposal[]           @relation("ProposalsReceived")
   placementDecisions PlacementDecision[]
+  seasonPlacements   SeasonTeamPlacement[]
   venueRelationships VenueRelationship[]
   iceTimeRequests    IceTimeRequest[]
   hostedSignupEvents SignupEvent[]
@@ -596,6 +598,7 @@ model Division {
   messageTargeting   MessageTargeting[]
   signupPhases       EventRegistrationPhase[] @relation("PhaseDivisions")
   placementDecisions PlacementDecision[]
+  seasonPlacements   SeasonTeamPlacement[]
 
   @@map("divisions")
 }
@@ -2526,6 +2529,13 @@ enum GameProposalEntryKind {
   WITHDRAW
 }
 
+enum SeasonScheduleVisibility {
+  PUBLIC
+  AUTHENTICATED
+  RELATIONSHIP_ONLY
+  PRIVATE
+}
+
 // A scheduling container ("Fall 2026") owned by a league or a standalone
 // team (exactly one — DB CHECK constraint). Format is never required.
 model Season {
@@ -2538,6 +2548,7 @@ model Season {
 
   format       ScheduleFormat?
   formatRounds Int?
+  scheduleVisibility SeasonScheduleVisibility @default(PRIVATE)
 
   leagueId String?
   league   League? @relation(fields: [leagueId], references: [id], onDelete: Cascade)
@@ -2553,6 +2564,7 @@ model Season {
   phases     SeasonPhase[]
   games      SeasonGame[]
   placements PlacementDecision[]
+  teamPlacements SeasonTeamPlacement[]
   proposals  GameProposal[]
 
   @@index([leagueId, startDate])
@@ -2731,6 +2743,35 @@ model PlacementDecision {
 
   @@index([seasonId, teamId, createdAt])
   @@map("placement_decisions")
+}
+
+// Mutable current placement projection for one season/team pair. Placement
+// history remains in PlacementDecision; snapshots keep season labels stable
+// when teams or divisions are renamed later.
+model SeasonTeamPlacement {
+  id String @id @default(cuid())
+
+  seasonId String
+  season   Season @relation(fields: [seasonId], references: [id], onDelete: Cascade)
+  teamId   String
+  team     Team   @relation(fields: [teamId], references: [id], onDelete: Cascade)
+
+  divisionId         String?
+  division           Division? @relation(fields: [divisionId], references: [id], onDelete: SetNull)
+  teamNameSnapshot   String
+  divisionNameSnapshot String?
+  rank               Int?
+  privateNote        String?
+
+  placedById String
+  placedBy   User   @relation("SeasonPlacementActor", fields: [placedById], references: [id], onDelete: Restrict)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([seasonId, teamId])
+  @@index([seasonId, divisionId])
+  @@index([seasonId, rank])
+  @@map("season_team_placements")
 }
 
 // ============================================================================

--- a/scripts/backfill-season-placements.ts
+++ b/scripts/backfill-season-placements.ts
@@ -1,0 +1,182 @@
+import { prisma } from "@/lib/db/prisma";
+
+export type SeasonPlacementBackfillReport = {
+  dryRun: boolean;
+  seasonsScanned: number;
+  teamsScanned: number;
+  placementsCreated: number;
+  placementsAlreadyPresent: number;
+};
+
+export type SeasonPlacementBackfillOptions = {
+  dryRun?: boolean;
+  now?: Date;
+};
+
+/**
+ * Populate the current season/team projection without changing placement
+ * history or Team.divisionId. Existing projections are never overwritten, so
+ * this can be safely re-run after a partial deployment.
+ */
+export async function backfillSeasonPlacements(
+  options: SeasonPlacementBackfillOptions = {},
+): Promise<SeasonPlacementBackfillReport> {
+  const dryRun = options.dryRun ?? false;
+  const now = options.now ?? new Date();
+  const seasons = await prisma.season.findMany({
+    select: {
+      id: true,
+      leagueId: true,
+      teamId: true,
+      createdById: true,
+      startDate: true,
+      endDate: true,
+      archivedAt: true,
+      placements: {
+        orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+        select: {
+          id: true,
+          teamId: true,
+          divisionId: true,
+          rank: true,
+          privateNote: true,
+          decidedById: true,
+          team: { select: { name: true } },
+          division: { select: { name: true } },
+        },
+      },
+      games: {
+        select: {
+          homeTeamId: true,
+          awayTeamId: true,
+          homeTeam: { select: { name: true } },
+          awayTeam: { select: { name: true } },
+        },
+      },
+    },
+    orderBy: { id: "asc" },
+  });
+
+  const report: SeasonPlacementBackfillReport = {
+    dryRun,
+    seasonsScanned: seasons.length,
+    teamsScanned: 0,
+    placementsCreated: 0,
+    placementsAlreadyPresent: 0,
+  };
+
+  for (const season of seasons) {
+    const isCurrentApplicable =
+      season.archivedAt === null
+      && season.startDate <= now
+      && season.endDate >= now;
+    const candidateTeamIds = new Set<string>();
+    const historicalTeamNames = new Map<string, string>();
+    for (const decision of season.placements) {
+      candidateTeamIds.add(decision.teamId);
+      historicalTeamNames.set(decision.teamId, decision.team.name);
+    }
+    for (const game of season.games) {
+      candidateTeamIds.add(game.homeTeamId);
+      candidateTeamIds.add(game.awayTeamId);
+      historicalTeamNames.set(game.homeTeamId, game.homeTeam.name);
+      historicalTeamNames.set(game.awayTeamId, game.awayTeam.name);
+    }
+
+    // Team.divisionId is a compatibility default for the current roster only.
+    // Applying it to every old season would rewrite history after transfers or
+    // after new teams join the league.
+    if (isCurrentApplicable) {
+      const currentRoster = await prisma.team.findMany({
+        where: season.leagueId
+          ? { leagueId: season.leagueId }
+          : season.teamId
+            ? { id: season.teamId }
+            : { id: "" },
+        select: { id: true },
+      });
+      for (const team of currentRoster) candidateTeamIds.add(team.id);
+    }
+
+    const teams = await prisma.team.findMany({
+      where: { id: { in: [...candidateTeamIds] } },
+      select: {
+        id: true,
+        name: true,
+        divisionId: true,
+        division: { select: { name: true } },
+      },
+      orderBy: { id: "asc" },
+    });
+    report.teamsScanned += teams.length;
+
+    const latestDecisionByTeam = new Map<string, (typeof season.placements)[number]>();
+    for (const decision of season.placements) {
+      if (!latestDecisionByTeam.has(decision.teamId)) {
+        latestDecisionByTeam.set(decision.teamId, decision);
+      }
+    }
+
+    for (const team of teams) {
+      const decision = latestDecisionByTeam.get(team.id);
+      const divisionId = decision
+        ? decision.divisionId
+        : isCurrentApplicable
+          ? team.divisionId ?? null
+          : null;
+      const divisionName = decision
+        ? decision.division?.name ?? null
+        : isCurrentApplicable
+          ? team.division?.name ?? null
+          : null;
+      const placedById = decision?.decidedById ?? season.createdById;
+
+      const existing = await prisma.seasonTeamPlacement.findUnique({
+        where: { seasonId_teamId: { seasonId: season.id, teamId: team.id } },
+        select: { id: true },
+      });
+      if (existing) {
+        report.placementsAlreadyPresent += 1;
+        continue;
+      }
+
+      report.placementsCreated += 1;
+      if (dryRun) continue;
+
+      await prisma.seasonTeamPlacement.upsert({
+        where: { seasonId_teamId: { seasonId: season.id, teamId: team.id } },
+        create: {
+          seasonId: season.id,
+          teamId: team.id,
+          divisionId,
+          teamNameSnapshot: historicalTeamNames.get(team.id) ?? team.name,
+          divisionNameSnapshot: divisionName,
+          rank: decision?.rank ?? null,
+          privateNote: decision?.privateNote ?? null,
+          placedById,
+        },
+        // Never replace a projection that was written by an administrator or
+        // by a concurrent backfill run after the existence check.
+        update: {},
+      });
+    }
+  }
+
+  return report;
+}
+
+async function main() {
+  const report = await backfillSeasonPlacements({
+    dryRun: process.argv.includes("--dry-run"),
+  });
+  console.log(JSON.stringify(report, null, 2));
+}
+
+if (import.meta.main) {
+  main()
+    .catch((error) => {
+      console.error(error);
+      process.exitCode = 1;
+    })
+    .finally(() => prisma.$disconnect());
+}

--- a/specs/007-association-operations/tasks.md
+++ b/specs/007-association-operations/tasks.md
@@ -90,31 +90,31 @@ description: "Dependency-ordered implementation backlog for association operatio
 
 ### Tests
 
-- [ ] T035 [P] [US2] Add season-specific placement and historical-preservation tests to `__tests__/lib/actions/placements.test.ts`
-- [ ] T036 [P] [US2] Add reservation-driven generation and publication-time recheck tests to `__tests__/lib/actions/season-generation.test.ts`
-- [ ] T037 [P] [US2] Add shared SeasonGame/Event reservation and RSVP fan-out tests to `__tests__/lib/actions/season-games.test.ts`
-- [ ] T038 [P] [US2] Add reservation-backed proposal acceptance tests to `__tests__/lib/actions/game-proposals.test.ts`
-- [ ] T039 [P] [US2] Add EventGame/parent-signup publication tests and a complete writer-by-conflicting-source matrix to `__tests__/lib/actions/event-teams.test.ts` and `__tests__/integration/reservation-writer-matrix.test.ts`
-- [ ] T040 [P] [US2] Add venue activity/closure occurrence materialization tests to `__tests__/lib/actions/venue-schedules.test.ts`
-- [ ] T041 [P] [US2] Add canonical association schedule, privacy, contents, and slug-based ICS contract tests to `__tests__/api/public-association-ics.test.ts`
+- [X] T035 [P] [US2] Add season-specific placement and historical-preservation tests to `__tests__/lib/actions/placements.test.ts`
+- [X] T036 [P] [US2] Add reservation-driven generation and publication-time recheck tests to `__tests__/lib/actions/season-generation.test.ts`
+- [X] T037 [P] [US2] Add shared SeasonGame/Event reservation and RSVP fan-out tests to `__tests__/lib/actions/season-games.test.ts`
+- [X] T038 [P] [US2] Add reservation-backed proposal acceptance tests to `__tests__/lib/actions/game-proposals.test.ts`
+- [X] T039 [P] [US2] Add EventGame/parent-signup publication tests and a complete writer-by-conflicting-source matrix to `__tests__/lib/actions/event-teams.test.ts` and `__tests__/integration/reservation-writer-matrix.test.ts`
+- [X] T040 [P] [US2] Add venue activity/closure occurrence materialization tests to `__tests__/lib/actions/venue-schedules.test.ts`
+- [X] T041 [P] [US2] Add canonical association schedule, privacy, contents, and slug-based ICS contract tests to `__tests__/api/public-association-ics.test.ts`
 
 ### Data and Services
 
-- [ ] T042 [US2] Add `SeasonTeamPlacement` and schedule visibility to `prisma/schema.prisma`
-- [ ] T043 [US2] Create season-placement migration and constraints, then regenerate Prisma before dependent actions, in `prisma/migrations/<timestamp>_add_season_team_placements/migration.sql` with `bun run db:generate`
-- [ ] T044 [US2] Add idempotent placement backfill and snapshots to `scripts/backfill-season-placements.ts`
-- [ ] T045 [US2] Update placement actions to append history and upsert season-specific placement atomically in `lib/actions/placements.ts`
-- [ ] T046 [US2] Make standings, generation, and season detail read season-specific placement in `lib/utils/season-standings.ts`, `lib/actions/season-generation.ts`, and `lib/actions/seasons.ts`
+- [X] T042 [US2] Add `SeasonTeamPlacement` and schedule visibility to `prisma/schema.prisma`
+- [X] T043 [US2] Create season-placement migration and constraints, then regenerate Prisma before dependent actions, in `prisma/migrations/<timestamp>_add_season_team_placements/migration.sql` with `bun run db:generate`
+- [X] T044 [US2] Add idempotent placement backfill and snapshots to `scripts/backfill-season-placements.ts`
+- [X] T045 [US2] Update placement actions to append history and upsert season-specific placement atomically in `lib/actions/placements.ts`
+- [X] T046 [US2] Make standings, generation, and season detail read season-specific placement in `lib/utils/season-standings.ts`, `lib/actions/season-generation.ts`, and `lib/actions/seasons.ts`
 
 ### Writer Cutover
 
-- [ ] T047 [US2] Route manual game create/update/delete/publish through reservations and share one reservation with the generated Event in `lib/actions/season-games.ts`
-- [ ] T048 [US2] Generate draft games from confirmed unassigned reservations and recheck every item during bulk publication in `lib/actions/season-generation.ts`
-- [ ] T049 [US2] Carry and atomically assign reservation inventory during proposal acceptance in `lib/actions/game-proposals.ts`
-- [ ] T050 [US2] Route team Events, EventGames, signup publication, venue activities/closures, specialty events, and surface archival checks through reservation services in `lib/actions/events.ts`, `lib/actions/event-teams.ts`, `lib/actions/signup-events.ts`, `lib/actions/venue-schedules.ts`, `lib/actions/venue-content.ts`, and `lib/actions/venue-surfaces.ts`
-- [ ] T051 [US2] Move league/team/venue calendar, report, and ICS readers to `lib/data/schedule-items.ts` in `lib/data/calendar.ts`, `lib/actions/league-context.ts`, `lib/services/league-reporting.ts`, `app/api/leagues/[leagueId]/schedule.ics/route.ts`, and `app/api/associations/[slug]/schedule.ics/route.ts`
-- [ ] T052 [US2] Implement and privacy-test the tenant-safe operations read model for pending requests, unassigned venue reservations, stale drafts, conflicts, migration overrides, unscheduled teams, urgent gear needs, overdue gear custody, gear outbox health, and upcoming changes in `lib/data/association-operations.ts`, `__tests__/lib/data/association-operations.test.ts`, `app/(dashboard)/league/[leagueId]/operations/page.tsx`, and `components/features/association-operations/OperationalDashboard.tsx`
-- [ ] T053 [US2] Add Operations and Venue Reservations destinations without regressing merged Gear navigation in `components/features/navigation/DashboardNav.tsx` and `components/features/navigation/MobileNavigation.tsx`
+- [X] T047 [US2] Route manual game create/update/delete/publish through reservations and share one reservation with the generated Event in `lib/actions/season-games.ts`
+- [X] T048 [US2] Generate draft games from confirmed unassigned reservations and recheck every item during bulk publication in `lib/actions/season-generation.ts`
+- [X] T049 [US2] Carry and atomically assign reservation inventory during proposal acceptance in `lib/actions/game-proposals.ts`
+- [X] T050 [US2] Route team Events, EventGames, signup publication, venue activities/closures, specialty events, and surface archival checks through reservation services in `lib/actions/events.ts`, `lib/actions/event-teams.ts`, `lib/actions/signup-events.ts`, `lib/actions/venue-schedules.ts`, `lib/actions/venue-content.ts`, and `lib/actions/venue-surfaces.ts`
+- [X] T051 [US2] Move league/team/venue calendar, report, and ICS readers to `lib/data/schedule-items.ts` in `lib/data/calendar.ts`, `lib/actions/league-context.ts`, `lib/services/league-reporting.ts`, `app/api/leagues/[leagueId]/schedule.ics/route.ts`, and `app/api/associations/[slug]/schedule.ics/route.ts`
+- [X] T052 [US2] Implement and privacy-test the tenant-safe operations read model for pending requests, unassigned venue reservations, stale drafts, conflicts, migration overrides, unscheduled teams, urgent gear needs, overdue gear custody, gear outbox health, and upcoming changes in `lib/data/association-operations.ts`, `__tests__/lib/data/association-operations.test.ts`, `app/(dashboard)/league/[leagueId]/operations/page.tsx`, and `components/features/association-operations/OperationalDashboard.tsx`
+- [X] T053 [US2] Add Operations and Venue Reservations destinations without regressing merged Gear navigation in `components/features/navigation/DashboardNav.tsx` and `components/features/navigation/MobileNavigation.tsx`
 
 **Checkpoint**: Association pre-season and in-season scheduling no longer requires external ice spreadsheets.
 

--- a/types/association-operations.ts
+++ b/types/association-operations.ts
@@ -92,6 +92,19 @@ export interface AssociationScheduleItemView {
   segmentId: string | null;
   /** Participant-facing Event/RSVP destination when one exists. */
   href?: string | null;
+  eventType?: string | null;
+  location?: string | null;
+  opponent?: string | null;
+  notes?: string | null;
+  updatedAt?: Date | null;
+  teamId?: string | null;
+  teamName?: string | null;
+  divisionName?: string | null;
+  homeTeam?: { id: string; name: string } | null;
+  awayTeam?: { id: string; name: string } | null;
+  venueName?: string | null;
+  leagueId?: string | null;
+  leagueName?: string | null;
 }
 
 export interface AssociationOperationsSummaryView {

--- a/types/seasons.ts
+++ b/types/seasons.ts
@@ -2,6 +2,7 @@ import type {
   GameProposalEntryKind,
   GameProposalStatus,
   ScheduleFormat,
+  SeasonScheduleVisibility,
   SeasonGameStatus,
   SeasonPhaseType,
   Sport,
@@ -17,6 +18,7 @@ export interface SeasonSummary {
   archivedAt: Date | null;
   format: ScheduleFormat | null;
   formatRounds: number | null;
+  scheduleVisibility: SeasonScheduleVisibility;
   leagueId: string | null;
   teamId: string | null;
   sport: Sport;
@@ -67,6 +69,7 @@ export interface GameProposalEntryView {
   startAt: Date | null;
   endAt: Date | null;
   venue: { id: string; name: string } | null;
+  venueReservationId?: string | null;
   note: string | null;
   actorTeamId: string;
   createdAt: Date;


### PR DESCRIPTION
## Summary
- add season-specific team placement while preserving historical division semantics
- cut season games, generation, proposals, signup events, venue blocks, reports, calendars, and ICS feeds over to canonical reservations
- add privacy-safe association operations visibility, public association schedule export, and complete writer/conflict coverage

## Scope
Completes Feature 007 T035-T053 and the association scheduling critical path. Workforce delegation, public content, operational notifications, accountability/export, and final migration protocol remain explicit follow-on tasks T054-T110.

## Stack
4 of 4. Depends on `mbeacom-approved-ice-practices`.