### PR TITLE
feat(venue): connect approved ice to practices

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -27,6 +27,20 @@ jobs:
     name: Type-check, lint, and test
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: openleague_test
+          POSTGRES_PASSWORD: openleague_test
+          POSTGRES_DB: openleague_t018
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U openleague_test -d openleague_t018"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
     # Version-bump commits change no source; release.yml skips them the same
     # way. Scoped to `push` on purpose: `github.event.head_commit` does not
     # exist on a pull_request event, and an expression that skipped there would
@@ -35,6 +49,9 @@ jobs:
     if: ${{ github.event_name != 'push' || !contains(github.event.head_commit.message, '[skip ci]') }}
 
     env:
+      # Dedicated ephemeral service database for PostgreSQL-backed integration
+      # tests. It is never pointed at a shared or secret-backed environment.
+      TEST_DATABASE_URL: postgresql://openleague_test:openleague_test@localhost:5432/openleague_t018
       # Prisma client generation runs during bun install. A real secret is used
       # when available; the fallback only satisfies generate-time URL parsing.
       DATABASE_URL: ${{ secrets.DATABASE_URL || 'postgresql://postgres:postgres@localhost:5432/openleague_ci' }}
@@ -58,6 +75,11 @@ jobs:
       # implicit in a lifecycle script.
       - name: Generate Prisma Client
         run: bun run db:generate
+
+      - name: Apply integration test database migrations
+        env:
+          DATABASE_URL: ${{ env.TEST_DATABASE_URL }}
+        run: bun run db:migrate:deploy
 
       - name: Type check
         run: bun run type-check

--- a/__tests__/components/features/venue-admin/AvailableIceBrowser.test.tsx
+++ b/__tests__/components/features/venue-admin/AvailableIceBrowser.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { AvailableIceBrowser } from "@/components/features/venue-admin/AvailableIceBrowser";
+
+describe("AvailableIceBrowser", () => {
+  it("renders staff occupancy and remaining slices without a public request action", () => {
+    render(
+      <AvailableIceBrowser
+        timeZone="America/New_York"
+        mode="staff"
+        blocks={[
+          {
+            id: "offering-1",
+            title: "Sunday ice",
+            startsAt: "2026-03-08T06:30:00.000Z",
+            endsAt: "2026-03-08T08:30:00.000Z",
+            occupancy: [
+              {
+                startsAt: "2026-03-08T06:45:00.000Z",
+                endsAt: "2026-03-08T07:15:00.000Z",
+              },
+            ],
+            remainingSlices: [
+              {
+                startsAt: "2026-03-08T06:30:00.000Z",
+                endsAt: "2026-03-08T06:45:00.000Z",
+              },
+              {
+                startsAt: "2026-03-08T07:15:00.000Z",
+                endsAt: "2026-03-08T08:30:00.000Z",
+              },
+            ],
+          },
+        ]}
+      />,
+    );
+
+    expect(
+      screen.getByText(
+        "Sun, Mar 8, 1:30 AM EST – Sun, Mar 8, 4:30 AM EDT",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Occupancy:.*1:45 AM EST.*3:15 AM EDT/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Remaining:.*1:30 AM EST.*1:45 AM EST.*3:15 AM EDT.*4:30 AM EDT/),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Request this ice" })).not.toBeInTheDocument();
+  });
+
+  it("renders public remaining slices and request action without occupancy detail", () => {
+    render(
+      <AvailableIceBrowser
+        timeZone="America/New_York"
+        mode="public"
+        blocks={[
+          {
+            id: "offering-1",
+            title: "Sunday ice",
+            startsAt: "2026-03-08T06:30:00.000Z",
+            endsAt: "2026-03-08T08:30:00.000Z",
+            remainingSlices: [
+              {
+                startsAt: "2026-03-08T06:30:00.000Z",
+                endsAt: "2026-03-08T08:30:00.000Z",
+              },
+            ],
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.queryByText(/Occupancy:/)).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Request this ice" })).toHaveStyle({
+      minHeight: "44px",
+    });
+  });
+});

--- a/__tests__/components/features/venue-admin/IceTimeRequestForm.test.tsx
+++ b/__tests__/components/features/venue-admin/IceTimeRequestForm.test.tsx
@@ -38,7 +38,18 @@ describe("ice time request components", () => {
     renderWithTheme(
       <>
         <AvailableIceBrowser
-          blocks={[{ id: "block-1", title: "Available Ice", startsAt: new Date("2026-03-01T10:00:00Z"), endsAt: new Date("2026-03-01T11:00:00Z") }]}
+          mode="public"
+          timeZone="America/New_York"
+          blocks={[{
+            id: "block-1",
+            title: "Available Ice",
+            startsAt: new Date("2026-03-01T10:00:00Z"),
+            endsAt: new Date("2026-03-01T11:00:00Z"),
+            remainingSlices: [{
+              startsAt: new Date("2026-03-01T10:00:00Z"),
+              endsAt: new Date("2026-03-01T11:00:00Z"),
+            }],
+          }]}
         />
         <IceTimeRequestForm
           scheduleBlockId="block-1"
@@ -94,12 +105,15 @@ describe("ice time request components", () => {
   it("renders private manager request queue details", () => {
     renderWithTheme(
       <IceTimeRequestQueue
+        organizationId="corg000000000000000000000"
+        venueId="cvenue0000000000000000000"
         requests={[
           {
             id: "request-1",
             contactName: "Coach One",
             contactEmail: "coach@example.com",
             status: "SUBMITTED",
+            timezone: "America/New_York",
             requestedStartAt: new Date("2026-03-01T10:00:00Z"),
             requestedEndAt: new Date("2026-03-01T11:00:00Z"),
           },

--- a/__tests__/components/features/venue-admin/IceTimeRequestQueue.test.tsx
+++ b/__tests__/components/features/venue-admin/IceTimeRequestQueue.test.tsx
@@ -1,0 +1,470 @@
+import { ThemeProvider } from "@mui/material/styles";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { IceTimeRequestQueue } from "@/components/features/venue-admin/IceTimeRequestQueue";
+import theme from "@/lib/theme";
+
+const {
+  mockAnnotateIceTimeRequest,
+  mockDecideIceTimeRequest,
+  mockCancelIceTimeRequest,
+  mockExpireIceTimeRequest,
+} = vi.hoisted(() => ({
+  mockAnnotateIceTimeRequest: vi.fn(),
+  mockDecideIceTimeRequest: vi.fn(),
+  mockCancelIceTimeRequest: vi.fn(),
+  mockExpireIceTimeRequest: vi.fn(),
+}));
+
+vi.mock("@/lib/actions/venue-requests", () => ({
+  annotateIceTimeRequest: (...args: unknown[]) => mockAnnotateIceTimeRequest(...args),
+  decideIceTimeRequest: (...args: unknown[]) => mockDecideIceTimeRequest(...args),
+  cancelIceTimeRequest: (...args: unknown[]) => mockCancelIceTimeRequest(...args),
+  expireIceTimeRequest: (...args: unknown[]) => mockExpireIceTimeRequest(...args),
+}));
+
+function renderWithTheme(component: React.ReactElement) {
+  return render(<ThemeProvider theme={theme}>{component}</ThemeProvider>);
+}
+
+const ORGANIZATION_ID = "clorgxxxxxxxxxxxxxxxxxxxxxxx";
+const VENUE_ID = "clvenxxxxxxxxxxxxxxxxxxxxxxx";
+const SURFACE_A_ID = "csurf000000000000000000000";
+const SURFACE_B_ID = "csurf111111111111111111111";
+const SEGMENT_A_ID = "csegm000000000000000000000";
+const SEGMENT_B_ID = "csegm111111111111111111111";
+
+const SURFACE_OPTIONS = [
+  {
+    id: SURFACE_A_ID,
+    name: "Rink A",
+    wholeLabel: "Full Rink A",
+    segments: [{ id: SEGMENT_A_ID, name: "Offensive Zone" }],
+  },
+  {
+    id: SURFACE_B_ID,
+    name: "Rink B",
+    wholeLabel: "Full Rink B",
+    segments: [{ id: SEGMENT_B_ID, name: "Studio Sheet" }],
+  },
+];
+
+const PENDING_REQUEST = {
+  id: "clreqxxxxxxxxxxxxxxxxxxxxxxx",
+  contactName: "Coach One",
+  contactEmail: "coach@example.com",
+  status: "SUBMITTED",
+  timezone: "America/New_York",
+  requestedStartAt: new Date("2026-03-01T10:00:00Z"),
+  requestedEndAt: new Date("2026-03-01T11:00:00Z"),
+  requestedSurfaceId: SURFACE_A_ID,
+  requestedSurfaceName: "Rink A",
+  requestedSegmentId: SEGMENT_A_ID,
+  requestedSegmentName: "Offensive Zone",
+  approvedSurfaceId: null,
+  approvedSegmentId: null,
+};
+
+const VENUE_WIDE_REQUEST = {
+  ...PENDING_REQUEST,
+  id: "clreqvenuewidexxxxxxxxxxxxx",
+  requestedSurfaceId: null,
+  requestedSurfaceName: null,
+  requestedSegmentId: null,
+  requestedSegmentName: null,
+};
+
+const ACCEPTED_REQUEST_WITH_RESERVATION = {
+  id: "clreqacceptedxxxxxxxxxxxxxx",
+  contactName: "Coach Two",
+  contactEmail: "coach2@example.com",
+  status: "PARTIALLY_ACCEPTED",
+  timezone: "America/New_York",
+  requestedStartAt: new Date("2026-03-02T10:00:00Z"),
+  requestedEndAt: new Date("2026-03-02T11:00:00Z"),
+  requestedSurfaceId: SURFACE_A_ID,
+  requestedSurfaceName: "Rink A",
+  requestedSegmentId: null,
+  requestedSegmentName: null,
+  approvedStartAt: new Date("2026-03-02T10:00:00Z"),
+  approvedEndAt: new Date("2026-03-02T10:30:00Z"),
+  approvedSurfaceId: SURFACE_B_ID,
+  approvedSurfaceName: "Rink B",
+  approvedSegmentId: SEGMENT_B_ID,
+  approvedSegmentName: "Studio Sheet",
+  reservation: {
+    id: "clresxxxxxxxxxxxxxxxxxxxxxx",
+    status: "CONFIRMED",
+    venueName: "North Rink",
+    surfaceName: "Rink B",
+    segmentName: "Studio Sheet",
+  },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockDecideIceTimeRequest.mockResolvedValue({
+    success: true,
+    data: { requestId: PENDING_REQUEST.id, status: "ACCEPTED", decidedAt: new Date() },
+  });
+  mockCancelIceTimeRequest.mockResolvedValue({
+    success: true,
+    data: { requestId: PENDING_REQUEST.id, status: "CANCELED" },
+  });
+  mockExpireIceTimeRequest.mockResolvedValue({
+    success: true,
+    data: { requestId: PENDING_REQUEST.id, status: "EXPIRED" },
+  });
+  mockAnnotateIceTimeRequest.mockResolvedValue({
+    success: true,
+    data: { requestId: PENDING_REQUEST.id, decisionMessage: "Saved" },
+  });
+});
+
+describe("IceTimeRequestQueue", () => {
+  it("renders baseline queue details and the empty state", () => {
+    const { rerender } = renderWithTheme(
+      <IceTimeRequestQueue
+        organizationId={ORGANIZATION_ID}
+        venueId={VENUE_ID}
+        venueName="North Rink"
+        venueTimeZone="America/New_York"
+        surfaceOptions={SURFACE_OPTIONS}
+        requests={[PENDING_REQUEST]}
+      />,
+    );
+
+    expect(screen.getByText("Request queue")).toBeInTheDocument();
+    expect(screen.getByText("Coach One")).toBeInTheDocument();
+    expect(screen.getByText("coach@example.com")).toBeInTheDocument();
+    expect(screen.getByText(/Requested space: Rink A \/ Offensive Zone/)).toBeInTheDocument();
+
+    rerender(
+      <ThemeProvider theme={theme}>
+        <IceTimeRequestQueue
+          organizationId={ORGANIZATION_ID}
+          venueId={VENUE_ID}
+          venueName="North Rink"
+          venueTimeZone="America/New_York"
+          surfaceOptions={SURFACE_OPTIONS}
+          requests={[]}
+        />
+      </ThemeProvider>,
+    );
+
+    expect(screen.getByText("No ice time requests yet.")).toBeInTheDocument();
+  });
+
+  it("fully approves a request with the exact requested interval and space", async () => {
+    const user = userEvent.setup();
+    renderWithTheme(
+      <IceTimeRequestQueue
+        organizationId={ORGANIZATION_ID}
+        venueId={VENUE_ID}
+        venueName="North Rink"
+        venueTimeZone="America/New_York"
+        surfaceOptions={SURFACE_OPTIONS}
+        requests={[PENDING_REQUEST]}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /approve in full/i }));
+
+    expect(mockDecideIceTimeRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        organizationId: ORGANIZATION_ID,
+        venueId: VENUE_ID,
+        requestId: PENDING_REQUEST.id,
+        status: "ACCEPTED",
+        approvedSurfaceId: SURFACE_A_ID,
+        approvedSegmentId: SEGMENT_A_ID,
+      }),
+    );
+    expect(mockDecideIceTimeRequest.mock.calls[0][0].approvedStartAt).toBeInstanceOf(Date);
+    expect(mockDecideIceTimeRequest.mock.calls[0][0].approvedEndAt).toBeInstanceOf(Date);
+  });
+
+  it("shows partial/full semantics and limits a segment request to its exact requested space", async () => {
+    const user = userEvent.setup();
+    renderWithTheme(
+      <IceTimeRequestQueue
+        organizationId={ORGANIZATION_ID}
+        venueId={VENUE_ID}
+        venueName="North Rink"
+        venueTimeZone="America/New_York"
+        surfaceOptions={SURFACE_OPTIONS}
+        requests={[PENDING_REQUEST]}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /partially approve/i }));
+    expect(screen.getByText(/will stay a full acceptance/i)).toBeInTheDocument();
+
+    await user.clear(screen.getByLabelText(/approved end/i));
+    await user.type(screen.getByLabelText(/approved end/i), "2026-03-01T10:30");
+    expect(screen.getByText(/makes this a partial acceptance/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("combobox", { name: /approved surface/i }));
+    expect(screen.queryByRole("option", { name: "Rink B" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: "Venue-wide" })).not.toBeInTheDocument();
+    await user.click(screen.getByRole("option", { name: "Rink A" }));
+    await user.click(screen.getByRole("combobox", { name: /approved segment/i }));
+    expect(screen.queryByRole("option", { name: "Full Rink A" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: "Studio Sheet" })).not.toBeInTheDocument();
+    await user.click(screen.getByRole("option", { name: "Offensive Zone" }));
+    await user.click(screen.getByRole("button", { name: /confirm partial approval/i }));
+
+    expect(mockDecideIceTimeRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        organizationId: ORGANIZATION_ID,
+        venueId: VENUE_ID,
+        requestId: PENDING_REQUEST.id,
+        status: "PARTIALLY_ACCEPTED",
+        approvedSurfaceId: SURFACE_A_ID,
+        approvedSegmentId: SEGMENT_A_ID,
+      }),
+    );
+  });
+
+  it("allows a venue-wide request to narrow to any surface and segment", async () => {
+    const user = userEvent.setup();
+    renderWithTheme(
+      <IceTimeRequestQueue
+        organizationId={ORGANIZATION_ID}
+        venueId={VENUE_ID}
+        venueName="North Rink"
+        venueTimeZone="America/New_York"
+        surfaceOptions={SURFACE_OPTIONS}
+        requests={[VENUE_WIDE_REQUEST]}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /partially approve/i }));
+    await user.click(screen.getByRole("combobox", { name: /approved surface/i }));
+    await user.click(screen.getByRole("option", { name: "Rink B" }));
+    await user.click(screen.getByRole("combobox", { name: /approved segment/i }));
+    await user.click(screen.getByRole("option", { name: "Studio Sheet" }));
+    await user.click(screen.getByRole("button", { name: /confirm partial approval/i }));
+
+    expect(mockDecideIceTimeRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        approvedSurfaceId: SURFACE_B_ID,
+        approvedSegmentId: SEGMENT_B_ID,
+      }),
+    );
+  });
+
+  it("allows a whole-surface request to narrow only within the same surface", async () => {
+    const user = userEvent.setup();
+    renderWithTheme(
+      <IceTimeRequestQueue
+        organizationId={ORGANIZATION_ID}
+        venueId={VENUE_ID}
+        venueName="North Rink"
+        venueTimeZone="America/New_York"
+        surfaceOptions={SURFACE_OPTIONS}
+        requests={[{
+          ...PENDING_REQUEST,
+          requestedSegmentId: null,
+          requestedSegmentName: null,
+        }]}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /partially approve/i }));
+    await user.click(screen.getByRole("combobox", { name: /approved surface/i }));
+    expect(screen.queryByRole("option", { name: "Rink B" })).not.toBeInTheDocument();
+    await user.click(screen.getByRole("option", { name: "Rink A" }));
+    await user.click(screen.getByRole("combobox", { name: /approved segment/i }));
+    expect(screen.getByRole("option", { name: "Full Rink A" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Offensive Zone" })).toBeInTheDocument();
+  });
+
+  it("requires an intentional venue-wide claim confirmation and reason, then sends them to the action", async () => {
+    const user = userEvent.setup();
+    renderWithTheme(
+      <IceTimeRequestQueue
+        organizationId={ORGANIZATION_ID}
+        venueId={VENUE_ID}
+        venueName="North Rink"
+        venueTimeZone="America/New_York"
+        surfaceOptions={SURFACE_OPTIONS}
+        requests={[VENUE_WIDE_REQUEST]}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /approve in full/i }));
+    await user.click(screen.getByRole("button", { name: /confirm full approval/i }));
+
+    expect(screen.getByText(/Confirm the intentional venue-wide claim/i)).toBeInTheDocument();
+    expect(mockDecideIceTimeRequest).not.toHaveBeenCalled();
+
+    await user.click(
+      screen.getByRole("checkbox", {
+        name: /I intentionally want a venue-wide claim that blocks every surface/i,
+      }),
+    );
+    await user.type(screen.getByLabelText(/^reason$/i), "Festival ice blocks the whole venue");
+    await user.click(screen.getByRole("button", { name: /confirm full approval/i }));
+
+    expect(mockDecideIceTimeRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requestId: VENUE_WIDE_REQUEST.id,
+        status: "ACCEPTED",
+        approvedSurfaceId: null,
+        approvedSegmentId: null,
+        intentionalVenueWideClaim: true,
+        overrideReason: "Festival ice blocks the whole venue",
+      }),
+    );
+  });
+
+  it("requires a reason for conflict overrides and passes the override fields to the action", async () => {
+    const user = userEvent.setup();
+    renderWithTheme(
+      <IceTimeRequestQueue
+        organizationId={ORGANIZATION_ID}
+        venueId={VENUE_ID}
+        venueName="North Rink"
+        venueTimeZone="America/New_York"
+        surfaceOptions={SURFACE_OPTIONS}
+        requests={[PENDING_REQUEST]}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /partially approve/i }));
+    await user.click(screen.getByRole("checkbox", { name: /override conflicts/i }));
+    await user.click(screen.getByRole("button", { name: /confirm full approval/i }));
+
+    expect(screen.getByText(/Enter a reason for this approval/i)).toBeInTheDocument();
+    expect(mockDecideIceTimeRequest).not.toHaveBeenCalled();
+
+    await user.type(screen.getByLabelText(/^reason$/i), "Scheduler confirmed the overlap is intentional");
+    await user.click(screen.getByRole("button", { name: /confirm full approval/i }));
+
+    expect(mockDecideIceTimeRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        overrideConflicts: true,
+        overrideReason: "Scheduler confirmed the overlap is intentional",
+      }),
+    );
+  });
+
+  it("renders server validation failures returned by decideIceTimeRequest", async () => {
+    mockDecideIceTimeRequest.mockResolvedValueOnce({
+      success: false,
+      error: "Venue-wide reservations require venue-manager authorization.",
+    });
+    const user = userEvent.setup();
+    renderWithTheme(
+      <IceTimeRequestQueue
+        organizationId={ORGANIZATION_ID}
+        venueId={VENUE_ID}
+        venueName="North Rink"
+        venueTimeZone="America/New_York"
+        surfaceOptions={SURFACE_OPTIONS}
+        requests={[PENDING_REQUEST]}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /approve in full/i }));
+
+    expect(await screen.findByText(/Venue-wide reservations require venue-manager authorization/i)).toBeInTheDocument();
+  });
+
+  it("declines, cancels, expires, and annotates with the exact request identity", async () => {
+    const user = userEvent.setup();
+    renderWithTheme(
+      <IceTimeRequestQueue
+        organizationId={ORGANIZATION_ID}
+        venueId={VENUE_ID}
+        venueName="North Rink"
+        venueTimeZone="America/New_York"
+        surfaceOptions={SURFACE_OPTIONS}
+        requests={[ACCEPTED_REQUEST_WITH_RESERVATION]}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /decline/i }));
+    await user.type(screen.getByLabelText(/decision message/i), "No longer available");
+    await user.click(screen.getByRole("button", { name: /confirm decline/i }));
+
+    expect(mockDecideIceTimeRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requestId: ACCEPTED_REQUEST_WITH_RESERVATION.id,
+        status: "DECLINED",
+        decisionMessage: "No longer available",
+      }),
+    );
+
+    await user.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(mockCancelIceTimeRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ requestId: ACCEPTED_REQUEST_WITH_RESERVATION.id }),
+    );
+
+    await user.click(screen.getByRole("button", { name: /expire/i }));
+    expect(mockExpireIceTimeRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ requestId: ACCEPTED_REQUEST_WITH_RESERVATION.id }),
+    );
+
+    await user.type(screen.getByLabelText(/internal note/i), "Flood crew confirmed split-sheet setup.");
+    await user.click(screen.getByRole("button", { name: /save note/i }));
+    expect(mockAnnotateIceTimeRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requestId: ACCEPTED_REQUEST_WITH_RESERVATION.id,
+        decisionMessage: "Flood crew confirmed split-sheet setup.",
+      }),
+    );
+  });
+
+  it("displays requested and approved space distinctly for partial approvals", () => {
+    renderWithTheme(
+      <IceTimeRequestQueue
+        organizationId={ORGANIZATION_ID}
+        venueId={VENUE_ID}
+        venueName="North Rink"
+        venueTimeZone="America/New_York"
+        surfaceOptions={SURFACE_OPTIONS}
+        requests={[ACCEPTED_REQUEST_WITH_RESERVATION]}
+      />,
+    );
+
+    const card = screen.getByText("Coach Two").closest(".MuiCard-root") as HTMLElement | null;
+    expect(card).not.toBeNull();
+    const scoped = within(card!);
+    expect(scoped.getByText(/Requested space: Rink A/)).toBeInTheDocument();
+    expect(scoped.getByText(/Approved: Rink B \/ Studio Sheet/)).toBeInTheDocument();
+  });
+
+  it("uses the venue timezone consistently across DST-sensitive rendering", () => {
+    renderWithTheme(
+      <IceTimeRequestQueue
+        organizationId={ORGANIZATION_ID}
+        venueId={VENUE_ID}
+        venueName="North Rink"
+        venueTimeZone="America/New_York"
+        surfaceOptions={SURFACE_OPTIONS}
+        requests={[
+          {
+            ...PENDING_REQUEST,
+            id: "clreqsummerxxxxxxxxxxxxxxx",
+            requestedStartAt: new Date("2026-07-10T22:00:00Z"),
+            requestedEndAt: new Date("2026-07-10T23:00:00Z"),
+          },
+          {
+            ...PENDING_REQUEST,
+            id: "clreqwinterxxxxxxxxxxxxxxx",
+            requestedStartAt: new Date("2026-01-10T23:00:00Z"),
+            requestedEndAt: new Date("2026-01-11T00:00:00Z"),
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText(/EDT/)).toBeInTheDocument();
+    expect(screen.getByText(/EST/)).toBeInTheDocument();
+    expect(screen.getAllByText(/America\/New_York/)[0]).toBeInTheDocument();
+  });
+});

--- a/__tests__/integration/venue-reservation-concurrency.test.ts
+++ b/__tests__/integration/venue-reservation-concurrency.test.ts
@@ -1,0 +1,371 @@
+import { randomUUID } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+const TEST_DATABASE_URL = process.env.TEST_DATABASE_URL;
+const describeWithTestDatabase = TEST_DATABASE_URL ? describe : describe.skip;
+
+type Fixture = {
+  managerId: string;
+  requesterIds: [string, string];
+  organizationId: string;
+  venueId: string;
+  leagueId: string;
+  relationshipId: string;
+  surfaceId: string;
+  segmentIds: [string, string];
+  scheduleBlockId: string;
+  requestIds: [string, string];
+  startsAt: Date;
+  endsAt: Date;
+};
+
+function createBarrier(parties: number) {
+  let arrivals = 0;
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+
+  return async () => {
+    arrivals += 1;
+    if (arrivals === parties) {
+      release();
+    }
+    await gate;
+  };
+}
+
+describeWithTestDatabase("venue reservation concurrency (T018)", () => {
+  let prisma: any;
+  let appPrisma: { $disconnect: () => Promise<void> } | null = null;
+  let decideIceTimeRequestInTransaction: any;
+  let runVenueReservationTransaction: any;
+  const originalDatabaseUrl = process.env.DATABASE_URL;
+
+  beforeAll(async () => {
+    process.env.DATABASE_URL = TEST_DATABASE_URL;
+    vi.resetModules();
+    // The transaction helper under test does not use request/session state, but
+    // its Server Action module imports the Auth.js boundary. Keep this
+    // database integration test independent of Next's runtime-only
+    // `next/server` export while still executing the real approval transaction.
+    vi.doMock("@/lib/auth/session", () => ({
+      requireUserId: vi.fn(),
+      requireVenueRequestManager: vi.fn(),
+      requireTeamMember: vi.fn(),
+      getUserLeagueRole: vi.fn(),
+    }));
+    vi.doMock("next/cache", () => ({ revalidatePath: vi.fn() }));
+
+    const [{ PrismaClient }, dbModule, actionModule, transactionModule] =
+      await Promise.all([
+        import("@prisma/client"),
+        import("@/lib/db/prisma"),
+        import("@/lib/actions/venue-requests"),
+        import("@/lib/services/venue-reservation-transaction"),
+      ]);
+
+    const connectionString = TEST_DATABASE_URL!;
+    if (/\.neon\.tech[/:]/.test(connectionString)) {
+      const { PrismaNeon } = await import("@prisma/adapter-neon");
+      prisma = new PrismaClient({
+        adapter: new PrismaNeon({ connectionString }),
+        log: ["error"],
+      });
+    } else {
+      const { PrismaPg } = await import("@prisma/adapter-pg");
+      prisma = new PrismaClient({
+        adapter: new PrismaPg({ connectionString }),
+        log: ["error"],
+      });
+    }
+
+    appPrisma = dbModule.prisma;
+    decideIceTimeRequestInTransaction =
+      actionModule.decideIceTimeRequestInTransaction;
+    runVenueReservationTransaction =
+      transactionModule.runVenueReservationTransaction;
+  });
+
+  afterAll(async () => {
+    await Promise.allSettled([
+      prisma?.$disconnect?.() ?? Promise.resolve(),
+      appPrisma?.$disconnect?.() ?? Promise.resolve(),
+    ]);
+
+    if (originalDatabaseUrl === undefined) {
+      delete process.env.DATABASE_URL;
+    } else {
+      process.env.DATABASE_URL = originalDatabaseUrl;
+    }
+    vi.resetModules();
+  });
+
+  async function createFixture(): Promise<Fixture> {
+    const nonce = randomUUID().replaceAll("-", "").slice(0, 12);
+    const startsAt = new Date("2026-04-01T10:00:00.000Z");
+    const endsAt = new Date("2026-04-01T11:00:00.000Z");
+
+    const [manager, requesterA, requesterB] = await Promise.all([
+      prisma.user.create({
+        data: {
+          email: `t018-manager-${nonce}@example.com`,
+          passwordHash: "integration-test-hash",
+          name: `T018 Manager ${nonce}`,
+        },
+        select: { id: true },
+      }),
+      prisma.user.create({
+        data: {
+          email: `t018-requester-a-${nonce}@example.com`,
+          passwordHash: "integration-test-hash",
+          name: `T018 Requester A ${nonce}`,
+        },
+        select: { id: true },
+      }),
+      prisma.user.create({
+        data: {
+          email: `t018-requester-b-${nonce}@example.com`,
+          passwordHash: "integration-test-hash",
+          name: `T018 Requester B ${nonce}`,
+        },
+        select: { id: true },
+      }),
+    ]);
+
+    const organization = await prisma.venueOrganization.create({
+      data: {
+        name: `T018 Org ${nonce}`,
+        createdById: manager.id,
+      },
+      select: { id: true },
+    });
+    const league = await prisma.league.create({
+      data: {
+        name: `T018 League ${nonce}`,
+        contactEmail: `t018-league-${nonce}@example.com`,
+      },
+      select: { id: true },
+    });
+
+    const venue = await prisma.venue.create({
+      data: {
+        name: `T018 Venue ${nonce}`,
+        slug: `t018-${nonce}`,
+        amenities: [],
+        timezone: "UTC",
+        organizationId: organization.id,
+        createdById: manager.id,
+      },
+      select: { id: true },
+    });
+
+    const surface = await prisma.iceSurface.create({
+      data: {
+        name: `T018 Surface ${nonce}`,
+        venueId: venue.id,
+        surfaceType: "ICE",
+        isDefault: true,
+      },
+      select: { id: true },
+    });
+
+    const [segmentA, segmentB] = await Promise.all([
+      prisma.surfaceSegment.create({
+        data: {
+          name: `T018 Segment A ${nonce}`,
+          surfaceId: surface.id,
+          geometry: { x: 0, y: 0, w: 0.5, h: 1 },
+        },
+        select: { id: true },
+      }),
+      prisma.surfaceSegment.create({
+        data: {
+          name: `T018 Segment B ${nonce}`,
+          surfaceId: surface.id,
+          geometry: { x: 0.5, y: 0, w: 0.5, h: 1 },
+        },
+        select: { id: true },
+      }),
+    ]);
+
+    await prisma.venueStaff.create({
+      data: {
+        organizationId: organization.id,
+        venueId: venue.id,
+        userId: manager.id,
+        role: "REQUEST_MANAGER",
+        status: "ACTIVE",
+        joinedAt: new Date(),
+      },
+      select: { id: true },
+    });
+    const relationship = await prisma.venueRelationship.create({
+      data: {
+        venueId: venue.id,
+        leagueId: league.id,
+        relationshipType: "PREFERRED",
+        targetType: "LEAGUE",
+        status: "ACTIVE",
+        invitedById: manager.id,
+        acceptedById: manager.id,
+      },
+      select: { id: true },
+    });
+
+    const scheduleBlock = await prisma.venueScheduleBlock.create({
+      data: {
+        title: `T018 Offering ${nonce}`,
+        activityType: "TEAM_ICE",
+        status: "PUBLISHED",
+        intent: "OFFERING",
+        registrationMode: "REQUEST_REQUIRED",
+        startsAt,
+        endsAt,
+        venueId: venue.id,
+        surfaceId: surface.id,
+        createdById: manager.id,
+      },
+      select: { id: true },
+    });
+
+    const [requestA, requestB] = await Promise.all([
+      prisma.iceTimeRequest.create({
+        data: {
+          scheduleBlockId: scheduleBlock.id,
+          venueId: venue.id,
+          requesterUserId: requesterA.id,
+          requesterLeagueId: league.id,
+          contactName: "Requester A",
+          contactEmail: `t018-contact-a-${nonce}@example.com`,
+          requestedStartAt: startsAt,
+          requestedEndAt: endsAt,
+          status: "SUBMITTED",
+        },
+        select: { id: true },
+      }),
+      prisma.iceTimeRequest.create({
+        data: {
+          scheduleBlockId: scheduleBlock.id,
+          venueId: venue.id,
+          requesterUserId: requesterB.id,
+          requesterLeagueId: league.id,
+          contactName: "Requester B",
+          contactEmail: `t018-contact-b-${nonce}@example.com`,
+          requestedStartAt: startsAt,
+          requestedEndAt: endsAt,
+          status: "SUBMITTED",
+        },
+        select: { id: true },
+      }),
+    ]);
+
+    return {
+      managerId: manager.id,
+      requesterIds: [requesterA.id, requesterB.id],
+      organizationId: organization.id,
+      venueId: venue.id,
+      leagueId: league.id,
+      relationshipId: relationship.id,
+      surfaceId: surface.id,
+      segmentIds: [segmentA.id, segmentB.id],
+      scheduleBlockId: scheduleBlock.id,
+      requestIds: [requestA.id, requestB.id],
+      startsAt,
+      endsAt,
+    };
+  }
+
+  it("lets only one overlapping non-coexisting approval commit", async () => {
+    const fixture = await createFixture();
+    const synchronizeBeforeReservation = createBarrier(2);
+
+    // Reservation transitions and reservations are intentionally append-only,
+    // so deleting fixture rows would violate the production invariants this
+    // test is exercising. TEST_DATABASE_URL must therefore name a dedicated,
+    // disposable database; the test disconnects in afterAll and the harness
+    // drops that exact database/container after the run.
+    const [segmentAId, segmentBId] = fixture.segmentIds;
+    const [requestAId, requestBId] = fixture.requestIds;
+
+    const outcomes = await Promise.allSettled([
+        runVenueReservationTransaction((tx: any) =>
+          decideIceTimeRequestInTransaction(
+            tx,
+            {
+              organizationId: fixture.organizationId,
+              venueId: fixture.venueId,
+              requestId: requestAId,
+              status: "ACCEPTED",
+              approvedStartAt: fixture.startsAt,
+              approvedEndAt: fixture.endsAt,
+              approvedSegmentId: segmentAId,
+            },
+            fixture.managerId,
+            { beforeCreateReservation: synchronizeBeforeReservation },
+          )),
+        runVenueReservationTransaction((tx: any) =>
+          decideIceTimeRequestInTransaction(
+            tx,
+            {
+              organizationId: fixture.organizationId,
+              venueId: fixture.venueId,
+              requestId: requestBId,
+              status: "ACCEPTED",
+              approvedStartAt: fixture.startsAt,
+              approvedEndAt: fixture.endsAt,
+              approvedSegmentId: segmentBId,
+            },
+            fixture.managerId,
+            { beforeCreateReservation: synchronizeBeforeReservation },
+          )),
+    ]);
+
+    const activeReservations = await prisma.venueReservation.findMany({
+        where: {
+          sourceRequestId: { in: [...fixture.requestIds] },
+          status: { in: ["HELD", "CONFIRMED", "COMPLETED"] },
+        },
+        select: {
+          id: true,
+          sourceRequestId: true,
+          segmentId: true,
+          status: true,
+        },
+    });
+    expect(activeReservations).toHaveLength(1);
+    expect(activeReservations[0].status).toBe("CONFIRMED");
+    expect(fixture.requestIds).toContain(activeReservations[0].sourceRequestId);
+
+    const requestStatuses = await prisma.iceTimeRequest.findMany({
+        where: { id: { in: [...fixture.requestIds] } },
+        select: { id: true, status: true },
+    });
+    expect(
+      requestStatuses.filter(({ status }: { status: string }) =>
+        ["ACCEPTED", "PARTIALLY_ACCEPTED"].includes(status)),
+    ).toHaveLength(1);
+
+    const approved = outcomes.filter(
+      (outcome) => outcome.status === "fulfilled" && outcome.value.success,
+    );
+    expect(approved).toHaveLength(1);
+
+    const losingOutcome = outcomes.find(
+      (outcome) => !(outcome.status === "fulfilled" && outcome.value.success),
+    );
+    expect(losingOutcome).toBeDefined();
+
+    if (losingOutcome?.status === "fulfilled") {
+      expect(losingOutcome.value.success).toBe(false);
+      expect(losingOutcome.value.error).toMatch(
+        /already been accepted|different final decision/i,
+      );
+    } else {
+      expect([
+        "VenueReservationConflictError",
+        "VenueReservationContentionError",
+      ]).toContain(losingOutcome?.reason?.name);
+    }
+  });
+});

--- a/__tests__/lib/actions/practice-sessions.test.ts
+++ b/__tests__/lib/actions/practice-sessions.test.ts
@@ -1,0 +1,458 @@
+/**
+ * T020: tests for the intended reservation-aware practice-session actions.
+ *
+ * Today `createPracticeSession`/`updatePracticeSession` only ever touch the
+ * legacy `PracticeSession.venueId/surfaceId/segmentId/startAt` +
+ * `conflictOverriddenById/At` fields (feature 006) and never create an Event,
+ * RSVPs, or a `VenueReservation` link. These tests express the T032 contract
+ * this feature adds on top of that foundation: a practice that references a
+ * confirmed `VenueReservation` must atomically link both the `PracticeSession`
+ * and its participant-facing `Event` to that single reservation (so the two
+ * "linked alias" rows share one occupied slot, per
+ * `assignVenueReservation`'s alias rules in `lib/services/venue-reservations.ts`),
+ * fan out RSVPs to the roster, and require an explicit override reason when
+ * the reservation was created against a conflict.
+ *
+ * The pre-existing admin-only authorization check is exercised too (and is
+ * expected to already pass), so this file also documents which parts of the
+ * contract the current implementation already satisfies versus what T032
+ * still needs to add.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockAuth, mockTx, mockPrisma, serviceAssignVenueReservation, serviceCreateVenueReservation } = vi.hoisted(() => {
+  // Shared model mocks: today's `createPracticeSession` calls `prisma.*`
+  // directly with no `$transaction` wrapper at all, while the intended T032
+  // contract wraps every write in one atomic `prisma.$transaction(tx => ...)`.
+  // Using the *same* mock objects for both `mockPrisma` and `mockTx` lets
+  // these tests observe calls correctly under either shape, so a test only
+  // fails because the expected call never happens - not because of which
+  // client reference the (current or future) implementation calls through.
+  const models = {
+    play: { findMany: vi.fn() },
+    practiceSession: {
+      create: vi.fn(),
+      delete: vi.fn(),
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+    practiceSessionPlay: { deleteMany: vi.fn() },
+    event: {
+      create: vi.fn(),
+      delete: vi.fn(),
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+    rSVP: { createMany: vi.fn() },
+    team: { findUnique: vi.fn() },
+    teamMember: { findMany: vi.fn(), findFirst: vi.fn() },
+    leagueUser: { findFirst: vi.fn() },
+    venue: { findUnique: vi.fn() },
+    venueReservation: { findUnique: vi.fn() },
+  };
+  return {
+    mockAuth: {
+      requireTeamAdmin: vi.fn(),
+      requireTeamMember: vi.fn(),
+      requireLeagueRole: vi.fn(),
+    },
+    mockTx: models,
+    mockPrisma: {
+      $transaction: vi.fn(async (callback: (tx: typeof models) => unknown) => callback(models)),
+      ...models,
+    },
+    serviceAssignVenueReservation: vi.fn(),
+    serviceCreateVenueReservation: vi.fn(),
+  };
+});
+
+vi.mock("@/lib/auth/session", () => mockAuth);
+vi.mock("@/lib/db/prisma", () => ({ prisma: mockPrisma }));
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("@/lib/actions/venues", () => ({ canUserAccessVenue: vi.fn().mockResolvedValue(true) }));
+vi.mock("@/lib/services/venue-reservations", () => ({
+  assignVenueReservation: serviceAssignVenueReservation,
+  createVenueReservation: serviceCreateVenueReservation,
+  VenueReservationConflictError: class VenueReservationConflictError extends Error {
+    conflicts: unknown[];
+    constructor(conflicts: unknown[]) {
+      super("That venue space is no longer available.");
+      this.conflicts = conflicts;
+    }
+  },
+  VenueReservationLifecycleError: class VenueReservationLifecycleError extends Error {},
+}));
+
+import {
+  createPracticeSession,
+  deletePracticeSession,
+  updatePracticeSession,
+} from "@/lib/actions/practice-sessions";
+
+const TEAM_ID = "cteamxxxxxxxxxxxxxxxxxxxx";
+const USER_ID = "cuserxxxxxxxxxxxxxxxxxxxx";
+const RESERVATION_ID = "cresxxxxxxxxxxxxxxxxxxxxx";
+const VENUE_ID = "cvenuexxxxxxxxxxxxxxxxxxx";
+const OTHER_TEAM_ID = "cteamyyyyyyyyyyyyyyyyyyyy";
+const SESSION_ID = "csessionxxxxxxxxxxxxxxxxx";
+const EVENT_ID = "ceventxxxxxxxxxxxxxxxxxxxx";
+
+function baseInput(overrides: Record<string, unknown> = {}) {
+  return {
+    title: "Tuesday practice",
+    date: new Date("2026-04-07T22:00:00.000Z"),
+    duration: 60,
+    teamId: TEAM_ID,
+    plays: [],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockAuth.requireTeamAdmin.mockResolvedValue(USER_ID);
+  mockAuth.requireLeagueRole.mockResolvedValue(USER_ID);
+  mockTx.teamMember.findFirst.mockResolvedValue({
+    id: "cmemberxxxxxxxxxxxxxxxxxxx",
+  });
+  mockTx.leagueUser.findFirst.mockResolvedValue({
+    id: "cleagueuserxxxxxxxxxxxxxxx",
+  });
+  mockTx.venueReservation.findUnique.mockResolvedValue({
+    id: RESERVATION_ID,
+    status: "CONFIRMED",
+    venueId: VENUE_ID,
+    startsAt: new Date("2026-04-07T22:00:00.000Z"),
+    endsAt: new Date("2026-04-07T23:00:00.000Z"),
+    ownerTeamId: TEAM_ID,
+    ownerLeagueId: null,
+    ownerVenueOrganizationId: null,
+  });
+  mockTx.practiceSession.create.mockResolvedValue({
+    id: SESSION_ID,
+    title: "Tuesday practice",
+    date: new Date("2026-04-07T22:00:00.000Z"),
+  });
+  mockTx.practiceSession.findUnique.mockResolvedValue({
+    id: SESSION_ID,
+    teamId: TEAM_ID,
+    isShared: false,
+    venueReservationId: RESERVATION_ID,
+  });
+  mockTx.practiceSession.update.mockResolvedValue({
+    id: SESSION_ID,
+    title: "Tuesday practice",
+    date: new Date("2026-04-07T22:00:00.000Z"),
+  });
+  mockTx.event.create.mockResolvedValue({ id: EVENT_ID });
+  mockTx.event.findUnique.mockResolvedValue({ id: EVENT_ID });
+  mockTx.event.update.mockResolvedValue({ id: EVENT_ID });
+  mockTx.team.findUnique.mockResolvedValue({ leagueId: null });
+  mockTx.teamMember.findMany.mockResolvedValue([
+    { userId: "cmember1xxxxxxxxxxxxxxxxxx" },
+    { userId: "cmember2xxxxxxxxxxxxxxxxxx" },
+  ]);
+  mockTx.venue.findUnique.mockResolvedValue({
+    name: "Test Rink",
+    timezone: "America/New_York",
+  });
+  serviceAssignVenueReservation.mockResolvedValue({ ok: true });
+  serviceCreateVenueReservation.mockResolvedValue({ id: RESERVATION_ID, status: "CONFIRMED" });
+});
+
+describe("createPracticeSession authorization (already enforced today)", () => {
+  it("rejects a non-admin team member", async () => {
+    mockAuth.requireTeamAdmin.mockRejectedValue(new Error("Unauthorized: Only team admins can create practice sessions"));
+
+    const result = await createPracticeSession(baseInput());
+
+    expect(result.success).toBe(false);
+    expect(mockTx.practiceSession.create).not.toHaveBeenCalled();
+  });
+});
+
+describe("createPracticeSession reservation linkage (T020 / T032 intended contract)", () => {
+  it("links the created PracticeSession to the referenced confirmed reservation", async () => {
+    const result = await createPracticeSession(baseInput({ reservationId: RESERVATION_ID }));
+
+    expect(result.success).toBe(true);
+    expect(serviceAssignVenueReservation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        reservationId: RESERVATION_ID,
+        targetType: "PRACTICE",
+        targetId: SESSION_ID,
+      }),
+    );
+  });
+
+  it("atomically creates a participant-facing Event linked to the same reservation (linked alias)", async () => {
+    await createPracticeSession(baseInput({ reservationId: RESERVATION_ID }));
+
+    expect(mockTx.event.create).toHaveBeenCalled();
+    expect(serviceAssignVenueReservation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        reservationId: RESERVATION_ID,
+        targetType: "EVENT",
+        targetId: EVENT_ID,
+      }),
+    );
+    // Both PracticeSession and Event creation, plus both assignments, happen
+    // inside the one committing transaction.
+    expect(mockPrisma.$transaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps a league-owned practice participant Event scoped to the exact team", async () => {
+    const leagueId = "cleaguexxxxxxxxxxxxxxxxxx";
+    mockTx.team.findUnique.mockResolvedValue({ leagueId });
+    mockTx.venueReservation.findUnique.mockResolvedValue({
+      id: RESERVATION_ID,
+      status: "CONFIRMED",
+      venueId: VENUE_ID,
+      startsAt: new Date("2026-04-07T22:00:00.000Z"),
+      endsAt: new Date("2026-04-07T23:00:00.000Z"),
+      ownerTeamId: null,
+      ownerLeagueId: leagueId,
+      ownerVenueOrganizationId: null,
+    });
+
+    const result = await createPracticeSession(
+      baseInput({ reservationId: RESERVATION_ID }),
+    );
+
+    expect(result.success).toBe(true);
+    expect(mockTx.event.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          teamId: TEAM_ID,
+          leagueId: null,
+        }),
+      }),
+    );
+  });
+
+  it("fans out RSVPs to the full active roster once the participant-facing Event exists", async () => {
+    await createPracticeSession(baseInput({ reservationId: RESERVATION_ID }));
+
+    expect(mockTx.rSVP.createMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.arrayContaining([
+          expect.objectContaining({ eventId: EVENT_ID, userId: "cmember1xxxxxxxxxxxxxxxxxx" }),
+          expect.objectContaining({ eventId: EVENT_ID, userId: "cmember2xxxxxxxxxxxxxxxxxx" }),
+        ]),
+      }),
+    );
+  });
+
+  it("rejects a reservation that belongs to a different team (cross-tenant)", async () => {
+    mockTx.venueReservation.findUnique.mockResolvedValue({
+      id: RESERVATION_ID,
+      status: "CONFIRMED",
+      venueId: VENUE_ID,
+      startsAt: new Date("2026-04-07T22:00:00.000Z"),
+      endsAt: new Date("2026-04-07T23:00:00.000Z"),
+      ownerTeamId: OTHER_TEAM_ID,
+      ownerLeagueId: null,
+      ownerVenueOrganizationId: null,
+    });
+
+    const result = await createPracticeSession(baseInput({ reservationId: RESERVATION_ID, teamId: TEAM_ID }));
+
+    expect(result.success).toBe(false);
+    expect(serviceAssignVenueReservation).not.toHaveBeenCalled();
+  });
+
+  it("permits a league admin to assign same-league inventory when exact team admin auth is unavailable", async () => {
+    const leagueId = "cleaguexxxxxxxxxxxxxxxxxx";
+    mockAuth.requireTeamAdmin.mockRejectedValue(new Error("Unauthorized"));
+    mockTx.team.findUnique.mockResolvedValue({ leagueId });
+    mockTx.venueReservation.findUnique.mockResolvedValue({
+      id: RESERVATION_ID,
+      status: "CONFIRMED",
+      venueId: VENUE_ID,
+      startsAt: new Date("2026-04-07T22:00:00.000Z"),
+      endsAt: new Date("2026-04-07T23:00:00.000Z"),
+      ownerTeamId: null,
+      ownerLeagueId: leagueId,
+      ownerVenueOrganizationId: null,
+    });
+
+    const result = await createPracticeSession(
+      baseInput({ reservationId: RESERVATION_ID }),
+    );
+
+    expect(result.success).toBe(true);
+    expect(mockAuth.requireLeagueRole).toHaveBeenCalledWith(
+      leagueId,
+      "LEAGUE_ADMIN",
+    );
+  });
+
+  it("rejects when the referenced reservation's interval does not match the practice's date/duration", async () => {
+    mockTx.venueReservation.findUnique.mockResolvedValue({
+      id: RESERVATION_ID,
+      status: "CONFIRMED",
+      venueId: VENUE_ID,
+      startsAt: new Date("2026-04-07T18:00:00.000Z"),
+      endsAt: new Date("2026-04-07T19:00:00.000Z"),
+      ownerTeamId: TEAM_ID,
+      ownerLeagueId: null,
+      ownerVenueOrganizationId: null,
+    });
+
+    const result = await createPracticeSession(baseInput({ reservationId: RESERVATION_ID }));
+
+    expect(result.success).toBe(false);
+  });
+
+  it("creates a new reservation via the shared service (with an override reason) when no reservationId is given but a conflicting slot is explicitly overridden", async () => {
+    const result = await createPracticeSession(
+      baseInput({
+        venueId: VENUE_ID,
+        surfaceId: "csurfacexxxxxxxxxxxxxxxxx",
+        startAt: new Date("2026-04-07T22:00:00.000Z"),
+        overrideConflicts: true,
+        overrideReason: "Ice reallocated by the association scheduler",
+      }),
+    );
+
+    expect(result.success).toBe(true);
+    expect(serviceCreateVenueReservation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ overrideReason: "Ice reallocated by the association scheduler" }),
+    );
+  });
+});
+
+describe("updatePracticeSession reservation idempotency", () => {
+  it("updates the one linked Event and deduplicates RSVP fanout", async () => {
+    const input = {
+      id: SESSION_ID,
+      ...baseInput({ reservationId: RESERVATION_ID }),
+    };
+
+    const first = await updatePracticeSession(input);
+    const second = await updatePracticeSession(input);
+
+    expect(first.success).toBe(true);
+    expect(second.success).toBe(true);
+    expect(mockTx.event.create).not.toHaveBeenCalled();
+    expect(mockTx.event.update).toHaveBeenCalledTimes(2);
+    expect(mockTx.rSVP.createMany).toHaveBeenCalledTimes(2);
+    expect(mockTx.rSVP.createMany).toHaveBeenLastCalledWith(
+      expect.objectContaining({ skipDuplicates: true }),
+    );
+    expect(serviceAssignVenueReservation).not.toHaveBeenCalled();
+  });
+
+  it("allows an exact team admin to retain an unchanged league reservation without league authority", async () => {
+    const leagueId = "cleaguexxxxxxxxxxxxxxxxxx";
+    mockTx.team.findUnique.mockResolvedValue({ leagueId });
+    mockTx.venueReservation.findUnique.mockResolvedValue({
+      id: RESERVATION_ID,
+      status: "CONFIRMED",
+      venueId: VENUE_ID,
+      startsAt: new Date("2026-04-07T22:00:00.000Z"),
+      endsAt: new Date("2026-04-07T23:00:00.000Z"),
+      ownerTeamId: null,
+      ownerLeagueId: leagueId,
+      ownerVenueOrganizationId: null,
+    });
+    mockAuth.requireLeagueRole.mockRejectedValue(
+      new Error("Unauthorized: LEAGUE_ADMIN role required"),
+    );
+
+    const result = await updatePracticeSession({
+      id: SESSION_ID,
+      ...baseInput({ reservationId: RESERVATION_ID, title: "Updated title" }),
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockAuth.requireLeagueRole).not.toHaveBeenCalled();
+    expect(serviceAssignVenueReservation).not.toHaveBeenCalled();
+    expect(mockTx.event.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          teamId: TEAM_ID,
+          leagueId: null,
+        }),
+      }),
+    );
+  });
+
+  it("rejects an unchanged update if the reservation relation changes before the transaction recheck", async () => {
+    mockTx.practiceSession.findUnique
+      .mockResolvedValueOnce({
+        id: SESSION_ID,
+        teamId: TEAM_ID,
+        isShared: false,
+        venueReservationId: RESERVATION_ID,
+      })
+      .mockResolvedValueOnce({
+        id: SESSION_ID,
+        teamId: TEAM_ID,
+        venueReservationId: "cresyyyyyyyyyyyyyyyyyyyyy",
+      });
+
+    const result = await updatePracticeSession({
+      id: SESSION_ID,
+      ...baseInput({ reservationId: RESERVATION_ID }),
+    });
+
+    expect(result.success).toBe(false);
+    expect(mockTx.practiceSession.update).not.toHaveBeenCalled();
+  });
+
+  it("does not let a team admin detach league-owned inventory without league authority", async () => {
+    const leagueId = "cleaguexxxxxxxxxxxxxxxxxx";
+    mockTx.team.findUnique.mockResolvedValue({ leagueId });
+    mockTx.venueReservation.findUnique.mockResolvedValue({
+      id: RESERVATION_ID,
+      status: "CONFIRMED",
+      venueId: VENUE_ID,
+      startsAt: new Date("2026-04-07T22:00:00.000Z"),
+      endsAt: new Date("2026-04-07T23:00:00.000Z"),
+      ownerTeamId: null,
+      ownerLeagueId: leagueId,
+      ownerVenueOrganizationId: null,
+    });
+    mockAuth.requireLeagueRole.mockRejectedValue(
+      new Error("Unauthorized: LEAGUE_ADMIN role required"),
+    );
+
+    const result = await updatePracticeSession({
+      id: SESSION_ID,
+      ...baseInput({ reservationId: null }),
+    });
+
+    expect(result.success).toBe(false);
+    expect(mockTx.practiceSession.update).not.toHaveBeenCalled();
+  });
+});
+
+describe("deletePracticeSession coordinated cleanup", () => {
+  it("deletes the participant Event/RSVP alias and returns the reservation to inventory", async () => {
+    mockTx.event.findUnique.mockResolvedValue({
+      id: EVENT_ID,
+      type: "PRACTICE",
+      teamId: TEAM_ID,
+    });
+    mockTx.event.delete.mockResolvedValue({ id: EVENT_ID });
+    mockTx.practiceSession.delete.mockResolvedValue({ id: SESSION_ID });
+
+    const result = await deletePracticeSession({
+      id: SESSION_ID,
+      teamId: TEAM_ID,
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockTx.event.delete).toHaveBeenCalledWith({
+      where: { id: EVENT_ID },
+    });
+    expect(mockTx.practiceSession.delete).toHaveBeenCalledWith({
+      where: { id: SESSION_ID },
+    });
+    expect(mockTx.venueReservation.findUnique).toHaveBeenCalled();
+  });
+});

--- a/__tests__/lib/actions/venue-requests-auth.test.ts
+++ b/__tests__/lib/actions/venue-requests-auth.test.ts
@@ -68,7 +68,7 @@ describe("ice time request authorization and booking safety", () => {
     expect(mockGetUserLeagueRole).toHaveBeenCalledWith(USER_ID, LEAGUE_ID);
   });
 
-  it("rejects accepted-request double booking", async () => {
+  it("allows competing requests because canonical conflicts are decided atomically at approval", async () => {
     mockPrisma.iceTimeRequest.findFirst.mockResolvedValue({ id: "existing-request" });
 
     const result = await submitIceTimeRequest({
@@ -80,7 +80,7 @@ describe("ice time request authorization and booking safety", () => {
       requestedEndAt: "2026-03-01T11:00:00Z",
     });
 
-    expect(result.success).toBe(false);
-    expect(mockPrisma.iceTimeRequest.create).not.toHaveBeenCalled();
+    expect(result.success).toBe(true);
+    expect(mockPrisma.iceTimeRequest.create).toHaveBeenCalled();
   });
 });

--- a/__tests__/lib/actions/venue-requests.test.ts
+++ b/__tests__/lib/actions/venue-requests.test.ts
@@ -2,16 +2,38 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
 
-const { mockRequireUserId, mockRequireVenueRequestManager, mockPrisma, mockSubmitEmail, mockDecisionEmail } = vi.hoisted(() => ({
+const {
+  mockRequireUserId,
+  mockRequireVenueRequestManager,
+  mockPrisma,
+  mockSubmitEmail,
+  mockDecisionEmail,
+  mockCreateVenueReservation,
+  mockTransitionVenueReservation,
+  mockFindLegacyAcceptedRequestConflicts,
+} = vi.hoisted(() => ({
   mockRequireUserId: vi.fn(),
   mockRequireVenueRequestManager: vi.fn(),
   mockSubmitEmail: vi.fn(),
   mockDecisionEmail: vi.fn(),
+  // T023/T024 (unbuilt): `decideIceTimeRequest`/cancel/expire are expected to
+  // start calling the already-implemented reservation service atomically
+  // alongside the `IceTimeRequest` row update. Mocked here as black boxes
+  // (matching the venue-reservations.ts service boundary, not
+  // lib/auth/session.ts helpers, since that's where the real authorization
+  // and conflict logic for reservations lives).
+  mockCreateVenueReservation: vi.fn(),
+  mockTransitionVenueReservation: vi.fn(),
+  mockFindLegacyAcceptedRequestConflicts: vi.fn(),
   mockPrisma: {
     $transaction: vi.fn(),
+    venue: { findFirst: vi.fn() },
     venueScheduleBlock: { findFirst: vi.fn() },
     iceTimeRequest: { create: vi.fn(), findFirst: vi.fn(), update: vi.fn(), findMany: vi.fn() },
-    venueStaff: { findMany: vi.fn() },
+    venueStaff: { findMany: vi.fn(), findFirst: vi.fn() },
+    venueReservation: { findUnique: vi.fn(), create: vi.fn() },
+    venueReservationOverride: { create: vi.fn() },
+    notificationOutbox: { create: vi.fn(), createMany: vi.fn(), upsert: vi.fn() },
   },
 }));
 
@@ -27,6 +49,26 @@ vi.mock("@/lib/email/templates", () => ({
   sendIceTimeRequestSubmittedEmail: (...args: unknown[]) => mockSubmitEmail(...args),
   sendIceTimeRequestDecisionEmail: (...args: unknown[]) => mockDecisionEmail(...args),
 }));
+vi.mock("@/lib/services/venue-reservations", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/services/venue-reservations")>(
+    "@/lib/services/venue-reservations",
+  );
+  return {
+    ...actual,
+    createVenueReservation: mockCreateVenueReservation,
+    transitionVenueReservation: mockTransitionVenueReservation,
+  };
+});
+vi.mock("@/lib/services/venue-reservation-availability", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/lib/services/venue-reservation-availability")
+  >("@/lib/services/venue-reservation-availability");
+  return {
+    ...actual,
+    findLegacyAcceptedRequestConflicts:
+      mockFindLegacyAcceptedRequestConflicts,
+  };
+});
 
 import {
   cancelIceTimeRequest,
@@ -35,15 +77,34 @@ import {
   getVenueRequestQueue,
   submitIceTimeRequest,
 } from "@/lib/actions/venue-requests";
+import { VenueReservationConflictError } from "@/lib/services/venue-reservations";
+import {
+  assertAssociationOperationsNotificationEvent,
+  parseAssociationOperationsNotificationEvent,
+} from "@/lib/services/association-operations-notification-registry";
 
 const USER_ID = "clusrxxxxxxxxxxxxxxxxxxxxxxx";
 const ORGANIZATION_ID = "clorgxxxxxxxxxxxxxxxxxxxxxxx";
 const VENUE_ID = "clvenxxxxxxxxxxxxxxxxxxxxxxx";
 const BLOCK_ID = "clblkxxxxxxxxxxxxxxxxxxxxxxx";
 const REQUEST_ID = "clreqxxxxxxxxxxxxxxxxxxxxxxx";
+// Valid, strict 25-char CUIDs (`^c[a-z0-9]{24}$`) for the notification
+// registry's `validateCuid`, distinct from the looser 28-char fixtures
+// above that only satisfy Zod's `.cuid()` check used elsewhere.
+const STRICT_REQUEST_ID = "creq000000000000000000000";
+const STRICT_RESERVATION_ID = "cres000000000000000000000";
+const RESERVATION_ID = "clresxxxxxxxxxxxxxxxxxxxxxx";
+const SURFACE_ID = "csurf000000000000000000000";
+const SURFACE_B_ID = "csurf111111111111111111111";
+const SEGMENT_ID = "csegm000000000000000000000";
+const SEGMENT_B_ID = "csegm111111111111111111111";
 
 beforeEach(() => {
-  vi.clearAllMocks();
+  // resetAllMocks (not clearAllMocks) so a leftover queued
+  // `mockResolvedValueOnce` from a test that threw before consuming it
+  // (e.g. Zod validation rejecting an unimplemented field/status) never
+  // bleeds into the next test's first call.
+  vi.resetAllMocks();
   mockPrisma.$transaction.mockImplementation((callback) => callback(mockPrisma));
   mockRequireUserId.mockResolvedValue(USER_ID);
   mockRequireVenueRequestManager.mockResolvedValue(USER_ID);
@@ -53,10 +114,37 @@ beforeEach(() => {
     endsAt: new Date("2026-03-01T12:00:00Z"),
     status: "PUBLISHED",
     registrationMode: "REQUEST_REQUIRED",
-    venue: { id: VENUE_ID, name: "North Rink", organizationId: ORGANIZATION_ID, slug: "north-rink" },
+    recurrenceRule: null,
+    recurrenceEndDate: null,
+    venue: {
+      id: VENUE_ID,
+      name: "North Rink",
+      organizationId: ORGANIZATION_ID,
+      slug: "north-rink",
+      timezone: "America/New_York",
+    },
   });
   mockPrisma.iceTimeRequest.findFirst.mockResolvedValue(null);
+  mockPrisma.venue.findFirst.mockResolvedValue({
+    id: VENUE_ID,
+    name: "North Rink",
+    timezone: "America/New_York",
+    surfaces: [
+      {
+        id: SURFACE_ID,
+        name: "Rink A",
+        surfaceType: "ICE_RINK",
+        wholeLabel: "Full Rink A",
+        segments: [{ id: SEGMENT_ID, name: "Offensive Zone" }],
+      },
+    ],
+  });
   mockPrisma.venueStaff.findMany.mockResolvedValue([{ user: { email: "manager@example.com" } }]);
+  mockPrisma.venueStaff.findFirst.mockResolvedValue({ id: "cstaff0000000000000000000" });
+  mockPrisma.notificationOutbox.upsert.mockResolvedValue({
+    id: "coutbox000000000000000000",
+  });
+  mockFindLegacyAcceptedRequestConflicts.mockResolvedValue([]);
 });
 
 describe("ice time request lifecycle", () => {
@@ -85,19 +173,53 @@ describe("ice time request lifecycle", () => {
     expect(mockSubmitEmail).toHaveBeenCalled();
   });
 
-  it("lets venue request managers accept, cancel, and expire requests", async () => {
-    const managedRequest = {
+  it("submits a request for a concrete recurring offering occurrence", async () => {
+    mockPrisma.venueScheduleBlock.findFirst.mockResolvedValueOnce({
+      id: BLOCK_ID,
+      startsAt: new Date("2026-03-01T15:00:00Z"),
+      endsAt: new Date("2026-03-01T16:00:00Z"),
+      title: "Weekly ice",
+      status: "PUBLISHED",
+      registrationMode: "REQUEST_REQUIRED",
+      recurrenceRule: "FREQ=WEEKLY;COUNT=3",
+      recurrenceEndDate: new Date("2026-03-15T14:00:00Z"),
+      venue: {
+        id: VENUE_ID,
+        name: "North Rink",
+        organizationId: ORGANIZATION_ID,
+        slug: "north-rink",
+        timezone: "America/New_York",
+      },
+    });
+    mockPrisma.iceTimeRequest.create.mockResolvedValue({
       id: REQUEST_ID,
-      requesterUserId: "other-user",
-      contactEmail: "coach@example.com",
+      status: "SUBMITTED",
+    });
+
+    const result = await submitIceTimeRequest({
       scheduleBlockId: BLOCK_ID,
-      requestedStartAt: new Date("2026-03-01T10:00:00Z"),
-      requestedEndAt: new Date("2026-03-01T11:00:00Z"),
-      venue: { organizationId: ORGANIZATION_ID, slug: "north-rink", name: "North Rink" },
-    };
+      venueId: VENUE_ID,
+      contactName: "Coach One",
+      contactEmail: "coach@example.com",
+      requestedStartAt: "2026-03-08T14:00:00Z",
+      requestedEndAt: "2026-03-08T15:00:00Z",
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockPrisma.iceTimeRequest.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          requestedStartAt: new Date("2026-03-08T14:00:00Z"),
+          requestedEndAt: new Date("2026-03-08T15:00:00Z"),
+        }),
+      }),
+    );
+  });
+
+  it("lets venue request managers accept, cancel, and expire requests", async () => {
+    const managedRequest = managedRequestFixture();
     mockPrisma.iceTimeRequest.findFirst
       .mockResolvedValueOnce(managedRequest)
-      .mockResolvedValueOnce(null)
       .mockResolvedValue(managedRequest);
     mockPrisma.iceTimeRequest.update
       .mockResolvedValueOnce({ id: REQUEST_ID, status: "ACCEPTED", decidedAt: new Date("2026-03-01T00:00:00Z") })
@@ -105,25 +227,21 @@ describe("ice time request lifecycle", () => {
       .mockResolvedValueOnce({ id: REQUEST_ID, status: "EXPIRED" });
 
     expect((await decideIceTimeRequest({ organizationId: ORGANIZATION_ID, venueId: VENUE_ID, requestId: REQUEST_ID, status: "ACCEPTED" })).success).toBe(true);
-    expect(mockPrisma.$transaction).toHaveBeenCalledWith(expect.any(Function), {
+    expect(mockPrisma.$transaction).toHaveBeenCalledWith(expect.any(Function), expect.objectContaining({
       isolationLevel: "Serializable",
-    });
+    }));
     expect((await cancelIceTimeRequest({ organizationId: ORGANIZATION_ID, venueId: VENUE_ID, requestId: REQUEST_ID })).success).toBe(true);
     expect((await expireIceTimeRequest({ organizationId: ORGANIZATION_ID, venueId: VENUE_ID, requestId: REQUEST_ID })).success).toBe(true);
-    expect(mockDecisionEmail).toHaveBeenCalled();
+    expect(mockPrisma.notificationOutbox.upsert).toHaveBeenCalled();
   });
 
   it("prevents accepting a request that overlaps an accepted request", async () => {
-    mockPrisma.iceTimeRequest.findFirst
-      .mockResolvedValueOnce({
-        id: REQUEST_ID,
-        contactEmail: "coach@example.com",
-        scheduleBlockId: BLOCK_ID,
-        requestedStartAt: new Date("2026-03-01T10:00:00Z"),
-        requestedEndAt: new Date("2026-03-01T11:00:00Z"),
-        venue: { organizationId: ORGANIZATION_ID, slug: "north-rink", name: "North Rink" },
-      })
-      .mockResolvedValueOnce({ id: "clreqacceptedxxxxxxxxxxxxxx" });
+    mockPrisma.iceTimeRequest.findFirst.mockResolvedValueOnce(
+      managedRequestFixture({ id: REQUEST_ID }),
+    );
+    mockFindLegacyAcceptedRequestConflicts.mockResolvedValueOnce([
+      { id: "clreqacceptedxxxxxxxxxxxxxx" },
+    ]);
 
     const result = await decideIceTimeRequest({
       organizationId: ORGANIZATION_ID,
@@ -133,19 +251,947 @@ describe("ice time request lifecycle", () => {
     });
 
     expect(result.success).toBe(false);
+    expect(mockFindLegacyAcceptedRequestConflicts).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        venueId: VENUE_ID,
+        excludeRequestId: REQUEST_ID,
+      }),
+    );
     expect(mockPrisma.iceTimeRequest.update).not.toHaveBeenCalled();
   });
 
+  it("does not bluntly reject a new request because an accepted request exists", async () => {
+    mockPrisma.iceTimeRequest.findFirst.mockResolvedValueOnce({
+      id: "legacy-accepted",
+    });
+    mockPrisma.iceTimeRequest.create.mockResolvedValue({
+      id: REQUEST_ID,
+      status: "SUBMITTED",
+    });
+
+    const result = await submitIceTimeRequest({
+      scheduleBlockId: BLOCK_ID,
+      venueId: VENUE_ID,
+      contactName: "Coach One",
+      contactEmail: "coach@example.com",
+      requestedStartAt: "2026-03-01T10:00:00Z",
+      requestedEndAt: "2026-03-01T11:00:00Z",
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockPrisma.iceTimeRequest.create).toHaveBeenCalledOnce();
+  });
+
   it("returns private request details for the manager queue", async () => {
-    mockPrisma.iceTimeRequest.findMany.mockResolvedValue([{ id: REQUEST_ID, contactEmail: "coach@example.com" }]);
+    mockPrisma.iceTimeRequest.findMany.mockResolvedValue([{
+      id: REQUEST_ID,
+      contactName: "Coach One",
+      contactEmail: "coach@example.com",
+      status: "SUBMITTED",
+      venue: { timezone: "America/New_York" },
+      requestedStartAt: new Date("2026-03-01T10:00:00Z"),
+      requestedEndAt: new Date("2026-03-01T11:00:00Z"),
+      approvedStartAt: null,
+      approvedEndAt: null,
+      approvedSurfaceId: null,
+      approvedSegmentId: null,
+      approvedSurface: null,
+      approvedSegment: null,
+      scheduleBlock: {
+        surfaceId: SURFACE_ID,
+        segmentId: SEGMENT_ID,
+        surface: { name: "Rink A" },
+        segment: { name: "Offensive Zone" },
+      },
+      venueReservation: null,
+    }]);
 
     const result = await getVenueRequestQueue(ORGANIZATION_ID, VENUE_ID);
 
     expect(result.success).toBe(true);
     expect(mockPrisma.iceTimeRequest.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: { venueId: VENUE_ID },
+        where: { venueId: VENUE_ID, venue: { organizationId: ORGANIZATION_ID } },
       })
     );
+    if (result.success) {
+      expect(result.data.timezone).toBe("America/New_York");
+      expect(result.data.surfaceOptions[0]).toMatchObject({
+        id: SURFACE_ID,
+        name: "Rink A",
+        wholeLabel: "Full Rink A",
+      });
+      expect(result.data.requests[0]).toMatchObject({
+        requestedSurfaceId: SURFACE_ID,
+        requestedSegmentId: SEGMENT_ID,
+      });
+    }
+  });
+});
+
+/**
+ * T017 tests below express the intended T023/T024 contract from
+ * `specs/007-association-operations/contracts/venue-reservation-actions.md`
+ * ("Decide Ice Request" / "Reservation Lifecycle") on top of the current
+ * `decideIceTimeRequest`/`cancelIceTimeRequest`/`expireIceTimeRequest`, which
+ * today only ever mutate the `IceTimeRequest` row and never touch a
+ * `VenueReservation` at all. Failures here are the intended red state for
+ * unimplemented T023/T024 work, not defects in the assertions themselves.
+ */
+function managedRequestFixture(overrides: Record<string, unknown> = {}) {
+  return {
+    id: STRICT_REQUEST_ID,
+    requesterUserId: "other-user",
+    requesterLeagueId: "cleague000000000000000000",
+    requesterTeamId: null,
+    requesterTeam: null,
+    status: "SUBMITTED",
+    decidedAt: null,
+    contactEmail: "coach@example.com",
+    scheduleBlockId: BLOCK_ID,
+    requestedStartAt: new Date("2026-03-01T10:00:00Z"),
+    requestedEndAt: new Date("2026-03-01T11:00:00Z"),
+    approvedStartAt: null,
+    approvedEndAt: null,
+    approvedSurfaceId: null,
+    approvedSegmentId: null,
+    scheduleBlock: {
+      id: BLOCK_ID,
+      surfaceId: SURFACE_ID,
+      segmentId: SEGMENT_ID,
+      intent: "OFFERING",
+    },
+    venue: {
+      id: VENUE_ID,
+      organizationId: ORGANIZATION_ID,
+      slug: "north-rink",
+      name: "North Rink",
+      timezone: "America/New_York",
+      leagueId: "cleague000000000000000000",
+      team: null,
+    },
+    venueReservation: null as { id: string; status: string } | null,
+    ...overrides,
+  };
+}
+
+describe("decideIceTimeRequest full/partial/decline approval (T017 -> T023 intended contract)", () => {
+  beforeEach(() => {
+    mockCreateVenueReservation.mockResolvedValue({
+      id: RESERVATION_ID,
+      status: "CONFIRMED",
+      startsAt: new Date("2026-03-01T10:00:00Z"),
+      endsAt: new Date("2026-03-01T11:00:00Z"),
+    });
+  });
+
+  it("fully approves a request, creates exactly one confirmed reservation, and returns queued notification identifiers", async () => {
+    mockPrisma.iceTimeRequest.findFirst.mockResolvedValueOnce(managedRequestFixture());
+    mockPrisma.iceTimeRequest.update.mockResolvedValueOnce({
+      id: REQUEST_ID,
+      status: "ACCEPTED",
+      decidedAt: new Date("2026-03-01T00:00:00Z"),
+    });
+
+    const result = await decideIceTimeRequest({
+      organizationId: ORGANIZATION_ID,
+      venueId: VENUE_ID,
+      requestId: REQUEST_ID,
+      status: "ACCEPTED",
+      approvedStartAt: new Date("2026-03-01T10:00:00Z"),
+      approvedEndAt: new Date("2026-03-01T11:00:00Z"),
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockCreateVenueReservation).toHaveBeenCalledTimes(1);
+    expect(mockCreateVenueReservation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        venueId: VENUE_ID,
+        status: "CONFIRMED",
+        sourceRequestId: STRICT_REQUEST_ID,
+        surfaceId: SURFACE_ID,
+        segmentId: SEGMENT_ID,
+      }),
+    );
+    if (result.success) {
+      const data = result.data as unknown as { notificationIds?: string[]; reservationId?: string };
+      expect(Array.isArray(data.notificationIds)).toBe(true);
+      expect((data.notificationIds ?? []).length).toBeGreaterThan(0);
+      expect(data.reservationId).toBe(RESERVATION_ID);
+    }
+  });
+
+  it("allows only a venue manager to record a reasoned override of a conflicting legacy accepted request", async () => {
+    mockPrisma.iceTimeRequest.findFirst.mockResolvedValueOnce(managedRequestFixture());
+    mockPrisma.iceTimeRequest.update.mockResolvedValueOnce({
+      id: REQUEST_ID,
+      status: "ACCEPTED",
+      decidedAt: new Date("2026-03-01T00:00:00Z"),
+    });
+    mockFindLegacyAcceptedRequestConflicts.mockResolvedValueOnce([
+      { id: "clegacy000000000000000000" },
+    ]);
+
+    const result = await decideIceTimeRequest({
+      organizationId: ORGANIZATION_ID,
+      venueId: VENUE_ID,
+      requestId: REQUEST_ID,
+      status: "ACCEPTED",
+      approvedStartAt: new Date("2026-03-01T10:00:00Z"),
+      approvedEndAt: new Date("2026-03-01T11:00:00Z"),
+      overrideConflicts: true,
+      overrideReason: "Venue manager approved the documented legacy overlap.",
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockPrisma.venueStaff.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          role: { in: ["OWNER", "MANAGER"] },
+        }),
+      }),
+    );
+    expect(mockPrisma.venueReservationOverride.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        reservationId: RESERVATION_ID,
+        reason: "Venue manager approved the documented legacy overlap.",
+        conflictingReservationIds: [],
+        candidateSnapshot: expect.objectContaining({
+          source: "LEGACY_ACCEPTED_REQUESTS",
+          legacyAcceptedRequestIds: ["clegacy000000000000000000"],
+        }),
+      }),
+    });
+  });
+
+  it("rejects a legacy accepted-request override from request-only staff", async () => {
+    mockPrisma.iceTimeRequest.findFirst.mockResolvedValueOnce(managedRequestFixture());
+    mockFindLegacyAcceptedRequestConflicts.mockResolvedValueOnce([
+      { id: "clegacy000000000000000000" },
+    ]);
+    mockPrisma.venueStaff.findFirst
+      .mockResolvedValueOnce({ id: "cstaff0000000000000000000" })
+      .mockResolvedValueOnce(null);
+
+    const result = await decideIceTimeRequest({
+      organizationId: ORGANIZATION_ID,
+      venueId: VENUE_ID,
+      requestId: REQUEST_ID,
+      status: "ACCEPTED",
+      approvedStartAt: new Date("2026-03-01T10:00:00Z"),
+      approvedEndAt: new Date("2026-03-01T11:00:00Z"),
+      overrideConflicts: true,
+      overrideReason: "Request staff attempted an override.",
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error: "Conflict overrides require venue-manager authorization.",
+    });
+    expect(mockCreateVenueReservation).not.toHaveBeenCalled();
+  });
+
+  it("treats a narrower approved interval as PARTIALLY_ACCEPTED even when the caller submits ACCEPTED", async () => {
+    mockPrisma.iceTimeRequest.findFirst.mockResolvedValueOnce(managedRequestFixture());
+    mockPrisma.iceTimeRequest.update.mockResolvedValueOnce({
+      id: REQUEST_ID,
+      status: "PARTIALLY_ACCEPTED",
+      decidedAt: new Date("2026-03-01T00:00:00Z"),
+    });
+
+    const approvedStartAt = new Date("2026-03-01T10:00:00Z");
+    const approvedEndAt = new Date("2026-03-01T10:30:00Z"); // narrower than the 10:00-11:00 request
+
+    const result = await decideIceTimeRequest({
+      organizationId: ORGANIZATION_ID,
+      venueId: VENUE_ID,
+      requestId: REQUEST_ID,
+      status: "ACCEPTED",
+      approvedStartAt,
+      approvedEndAt,
+      decisionMessage: "Only the first half hour is available",
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockPrisma.iceTimeRequest.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ status: "PARTIALLY_ACCEPTED" }),
+      }),
+    );
+    expect(mockCreateVenueReservation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ startsAt: approvedStartAt, endsAt: approvedEndAt }),
+    );
+  });
+
+  it("rejects partial approval onto an unrelated surface", async () => {
+    mockPrisma.iceTimeRequest.findFirst.mockResolvedValueOnce(managedRequestFixture());
+
+    const result = await decideIceTimeRequest({
+      organizationId: ORGANIZATION_ID,
+      venueId: VENUE_ID,
+      requestId: REQUEST_ID,
+      status: "ACCEPTED",
+      approvedStartAt: new Date("2026-03-01T10:00:00Z"),
+      approvedEndAt: new Date("2026-03-01T11:00:00Z"),
+      approvedSurfaceId: SURFACE_B_ID,
+      approvedSegmentId: SEGMENT_B_ID,
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error: expect.stringMatching(/must stay within the requested/i),
+    });
+    expect(mockPrisma.iceTimeRequest.update).not.toHaveBeenCalled();
+    expect(mockCreateVenueReservation).not.toHaveBeenCalled();
+  });
+
+  it("keeps an exact venue-wide approval as ACCEPTED when the manager explicitly confirms the full-venue claim", async () => {
+    mockPrisma.iceTimeRequest.findFirst.mockResolvedValueOnce(
+      managedRequestFixture({
+        scheduleBlock: {
+          id: BLOCK_ID,
+          surfaceId: null,
+          segmentId: null,
+          intent: "OFFERING",
+        },
+      }),
+    );
+    mockPrisma.iceTimeRequest.update.mockResolvedValueOnce({
+      id: REQUEST_ID,
+      status: "ACCEPTED",
+      decidedAt: new Date("2026-03-01T00:00:00Z"),
+    });
+
+    const result = await decideIceTimeRequest({
+      organizationId: ORGANIZATION_ID,
+      venueId: VENUE_ID,
+      requestId: REQUEST_ID,
+      status: "ACCEPTED",
+      approvedStartAt: new Date("2026-03-01T10:00:00Z"),
+      approvedEndAt: new Date("2026-03-01T11:00:00Z"),
+      approvedSurfaceId: null,
+      approvedSegmentId: null,
+      intentionalVenueWideClaim: true,
+      overrideReason: "Tournament setup uses the full venue",
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockPrisma.iceTimeRequest.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ status: "ACCEPTED" }),
+      }),
+    );
+    expect(mockCreateVenueReservation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        surfaceId: null,
+        segmentId: null,
+        overrideReason: "Tournament setup uses the full venue",
+      }),
+    );
+  });
+
+  it("rejects widening a surface request into a venue-wide approval", async () => {
+    mockPrisma.iceTimeRequest.findFirst.mockResolvedValueOnce(
+      managedRequestFixture(),
+    );
+
+    const result = await decideIceTimeRequest({
+      organizationId: ORGANIZATION_ID,
+      venueId: VENUE_ID,
+      requestId: REQUEST_ID,
+      status: "ACCEPTED",
+      approvedStartAt: new Date("2026-03-01T10:00:00Z"),
+      approvedEndAt: new Date("2026-03-01T11:00:00Z"),
+      approvedSurfaceId: null,
+      approvedSegmentId: null,
+      intentionalVenueWideClaim: true,
+      overrideReason: "The approved allocation intentionally uses the full venue",
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error: expect.stringMatching(/must stay within the requested/i),
+    });
+    expect(mockPrisma.iceTimeRequest.update).not.toHaveBeenCalled();
+    expect(mockCreateVenueReservation).not.toHaveBeenCalled();
+  });
+
+  it("allows a whole-surface request to be partially approved to a segment on that surface", async () => {
+    mockPrisma.iceTimeRequest.findFirst.mockResolvedValueOnce(
+      managedRequestFixture({
+        scheduleBlock: {
+          id: BLOCK_ID,
+          surfaceId: SURFACE_ID,
+          segmentId: null,
+          intent: "OFFERING",
+        },
+      }),
+    );
+    mockPrisma.iceTimeRequest.update.mockResolvedValueOnce({
+      id: REQUEST_ID,
+      status: "PARTIALLY_ACCEPTED",
+      decidedAt: new Date("2026-03-01T00:00:00Z"),
+    });
+
+    const result = await decideIceTimeRequest({
+      organizationId: ORGANIZATION_ID,
+      venueId: VENUE_ID,
+      requestId: REQUEST_ID,
+      status: "PARTIALLY_ACCEPTED",
+      approvedStartAt: new Date("2026-03-01T10:00:00Z"),
+      approvedEndAt: new Date("2026-03-01T11:00:00Z"),
+      approvedSurfaceId: SURFACE_ID,
+      approvedSegmentId: SEGMENT_ID,
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockCreateVenueReservation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        surfaceId: SURFACE_ID,
+        segmentId: SEGMENT_ID,
+      }),
+    );
+  });
+
+  it("creates venue-organization ownership only for an unaffiliated public request", async () => {
+    mockPrisma.iceTimeRequest.findFirst.mockResolvedValueOnce(
+      managedRequestFixture({
+        requesterLeagueId: null,
+        requesterTeamId: null,
+      }),
+    );
+    mockPrisma.iceTimeRequest.update.mockResolvedValueOnce({
+      id: REQUEST_ID,
+      status: "ACCEPTED",
+      decidedAt: new Date("2026-03-01T00:00:00Z"),
+    });
+
+    const result = await decideIceTimeRequest({
+      organizationId: ORGANIZATION_ID,
+      venueId: VENUE_ID,
+      requestId: REQUEST_ID,
+      status: "ACCEPTED",
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockCreateVenueReservation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        ownerVenueOrganizationId: ORGANIZATION_ID,
+        sourceRequestId: STRICT_REQUEST_ID,
+      }),
+    );
+    expect(mockCreateVenueReservation.mock.calls[0][1]).not.toHaveProperty(
+      "ownerLeagueId",
+    );
+    expect(mockCreateVenueReservation.mock.calls[0][1]).not.toHaveProperty(
+      "ownerTeamId",
+    );
+  });
+
+  it("materializes a matching legacy accepted request that lacks a reservation", async () => {
+    mockPrisma.iceTimeRequest.findFirst.mockResolvedValueOnce(
+      managedRequestFixture({
+        status: "ACCEPTED",
+        decidedAt: new Date("2026-02-01T00:00:00Z"),
+        approvedStartAt: new Date("2026-03-01T10:00:00Z"),
+        approvedEndAt: new Date("2026-03-01T11:00:00Z"),
+        approvedSurfaceId: SURFACE_ID,
+        approvedSegmentId: SEGMENT_ID,
+        venueReservation: null,
+      }),
+    );
+
+    const result = await decideIceTimeRequest({
+      organizationId: ORGANIZATION_ID,
+      venueId: VENUE_ID,
+      requestId: REQUEST_ID,
+      status: "ACCEPTED",
+      approvedStartAt: new Date("2026-03-01T10:00:00Z"),
+      approvedEndAt: new Date("2026-03-01T11:00:00Z"),
+      approvedSurfaceId: SURFACE_ID,
+      approvedSegmentId: SEGMENT_ID,
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockPrisma.iceTimeRequest.update).not.toHaveBeenCalled();
+    expect(mockCreateVenueReservation).toHaveBeenCalledOnce();
+  });
+
+  it("repairs a missing legacy approval snapshot before materializing its reservation", async () => {
+    mockPrisma.iceTimeRequest.findFirst.mockResolvedValueOnce(
+      managedRequestFixture({
+        status: "ACCEPTED",
+        decidedAt: new Date("2026-02-01T00:00:00Z"),
+        approvedStartAt: null,
+        approvedEndAt: null,
+        approvedSurfaceId: null,
+        approvedSegmentId: null,
+        venueReservation: null,
+      }),
+    );
+    mockPrisma.iceTimeRequest.update.mockResolvedValueOnce({
+      id: REQUEST_ID,
+      status: "ACCEPTED",
+      decidedAt: new Date("2026-02-01T00:00:00Z"),
+    });
+
+    const result = await decideIceTimeRequest({
+      organizationId: ORGANIZATION_ID,
+      venueId: VENUE_ID,
+      requestId: REQUEST_ID,
+      status: "ACCEPTED",
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockPrisma.iceTimeRequest.update).toHaveBeenCalledWith({
+      where: { id: STRICT_REQUEST_ID },
+      data: {
+        approvedStartAt: new Date("2026-03-01T10:00:00Z"),
+        approvedEndAt: new Date("2026-03-01T11:00:00Z"),
+        approvedSurfaceId: SURFACE_ID,
+        approvedSegmentId: SEGMENT_ID,
+      },
+      select: { id: true, status: true, decidedAt: true },
+    });
+    expect(mockCreateVenueReservation).toHaveBeenCalledOnce();
+  });
+
+  it("declines a request without creating any reservation", async () => {
+    mockPrisma.iceTimeRequest.findFirst.mockResolvedValueOnce(managedRequestFixture());
+    mockPrisma.iceTimeRequest.update.mockResolvedValueOnce({
+      id: REQUEST_ID,
+      status: "DECLINED",
+      decidedAt: new Date("2026-03-01T00:00:00Z"),
+    });
+
+    const result = await decideIceTimeRequest({
+      organizationId: ORGANIZATION_ID,
+      venueId: VENUE_ID,
+      requestId: REQUEST_ID,
+      status: "DECLINED",
+      decisionMessage: "No ice available at this time",
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockCreateVenueReservation).not.toHaveBeenCalled();
+    if (result.success) {
+      const data = result.data as unknown as { reservationId?: string | null };
+      expect(data.reservationId ?? null).toBeNull();
+    }
+  });
+
+  it("is idempotent: re-approving an already-accepted request with an existing reservation does not create a second one", async () => {
+    mockPrisma.iceTimeRequest.findFirst.mockResolvedValueOnce(
+      managedRequestFixture({
+        status: "ACCEPTED",
+        decidedAt: new Date("2026-03-01T00:00:00Z"),
+        approvedStartAt: new Date("2026-03-01T10:00:00Z"),
+        approvedEndAt: new Date("2026-03-01T11:00:00Z"),
+        approvedSurfaceId: SURFACE_ID,
+        approvedSegmentId: SEGMENT_ID,
+        venueReservation: {
+          id: RESERVATION_ID,
+          status: "CONFIRMED",
+          startsAt: new Date("2026-03-01T10:00:00Z"),
+          endsAt: new Date("2026-03-01T11:00:00Z"),
+          surfaceId: SURFACE_ID,
+          segmentId: SEGMENT_ID,
+        },
+      }),
+    );
+    mockPrisma.iceTimeRequest.update.mockResolvedValueOnce({
+      id: REQUEST_ID,
+      status: "ACCEPTED",
+      decidedAt: new Date("2026-03-01T00:00:00Z"),
+    });
+
+    const result = await decideIceTimeRequest({
+      organizationId: ORGANIZATION_ID,
+      venueId: VENUE_ID,
+      requestId: REQUEST_ID,
+      status: "ACCEPTED",
+      approvedStartAt: new Date("2026-03-01T10:00:00Z"),
+      approvedEndAt: new Date("2026-03-01T11:00:00Z"),
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockCreateVenueReservation).not.toHaveBeenCalled();
+    expect(mockPrisma.iceTimeRequest.update).not.toHaveBeenCalled();
+  });
+
+  it("rejects a different final decision once a confirmed reservation exists", async () => {
+    mockPrisma.iceTimeRequest.findFirst.mockResolvedValueOnce(
+      managedRequestFixture({
+        status: "ACCEPTED",
+        decidedAt: new Date("2026-03-01T00:00:00Z"),
+        approvedStartAt: new Date("2026-03-01T10:00:00Z"),
+        approvedEndAt: new Date("2026-03-01T11:00:00Z"),
+        approvedSurfaceId: SURFACE_ID,
+        approvedSegmentId: SEGMENT_ID,
+        venueReservation: {
+          id: RESERVATION_ID,
+          status: "CONFIRMED",
+          startsAt: new Date("2026-03-01T10:00:00Z"),
+          endsAt: new Date("2026-03-01T11:00:00Z"),
+          surfaceId: SURFACE_ID,
+          segmentId: SEGMENT_ID,
+        },
+      }),
+    );
+
+    const result = await decideIceTimeRequest({
+      organizationId: ORGANIZATION_ID,
+      venueId: VENUE_ID,
+      requestId: REQUEST_ID,
+      status: "DECLINED",
+      decisionMessage: "Changed after approval",
+    });
+
+    expect(result.success).toBe(false);
+    expect(mockPrisma.iceTimeRequest.update).not.toHaveBeenCalled();
+    expect(mockTransitionVenueReservation).not.toHaveBeenCalled();
+  });
+
+  it("requires an override reason before overriding a detected conflict rather than silently double-booking", async () => {
+    mockPrisma.iceTimeRequest.findFirst.mockResolvedValueOnce(managedRequestFixture());
+    mockCreateVenueReservation.mockRejectedValueOnce(
+      new VenueReservationConflictError([
+        {
+          id: "cotherxxxxxxxxxxxxxxxxxxxx",
+          status: "CONFIRMED",
+          startsAt: new Date(),
+          endsAt: new Date(),
+          timezone: "UTC",
+          venueId: VENUE_ID,
+          surfaceId: null,
+          segmentId: null,
+        },
+      ]),
+    );
+
+    const result = await decideIceTimeRequest({
+      organizationId: ORGANIZATION_ID,
+      venueId: VENUE_ID,
+      requestId: REQUEST_ID,
+      status: "ACCEPTED",
+      approvedStartAt: new Date("2026-03-01T10:00:00Z"),
+      approvedEndAt: new Date("2026-03-01T11:00:00Z"),
+      overrideConflicts: false,
+    });
+
+    expect(result.success).toBe(false);
+    // The unit mock cannot model transaction rollback. The returned failure,
+    // plus the PostgreSQL-backed concurrency suite, verifies no decision can
+    // commit independently from reservation creation.
+  });
+
+  it("proceeds past a detected conflict once an explicit override reason is supplied", async () => {
+    mockPrisma.iceTimeRequest.findFirst.mockResolvedValueOnce(managedRequestFixture());
+    mockPrisma.iceTimeRequest.update.mockResolvedValueOnce({
+      id: REQUEST_ID,
+      status: "ACCEPTED",
+      decidedAt: new Date("2026-03-01T00:00:00Z"),
+    });
+
+    const result = await decideIceTimeRequest({
+      organizationId: ORGANIZATION_ID,
+      venueId: VENUE_ID,
+      requestId: REQUEST_ID,
+      status: "ACCEPTED",
+      approvedStartAt: new Date("2026-03-01T10:00:00Z"),
+      approvedEndAt: new Date("2026-03-01T11:00:00Z"),
+      overrideConflicts: true,
+      overrideReason: "Association scheduler manually reallocated the ice",
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockCreateVenueReservation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ overrideReason: "Association scheduler manually reallocated the ice" }),
+    );
+  });
+});
+
+describe("cancel/expire ice time requests propagate to the linked reservation (T017 -> T024 intended contract)", () => {
+  it("cancelIceTimeRequest releases the linked reservation atomically instead of leaving it orphaned", async () => {
+    mockPrisma.iceTimeRequest.findFirst.mockResolvedValueOnce(
+      managedRequestFixture({ venueReservation: { id: RESERVATION_ID, status: "CONFIRMED" } }),
+    );
+    mockPrisma.iceTimeRequest.update.mockResolvedValueOnce({ id: REQUEST_ID, status: "CANCELED" });
+    mockTransitionVenueReservation.mockResolvedValueOnce({ id: RESERVATION_ID, status: "RELEASED" });
+
+    const result = await cancelIceTimeRequest({
+      organizationId: ORGANIZATION_ID,
+      venueId: VENUE_ID,
+      requestId: REQUEST_ID,
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockTransitionVenueReservation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ reservationId: RESERVATION_ID, nextStatus: "RELEASED" }),
+    );
+    // The request update and the reservation release belong to one atomic
+    // operation, not two independently-committed writes.
+    expect(mockPrisma.$transaction).toHaveBeenCalled();
+  });
+
+  it("expireIceTimeRequest releases the linked reservation the same way cancellation does", async () => {
+    mockPrisma.iceTimeRequest.findFirst.mockResolvedValueOnce(
+      managedRequestFixture({ venueReservation: { id: RESERVATION_ID, status: "CONFIRMED" } }),
+    );
+    mockPrisma.iceTimeRequest.update.mockResolvedValueOnce({ id: REQUEST_ID, status: "EXPIRED" });
+    mockTransitionVenueReservation.mockResolvedValueOnce({ id: RESERVATION_ID, status: "RELEASED" });
+
+    const result = await expireIceTimeRequest({
+      organizationId: ORGANIZATION_ID,
+      venueId: VENUE_ID,
+      requestId: REQUEST_ID,
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockTransitionVenueReservation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ reservationId: RESERVATION_ID, nextStatus: "RELEASED" }),
+    );
+  });
+
+  it("cancelIceTimeRequest releases the replacement reservation now linked after a reschedule", async () => {
+    const replacementReservationId = "clresreplacementxxxxxxxxxx";
+    mockPrisma.iceTimeRequest.findFirst.mockResolvedValueOnce(
+      managedRequestFixture({
+        status: "ACCEPTED",
+        venueReservation: { id: replacementReservationId, status: "CONFIRMED" },
+      }),
+    );
+    mockPrisma.iceTimeRequest.update.mockResolvedValueOnce({ id: REQUEST_ID, status: "CANCELED" });
+    mockTransitionVenueReservation.mockResolvedValueOnce({
+      id: replacementReservationId,
+      status: "RELEASED",
+    });
+
+    const result = await cancelIceTimeRequest({
+      organizationId: ORGANIZATION_ID,
+      venueId: VENUE_ID,
+      requestId: REQUEST_ID,
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockTransitionVenueReservation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        reservationId: replacementReservationId,
+        nextStatus: "RELEASED",
+      }),
+    );
+  });
+
+  it("expireIceTimeRequest releases the replacement reservation now linked after a reschedule", async () => {
+    const replacementReservationId = "clresreplacementxxxxxxxxxx";
+    mockPrisma.iceTimeRequest.findFirst.mockResolvedValueOnce(
+      managedRequestFixture({
+        status: "PARTIALLY_ACCEPTED",
+        venueReservation: { id: replacementReservationId, status: "CONFIRMED" },
+      }),
+    );
+    mockPrisma.iceTimeRequest.update.mockResolvedValueOnce({ id: REQUEST_ID, status: "EXPIRED" });
+    mockTransitionVenueReservation.mockResolvedValueOnce({
+      id: replacementReservationId,
+      status: "RELEASED",
+    });
+
+    const result = await expireIceTimeRequest({
+      organizationId: ORGANIZATION_ID,
+      venueId: VENUE_ID,
+      requestId: REQUEST_ID,
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockTransitionVenueReservation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        reservationId: replacementReservationId,
+        nextStatus: "RELEASED",
+      }),
+    );
+  });
+
+  it("cancelling a request with no linked reservation still succeeds without calling the reservation service", async () => {
+    mockPrisma.iceTimeRequest.findFirst.mockResolvedValueOnce(managedRequestFixture({ venueReservation: null }));
+    mockPrisma.iceTimeRequest.update.mockResolvedValueOnce({ id: REQUEST_ID, status: "CANCELED" });
+
+    const result = await cancelIceTimeRequest({
+      organizationId: ORGANIZATION_ID,
+      venueId: VENUE_ID,
+      requestId: REQUEST_ID,
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockTransitionVenueReservation).not.toHaveBeenCalled();
+  });
+});
+
+describe("exact auth / cross-tenant protections on ice time request decisions", () => {
+  it("scopes decideIceTimeRequest's lookup to the exact organization and venue (existing protection)", async () => {
+    mockPrisma.iceTimeRequest.findFirst.mockResolvedValueOnce(null);
+
+    const result = await decideIceTimeRequest({
+      organizationId: ORGANIZATION_ID,
+      venueId: VENUE_ID,
+      requestId: REQUEST_ID,
+      status: "ACCEPTED",
+    });
+
+    expect(result.success).toBe(false);
+    expect(mockPrisma.iceTimeRequest.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          id: REQUEST_ID,
+          venueId: VENUE_ID,
+          venue: { organizationId: ORGANIZATION_ID },
+        }),
+      }),
+    );
+  });
+
+  it("checks venue-request-manager authority for the exact organization/venue pair before deciding (existing protection)", async () => {
+    mockPrisma.iceTimeRequest.findFirst.mockResolvedValueOnce(managedRequestFixture());
+    mockPrisma.iceTimeRequest.update.mockResolvedValueOnce({
+      id: REQUEST_ID,
+      status: "ACCEPTED",
+      decidedAt: new Date(),
+    });
+
+    await decideIceTimeRequest({
+      organizationId: ORGANIZATION_ID,
+      venueId: VENUE_ID,
+      requestId: REQUEST_ID,
+      status: "ACCEPTED",
+    });
+
+    expect(mockRequireVenueRequestManager).toHaveBeenCalledWith(ORGANIZATION_ID, VENUE_ID);
+  });
+
+  it("rejects a decision attempt when the caller's venue-request authority is scoped to a different venue (cross-tenant)", async () => {
+    mockRequireVenueRequestManager.mockRejectedValueOnce(
+      new Error("Unauthorized: You do not have permission to manage this venue"),
+    );
+
+    const result = await decideIceTimeRequest({
+      organizationId: ORGANIZATION_ID,
+      venueId: VENUE_ID,
+      requestId: REQUEST_ID,
+      status: "ACCEPTED",
+    });
+
+    expect(result.success).toBe(false);
+    expect(mockPrisma.iceTimeRequest.findFirst).not.toHaveBeenCalled();
+  });
+});
+
+describe("durable notification identifiers and the association-operations notification registry", () => {
+  it("accepts a valid venue_request.approved envelope whose payload id matches the aggregate id (registry contract, already implemented)", () => {
+    const payload = { kind: "VENUE_REQUEST" as const, data: { requestId: STRICT_REQUEST_ID } };
+
+    expect(() =>
+      assertAssociationOperationsNotificationEvent({
+        eventType: "association.venue_request.approved",
+        aggregateType: "VENUE_REQUEST",
+        aggregateId: STRICT_REQUEST_ID,
+        payload,
+      }),
+    ).not.toThrow();
+
+    const parsed = parseAssociationOperationsNotificationEvent({
+      eventType: "association.venue_request.approved",
+      aggregateType: "VENUE_REQUEST",
+      aggregateId: STRICT_REQUEST_ID,
+      payload,
+    });
+    expect(parsed.ok).toBe(true);
+    if (parsed.ok) {
+      expect((parsed.event.payload as { requestId: string }).requestId).toBe(STRICT_REQUEST_ID);
+    }
+  });
+
+  it("accepts a valid venue_reservation.confirmed envelope (registry contract, already implemented)", () => {
+    const payload = {
+      kind: "VENUE_RESERVATION" as const,
+      data: { venueReservationId: STRICT_RESERVATION_ID },
+    };
+
+    expect(() =>
+      assertAssociationOperationsNotificationEvent({
+        eventType: "association.venue_reservation.confirmed",
+        aggregateType: "VENUE_RESERVATION",
+        aggregateId: STRICT_RESERVATION_ID,
+        payload,
+      }),
+    ).not.toThrow();
+  });
+
+  it("rejects an envelope whose payload id does not match the aggregate id, guarding against notification-ID drift", () => {
+    const mismatchedId = "creq111111111111111111111";
+    const payload = { kind: "VENUE_REQUEST" as const, data: { requestId: mismatchedId } };
+
+    expect(() =>
+      assertAssociationOperationsNotificationEvent({
+        eventType: "association.venue_request.approved",
+        aggregateType: "VENUE_REQUEST",
+        aggregateId: STRICT_REQUEST_ID,
+        payload,
+      }),
+    ).toThrow();
+  });
+
+  it("rejects a mismatched aggregateType for a known eventType", () => {
+    const payload = { kind: "VENUE_REQUEST" as const, data: { requestId: STRICT_REQUEST_ID } };
+
+    expect(() =>
+      assertAssociationOperationsNotificationEvent({
+        eventType: "association.venue_request.approved",
+        aggregateType: "VENUE_RESERVATION",
+        aggregateId: STRICT_REQUEST_ID,
+        payload,
+      }),
+    ).toThrow();
+  });
+
+  it("every notification id returned by a full approval is itself a strictly valid CUID the registry would accept", async () => {
+    mockPrisma.iceTimeRequest.findFirst.mockResolvedValueOnce(managedRequestFixture());
+    mockPrisma.iceTimeRequest.update.mockResolvedValueOnce({
+      id: REQUEST_ID,
+      status: "ACCEPTED",
+      decidedAt: new Date("2026-03-01T00:00:00Z"),
+    });
+    mockCreateVenueReservation.mockResolvedValueOnce({
+      id: RESERVATION_ID,
+      status: "CONFIRMED",
+      startsAt: new Date("2026-03-01T10:00:00Z"),
+      endsAt: new Date("2026-03-01T11:00:00Z"),
+    });
+
+    const result = await decideIceTimeRequest({
+      organizationId: ORGANIZATION_ID,
+      venueId: VENUE_ID,
+      requestId: REQUEST_ID,
+      status: "ACCEPTED",
+      approvedStartAt: new Date("2026-03-01T10:00:00Z"),
+      approvedEndAt: new Date("2026-03-01T11:00:00Z"),
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as unknown as { notificationIds?: string[] };
+      for (const id of data.notificationIds ?? []) {
+        expect(id).toMatch(/^c[a-z0-9]{24}$/);
+      }
+    }
   });
 });

--- a/__tests__/lib/actions/venue-reservations.test.ts
+++ b/__tests__/lib/actions/venue-reservations.test.ts
@@ -1,0 +1,612 @@
+/**
+ * T019: Server Action tests for the not-yet-built `lib/actions/venue-reservations.ts`
+ * (T025). These express the intended contract from
+ * `specs/007-association-operations/contracts/venue-reservation-actions.md`
+ * ("Assign Venue Reservation", "Reservation Lifecycle", "Availability
+ * Preview") against the already-implemented `lib/services/venue-reservations.ts`
+ * and `lib/services/venue-reservation-availability.ts` foundation.
+ *
+ * Every test in this file imports from `@/lib/actions/venue-reservations`,
+ * which does not exist until T025 lands, so the whole suite is expected to
+ * fail at module resolution today. That failure is the intended "red" state
+ * of tests-first work for an unimplemented action module, not a defect in
+ * the tests themselves — each test still pins the exact contract T025 must
+ * satisfy (auth/cross-tenant checks, disposition requirements on
+ * release/cancel, idempotent assignment, and public-safe availability
+ * previews) so it can be turned green mechanically once the action exists.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockAuth,
+  mockTx,
+  mockPrisma,
+  serviceAssignVenueReservation,
+  serviceTransitionVenueReservation,
+  serviceCreateVenueReservation,
+  serviceFindVenueReservationAvailability,
+} = vi.hoisted(() => {
+  const transaction = {
+    venueReservation: {
+      findUnique: vi.fn(),
+      findFirst: vi.fn(),
+      update: vi.fn(),
+    },
+    practiceSession: {
+      findUnique: vi.fn(),
+      findFirst: vi.fn(),
+      update: vi.fn(),
+      updateMany: vi.fn(),
+    },
+    event: {
+      findUnique: vi.fn(),
+      create: vi.fn(),
+      deleteMany: vi.fn(),
+      update: vi.fn(),
+      updateMany: vi.fn(),
+    },
+    teamMember: { findMany: vi.fn() },
+    rSVP: { createMany: vi.fn() },
+    seasonGame: { updateMany: vi.fn() },
+    eventGame: { updateMany: vi.fn() },
+    signupEvent: { updateMany: vi.fn() },
+    gameProposalEntry: { updateMany: vi.fn() },
+    venue: { findUnique: vi.fn(), findFirst: vi.fn() },
+    venueStaff: { findFirst: vi.fn() },
+    leagueUser: { findFirst: vi.fn() },
+    auditLog: { create: vi.fn() },
+  };
+  return {
+    mockAuth: {
+      requireUserId: vi.fn(),
+      requireVenueScheduleManager: vi.fn(),
+      requireLeagueRole: vi.fn(),
+      requireTeamAdmin: vi.fn(),
+    },
+    mockTx: transaction,
+    mockPrisma: {
+      $transaction: vi.fn(async (callback: (tx: typeof transaction) => unknown) => callback(transaction)),
+      venueReservation: { findUnique: vi.fn(), findFirst: vi.fn() },
+    },
+    serviceAssignVenueReservation: vi.fn(),
+    serviceTransitionVenueReservation: vi.fn(),
+    serviceCreateVenueReservation: vi.fn(),
+    serviceFindVenueReservationAvailability: vi.fn(),
+  };
+});
+
+vi.mock("@/lib/auth/session", () => mockAuth);
+vi.mock("@/lib/db/prisma", () => ({ prisma: mockPrisma }));
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("@/lib/services/venue-reservations", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/services/venue-reservations")>(
+    "@/lib/services/venue-reservations",
+  );
+  return {
+    ...actual,
+    assignVenueReservation: serviceAssignVenueReservation,
+    transitionVenueReservation: serviceTransitionVenueReservation,
+    createVenueReservation: serviceCreateVenueReservation,
+  };
+});
+vi.mock("@/lib/services/venue-reservation-availability", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/lib/services/venue-reservation-availability")
+  >("@/lib/services/venue-reservation-availability");
+  return {
+    ...actual,
+    findVenueReservationAvailability: serviceFindVenueReservationAvailability,
+  };
+});
+
+import {
+  VenueReservationConflictError,
+  VenueReservationLifecycleError,
+} from "@/lib/services/venue-reservations";
+import {
+  assignVenueReservation,
+  cancelVenueReservation,
+  checkVenueReservationAvailability,
+  completeVenueReservation,
+  markVenueReservationUnused,
+  releaseVenueReservation,
+  rescheduleVenueReservation,
+  unassignVenueReservation,
+} from "@/lib/actions/venue-reservations";
+
+const ORG_ID = "corgxxxxxxxxxxxxxxxxxxxxx";
+const OTHER_ORG_ID = "corgyyyyyyyyyyyyyyyyyyyyy";
+const VENUE_ID = "cvenuexxxxxxxxxxxxxxxxxxx";
+const OTHER_VENUE_ID = "cvenueyyyyyyyyyyyyyyyyyyy";
+const RESERVATION_ID = "cresxxxxxxxxxxxxxxxxxxxxx";
+const PRACTICE_ID = "cpracticexxxxxxxxxxxxxxxx";
+const USER_ID = "cuserxxxxxxxxxxxxxxxxxxxxx";
+
+function ownedReservation(overrides: Partial<{ venueId: string; organizationId: string; status: string }> = {}) {
+  return {
+    id: RESERVATION_ID,
+    venueId: overrides.venueId ?? VENUE_ID,
+    status: overrides.status ?? "CONFIRMED",
+    startsAt: new Date("2026-05-01T18:00:00.000Z"),
+    endsAt: new Date("2026-05-01T19:00:00.000Z"),
+    timezone: "America/New_York",
+    ownerLeagueId: null,
+    ownerTeamId: null,
+    venue: {
+      organizationId: overrides.organizationId ?? ORG_ID,
+      name: "North Rink",
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockAuth.requireUserId.mockResolvedValue(USER_ID);
+  mockAuth.requireVenueScheduleManager.mockResolvedValue(USER_ID);
+  mockAuth.requireLeagueRole.mockResolvedValue(USER_ID);
+  mockAuth.requireTeamAdmin.mockResolvedValue(USER_ID);
+  mockTx.venueReservation.findUnique.mockResolvedValue(ownedReservation());
+  mockTx.venueReservation.findFirst.mockResolvedValue(null);
+  mockTx.venueReservation.update.mockResolvedValue({ id: RESERVATION_ID });
+  mockTx.venue.findUnique.mockResolvedValue({ organizationId: ORG_ID });
+  mockTx.venue.findFirst.mockResolvedValue({ organizationId: ORG_ID });
+  mockTx.venueStaff.findFirst.mockResolvedValue({ id: "cstaffxxxxxxxxxxxxxxxxxxxx", role: "MANAGER" });
+  mockPrisma.venueReservation.findUnique.mockResolvedValue(ownedReservation());
+  mockTx.practiceSession.findUnique.mockResolvedValue({
+    id: PRACTICE_ID,
+    title: "Tuesday practice",
+    teamId: "cteamxxxxxxxxxxxxxxxxxxxx",
+    team: { leagueId: "cleaguexxxxxxxxxxxxxxxxxx" },
+  });
+  mockTx.practiceSession.findFirst.mockResolvedValue({
+    id: PRACTICE_ID,
+    teamId: "cteamxxxxxxxxxxxxxxxxxxxx",
+    venueId: VENUE_ID,
+    startAt: new Date("2026-05-01T18:00:00.000Z"),
+    duration: 60,
+  });
+  mockTx.practiceSession.update.mockResolvedValue({ id: PRACTICE_ID });
+  mockTx.practiceSession.updateMany.mockResolvedValue({ count: 1 });
+  mockTx.event.findUnique.mockResolvedValue(null);
+  mockTx.event.create.mockResolvedValue({ id: "ceventxxxxxxxxxxxxxxxxxxxx" });
+  mockTx.teamMember.findMany.mockResolvedValue([]);
+  mockTx.venue.findUnique.mockResolvedValue({ organizationId: ORG_ID });
+  mockTx.venueStaff.findFirst.mockResolvedValue({ id: "cstaffxxxxxxxxxxxxxxxxxxxx" });
+});
+
+describe("assignVenueReservation action (T019)", () => {
+  it("authorizes against the reservation's own venue/organization and links the target", async () => {
+    serviceAssignVenueReservation.mockResolvedValue({
+      reservation: ownedReservation(),
+      canonicalScheduleId: `reservation:${RESERVATION_ID}`,
+      rsvpCount: 0,
+    });
+
+    const result = await assignVenueReservation({
+      reservationId: RESERVATION_ID,
+      targetType: "PRACTICE",
+      targetId: PRACTICE_ID,
+      overrideConflicts: false,
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockAuth.requireVenueScheduleManager).toHaveBeenCalledWith(ORG_ID, VENUE_ID);
+    expect(serviceAssignVenueReservation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ reservationId: RESERVATION_ID, targetType: "PRACTICE", targetId: PRACTICE_ID }),
+    );
+  });
+
+  it("rejects assignment when the caller only holds venue-schedule authority at a different venue (cross-tenant)", async () => {
+    mockTx.venueReservation.findUnique.mockResolvedValue(
+      ownedReservation({ venueId: OTHER_VENUE_ID, organizationId: OTHER_ORG_ID }),
+    );
+    mockPrisma.venueReservation.findUnique.mockResolvedValue(
+      ownedReservation({ venueId: OTHER_VENUE_ID, organizationId: OTHER_ORG_ID }),
+    );
+    mockAuth.requireVenueScheduleManager.mockImplementation(async (organizationId: string) => {
+      if (organizationId === OTHER_ORG_ID) {
+        throw new Error("Unauthorized: You do not have permission to manage this venue");
+      }
+      return USER_ID;
+    });
+
+    const result = await assignVenueReservation({
+      reservationId: RESERVATION_ID,
+      targetType: "PRACTICE",
+      targetId: PRACTICE_ID,
+      overrideConflicts: false,
+    });
+
+    expect(result.success).toBe(false);
+    expect(serviceAssignVenueReservation).not.toHaveBeenCalled();
+  });
+
+  it("is idempotent: assigning the same reservation to the same already-linked target twice succeeds both times", async () => {
+    serviceAssignVenueReservation.mockResolvedValue({
+      reservation: ownedReservation(),
+      canonicalScheduleId: `reservation:${RESERVATION_ID}`,
+      rsvpCount: 0,
+    });
+
+    const input = {
+      reservationId: RESERVATION_ID,
+      targetType: "PRACTICE" as const,
+      targetId: PRACTICE_ID,
+      overrideConflicts: false,
+    };
+    const first = await assignVenueReservation(input);
+    const second = await assignVenueReservation(input);
+
+    expect(first.success).toBe(true);
+    expect(second.success).toBe(true);
+    // Each operation links the practice and its participant-facing Event.
+    expect(serviceAssignVenueReservation).toHaveBeenCalledTimes(4);
+  });
+
+  it("creates a team-scoped participant Event for a practice using league-owned inventory", async () => {
+    const leagueId = "cleaguexxxxxxxxxxxxxxxxxx";
+    const leagueReservation = {
+      ...ownedReservation(),
+      ownerLeagueId: leagueId,
+      ownerTeamId: null,
+    };
+    mockPrisma.venueReservation.findUnique.mockResolvedValue(leagueReservation);
+    mockTx.venueReservation.findUnique.mockResolvedValue(leagueReservation);
+    serviceAssignVenueReservation.mockResolvedValue({
+      reservation: leagueReservation,
+      canonicalScheduleId: `reservation:${RESERVATION_ID}`,
+      rsvpCount: 0,
+    });
+
+    const result = await assignVenueReservation({
+      reservationId: RESERVATION_ID,
+      targetType: "PRACTICE",
+      targetId: PRACTICE_ID,
+      overrideConflicts: false,
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockTx.event.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          teamId: "cteamxxxxxxxxxxxxxxxxxxxx",
+          leagueId: null,
+        }),
+      }),
+    );
+  });
+
+  it("keeps the participant Event team-scoped when a practice assignment updates it", async () => {
+    const leagueId = "cleaguexxxxxxxxxxxxxxxxxx";
+    const leagueReservation = {
+      ...ownedReservation(),
+      ownerLeagueId: leagueId,
+      ownerTeamId: null,
+    };
+    mockPrisma.venueReservation.findUnique.mockResolvedValue(leagueReservation);
+    mockTx.venueReservation.findUnique.mockResolvedValue(leagueReservation);
+    mockTx.event.findUnique.mockResolvedValue({
+      id: "ceventxxxxxxxxxxxxxxxxxxxx",
+      teamId: "cteamxxxxxxxxxxxxxxxxxxxx",
+      type: "PRACTICE",
+    });
+    serviceAssignVenueReservation.mockResolvedValue({
+      reservation: leagueReservation,
+      canonicalScheduleId: `reservation:${RESERVATION_ID}`,
+      rsvpCount: 0,
+    });
+
+    const result = await assignVenueReservation({
+      reservationId: RESERVATION_ID,
+      targetType: "PRACTICE",
+      targetId: PRACTICE_ID,
+      overrideConflicts: false,
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockTx.event.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          teamId: "cteamxxxxxxxxxxxxxxxxxxxx",
+          leagueId: null,
+        }),
+      }),
+    );
+  });
+
+  it("surfaces a conflict error requiring an override reason instead of silently double-booking", async () => {
+    serviceAssignVenueReservation.mockRejectedValue(
+      new VenueReservationConflictError([
+        {
+          id: "cotherxxxxxxxxxxxxxxxxxxxx",
+          status: "CONFIRMED",
+          startsAt: new Date(),
+          endsAt: new Date(),
+          timezone: "UTC",
+          venueId: VENUE_ID,
+          surfaceId: null,
+          segmentId: null,
+        },
+      ]),
+    );
+
+    const result = await assignVenueReservation({
+      reservationId: RESERVATION_ID,
+      targetType: "PRACTICE",
+      targetId: PRACTICE_ID,
+      overrideConflicts: false,
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toMatch(/no longer available|conflict/i);
+    }
+  });
+});
+
+describe("reservation lifecycle actions (T019)", () => {
+  it("releaseVenueReservation requires an explicit disposition when a linked activity exists", async () => {
+    mockTx.venueReservation.findUnique.mockResolvedValue({
+      ...ownedReservation(),
+      practiceSessions: [{ id: PRACTICE_ID }],
+    });
+
+    const result = await releaseVenueReservation({
+      reservationId: RESERVATION_ID,
+      nextStatus: "RELEASED",
+      reason: "Ice time no longer needed",
+    });
+
+    expect(result.success).toBe(false);
+    expect(serviceTransitionVenueReservation).not.toHaveBeenCalled();
+  });
+
+  it("releaseVenueReservation proceeds once allowAssignedDisposition is explicitly set", async () => {
+    mockTx.venueReservation.findUnique.mockResolvedValue({
+      ...ownedReservation(),
+      practiceSessions: [{ id: PRACTICE_ID }],
+    });
+    serviceTransitionVenueReservation.mockResolvedValue({ ...ownedReservation(), status: "RELEASED" });
+
+    const result = await releaseVenueReservation({
+      reservationId: RESERVATION_ID,
+      nextStatus: "RELEASED",
+      reason: "Ice time no longer needed",
+      allowAssignedDisposition: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect(serviceTransitionVenueReservation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ nextStatus: "RELEASED", allowAssignedDisposition: false }),
+    );
+  });
+
+  it("cancelVenueReservation requires the same explicit disposition for linked activities", async () => {
+    mockTx.venueReservation.findUnique.mockResolvedValue({
+      ...ownedReservation(),
+      practiceSessions: [{ id: PRACTICE_ID }],
+    });
+    serviceTransitionVenueReservation.mockRejectedValue(
+      new VenueReservationLifecycleError(
+        "Cannot cancel a reservation with a linked activity without an explicit disposition.",
+      ),
+    );
+
+    const result = await cancelVenueReservation({
+      reservationId: RESERVATION_ID,
+      nextStatus: "CANCELED",
+      reason: "Rink closed for maintenance",
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("completeVenueReservation marks the reservation COMPLETED with a usage status", async () => {
+    serviceTransitionVenueReservation.mockResolvedValue({
+      ...ownedReservation(),
+      status: "COMPLETED",
+      usageStatus: "USED",
+    });
+
+    const result = await completeVenueReservation({
+      reservationId: RESERVATION_ID,
+      nextStatus: "COMPLETED",
+      reason: "Ice time used as scheduled",
+      usageStatus: "USED",
+    });
+
+    expect(result.success).toBe(true);
+    expect(serviceTransitionVenueReservation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ nextStatus: "COMPLETED", usageStatus: "USED" }),
+    );
+  });
+
+  it("markVenueReservationUnused records a completed-but-unused disposition", async () => {
+    serviceTransitionVenueReservation.mockResolvedValue({
+      ...ownedReservation(),
+      status: "COMPLETED",
+      usageStatus: "UNUSED",
+    });
+
+    const result = await markVenueReservationUnused({
+      reservationId: RESERVATION_ID,
+      reason: "Team did not attend",
+    });
+
+    expect(result.success).toBe(true);
+    expect(serviceTransitionVenueReservation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ usageStatus: "UNUSED" }),
+    );
+  });
+
+  it.each([
+    ["requesting team admin", { ownerTeamId: "cteamxxxxxxxxxxxxxxxxxxxx" }],
+    ["association scheduler", { ownerLeagueId: "cleaguexxxxxxxxxxxxxxxxxx" }],
+    ["venue scheduler", { ownerVenueOrganizationId: ORG_ID }],
+  ])("rejects generic rescheduling by the %s and preserves request lineage", async (
+    _path,
+    owner,
+  ) => {
+    const requestBacked = {
+      ...ownedReservation(),
+      ownerLeagueId: null,
+      ownerTeamId: null,
+      ownerVenueOrganizationId: null,
+      ...owner,
+      sourceRequestId: "crequestxxxxxxxxxxxxxxxxxx",
+      offeringBlockId: "cofferxxxxxxxxxxxxxxxxxxx",
+    };
+    mockPrisma.venueReservation.findUnique.mockResolvedValueOnce(requestBacked);
+    mockTx.venueReservation.findUnique.mockResolvedValueOnce(requestBacked);
+    mockAuth.requireTeamAdmin.mockResolvedValue(USER_ID);
+    mockAuth.requireLeagueRole.mockResolvedValue(USER_ID);
+
+    const result = await rescheduleVenueReservation({
+      reservationId: RESERVATION_ID,
+      startsAt: new Date("2026-05-01T20:00:00.000Z"),
+      endsAt: new Date("2026-05-01T21:00:00.000Z"),
+      reason: "Move the approved request",
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error: expect.stringMatching(/cancel or amend.*approved request/i),
+    });
+    expect(requestBacked.sourceRequestId).toBe(
+      "crequestxxxxxxxxxxxxxxxxxx",
+    );
+    expect(mockTx.venueReservation.update).not.toHaveBeenCalled();
+    expect(serviceTransitionVenueReservation).not.toHaveBeenCalled();
+    expect(serviceCreateVenueReservation).not.toHaveBeenCalled();
+  });
+
+  it("unassignVenueReservation clears the linkage without deleting the reservation or the target", async () => {
+    const result = await unassignVenueReservation({
+      reservationId: RESERVATION_ID,
+      targetType: "PRACTICE",
+      targetId: PRACTICE_ID,
+      reason: "Practice moved to a different reservation",
+    });
+
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("checkVenueReservationAvailability action (T019)", () => {
+  it("returns offerings, occupancy, and override eligibility for an authorized manager", async () => {
+    serviceFindVenueReservationAvailability.mockResolvedValue({
+      offerings: [],
+      occupancy: [],
+      conflicts: [],
+    });
+
+    const result = await checkVenueReservationAvailability({
+      venueId: VENUE_ID,
+      startsAt: new Date("2026-05-01T18:00:00.000Z"),
+      endsAt: new Date("2026-05-01T19:00:00.000Z"),
+      mode: "STAFF",
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toHaveProperty("canOverride");
+    }
+  });
+
+  it("returns only public offerings and available slices for a published venue", async () => {
+    serviceFindVenueReservationAvailability.mockResolvedValue({
+      offerings: [],
+      occupancy: [
+        {
+          id: RESERVATION_ID,
+          ownerTeamId: "cteamxxxxxxxxxxxxxxxxxxxx",
+          status: "CONFIRMED",
+          startsAt: new Date("2026-05-01T18:15:00.000Z"),
+          endsAt: new Date("2026-05-01T18:45:00.000Z"),
+        },
+      ],
+      conflicts: [],
+    });
+
+    const result = await checkVenueReservationAvailability({
+      venueId: VENUE_ID,
+      startsAt: new Date("2026-05-01T18:00:00.000Z"),
+      endsAt: new Date("2026-05-01T19:00:00.000Z"),
+      mode: "PUBLIC",
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const serialized = JSON.stringify(result.data);
+      expect(serialized).not.toMatch(
+        /reservationId|status|occupancy|conflicts|ownerTeamId|ownerLeagueId|ownerVenueOrganizationId/,
+      );
+      expect(result.data).toEqual(
+        expect.objectContaining({
+          offerings: [],
+          availableSlices: [
+            {
+              startsAt: new Date("2026-05-01T18:00:00.000Z"),
+              endsAt: new Date("2026-05-01T18:15:00.000Z"),
+            },
+            {
+              startsAt: new Date("2026-05-01T18:45:00.000Z"),
+              endsAt: new Date("2026-05-01T19:00:00.000Z"),
+            },
+          ],
+          canOverride: false,
+        }),
+      );
+    }
+  });
+
+  it("rejects public previews for unpublished or private venues", async () => {
+    mockTx.venue.findFirst.mockResolvedValue(null);
+    serviceFindVenueReservationAvailability.mockResolvedValue({
+      offerings: [],
+      occupancy: [],
+      conflicts: [],
+    });
+
+    const result = await checkVenueReservationAvailability({
+      venueId: VENUE_ID,
+      startsAt: new Date("2026-05-01T18:00:00.000Z"),
+      endsAt: new Date("2026-05-01T19:00:00.000Z"),
+      mode: "PUBLIC",
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error: "Unable to check venue availability.",
+    });
+    expect(serviceFindVenueReservationAvailability).not.toHaveBeenCalled();
+    expect(mockTx.venue.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          id: VENUE_ID,
+          isActive: true,
+          visibility: "PUBLIC",
+          profileStatus: "PUBLISHED",
+        }),
+      }),
+    );
+  });
+
+  it("requires exact active venue staff for staff availability", async () => {
+    mockTx.venueStaff.findFirst.mockResolvedValue(null);
+
+    const result = await checkVenueReservationAvailability({
+      venueId: VENUE_ID,
+      startsAt: new Date("2026-05-01T18:00:00.000Z"),
+      endsAt: new Date("2026-05-01T19:00:00.000Z"),
+      mode: "STAFF",
+    });
+
+    expect(result.success).toBe(false);
+    expect(serviceFindVenueReservationAvailability).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/lib/actions/venue-schedules.test.ts
+++ b/__tests__/lib/actions/venue-schedules.test.ts
@@ -9,10 +9,12 @@ const {
   mockPrisma,
   mockLogVenueActivity,
   mockFindBookingConflicts,
+  mockPopulateVenueOfferingAvailability,
 } = vi.hoisted(() => ({
   mockRequireVenueScheduleManager: vi.fn(),
   mockLogVenueActivity: vi.fn(),
   mockFindBookingConflicts: vi.fn(),
+  mockPopulateVenueOfferingAvailability: vi.fn(),
   mockPrisma: {
     venue: {
       findFirst: vi.fn(),
@@ -21,6 +23,12 @@ const {
       create: vi.fn(),
       update: vi.fn(),
       findFirst: vi.fn(),
+      findMany: vi.fn(),
+    },
+    iceSurface: {
+      findMany: vi.fn(),
+    },
+    venueOperatingHour: {
       findMany: vi.fn(),
     },
     surfaceSegment: {
@@ -38,6 +46,11 @@ vi.mock("@/lib/auth/session", () => ({
 // __tests__/lib/utils/availability.test.ts.
 vi.mock("@/lib/utils/availability", () => ({
   findBookingConflicts: (...args: unknown[]) => mockFindBookingConflicts(...args),
+}));
+
+vi.mock("@/lib/services/venue-reservation-availability", () => ({
+  populateVenueOfferingAvailability: (...args: unknown[]) =>
+    mockPopulateVenueOfferingAvailability(...args),
 }));
 
 vi.mock("@/lib/db/prisma", () => ({
@@ -64,6 +77,7 @@ vi.mock("@/lib/actions/venue-organizations", () => ({
 import {
   cancelScheduleBlock,
   createScheduleBlock,
+  getVenueScheduleAdminData,
   getPublicVenueSchedule,
   publishScheduleBlock,
   updateScheduleBlock,
@@ -79,7 +93,10 @@ beforeEach(() => {
   mockRequireVenueScheduleManager.mockResolvedValue(USER_ID);
   mockPrisma.venue.findFirst.mockResolvedValue({ id: VENUE_ID, organizationId: ORGANIZATION_ID });
   mockPrisma.venueScheduleBlock.findMany.mockResolvedValue([]);
+  mockPrisma.iceSurface.findMany.mockResolvedValue([]);
+  mockPrisma.venueOperatingHour.findMany.mockResolvedValue([]);
   mockFindBookingConflicts.mockResolvedValue([]);
+  mockPopulateVenueOfferingAvailability.mockResolvedValue([]);
   mockLogVenueActivity.mockResolvedValue({ id: "cllogxxxxxxxxxxxxxxxxxxxxxxx" });
 });
 
@@ -257,7 +274,12 @@ describe("public schedule query", () => {
 
     const result = await getPublicVenueSchedule("north-rink");
 
-    expect(result).toEqual({ id: VENUE_ID, name: "North Rink", scheduleBlocks: [] });
+    expect(result).toEqual({
+      id: VENUE_ID,
+      name: "North Rink",
+      scheduleBlocks: [],
+      availableIce: [],
+    });
     expect(mockPrisma.venue.findFirst).toHaveBeenCalledWith(
       expect.objectContaining({
         where: expect.objectContaining({
@@ -265,6 +287,208 @@ describe("public schedule query", () => {
           profileStatus: "PUBLISHED",
         }),
       })
+    );
+  });
+
+  it("populates public requestable offerings with remaining slices and no occupancy detail", async () => {
+    const startsAt = new Date("2026-09-01T18:00:00.000Z");
+    const endsAt = new Date("2026-09-01T20:00:00.000Z");
+    const block = {
+      id: BLOCK_ID,
+      title: "Requestable ice",
+      startsAt,
+      endsAt,
+      registrationMode: "REQUEST_REQUIRED",
+      intent: "OFFERING",
+      surfaceId: "csurfacexxxxxxxxxxxxxxxxxx",
+      segmentId: null,
+      surface: { id: "csurfacexxxxxxxxxxxxxxxxxx", name: "Rink A" },
+      segment: null,
+      skillLevels: [],
+      registrations: [],
+    };
+    mockPrisma.venue.findFirst.mockResolvedValue({
+      id: VENUE_ID,
+      name: "North Rink",
+      timezone: "America/New_York",
+      scheduleBlocks: [block],
+      lessonOfferings: [],
+    });
+    mockPopulateVenueOfferingAvailability.mockResolvedValue([
+      {
+        ...block,
+        surfaceName: "Rink A",
+        remainingSlices: [
+          {
+            startsAt,
+            endsAt: new Date("2026-09-01T18:30:00.000Z"),
+          },
+          {
+            startsAt: new Date("2026-09-01T19:00:00.000Z"),
+            endsAt,
+          },
+        ],
+      },
+    ]);
+
+    const result = await getPublicVenueSchedule("north-rink");
+
+    expect(mockPopulateVenueOfferingAvailability).toHaveBeenCalledWith(
+      mockPrisma,
+      expect.objectContaining({
+        venueId: VENUE_ID,
+        offerings: [
+          expect.objectContaining({
+            id: BLOCK_ID,
+            surfaceId: "csurfacexxxxxxxxxxxxxxxxxx",
+            segmentId: null,
+          }),
+        ],
+        mode: "PUBLIC",
+      }),
+    );
+    expect(result?.availableIce[0]).toEqual(
+      expect.objectContaining({
+        remainingSlices: expect.any(Array),
+      }),
+    );
+    expect(result?.availableIce[0]).not.toHaveProperty("occupancy");
+    expect(mockPrisma.venue.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        select: expect.objectContaining({
+          scheduleBlocks: expect.objectContaining({
+            where: expect.objectContaining({
+              audience: "PUBLIC",
+              visibility: "PUBLIC",
+              status: "PUBLISHED",
+            }),
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("expands recurring requestable offerings into concrete future occurrences", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-17T12:00:00.000Z"));
+    try {
+      const block = {
+        id: BLOCK_ID,
+        title: "Weekly requestable ice",
+        startsAt: new Date("2026-08-23T14:00:00.000Z"),
+        endsAt: new Date("2026-08-23T15:00:00.000Z"),
+        registrationMode: "REQUEST_REQUIRED",
+        intent: "OFFERING",
+        recurrenceRule: "FREQ=WEEKLY;COUNT=2",
+        recurrenceEndDate: new Date("2026-08-30T14:00:00.000Z"),
+        surfaceId: null,
+        segmentId: null,
+        surface: null,
+        segment: null,
+        skillLevels: [],
+        registrations: [],
+      };
+      mockPrisma.venue.findFirst.mockResolvedValue({
+        id: VENUE_ID,
+        name: "North Rink",
+        timezone: "America/New_York",
+        scheduleBlocks: [block],
+        lessonOfferings: [],
+      });
+      mockPopulateVenueOfferingAvailability.mockImplementation(
+        async (
+          _client: unknown,
+          input: { offerings: Array<Record<string, unknown>> },
+        ) =>
+          input.offerings.map((offering: Record<string, unknown>) => ({
+            ...offering,
+            remainingSlices: [
+              {
+                startsAt: offering.startsAt,
+                endsAt: offering.endsAt,
+              },
+            ],
+          })),
+      );
+
+      const result = await getPublicVenueSchedule("north-rink");
+
+      expect(mockPopulateVenueOfferingAvailability).toHaveBeenCalledWith(
+        mockPrisma,
+        expect.objectContaining({
+          offerings: [
+            expect.objectContaining({
+              offeringBlockId: BLOCK_ID,
+              startsAt: new Date("2026-08-23T14:00:00.000Z"),
+            }),
+            expect.objectContaining({
+              offeringBlockId: BLOCK_ID,
+              startsAt: new Date("2026-08-30T14:00:00.000Z"),
+            }),
+          ],
+          mode: "PUBLIC",
+        }),
+      );
+      expect(result?.availableIce).toHaveLength(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe("admin schedule availability", () => {
+  it("populates the admin available-ice browser data", async () => {
+    const startsAt = new Date("2026-09-01T18:00:00.000Z");
+    const endsAt = new Date("2026-09-01T20:00:00.000Z");
+    mockPrisma.venue.findFirst.mockResolvedValue({
+      id: VENUE_ID,
+      organizationId: ORGANIZATION_ID,
+      slug: "north-rink",
+      timezone: "America/New_York",
+    });
+    mockPrisma.venueScheduleBlock.findMany.mockResolvedValue([
+      {
+        id: BLOCK_ID,
+        title: "Requestable ice",
+        startsAt,
+        endsAt,
+        activityType: "OTHER",
+        status: "PUBLISHED",
+        intent: "OFFERING",
+        registrationMode: "REQUEST_REQUIRED",
+        surfaceId: null,
+        segmentId: null,
+        surface: null,
+      },
+    ]);
+    mockPopulateVenueOfferingAvailability.mockResolvedValue([
+      {
+        id: BLOCK_ID,
+        title: "Requestable ice",
+        startsAt,
+        endsAt,
+        surfaceId: null,
+        segmentId: null,
+        surfaceName: null,
+        occupancy: [],
+        remainingSlices: [{ startsAt, endsAt }],
+      },
+    ]);
+
+    const result = await getVenueScheduleAdminData(ORGANIZATION_ID, VENUE_ID);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.availableIce).toEqual([
+        expect.objectContaining({
+          id: BLOCK_ID,
+          remainingSlices: [{ startsAt, endsAt }],
+        }),
+      ]);
+    }
+    expect(mockPopulateVenueOfferingAvailability).toHaveBeenCalledWith(
+      mockPrisma,
+      expect.objectContaining({ mode: "STAFF" }),
     );
   });
 });

--- a/__tests__/lib/data/calendar.test.ts
+++ b/__tests__/lib/data/calendar.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockPrisma, mockAuth, mockDashboard } = vi.hoisted(() => ({
+  mockPrisma: {
+    event: { findMany: vi.fn() },
+    practiceSession: { findMany: vi.fn() },
+    signupEvent: { findMany: vi.fn() },
+    venueStaff: { findMany: vi.fn() },
+  },
+  mockAuth: {
+    getViewableTeamIds: vi.fn(),
+    requireUserId: vi.fn(),
+  },
+  mockDashboard: { getViewerMemberships: vi.fn() },
+}));
+
+vi.mock("@/lib/db/prisma", () => ({ prisma: mockPrisma }));
+vi.mock("@/lib/auth/session", () => mockAuth);
+vi.mock("@/lib/data/dashboard", () => mockDashboard);
+
+import {
+  deduplicateCalendarItems,
+  getUserCalendarItems,
+} from "@/lib/data/calendar";
+import type { CalendarItem } from "@/types/events";
+
+function item(overrides: Partial<CalendarItem>): CalendarItem {
+  return {
+    id: "event-1",
+    source: "event",
+    title: "Practice RSVP",
+    startAt: "2026-09-07T10:00:00.000Z",
+    endAt: "2026-09-07T11:00:00.000Z",
+    scope: { teamId: "team-1", teamName: "Hawks" },
+    href: "/events/event-1",
+    ...overrides,
+  };
+}
+
+describe("deduplicateCalendarItems", () => {
+  it("uses practice metadata but preserves the participant Event RSVP href in either input order", () => {
+    const aliases = [
+      item({ venueReservationId: "reservation-1" }),
+      item({
+        id: "practice-1",
+        source: "practice",
+        title: "Team practice",
+        href: "/practice-planner/practice-1",
+        venueReservationId: "reservation-1",
+      }),
+    ];
+
+    for (const result of [
+      deduplicateCalendarItems(aliases),
+      deduplicateCalendarItems([...aliases].reverse()),
+    ]) {
+      expect(result).toEqual([
+        expect.objectContaining({
+          id: "practice-1",
+          source: "practice",
+          title: "Team practice",
+          href: "/events/event-1",
+        }),
+      ]);
+    }
+  });
+
+  it("preserves independent legacy items without a reservation link", () => {
+    const result = deduplicateCalendarItems([
+      item({ id: "event-1" }),
+      item({
+        id: "practice-1",
+        source: "practice",
+        href: "/practice-planner/practice-1",
+      }),
+    ]);
+
+    expect(result).toHaveLength(2);
+  });
+});
+
+describe("getUserCalendarItems event privacy", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuth.requireUserId.mockResolvedValue("user-1");
+    mockAuth.getViewableTeamIds.mockResolvedValue([]);
+    mockDashboard.getViewerMemberships.mockResolvedValue({
+      teams: [],
+      leagues: [{
+        role: "MEMBER",
+        league: { id: "league-1", name: "Association" },
+      }],
+    });
+    mockPrisma.event.findMany.mockResolvedValue([]);
+    mockPrisma.practiceSession.findMany.mockResolvedValue([]);
+    mockPrisma.signupEvent.findMany.mockResolvedValue([]);
+    mockPrisma.venueStaff.findMany.mockResolvedValue([]);
+  });
+
+  it("does not broaden a team-scoped participant Event to every league member", async () => {
+    await getUserCalendarItems({
+      from: "2026-09-01T00:00:00.000Z",
+      to: "2026-10-01T00:00:00.000Z",
+    });
+
+    expect(mockPrisma.event.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          AND: expect.arrayContaining([
+            {
+              OR: [{ leagueId: { in: ["league-1"] } }],
+            },
+          ]),
+        }),
+      }),
+    );
+  });
+});

--- a/__tests__/lib/data/schedule-items.test.ts
+++ b/__tests__/lib/data/schedule-items.test.ts
@@ -21,6 +21,7 @@ function scheduleItem(
     venueId: "venue-1",
     surfaceId: "surface-1",
     segmentId: null,
+    href: null,
     ...overrides,
   };
 }
@@ -67,6 +68,120 @@ describe("deduplicateAssociationScheduleItems", () => {
         source: "seasonGame",
         canonicalScheduleId: "reservation:reservation-1",
       }),
+    ]);
+  });
+
+  // T021: a practice and its participant-facing Event alias sharing one
+  // VenueReservation must collapse to a single canonical row, with the
+  // practice (domain activity) winning over the bare Event alias -- this is
+  // the exact linkage the not-yet-built T032 practice-session flow is meant
+  // to establish (see __tests__/lib/actions/practice-sessions.test.ts).
+  it("keeps practice metadata and the participant Event RSVP href regardless of input order", () => {
+    const aliases = [
+      scheduleItem({
+        id: "event-alias-1",
+        venueReservationId: "reservation-2",
+        source: "event",
+        sourceId: "event-alias-1",
+        title: "Practice (roster view)",
+        href: "/events/event-alias-1",
+      }),
+      scheduleItem({
+        id: "practice-1",
+        venueReservationId: "reservation-2",
+        source: "practice",
+        sourceId: "practice-1",
+        title: "Team practice",
+        href: "/practice-planner/practice-1",
+      }),
+    ];
+
+    for (const result of [
+      deduplicateAssociationScheduleItems(aliases),
+      deduplicateAssociationScheduleItems([...aliases].reverse()),
+    ]) {
+      expect(result).toEqual([
+        expect.objectContaining({
+          source: "practice",
+          canonicalScheduleId: "reservation:reservation-2",
+          title: "Team practice",
+          href: "/events/event-alias-1",
+        }),
+      ]);
+    }
+  });
+
+  it("collapses more than two aliases of the same reservation to the single highest-priority source, in either input order", () => {
+    const aliases = [
+      scheduleItem({
+        id: "res-alias",
+        venueReservationId: "reservation-3",
+        source: "venueReservation",
+        sourceId: "reservation-3",
+      }),
+      scheduleItem({
+        id: "event-alias",
+        venueReservationId: "reservation-3",
+        source: "event",
+        sourceId: "event-alias",
+      }),
+      scheduleItem({
+        id: "signup-alias",
+        venueReservationId: "reservation-3",
+        source: "signupEvent",
+        sourceId: "signup-alias",
+      }),
+      scheduleItem({
+        id: "eventgame-alias",
+        venueReservationId: "reservation-3",
+        source: "eventGame",
+        sourceId: "eventgame-alias",
+      }),
+      scheduleItem({
+        id: "seasongame-alias",
+        venueReservationId: "reservation-3",
+        source: "seasonGame",
+        sourceId: "seasongame-alias",
+      }),
+    ];
+
+    const forward = deduplicateAssociationScheduleItems(aliases);
+    const reversed = deduplicateAssociationScheduleItems([...aliases].reverse());
+
+    for (const result of [forward, reversed]) {
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual(
+        expect.objectContaining({
+          source: "seasonGame",
+          canonicalScheduleId: "reservation:reservation-3",
+        }),
+      );
+    }
+  });
+
+  it("collapses two fully identical unlinked occurrences (same source, sourceId, and start time) to one row", () => {
+    const result = deduplicateAssociationScheduleItems([
+      scheduleItem({ id: "dup-a" }),
+      scheduleItem({ id: "dup-b" }),
+    ]);
+
+    expect(result).toHaveLength(1);
+  });
+
+  it("sorts canonical items by start time, then by canonical schedule ID as a stable tiebreaker for same-instant items", () => {
+    const sameInstant = new Date("2026-09-21T09:00:00.000Z");
+    const earlier = new Date("2026-09-20T09:00:00.000Z");
+
+    const result = deduplicateAssociationScheduleItems([
+      scheduleItem({ id: "z-item", source: "event", sourceId: "zzz", startsAt: sameInstant }),
+      scheduleItem({ id: "a-item", source: "event", sourceId: "aaa", startsAt: sameInstant }),
+      scheduleItem({ id: "earliest-item", source: "event", sourceId: "earliest", startsAt: earlier }),
+    ]);
+
+    expect(result.map((item) => item.canonicalScheduleId)).toEqual([
+      `event:earliest:${earlier.toISOString()}`,
+      `event:aaa:${sameInstant.toISOString()}`,
+      `event:zzz:${sameInstant.toISOString()}`,
     ]);
   });
 });

--- a/__tests__/lib/services/venue-reservation-availability.test.ts
+++ b/__tests__/lib/services/venue-reservation-availability.test.ts
@@ -1,8 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Prisma } from "@prisma/client";
 import {
+  approvedSpaceWithinRequestedSpace,
+  findLegacyAcceptedRequestConflicts,
   findVenueReservationAvailability,
   findVenueReservationConflicts,
+  populateVenueOfferingAvailability,
+  subtractVenueReservationOccupancy,
 } from "@/lib/services/venue-reservation-availability";
 
 const baseCandidate = {
@@ -50,6 +54,7 @@ function offering(overrides: Record<string, unknown> = {}) {
 function tx() {
   return {
     venueReservation: { findMany: vi.fn().mockResolvedValue([]) },
+    iceTimeRequest: { findMany: vi.fn().mockResolvedValue([]) },
     segmentCoexistence: { findMany: vi.fn().mockResolvedValue([]) },
     venueScheduleBlock: { findMany: vi.fn().mockResolvedValue([]) },
   } as unknown as Prisma.TransactionClient;
@@ -96,6 +101,63 @@ describe("venue reservation availability", () => {
     ] as never);
 
     await expect(findVenueReservationConflicts(client, baseCandidate)).resolves.toEqual([]);
+  });
+
+  it("enforces the requested venue/surface/segment containment hierarchy", () => {
+    expect(approvedSpaceWithinRequestedSpace(
+      { surfaceId: null, segmentId: null },
+      { surfaceId: "surface-b", segmentId: "segment-b" },
+    )).toBe(true);
+    expect(approvedSpaceWithinRequestedSpace(
+      { surfaceId: "surface-a", segmentId: null },
+      { surfaceId: "surface-a", segmentId: "segment-a" },
+    )).toBe(true);
+    expect(approvedSpaceWithinRequestedSpace(
+      { surfaceId: "surface-a", segmentId: "segment-a" },
+      { surfaceId: "surface-a", segmentId: null },
+    )).toBe(false);
+    expect(approvedSpaceWithinRequestedSpace(
+      { surfaceId: "surface-a", segmentId: null },
+      { surfaceId: "surface-b", segmentId: null },
+    )).toBe(false);
+  });
+
+  it("applies canonical split-segment coexistence to legacy accepted requests", async () => {
+    const client = tx();
+    vi.mocked(client.iceTimeRequest.findMany).mockResolvedValue([{
+      id: "legacy-request",
+      requestedStartAt: baseCandidate.startsAt,
+      requestedEndAt: baseCandidate.endsAt,
+      approvedStartAt: baseCandidate.startsAt,
+      approvedEndAt: baseCandidate.endsAt,
+      approvedSurfaceId: baseCandidate.surfaceId,
+      approvedSegmentId: "csegment000000000000000002",
+      scheduleBlock: {
+        surfaceId: baseCandidate.surfaceId,
+        segmentId: "csegment000000000000000002",
+      },
+    }] as never);
+    vi.mocked(client.segmentCoexistence.findMany).mockResolvedValue([{
+      segmentAId: baseCandidate.segmentId,
+      segmentBId: "csegment000000000000000002",
+    }] as never);
+
+    await expect(
+      findLegacyAcceptedRequestConflicts(client, baseCandidate),
+    ).resolves.toEqual([]);
+    expect(client.iceTimeRequest.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          status: { in: ["ACCEPTED", "PARTIALLY_ACCEPTED"] },
+          venueReservation: null,
+        }),
+      }),
+    );
+
+    vi.mocked(client.segmentCoexistence.findMany).mockResolvedValue([]);
+    await expect(
+      findLegacyAcceptedRequestConflicts(client, baseCandidate),
+    ).resolves.toEqual([{ id: "legacy-request" }]);
   });
 
   it("treats whole-surface reservations as conflicts for every segment", async () => {
@@ -272,18 +334,116 @@ describe("venue reservation availability", () => {
     ]);
   });
 
-  it("redacts owner and request identity from public conflicts", async () => {
-    const client = tx();
-    vi.mocked(client.venueReservation.findMany).mockResolvedValue([reservation()] as never);
+  it("subtracts merged partial occupancy into concrete remaining slices", () => {
+    expect(
+      subtractVenueReservationOccupancy(
+        {
+          startsAt: new Date("2026-09-01T18:00:00.000Z"),
+          endsAt: new Date("2026-09-01T20:00:00.000Z"),
+        },
+        [
+          {
+            startsAt: new Date("2026-09-01T18:30:00.000Z"),
+            endsAt: new Date("2026-09-01T19:00:00.000Z"),
+          },
+          {
+            startsAt: new Date("2026-09-01T18:45:00.000Z"),
+            endsAt: new Date("2026-09-01T19:30:00.000Z"),
+          },
+        ],
+      ),
+    ).toEqual({
+      occupancy: [
+        {
+          startsAt: new Date("2026-09-01T18:30:00.000Z"),
+          endsAt: new Date("2026-09-01T19:30:00.000Z"),
+        },
+      ],
+      remainingSlices: [
+        {
+          startsAt: new Date("2026-09-01T18:00:00.000Z"),
+          endsAt: new Date("2026-09-01T18:30:00.000Z"),
+        },
+        {
+          startsAt: new Date("2026-09-01T19:30:00.000Z"),
+          endsAt: new Date("2026-09-01T20:00:00.000Z"),
+        },
+      ],
+    });
+  });
 
-    const [conflict] = await findVenueReservationConflicts(client, {
-      ...baseCandidate,
-      publicView: true,
+  it("keeps coexisting segment occupancy out of an offering occurrence", async () => {
+    const client = tx();
+    vi.mocked(client.venueReservation.findMany).mockResolvedValue([
+      reservation({
+        segmentId: "csegment000000000000000002",
+        startsAt: new Date("2026-09-01T18:15:00.000Z"),
+        endsAt: new Date("2026-09-01T18:45:00.000Z"),
+      }),
+    ] as never);
+    vi.mocked(client.segmentCoexistence.findMany).mockResolvedValue([
+      {
+        segmentAId: baseCandidate.segmentId,
+        segmentBId: "csegment000000000000000002",
+      },
+    ] as never);
+
+    const [result] = await populateVenueOfferingAvailability(client, {
+      venueId: baseCandidate.venueId,
+      offerings: [offering()],
+      now: baseCandidate.now,
+      mode: "STAFF",
     });
 
-    expect(conflict).not.toHaveProperty("ownerLeagueId");
-    expect(conflict).not.toHaveProperty("ownerTeamId");
-    expect(conflict).not.toHaveProperty("ownerVenueOrganizationId");
-    expect(conflict).not.toHaveProperty("sourceRequestId");
+    expect(result.occupancy).toEqual([]);
+    expect(result.remainingSlices).toEqual([
+      {
+        startsAt: baseCandidate.startsAt,
+        endsAt: baseCandidate.endsAt,
+      },
+    ]);
+  });
+
+  it("returns only remaining slices for public offerings without occupancy details", async () => {
+    const client = tx();
+    vi.mocked(client.venueReservation.findMany).mockResolvedValue([
+      reservation({
+        segmentId: null,
+        startsAt: new Date("2026-09-01T18:20:00.000Z"),
+        endsAt: new Date("2026-09-01T18:40:00.000Z"),
+      }),
+    ] as never);
+
+    const [result] = await populateVenueOfferingAvailability(client, {
+      venueId: baseCandidate.venueId,
+      offerings: [offering()],
+      now: baseCandidate.now,
+      mode: "PUBLIC",
+    });
+
+    expect(result).not.toHaveProperty("occupancy");
+    expect(result.remainingSlices).toHaveLength(2);
+  });
+
+  it("filters public offering discovery to PUBLIC audience and visibility", async () => {
+    const client = tx();
+    vi.mocked(client.venueReservation.findMany).mockResolvedValue([] as never);
+    vi.mocked(client.venueScheduleBlock.findMany).mockResolvedValue([] as never);
+
+    await findVenueReservationAvailability(client, {
+      ...baseCandidate,
+      includeOfferings: true,
+      offeringAccess: "PUBLIC",
+    });
+
+    expect(client.venueScheduleBlock.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          audience: "PUBLIC",
+          visibility: "PUBLIC",
+          status: "PUBLISHED",
+        }),
+      }),
+    );
   });
 });

--- a/__tests__/lib/services/venue-reservations.test.ts
+++ b/__tests__/lib/services/venue-reservations.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Prisma } from "@prisma/client";
 import {
   assignVenueReservation,
+  assertGenericRescheduleAllowed,
   createVenueReservation,
   transitionVenueReservation,
 } from "@/lib/services/venue-reservations";
@@ -456,6 +457,52 @@ describe("createVenueReservation validation", () => {
     );
   });
 
+  it("creates a public-request reservation only for the venue's organization", async () => {
+    const tx = makeTx();
+    vi.mocked(tx.venueStaff.findFirst).mockResolvedValue({ id: "staff-1" } as never);
+    vi.mocked(tx.venueScheduleBlock.findFirst).mockResolvedValue({
+      id: "offering-1",
+      venueId: "venue-1",
+      surfaceId: "surface-1",
+      segmentId: null,
+      startsAt,
+      endsAt,
+      recurrenceRule: null,
+      recurrenceEndDate: null,
+    } as never);
+    vi.mocked(tx.iceTimeRequest.findUnique).mockResolvedValue({
+      status: "ACCEPTED",
+      venueId: "venue-1",
+      scheduleBlockId: "offering-1",
+      approvedStartAt: startsAt,
+      approvedEndAt: endsAt,
+      approvedSurfaceId: "surface-1",
+      approvedSegmentId: "segment-1",
+      requesterTeamId: null,
+      requesterLeagueId: null,
+      requestedStartAt: startsAt,
+      requestedEndAt: endsAt,
+      venueReservation: null,
+    } as never);
+
+    await expect(createVenueReservation(tx, createInput({
+      ownerLeagueId: undefined,
+      ownerVenueOrganizationId: "venue-org-1",
+      sourceRequestId: "request-1",
+      offeringBlockId: "offering-1",
+    }))).resolves.toEqual({ id: venueReservationId });
+    expect(tx.venueReservation.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          ownerLeagueId: null,
+          ownerTeamId: null,
+          ownerVenueOrganizationId: "venue-org-1",
+          sourceRequestId: "request-1",
+        }),
+      }),
+    );
+  });
+
   it("requires exact active venue request staff for a source request", async () => {
     const tx = makeTx();
 
@@ -606,6 +653,34 @@ describe("assignVenueReservation validation", () => {
     expect(tx.practiceSession.update).not.toHaveBeenCalled();
   });
 
+  it("prevents assigning public-request venue inventory to team activities", async () => {
+    const tx = makeTx();
+    vi.mocked(tx.venueReservation.findUnique).mockResolvedValue(reservation({
+      ownerLeagueId: null,
+      ownerVenueOrganizationId: "venue-org-1",
+      sourceRequestId: "request-1",
+    }) as never);
+    const targetId = setAssignmentTarget(tx, "PRACTICE");
+
+    await expect(assignVenueReservation(tx, {
+      reservationId: "reservation-1",
+      targetType: "PRACTICE",
+      targetId,
+      actorId: "actor-1",
+    })).rejects.toThrow("cannot be assigned to association or team activities");
+    expect(tx.practiceSession.update).not.toHaveBeenCalled();
+  });
+
+  describe("request-backed rescheduling", () => {
+    it("rejects generic rescheduling without mutating request lineage", () => {
+      const requestBacked = { sourceRequestId: "request-1" };
+      expect(() => assertGenericRescheduleAllowed(requestBacked)).toThrow(
+        "cancel or amend the approved request",
+      );
+      expect(requestBacked.sourceRequestId).toBe("request-1");
+    });
+  });
+
   it.each<TargetType>([
     "EVENT",
     "SEASON_GAME",
@@ -751,5 +826,37 @@ describe("transitionVenueReservation authorization", () => {
       reason: "Approve held inventory",
       overrideReason: "Approved overlap",
     })).resolves.toEqual({ id: venueReservationId });
+  });
+
+  it("persists an optional transition snapshot for reschedule bookkeeping", async () => {
+    const tx = makeTx();
+    const snapshot = {
+      kind: "RESCHEDULE",
+      priorSourceRequestId: "request-1",
+      replacementStartsAt: "2026-09-08T18:00:00.000Z",
+      replacementEndsAt: "2026-09-08T19:00:00.000Z",
+    } as const;
+
+    await expect(transitionVenueReservation(tx, {
+      reservationId: "reservation-1",
+      nextStatus: "RELEASED",
+      actorId: "actor-1",
+      reason: "Moved to a replacement slot",
+      snapshot,
+    })).resolves.toEqual({ id: venueReservationId });
+
+    expect(tx.venueReservation.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: venueReservationId },
+        data: expect.objectContaining({
+          transitions: {
+            create: expect.objectContaining({
+              reason: "Moved to a replacement slot",
+              snapshot,
+            }),
+          },
+        }),
+      }),
+    );
   });
 });

--- a/__tests__/performance/venue-reservation-availability.test.ts
+++ b/__tests__/performance/venue-reservation-availability.test.ts
@@ -1,0 +1,103 @@
+/**
+ * T018 (part 2): documented-scale performance for venue reservation conflict
+ * detection, mirroring the existing SC-008 pattern in
+ * `__tests__/lib/utils/availability.test.ts` (50 timed runs, p95 assertion)
+ * but against `findVenueReservationConflicts` — the reservation-native
+ * successor availability primitive introduced in this feature.
+ */
+import { describe, expect, it } from "vitest";
+
+import { findVenueReservationConflicts } from "@/lib/services/venue-reservation-availability";
+
+const VENUE_ID = "cvenue0000000000000000000";
+const SURFACE_1 = "csurf10000000000000000000";
+const SURFACE_2 = "csurf20000000000000000000";
+const SEG_A = "cseg_a0000000000000000000";
+const SEG_B = "cseg_b0000000000000000000";
+const SEG_C = "cseg_c0000000000000000000";
+
+type ReservationRow = {
+  id: string;
+  status: "HELD" | "CONFIRMED" | "COMPLETED";
+  startsAt: Date;
+  endsAt: Date;
+  timezone: string;
+  venueId: string;
+  surfaceId: string | null;
+  segmentId: string | null;
+  ownerLeagueId: string | null;
+  ownerTeamId: string | null;
+  ownerVenueOrganizationId: string | null;
+  sourceRequestId: string | null;
+};
+
+describe("venue reservation availability performance (SC-008 analogue, T018 part 2)", () => {
+  it("keeps p95 conflict-lookup latency under 500ms across 50 runs at 25,000 annual commitments", async () => {
+    const hour = 3_600_000;
+    const monthStart = Date.UTC(2026, 8, 1, 6);
+    const segCycle: (string | null)[] = [SEG_A, SEG_B, SEG_C, null];
+
+    const reservations: ReservationRow[] = [];
+    for (let i = 0; i < 25_000; i++) {
+      const startsAt = new Date(monthStart + (i % 30) * 24 * hour + (i % 12) * hour);
+      const endsAt = new Date(startsAt.getTime() + hour);
+      const surfaceId = i % 2 === 0 ? SURFACE_1 : SURFACE_2;
+      const segmentId = surfaceId === SURFACE_1 ? segCycle[i % 4] : null;
+
+      reservations.push({
+        id: `perf-reservation-${i}`,
+        status: i % 17 === 0 ? "HELD" : "CONFIRMED",
+        startsAt,
+        endsAt,
+        timezone: "UTC",
+        venueId: VENUE_ID,
+        surfaceId,
+        segmentId,
+        ownerLeagueId: null,
+        ownerTeamId: `team-${i % 25}`,
+        ownerVenueOrganizationId: null,
+        sourceRequestId: null,
+      });
+    }
+
+    const tx = {
+      venueReservation: {
+        // Real Prisma applies the where-clause in the database; here the
+        // fixture is returned unfiltered so the timed cost measures the
+        // service's own JS-side scope/coexistence computation across the
+        // full 1,000-row candidate set, exactly like the SC-008 precedent.
+        findMany: async () =>
+          reservations.map((row) => ({ ...row, heldUntil: row.status === "HELD" ? new Date(monthStart + 365 * 24 * hour) : null })),
+      },
+      segmentCoexistence: {
+        findMany: async () => [],
+      },
+    } as any;
+
+    // SEG_C conflicts with A/C rows (and venue-wide/whole-surface rows) while
+    // coexisting with B (no coexistence pairs registered), exercising the
+    // full scope/segment comparison across a wide same-day window.
+    const candidate = {
+      venueId: VENUE_ID,
+      surfaceId: SURFACE_1,
+      segmentId: SEG_C,
+      startsAt: new Date(Date.UTC(2026, 8, 15, 6)),
+      endsAt: new Date(Date.UTC(2026, 8, 15, 18)),
+    };
+
+    const durations: number[] = [];
+    let lastResult: Awaited<ReturnType<typeof findVenueReservationConflicts>> = [];
+    for (let run = 0; run < 50; run++) {
+      const started = performance.now();
+      lastResult = await findVenueReservationConflicts(tx, candidate);
+      durations.push(performance.now() - started);
+    }
+
+    // The fixture must actually produce work: conflicts exist in the window.
+    expect(lastResult.length).toBeGreaterThan(0);
+
+    durations.sort((a, b) => a - b);
+    const p95 = durations[Math.ceil(durations.length * 0.95) - 1];
+    expect(p95).toBeLessThanOrEqual(500);
+  });
+});

--- a/__tests__/prisma/venue-reservation-migration.test.ts
+++ b/__tests__/prisma/venue-reservation-migration.test.ts
@@ -55,13 +55,37 @@ describe("canonical venue reservation migration parity", () => {
       'request."requesterTeamId" IS NOT NULL',
     );
     expect(migration).toContain(
+      'request."requesterLeagueId" IS NULL',
+    );
+    expect(migration).toMatch(
+      /request_venue\."organizationId"\s*=\s*NEW\."ownerVenueOrganizationId"/,
+    );
+    expect(migration).toContain(
       "venue reservation league owner has no active venue relationship",
     );
     expect(migration).toContain('"ice_time_requests_approval_ancestry_trigger"');
-    expect(migration).toContain(
-      '"id" = NEW."scheduleBlockId" AND "venueId" = NEW."venueId"',
+    expect(migration).toMatch(
+      /block\."id" = NEW\."scheduleBlockId"[\s\S]*block\."venueId" = NEW\."venueId"/,
     );
     expect(migration).toContain('"venue_schedule_blocks_ancestry_trigger"');
+  });
+
+  it("enforces partial approval space containment at the database boundary", () => {
+    expect(migration).toContain(
+      "approved space widens or leaves requested space",
+    );
+    expect(migration).toContain(
+      "approved space widens requested surface to venue",
+    );
+    expect(migration).toMatch(
+      /block\."surfaceId" IS NULL[\s\S]*NEW\."approvedSurfaceId" = block\."surfaceId"[\s\S]*block\."segmentId" IS NULL[\s\S]*NEW\."approvedSegmentId" = block\."segmentId"/,
+    );
+    expect(migration).toContain(
+      `NEW."status" IN ('ACCEPTED', 'PARTIALLY_ACCEPTED')`,
+    );
+    expect(migration).toMatch(
+      /UPDATE OF "scheduleBlockId", "venueId", "status",[\s\S]*"approvedStartAt", "approvedEndAt"/,
+    );
   });
 
   it("uses distinct offering and occupying-block provenance with occurrence uniqueness", () => {

--- a/__tests__/scripts/backfill-venue-reservations.test.ts
+++ b/__tests__/scripts/backfill-venue-reservations.test.ts
@@ -48,7 +48,10 @@ function verifierEmptyDelegates() {
   };
 }
 
-function materializationClient(options: { failStandaloneLink?: boolean } = {}) {
+function materializationClient(options: {
+  failStandaloneLink?: boolean;
+  publicRequest?: boolean;
+} = {}) {
   const at = (day: number) => new Date(`2026-09-0${day}T10:00:00Z`);
   const end = (day: number) => new Date(`2026-09-0${day}T11:00:00Z`);
   let state = {
@@ -241,10 +244,13 @@ function materializationClient(options: { failStandaloneLink?: boolean } = {}) {
       approvedEndAt: null,
       approvedSurfaceId: null,
       approvedSegmentId: null,
-      requesterTeamId: "request-team",
+      requesterTeamId: options.publicRequest ? null : "request-team",
       requesterLeagueId: null,
       venueId: "venue",
-      venue: { timezone: "UTC" },
+      venue: {
+        timezone: "UTC",
+        organizationId: "venue-organization",
+      },
       venueReservation: null,
       scheduleBlockId: "offering",
     })),
@@ -479,6 +485,7 @@ describe("venue reservation backfill", () => {
       preservedOverlaps: 1,
       unresolved: [],
     });
+
     expect(fixture.state.links.season).toBe(fixture.state.links.seasonEvent);
     expect(fixture.state.links.practice).toBe(fixture.state.links.practiceEvent);
     expect(fixture.state.links.eventGame).toBe(fixture.state.links.signupEvent);
@@ -507,6 +514,27 @@ describe("venue reservation backfill", () => {
       unresolved: [],
     });
     expect(fixture.state.reservations).toHaveLength(7);
+  });
+
+  it("backfills unaffiliated accepted requests to the venue organization owner", async () => {
+    const fixture = materializationClient({ publicRequest: true });
+
+    const report = await backfillVenueReservations(
+      {
+        dryRun: false,
+        systemActorId: "cactor00000000000000000001",
+      },
+      fixture.client as never,
+    );
+
+    expect(report.unresolved).toEqual([]);
+    expect(fixture.state.reservations.find(
+      (reservation) => reservation.sourceRequestId === "request",
+    )).toMatchObject({
+      ownerLeagueId: null,
+      ownerTeamId: null,
+      ownerVenueOrganizationId: "venue-organization",
+    });
   });
 
   it("recomputes a shortened recurrence inside each transaction and skips the stale later candidate", async () => {

--- a/app/(dashboard)/league/[leagueId]/venue-reservations/page.tsx
+++ b/app/(dashboard)/league/[leagueId]/venue-reservations/page.tsx
@@ -1,0 +1,246 @@
+import { notFound } from "next/navigation";
+import { PageContainer } from "@/components/ui/PageContainer";
+import { PageHeader } from "@/components/ui/PageHeader";
+import {
+  VenueReservationInventory,
+  type VenueReservationFilters,
+  type VenueReservationInventoryItem,
+} from "@/components/features/association-operations/VenueReservationInventory";
+import { requireUserId } from "@/lib/auth/session";
+import { prisma } from "@/lib/db/prisma";
+import { formatDateTimeInZone } from "@/lib/utils/date";
+
+export const dynamic = "force-dynamic";
+
+interface VenueReservationsPageProps {
+  params: Promise<{ leagueId: string }>;
+  searchParams: Promise<{
+    assignment?: string | string[];
+    owner?: string | string[];
+    venueId?: string | string[];
+  }>;
+}
+
+function one(value: string | string[] | undefined): string {
+  return Array.isArray(value) ? value[0] ?? "" : value ?? "";
+}
+
+function parseFilters(
+  search: Awaited<VenueReservationsPageProps["searchParams"]>,
+): VenueReservationFilters {
+  const assignment = one(search.assignment);
+  const owner = one(search.owner);
+  return {
+    assignment:
+      assignment === "assigned" || assignment === "unassigned" ? assignment : "all",
+    owner: owner === "league" || owner === "team" ? owner : "all",
+    venueId: one(search.venueId),
+  };
+}
+
+function assignmentLabel(reservation: {
+  practiceSessions: Array<{ title: string; team: { name: string } }>;
+  seasonGames: Array<{ id: string }>;
+  events: Array<{ id: string }>;
+  signupEvents: Array<{ id: string }>;
+  eventGames: Array<{ id: string }>;
+  proposalEntries: Array<{ id: string }>;
+}): string | null {
+  const practice = reservation.practiceSessions[0];
+  if (practice) return `Practice: ${practice.team.name} — ${practice.title}`;
+  if (reservation.seasonGames.length) return "Season game";
+  if (reservation.eventGames.length) return "Signup-event game";
+  if (reservation.signupEvents.length) return "Signup event";
+  if (reservation.events.length) return "Event";
+  if (reservation.proposalEntries.length) return "Game proposal";
+  return null;
+}
+
+export default async function VenueReservationsPage({
+  params,
+  searchParams,
+}: VenueReservationsPageProps) {
+  const [{ leagueId }, search, userId] = await Promise.all([
+    params,
+    searchParams,
+    requireUserId(),
+  ]);
+  const filters = parseFilters(search);
+
+  // Bind authorization to this exact league before loading any inventory.
+  const membership = await prisma.leagueUser.findUnique({
+    where: { userId_leagueId: { userId, leagueId } },
+    select: {
+      role: true,
+      league: { select: { id: true, name: true, isActive: true } },
+    },
+  });
+  if (
+    !membership
+    || membership.role !== "LEAGUE_ADMIN"
+    || !membership.league.isActive
+  ) {
+    notFound();
+  }
+
+  const [rawReservations, practices] = await Promise.all([
+    prisma.venueReservation.findMany({
+      where: {
+        status: "CONFIRMED",
+        OR: [
+          { ownerLeagueId: leagueId },
+          {
+            ownerLeagueId: null,
+            ownerTeam: { is: { leagueId, isActive: true } },
+          },
+        ],
+      },
+      select: {
+        id: true,
+        startsAt: true,
+        endsAt: true,
+        timezone: true,
+        surfaceId: true,
+        segmentId: true,
+        venue: { select: { id: true, name: true } },
+        surface: { select: { name: true, wholeLabel: true } },
+        segment: { select: { name: true } },
+        ownerLeague: { select: { name: true } },
+        ownerTeamId: true,
+        ownerTeam: {
+          select: {
+            name: true,
+            members: {
+              where: { userId, role: "ADMIN" },
+              select: { id: true },
+              take: 1,
+            },
+          },
+        },
+        practiceSessions: {
+          where: { team: { leagueId } },
+          select: { title: true, team: { select: { name: true } } },
+        },
+        seasonGames: { select: { id: true } },
+        events: { select: { id: true } },
+        signupEvents: { select: { id: true } },
+        eventGames: { select: { id: true } },
+        proposalEntries: { select: { id: true } },
+      },
+      orderBy: [{ startsAt: "asc" }, { venue: { name: "asc" } }],
+    }),
+    prisma.practiceSession.findMany({
+      where: {
+        team: { leagueId, isActive: true },
+        venueReservationId: null,
+        venueId: { not: null },
+        startAt: { not: null },
+      },
+      select: {
+        id: true,
+        title: true,
+        duration: true,
+        venueId: true,
+        surfaceId: true,
+        segmentId: true,
+        startAt: true,
+        team: { select: { name: true } },
+        teamId: true,
+      },
+      orderBy: [{ startAt: "asc" }, { title: "asc" }],
+    }),
+  ]);
+
+  const allItems: Array<VenueReservationInventoryItem & { venueId: string }> =
+    rawReservations.map((reservation) => {
+      const assignment = assignmentLabel(reservation);
+      const matchingPractices = practices.filter((practice) => {
+        if (!practice.startAt || practice.venueId !== reservation.venue.id) return false;
+        if (
+          reservation.ownerTeamId
+          && practice.teamId !== reservation.ownerTeamId
+        ) {
+          return false;
+        }
+        const practiceEndsAt =
+          practice.startAt.getTime() + practice.duration * 60_000;
+        const spaceMatches =
+          reservation.surfaceId === null
+          || (
+            practice.surfaceId === reservation.surfaceId
+            && (
+              reservation.segmentId === null
+              || practice.segmentId === reservation.segmentId
+            )
+          );
+        return (
+          practice.startAt.getTime() === reservation.startsAt.getTime()
+          && practiceEndsAt === reservation.endsAt.getTime()
+          && spaceMatches
+        );
+      });
+
+      return {
+        id: reservation.id,
+        venueId: reservation.venue.id,
+        venueName: reservation.venue.name,
+        localTime: `${formatDateTimeInZone(
+          reservation.startsAt,
+          reservation.timezone,
+        )} – ${formatDateTimeInZone(reservation.endsAt, reservation.timezone)}`,
+        space: reservation.surface
+          ? `${reservation.surface.name} / ${
+              reservation.segment?.name
+              ?? reservation.surface.wholeLabel
+              ?? "Full surface"
+            }`
+          : "Venue-wide",
+        owner: reservation.ownerLeague?.name ?? reservation.ownerTeam?.name ?? "Unknown owner",
+        ownerType: reservation.ownerLeague ? "LEAGUE" : "TEAM",
+        assignment,
+        canAssign:
+          !assignment
+          && Boolean(reservation.ownerLeague || reservation.ownerTeam?.members.length),
+        practices: matchingPractices.map((practice) => ({
+          id: practice.id,
+          title: practice.title,
+          teamName: practice.team.name,
+        })),
+      };
+    });
+
+  const venues = Array.from(
+    new Map(
+      allItems.map((item) => [item.venueId, { id: item.venueId, name: item.venueName }]),
+    ).values(),
+  ).sort((a, b) => a.name.localeCompare(b.name));
+  const effectiveFilters = {
+    ...filters,
+    venueId: venues.some((venue) => venue.id === filters.venueId)
+      ? filters.venueId
+      : "",
+  };
+  const items = allItems.filter((item) => {
+    if (effectiveFilters.venueId && item.venueId !== effectiveFilters.venueId) return false;
+    if (effectiveFilters.owner === "league" && item.ownerType !== "LEAGUE") return false;
+    if (effectiveFilters.owner === "team" && item.ownerType !== "TEAM") return false;
+    if (effectiveFilters.assignment === "assigned" && !item.assignment) return false;
+    if (effectiveFilters.assignment === "unassigned" && item.assignment) return false;
+    return true;
+  });
+
+  return (
+    <PageContainer maxWidth="xl">
+      <PageHeader
+        title="Venue reservations"
+        subtitle={`Confirmed ice inventory for ${membership.league.name}. Times are shown in each venue's local timezone.`}
+      />
+      <VenueReservationInventory
+        leagueId={leagueId}
+        reservations={items}
+        venues={venues}
+        filters={effectiveFilters}
+      />
+    </PageContainer>
+  );
+}

--- a/app/(dashboard)/practice-planner/[sessionId]/edit/EditSessionWrapper.tsx
+++ b/app/(dashboard)/practice-planner/[sessionId]/edit/EditSessionWrapper.tsx
@@ -46,6 +46,7 @@ export function EditSessionWrapper({
           duration: play.duration,
           instructions: play.instructions || "",
         })),
+        reservationId: session.reservationId,
         // Optional venue booking (006, FR-019); the attachment is replaced
         // wholesale — omitting venueId detaches the practice.
         venueId: session.venueId || undefined,
@@ -53,6 +54,7 @@ export function EditSessionWrapper({
         segmentId: session.segmentId || undefined,
         startAt: session.startAt || undefined,
         overrideConflicts: session.overrideConflicts,
+        overrideReason: session.overrideReason || undefined,
       });
 
       if (!result.success) {
@@ -91,8 +93,12 @@ export function EditSessionWrapper({
     <PracticeSessionEditor
       sessionId={sessionId}
       teamId={teamId}
-      initialData={initialData}
+      initialData={{
+        ...initialData,
+        reservationId: bookingOptions.currentReservationId,
+      }}
       venues={bookingOptions.venues}
+      reservations={bookingOptions.reservations}
       surfacesByVenue={bookingOptions.surfacesByVenue}
       segmentsBySurface={bookingOptions.segmentsBySurface}
       wholeLabelBySurface={bookingOptions.wholeLabelBySurface}

--- a/app/(dashboard)/practice-planner/[sessionId]/edit/page.tsx
+++ b/app/(dashboard)/practice-planner/[sessionId]/edit/page.tsx
@@ -26,7 +26,7 @@ export default async function EditPracticeSessionPage({ params }: PageProps) {
   }
 
   // Venue/surface/segment options for the optional ice booking (006, FR-019).
-  const bookingOptions = await getVenueBookingOptions();
+  const bookingOptions = await getVenueBookingOptions(data.teamId, sessionId);
 
   return (
     <PageContainer>

--- a/app/(dashboard)/practice-planner/new/PracticeSessionEditorWrapper.tsx
+++ b/app/(dashboard)/practice-planner/new/PracticeSessionEditorWrapper.tsx
@@ -36,12 +36,14 @@ export function PracticeSessionEditorWrapper({
           duration: play.duration,
           instructions: play.instructions || "",
         })),
+        reservationId: session.reservationId,
         // Optional venue booking (006, FR-019); omitted fields mean unbooked.
         venueId: session.venueId || undefined,
         surfaceId: session.surfaceId || undefined,
         segmentId: session.segmentId || undefined,
         startAt: session.startAt || undefined,
         overrideConflicts: session.overrideConflicts,
+        overrideReason: session.overrideReason || undefined,
       });
 
       if (!result.success) {
@@ -67,6 +69,7 @@ export function PracticeSessionEditorWrapper({
     <PracticeSessionEditor
       teamId={teamId}
       venues={bookingOptions.venues}
+      reservations={bookingOptions.reservations}
       surfacesByVenue={bookingOptions.surfacesByVenue}
       segmentsBySurface={bookingOptions.segmentsBySurface}
       wholeLabelBySurface={bookingOptions.wholeLabelBySurface}

--- a/app/(dashboard)/practice-planner/new/page.tsx
+++ b/app/(dashboard)/practice-planner/new/page.tsx
@@ -18,7 +18,7 @@ export default async function NewPracticeSessionPage() {
   }
 
   // Venue/surface/segment options for the optional ice booking (006, FR-019).
-  const bookingOptions = await getVenueBookingOptions();
+  const bookingOptions = await getVenueBookingOptions(context.teamId);
 
   return (
     <PageContainer>

--- a/app/(dashboard)/practice-planner/venue-booking-options.ts
+++ b/app/(dashboard)/practice-planner/venue-booking-options.ts
@@ -1,6 +1,10 @@
 import { prisma } from "@/lib/db/prisma";
 import { getAvailableVenues } from "@/lib/actions/venues";
-import type { VenueBookingOption } from "@/components/features/practice-planner/PracticeSessionEditor";
+import { requireUserId } from "@/lib/auth/session";
+import type {
+  VenueBookingOption,
+  VenueReservationBookingOption,
+} from "@/components/features/practice-planner/PracticeSessionEditor";
 
 /**
  * Venue/surface/segment option data for the practice editor's optional
@@ -10,6 +14,8 @@ import type { VenueBookingOption } from "@/components/features/practice-planner/
  */
 export interface VenueBookingOptions {
   venues: VenueBookingOption[];
+  reservations: VenueReservationBookingOption[];
+  currentReservationId: string | null;
   /** Active surfaces per venue id. */
   surfacesByVenue: Record<string, Array<{ id: string; name: string }>>;
   /** Active segments per surface id. */
@@ -18,7 +24,11 @@ export interface VenueBookingOptions {
   wholeLabelBySurface: Record<string, string>;
 }
 
-export async function getVenueBookingOptions(): Promise<VenueBookingOptions> {
+export async function getVenueBookingOptions(
+  teamId: string,
+  practiceSessionId?: string,
+): Promise<VenueBookingOptions> {
+  const userId = await requireUserId();
   // Venues visible to the user (PUBLIC + their leagues/teams).
   const venueRows = await getAvailableVenues();
   const venues = venueRows.map((venue) => ({
@@ -26,6 +36,95 @@ export async function getVenueBookingOptions(): Promise<VenueBookingOptions> {
     name: venue.name,
     timezone: venue.timezone,
   }));
+  const [team, currentPractice] = await Promise.all([
+    prisma.team.findUnique({
+      where: { id: teamId },
+      select: { leagueId: true },
+    }),
+    practiceSessionId
+      ? prisma.practiceSession.findFirst({
+          where: { id: practiceSessionId, teamId },
+          select: { venueReservationId: true },
+        })
+      : Promise.resolve(null),
+  ]);
+  const mayAssignLeagueInventory = team?.leagueId
+    ? Boolean(await prisma.leagueUser.findFirst({
+        where: {
+          userId,
+          leagueId: team.leagueId,
+          role: "LEAGUE_ADMIN",
+        },
+        select: { id: true },
+      }))
+    : false;
+  const currentReservationId = currentPractice?.venueReservationId ?? null;
+  const ownership = [
+    { ownerTeamId: teamId },
+    ...(team?.leagueId && mayAssignLeagueInventory
+      ? [{ ownerLeagueId: team.leagueId }]
+      : []),
+    ...(currentReservationId ? [{ id: currentReservationId }] : []),
+  ];
+  const unassigned = {
+    events: { none: {} },
+    seasonGames: { none: {} },
+    eventGames: { none: {} },
+    signupEvents: { none: {} },
+    practiceSessions: { none: {} },
+    proposalEntries: { none: {} },
+  };
+  const reservationRows = await prisma.venueReservation.findMany({
+    where: {
+      status: "CONFIRMED",
+      OR: ownership,
+      AND: [
+        currentReservationId
+          ? {
+              OR: [
+                unassigned,
+                {
+                  id: currentReservationId,
+                  practiceSessions: {
+                    some: { id: practiceSessionId, teamId },
+                  },
+                },
+              ],
+            }
+          : unassigned,
+      ],
+    },
+    select: {
+      id: true,
+      startsAt: true,
+      endsAt: true,
+      timezone: true,
+      venueId: true,
+      surfaceId: true,
+      segmentId: true,
+      ownerLeagueId: true,
+      ownerTeamId: true,
+      venue: { select: { name: true } },
+      surface: { select: { name: true } },
+      segment: { select: { name: true } },
+    },
+    orderBy: { startsAt: "asc" },
+  });
+  const reservations: VenueReservationBookingOption[] = reservationRows.map(
+    (reservation) => ({
+      id: reservation.id,
+      startsAt: reservation.startsAt.toISOString(),
+      endsAt: reservation.endsAt.toISOString(),
+      timezone: reservation.timezone,
+      venueId: reservation.venueId,
+      venueName: reservation.venue.name,
+      surfaceId: reservation.surfaceId,
+      surfaceName: reservation.surface?.name ?? null,
+      segmentId: reservation.segmentId,
+      segmentName: reservation.segment?.name ?? null,
+      ownerType: reservation.ownerLeagueId ? "league" : "team",
+    }),
+  );
 
   const surfaces = venues.length
     ? await prisma.iceSurface.findMany({
@@ -55,5 +154,12 @@ export async function getVenueBookingOptions(): Promise<VenueBookingOptions> {
     (segmentsBySurface[segment.surfaceId] ??= []).push({ id: segment.id, name: segment.name });
   }
 
-  return { venues, surfacesByVenue, segmentsBySurface, wholeLabelBySurface };
+  return {
+    venues,
+    reservations,
+    currentReservationId,
+    surfacesByVenue,
+    segmentsBySurface,
+    wholeLabelBySurface,
+  };
 }

--- a/app/(dashboard)/venue-admin/[organizationId]/venues/[venueId]/requests/page.tsx
+++ b/app/(dashboard)/venue-admin/[organizationId]/venues/[venueId]/requests/page.tsx
@@ -22,7 +22,14 @@ export default async function VenueRequestsPage({ params }: VenueRequestsPagePro
   return (
     <PageContainer>
       <PageHeader title="Ice Time Requests" />
-      <IceTimeRequestQueue requests={result.data.requests} />
+      <IceTimeRequestQueue
+        organizationId={organizationId}
+        venueId={venueId}
+        venueName={result.data.venueName}
+        venueTimeZone={result.data.timezone}
+        surfaceOptions={result.data.surfaceOptions}
+        requests={result.data.requests}
+      />
     </PageContainer>
   );
 }

--- a/app/(dashboard)/venue-admin/[organizationId]/venues/[venueId]/schedule/page.tsx
+++ b/app/(dashboard)/venue-admin/[organizationId]/venues/[venueId]/schedule/page.tsx
@@ -8,7 +8,11 @@ import {
   getVenueScheduleBoard,
 } from "@/lib/actions/venue-schedules";
 import { resolveTimeZone } from "@/lib/utils/date";
-import { IceSurfaceManager, OperatingHoursEditor } from "@/components/features/venue-admin";
+import {
+  AvailableIceBrowser,
+  IceSurfaceManager,
+  OperatingHoursEditor,
+} from "@/components/features/venue-admin";
 import { VenueScheduleBoard } from "@/components/features/venue-admin/VenueScheduleBoard";
 
 interface VenueSchedulePageProps {
@@ -88,6 +92,11 @@ export default async function VenueSchedulePage({ params }: VenueSchedulePagePro
       <Stack spacing={3}>
         <IceSurfaceManager organizationId={organizationId} venueId={venueId} surfaces={surfaces} />
         <OperatingHoursEditor organizationId={organizationId} venueId={venueId} operatingHours={operatingHours} />
+        <AvailableIceBrowser
+          blocks={result.data.availableIce}
+          timeZone={timeZone}
+          mode="staff"
+        />
         <VenueScheduleBoard
           organizationId={organizationId}
           venueId={venueId}

--- a/app/(marketing)/rinks/[slug]/schedule/page.tsx
+++ b/app/(marketing)/rinks/[slug]/schedule/page.tsx
@@ -60,7 +60,7 @@ export default async function PublicRinkSchedulePage({ params, searchParams }: P
   const defaultEmail = session?.user?.email ?? undefined;
   const loginRedirect = `/rinks/${slug}/schedule`;
 
-  const requestableBlocks = venue.scheduleBlocks.filter((block) => block.registrationMode === "REQUEST_REQUIRED");
+  const requestableBlocks = venue.availableIce;
   const registrableBlocks = venue.scheduleBlocks.filter((block) => block.registrationMode === "SELF_REGISTER");
   const registrableLessons = venue.lessonOfferings;
 
@@ -236,18 +236,25 @@ export default async function PublicRinkSchedulePage({ params, searchParams }: P
         ) : null}
 
         <VenueScheduleCalendar blocks={venue.scheduleBlocks.map((block) => ({ ...block, status: "PUBLISHED" }))} />
-        <AvailableIceBrowser blocks={requestableBlocks} />
-        {requestableBlocks.map((block) => (
-          <IceTimeRequestForm
-            key={block.id}
-            scheduleBlockId={block.id}
-            venueId={venue.id}
-            venueName={venue.name}
-            startsAt={block.startsAt}
-            endsAt={block.endsAt}
-            timezone={venue.timezone}
-          />
-        ))}
+        <AvailableIceBrowser
+          blocks={requestableBlocks}
+          timeZone={venue.timezone}
+          mode="public"
+        />
+        {requestableBlocks.flatMap((block) =>
+          block.remainingSlices.map((slice, index) => (
+            <IceTimeRequestForm
+              key={`${block.id}-${slice.startsAt.toISOString()}`}
+              anchorId={`request-${block.id}-${index}`}
+              scheduleBlockId={block.offeringBlockId ?? block.id}
+              venueId={venue.id}
+              venueName={venue.name}
+              startsAt={slice.startsAt}
+              endsAt={slice.endsAt}
+              timezone={venue.timezone}
+            />
+          )),
+        )}
       </Stack>
     </Container>
   );

--- a/components/features/association-operations/VenueReservationAssignmentDialog.tsx
+++ b/components/features/association-operations/VenueReservationAssignmentDialog.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import {
+  Alert,
+  Button,
+  Checkbox,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControlLabel,
+  MenuItem,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { assignVenueReservation } from "@/lib/actions/venue-reservations";
+
+export interface ReservationPracticeOption {
+  id: string;
+  title: string;
+  teamName: string;
+}
+
+interface VenueReservationAssignmentDialogProps {
+  reservationId: string;
+  venueName: string;
+  localTime: string;
+  practices: ReservationPracticeOption[];
+}
+
+export function VenueReservationAssignmentDialog(
+  props: VenueReservationAssignmentDialogProps,
+) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <Button
+        variant="contained"
+        size="small"
+        onClick={() => setOpen(true)}
+        sx={{ minHeight: 44 }}
+      >
+        Assign practice
+      </Button>
+      <Dialog open={open} onClose={() => setOpen(false)} fullWidth maxWidth="sm">
+        {open ? (
+          <AssignmentDialogBody {...props} onClose={() => setOpen(false)} />
+        ) : null}
+      </Dialog>
+    </>
+  );
+}
+
+function AssignmentDialogBody({
+  reservationId,
+  venueName,
+  localTime,
+  practices,
+  onClose,
+}: VenueReservationAssignmentDialogProps & { onClose: () => void }) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [practiceId, setPracticeId] = useState("");
+  const [overrideConflicts, setOverrideConflicts] = useState(false);
+  const [overrideReason, setOverrideReason] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const handleAssign = () => {
+    if (!practiceId) {
+      setError("Select a planned practice.");
+      return;
+    }
+    if (overrideConflicts && !overrideReason.trim()) {
+      setError("Enter a reason for the conflict override.");
+      return;
+    }
+
+    startTransition(async () => {
+      setError(null);
+      const result = await assignVenueReservation({
+        reservationId,
+        targetType: "PRACTICE",
+        targetId: practiceId,
+        overrideConflicts,
+        overrideReason: overrideConflicts ? overrideReason.trim() : undefined,
+      });
+      if (!result.success) {
+        setError(result.error);
+        return;
+      }
+      onClose();
+      router.refresh();
+    });
+  };
+
+  return (
+    <>
+      <DialogTitle>Assign reservation to practice</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} sx={{ pt: 1 }}>
+          {error ? <Alert severity="error">{error}</Alert> : null}
+          <Stack spacing={0.5}>
+            <Typography fontWeight={700}>{venueName}</Typography>
+            <Typography variant="body2" color="text.secondary">
+              {localTime}
+            </Typography>
+          </Stack>
+
+          {practices.length === 0 ? (
+            <Alert severity="info">
+              No unassigned planned practices match this venue, space, and time.
+            </Alert>
+          ) : (
+            <TextField
+              select
+              required
+              fullWidth
+              label="Planned practice"
+              value={practiceId}
+              onChange={(event) => setPracticeId(event.target.value)}
+              disabled={isPending}
+              sx={{ "& .MuiInputBase-root": { minHeight: 44 } }}
+            >
+              {practices.map((practice) => (
+                <MenuItem key={practice.id} value={practice.id} sx={{ minHeight: 44 }}>
+                  {practice.teamName} — {practice.title}
+                </MenuItem>
+              ))}
+            </TextField>
+          )}
+
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={overrideConflicts}
+                onChange={(event) => setOverrideConflicts(event.target.checked)}
+                disabled={isPending}
+                sx={{ minWidth: 44, minHeight: 44 }}
+              />
+            }
+            label="Override detected conflicts"
+          />
+          {overrideConflicts ? (
+            <TextField
+              required
+              fullWidth
+              multiline
+              minRows={2}
+              label="Override reason"
+              value={overrideReason}
+              onChange={(event) => setOverrideReason(event.target.value)}
+              disabled={isPending}
+              slotProps={{ htmlInput: { maxLength: 1000 } }}
+              helperText="A reason is required and is included with the assignment request."
+            />
+          ) : null}
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={isPending} sx={{ minHeight: 44 }}>
+          Cancel
+        </Button>
+        <Button
+          variant="contained"
+          onClick={handleAssign}
+          disabled={
+            isPending
+            || !practiceId
+            || practices.length === 0
+            || (overrideConflicts && !overrideReason.trim())
+          }
+          sx={{ minHeight: 44 }}
+        >
+          {isPending ? "Assigning…" : "Assign practice"}
+        </Button>
+      </DialogActions>
+    </>
+  );
+}

--- a/components/features/association-operations/VenueReservationInventory.tsx
+++ b/components/features/association-operations/VenueReservationInventory.tsx
@@ -1,0 +1,219 @@
+import {
+  Alert,
+  Button,
+  Card,
+  Chip,
+  MenuItem,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { LinkButton } from "@/components/ui/NextLinkComposites";
+import { VenueReservationAssignmentDialog } from "./VenueReservationAssignmentDialog";
+
+export interface VenueReservationInventoryItem {
+  id: string;
+  venueName: string;
+  localTime: string;
+  space: string;
+  owner: string;
+  ownerType: "LEAGUE" | "TEAM";
+  assignment: string | null;
+  canAssign: boolean;
+  practices: Array<{ id: string; title: string; teamName: string }>;
+}
+
+export interface VenueReservationFilters {
+  assignment: "all" | "assigned" | "unassigned";
+  owner: "all" | "league" | "team";
+  venueId: string;
+}
+
+interface VenueReservationInventoryProps {
+  leagueId: string;
+  reservations: VenueReservationInventoryItem[];
+  venues: Array<{ id: string; name: string }>;
+  filters: VenueReservationFilters;
+}
+
+function AssignmentControl({
+  reservation,
+}: {
+  reservation: VenueReservationInventoryItem;
+}) {
+  if (reservation.assignment) {
+    return <Chip color="success" label="Assigned" size="small" />;
+  }
+  if (!reservation.canAssign) {
+    return (
+      <Stack spacing={0.5} alignItems={{ md: "flex-end" }}>
+        <Chip label="Unassigned" size="small" variant="outlined" />
+        <Typography variant="caption" color="text.secondary">
+          Exact team admin required
+        </Typography>
+      </Stack>
+    );
+  }
+  return (
+    <VenueReservationAssignmentDialog
+      reservationId={reservation.id}
+      venueName={reservation.venueName}
+      localTime={reservation.localTime}
+      practices={reservation.practices}
+    />
+  );
+}
+
+export function VenueReservationInventory({
+  leagueId,
+  reservations,
+  venues,
+  filters,
+}: VenueReservationInventoryProps) {
+  return (
+    <Stack spacing={3}>
+      <Card
+        component="form"
+        action={`/league/${leagueId}/venue-reservations`}
+        method="get"
+        variant="outlined"
+        sx={{ p: 2 }}
+      >
+        <Stack direction={{ xs: "column", md: "row" }} spacing={2} alignItems={{ md: "center" }}>
+          <TextField
+            select
+            name="assignment"
+            label="Assignment"
+            defaultValue={filters.assignment}
+            fullWidth
+            sx={{ "& .MuiInputBase-root": { minHeight: 44 } }}
+          >
+            <MenuItem value="all">All assignments</MenuItem>
+            <MenuItem value="unassigned">Unassigned</MenuItem>
+            <MenuItem value="assigned">Assigned</MenuItem>
+          </TextField>
+          <TextField
+            select
+            name="owner"
+            label="Owner"
+            defaultValue={filters.owner}
+            fullWidth
+            sx={{ "& .MuiInputBase-root": { minHeight: 44 } }}
+          >
+            <MenuItem value="all">All owners</MenuItem>
+            <MenuItem value="league">Association owned</MenuItem>
+            <MenuItem value="team">Team owned</MenuItem>
+          </TextField>
+          <TextField
+            select
+            name="venueId"
+            label="Venue"
+            defaultValue={filters.venueId}
+            fullWidth
+            sx={{ "& .MuiInputBase-root": { minHeight: 44 } }}
+          >
+            <MenuItem value="">All venues</MenuItem>
+            {venues.map((venue) => (
+              <MenuItem key={venue.id} value={venue.id}>
+                {venue.name}
+              </MenuItem>
+            ))}
+          </TextField>
+          <Stack direction="row" spacing={1}>
+            <Button type="submit" variant="contained" sx={{ minHeight: 44 }}>
+              Apply
+            </Button>
+            <LinkButton
+              href={`/league/${leagueId}/venue-reservations`}
+              variant="outlined"
+              sx={{ minHeight: 44 }}
+            >
+              Reset
+            </LinkButton>
+          </Stack>
+        </Stack>
+      </Card>
+
+      {reservations.length === 0 ? (
+        <Alert severity="info">No confirmed venue reservations match these filters.</Alert>
+      ) : (
+        <>
+          <Stack spacing={2} sx={{ display: { xs: "flex", md: "none" } }}>
+            {reservations.map((reservation) => (
+              <Card key={reservation.id} variant="outlined" sx={{ p: 2 }}>
+                <Stack spacing={1.5}>
+                  <Stack direction="row" justifyContent="space-between" spacing={1}>
+                    <Typography fontWeight={700}>{reservation.venueName}</Typography>
+                    <Chip
+                      size="small"
+                      variant="outlined"
+                      label={reservation.ownerType === "LEAGUE" ? "Association" : "Team"}
+                    />
+                  </Stack>
+                  <Typography variant="body2">{reservation.localTime}</Typography>
+                  <Typography variant="body2">Space: {reservation.space}</Typography>
+                  <Typography variant="body2">Owner: {reservation.owner}</Typography>
+                  {reservation.assignment ? (
+                    <Typography variant="body2">Assigned to: {reservation.assignment}</Typography>
+                  ) : null}
+                  <AssignmentControl reservation={reservation} />
+                </Stack>
+              </Card>
+            ))}
+          </Stack>
+
+          <TableContainer
+            component={Card}
+            variant="outlined"
+            sx={{ display: { xs: "none", md: "block" } }}
+          >
+            <Table>
+              <TableHead>
+                <TableRow>
+                  <TableCell>Venue / local time</TableCell>
+                  <TableCell>Surface / segment</TableCell>
+                  <TableCell>Owner</TableCell>
+                  <TableCell>Assignment</TableCell>
+                  <TableCell align="right">Action</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {reservations.map((reservation) => (
+                  <TableRow key={reservation.id}>
+                    <TableCell>
+                      <Typography fontWeight={700}>{reservation.venueName}</Typography>
+                      <Typography variant="body2" color="text.secondary">
+                        {reservation.localTime}
+                      </Typography>
+                    </TableCell>
+                    <TableCell>{reservation.space}</TableCell>
+                    <TableCell>
+                      <Typography variant="body2">{reservation.owner}</Typography>
+                      <Typography variant="caption" color="text.secondary">
+                        {reservation.ownerType === "LEAGUE" ? "Association" : "Team"}
+                      </Typography>
+                    </TableCell>
+                    <TableCell>
+                      {reservation.assignment ?? (
+                        <Typography color="text.secondary">Unassigned</Typography>
+                      )}
+                    </TableCell>
+                    <TableCell align="right">
+                      <AssignmentControl reservation={reservation} />
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        </>
+      )}
+    </Stack>
+  );
+}

--- a/components/features/practice-planner/PracticeSessionEditor.tsx
+++ b/components/features/practice-planner/PracticeSessionEditor.tsx
@@ -74,11 +74,26 @@ export interface VenueBookingOption {
     timezone: string;
 }
 
+export interface VenueReservationBookingOption {
+    id: string;
+    startsAt: string;
+    endsAt: string;
+    timezone: string;
+    venueId: string;
+    venueName: string;
+    surfaceId: string | null;
+    surfaceName: string | null;
+    segmentId: string | null;
+    segmentName: string | null;
+    ownerType: "league" | "team";
+}
+
 /**
  * Optional venue attachment fields carried alongside the session data
  * on save (feature 006, FR-019). All null when the practice is unbooked.
  */
 export interface PracticeVenueAttachment {
+    reservationId: string | null;
     venueId: string | null;
     surfaceId: string | null;
     segmentId: string | null;
@@ -90,6 +105,7 @@ export interface PracticeSessionSubmitData
     extends PracticeSessionData,
         PracticeVenueAttachment {
     overrideConflicts: boolean;
+    overrideReason: string;
 }
 
 /**
@@ -108,7 +124,21 @@ export function extractBookingConflicts(details: unknown): BookingConflict[] | u
     if (details && typeof details === "object" && "conflicts" in details) {
         const conflicts = (details as { conflicts: unknown }).conflicts;
         if (Array.isArray(conflicts) && conflicts.length > 0) {
-            return conflicts as BookingConflict[];
+            return conflicts.map((conflict): BookingConflict => {
+                const item = conflict as Partial<BookingConflict> & {
+                    startsAt?: Date | string;
+                    endsAt?: Date | string | null;
+                };
+                return {
+                    source: item.source ?? "venueReservation",
+                    title: item.title ?? "Existing venue reservation",
+                    startAt: new Date(item.startsAt ?? 0),
+                    endAt: item.endsAt ? new Date(item.endsAt) : null,
+                    surfaceId: item.surfaceId ?? null,
+                    segmentId: item.segmentId ?? null,
+                    segmentName: item.segmentName ?? null,
+                };
+            });
         }
     }
     return undefined;
@@ -123,6 +153,8 @@ export interface PracticeSessionEditorProps {
     initialData?: Partial<PracticeSessionData> & Partial<PracticeVenueAttachment>;
     /** Venues available for the optional ice booking (feature 006). */
     venues?: VenueBookingOption[];
+    /** Confirmed, unassigned inventory eligible for this exact team. */
+    reservations?: VenueReservationBookingOption[];
     /** Active surfaces per venue id. */
     surfacesByVenue?: Record<string, Array<{ id: string; name: string }>>;
     /** Active segments per surface id. */
@@ -380,6 +412,7 @@ export function PracticeSessionEditor({
     teamId,
     initialData,
     venues = [],
+    reservations = [],
     surfacesByVenue = {},
     segmentsBySurface = {},
     wholeLabelBySurface = {},
@@ -397,6 +430,10 @@ export function PracticeSessionEditor({
     const [duration, setDuration] = useState(initialData?.duration || 60);
     const [plays, setPlays] = useState<PlayInSession[]>(initialData?.plays || []);
     const [isShared, setIsShared] = useState(initialData?.isShared || false);
+    const [reservationId, setReservationId] = useState(
+        initialData?.reservationId ?? "",
+    );
+    const [overrideReason, setOverrideReason] = useState("");
 
     // Ice booking state (feature 006, FR-019): optional venue attachment.
     // startTime is a wall-clock HH:MM interpreted in the venue's timezone.
@@ -431,15 +468,19 @@ export function PracticeSessionEditor({
 
     // Timezone the booking start time is entered in (the venue's zone,
     // matching GameForm's wall-clock handling).
+    const selectedReservation = reservations.find(
+        (reservation) => reservation.id === reservationId,
+    );
     const selectedVenueTimeZone = resolveTimeZone(
-        venues.find((venue) => venue.id === venueId)?.timezone
+        selectedReservation?.timezone
+        ?? venues.find((venue) => venue.id === venueId)?.timezone
     );
 
     /**
      * Validate form fields
      * Requirements: 2.1 - Form validation for required fields
      */
-    const validateForm = useCallback((): boolean => {
+    const validateForm = useCallback((requiresOverrideReason = false): boolean => {
         const errors: Record<string, string> = {};
 
         // Validate title
@@ -468,10 +509,13 @@ export function PracticeSessionEditor({
         if (venueId && !startTime) {
             errors.startTime = "Start time is required when booking a venue";
         }
+        if (requiresOverrideReason && !overrideReason.trim()) {
+            errors.overrideReason = "Explain why this conflict should be overridden";
+        }
 
         setValidationErrors(errors);
         return Object.keys(errors).length === 0;
-    }, [title, date, duration, venueId, startTime]);
+    }, [title, date, duration, venueId, startTime, overrideReason]);
 
     /**
      * Handle title change
@@ -531,12 +575,42 @@ export function PracticeSessionEditor({
      * stale selections would be rejected server-side, matching GameForm).
      */
     const handleVenueChange = (nextVenueId: string) => {
+        setReservationId("");
         setVenueId(nextVenueId);
         setSurfaceId("");
         setSegmentId("");
         setBookingConflicts(null);
         setHasUnsavedChanges(true);
         setSaveSuccess(false);
+    };
+
+    const handleReservationChange = (nextReservationId: string) => {
+        setReservationId(nextReservationId);
+        setBookingConflicts(null);
+        setOverrideReason("");
+        setHasUnsavedChanges(true);
+        setSaveSuccess(false);
+        const reservation = reservations.find(
+            (option) => option.id === nextReservationId,
+        );
+        if (!reservation) {
+            setVenueId("");
+            setSurfaceId("");
+            setSegmentId("");
+            setStartTime("");
+            return;
+        }
+
+        const startsAt = new Date(reservation.startsAt);
+        const endsAt = new Date(reservation.endsAt);
+        setDate(startsAt);
+        setDuration(Math.round((endsAt.getTime() - startsAt.getTime()) / 60_000));
+        setVenueId(reservation.venueId);
+        setSurfaceId(reservation.surfaceId ?? "");
+        setSegmentId(reservation.segmentId ?? "");
+        setStartTime(
+            formatDateTimeLocalInput(startsAt, reservation.timezone).slice(11, 16),
+        );
     };
 
     const handleSurfaceChange = (nextSurfaceId: string) => {
@@ -572,11 +646,13 @@ export function PracticeSessionEditor({
      * loses its availability footprint and behaves exactly as before.
      */
     const handleClearBooking = () => {
+        setReservationId("");
         setVenueId("");
         setSurfaceId("");
         setSegmentId("");
         setStartTime("");
         setBookingConflicts(null);
+        setOverrideReason("");
         setHasUnsavedChanges(true);
         setSaveSuccess(false);
         if (validationErrors.startTime) {
@@ -594,7 +670,7 @@ export function PracticeSessionEditor({
      */
     const handleSave = useCallback(async (overrideConflicts: boolean = false) => {
         // Validate form (includes date validation)
-        if (!validateForm()) {
+        if (!validateForm(overrideConflicts)) {
             setSaveError("Please fix the validation errors");
             return;
         }
@@ -605,7 +681,9 @@ export function PracticeSessionEditor({
         // Combine the practice date with the entered wall-clock start time in
         // the venue's timezone to form the booking instant (FR-019).
         let startAt: Date | null = null;
-        if (venueId) {
+        if (selectedReservation) {
+            startAt = new Date(selectedReservation.startsAt);
+        } else if (venueId) {
             // Derive the booking day in the venue's zone — not via browser-local
             // getFullYear/getMonth/getDate — so the day doesn't shift across
             // midnight between zones (matches the initial startTime derivation).
@@ -635,11 +713,13 @@ export function PracticeSessionEditor({
                 duration,
                 plays,
                 isShared,
+                reservationId: reservationId || null,
                 venueId: venueId || null,
                 surfaceId: venueId ? surfaceId || null : null,
                 segmentId: venueId && surfaceId ? segmentId || null : null,
                 startAt,
                 overrideConflicts,
+                overrideReason: overrideConflicts ? overrideReason.trim() : "",
             };
 
             // Call onSave callback if provided
@@ -682,11 +762,14 @@ export function PracticeSessionEditor({
         plays,
         isShared,
         sessionId,
+        reservationId,
         venueId,
         surfaceId,
         segmentId,
         startTime,
         selectedVenueTimeZone,
+        selectedReservation,
+        overrideReason,
         onSave,
         validateForm,
     ]);
@@ -976,10 +1059,12 @@ export function PracticeSessionEditor({
                         label="Practice Date & Time"
                         value={date}
                         onChange={handleDateChange}
+                        disabled={Boolean(selectedReservation)}
                         slotProps={{
                             textField: {
                                 fullWidth: true,
                                 required: true,
+                                sx: { "& .MuiInputBase-root": { minHeight: 44 } },
                                 error: !!validationErrors.date,
                                 helperText: validationErrors.date,
                             },
@@ -995,6 +1080,8 @@ export function PracticeSessionEditor({
                         onChange={handleDurationChange}
                         fullWidth
                         required
+                        disabled={Boolean(selectedReservation)}
+                        sx={{ "& .MuiInputBase-root": { minHeight: 44 } }}
                         inputProps={{
                             min: VALIDATION_CONSTRAINTS.MIN_DURATION,
                             max: VALIDATION_CONSTRAINTS.MAX_DURATION,
@@ -1016,9 +1103,7 @@ export function PracticeSessionEditor({
                 </Stack>
             </Paper>
 
-            {/* Ice Booking (feature 006, FR-019) */}
-            {/* Optional venue attachment: venue → surface → segment + start time. */}
-            {venues.length > 0 && (
+            {(reservations.length > 0 || venues.length > 0) && (
                 <Paper elevation={2} sx={{ p: 2 }}>
                     <Stack spacing={2}>
                         <Stack
@@ -1027,39 +1112,116 @@ export function PracticeSessionEditor({
                             alignItems="center"
                         >
                             <Typography variant="h6" component="h2">
-                                Ice Booking (optional)
+                                Venue reservation
                             </Typography>
-                            {venueId && (
+                            {(reservationId || venueId) && (
                                 <Button
-                                    size="small"
                                     color="inherit"
                                     onClick={handleClearBooking}
                                     disabled={isSaving || isSharing}
+                                    sx={{ minHeight: 44 }}
                                 >
                                     Clear booking
                                 </Button>
                             )}
                         </Stack>
                         <Typography variant="body2" color="text.secondary">
-                            Book a venue for this practice so it appears on the venue&apos;s
-                            schedule and other bookings warn against it.
+                            Select confirmed inventory. Its venue-local interval, surface,
+                            and segment become the practice schedule.
                         </Typography>
-                        <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
+                        {reservations.length > 0 && (
                             <TextField
                                 select
-                                label="Venue"
+                                label="Confirmed reservation"
                                 fullWidth
-                                value={venueId}
-                                onChange={(event) => handleVenueChange(event.target.value)}
+                                value={reservationId}
+                                onChange={(event) =>
+                                    handleReservationChange(event.target.value)
+                                }
+                                helperText="Only confirmed, unassigned inventory owned by this team or its league is shown"
+                                sx={{ "& .MuiInputBase-root": { minHeight: 44 } }}
                             >
-                                <MenuItem value="">No venue booking</MenuItem>
-                                {venues.map((venue) => (
-                                    <MenuItem key={venue.id} value={venue.id}>
-                                        {venue.name}
+                                <MenuItem value="" sx={{ minHeight: 44 }}>
+                                    No reservation
+                                </MenuItem>
+                                {reservations.map((reservation) => (
+                                    <MenuItem
+                                        key={reservation.id}
+                                        value={reservation.id}
+                                        sx={{ minHeight: 44 }}
+                                    >
+                                        {reservation.venueName} ·{" "}
+                                        {formatDateTimeInZone(
+                                            reservation.startsAt,
+                                            reservation.timezone,
+                                        )}
+                                        {" – "}
+                                        {formatDateTimeInZone(
+                                            reservation.endsAt,
+                                            reservation.timezone,
+                                        )}
                                     </MenuItem>
                                 ))}
                             </TextField>
-                            {venueId && (
+                        )}
+                        {selectedReservation && (
+                            <Alert severity="info">
+                                <AlertTitle>
+                                    {selectedReservation.venueName}
+                                    {selectedReservation.surfaceName
+                                        ? ` · ${selectedReservation.surfaceName}`
+                                        : ""}
+                                    {selectedReservation.segmentName
+                                        ? ` · ${selectedReservation.segmentName}`
+                                        : ""}
+                                </AlertTitle>
+                                {formatDateTimeInZone(
+                                    selectedReservation.startsAt,
+                                    selectedReservation.timezone,
+                                )}
+                                {" – "}
+                                {formatDateTimeInZone(
+                                    selectedReservation.endsAt,
+                                    selectedReservation.timezone,
+                                )}
+                                {" "}
+                                ({selectedReservation.timezone})
+                            </Alert>
+                        )}
+                        {(reservations.length === 0
+                            || (!reservationId && Boolean(initialData?.venueId))) && (
+                            <>
+                                {reservations.length > 0 && (
+                                    <Alert severity="warning">
+                                        This is a legacy unreserved practice. Keep its venue
+                                        details for compatibility, or select confirmed inventory.
+                                    </Alert>
+                                )}
+                                <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
+                                    <TextField
+                                        select
+                                        label="Venue"
+                                        fullWidth
+                                        value={venueId}
+                                        onChange={(event) =>
+                                            handleVenueChange(event.target.value)
+                                        }
+                                        sx={{ "& .MuiInputBase-root": { minHeight: 44 } }}
+                                    >
+                                        <MenuItem value="" sx={{ minHeight: 44 }}>
+                                            No venue booking
+                                        </MenuItem>
+                                        {venues.map((venue) => (
+                                            <MenuItem
+                                                key={venue.id}
+                                                value={venue.id}
+                                                sx={{ minHeight: 44 }}
+                                            >
+                                                {venue.name}
+                                            </MenuItem>
+                                        ))}
+                                    </TextField>
+                                    {venueId && (
                                 <TextField
                                     label="Start time"
                                     type="time"
@@ -1073,9 +1235,10 @@ export function PracticeSessionEditor({
                                         `On the practice date, in ${selectedVenueTimeZone} (the venue's timezone); runs ${duration} min`
                                     }
                                     slotProps={{ inputLabel: { shrink: true } }}
+                                    sx={{ "& .MuiInputBase-root": { minHeight: 44 } }}
                                 />
-                            )}
-                        </Stack>
+                                    )}
+                                </Stack>
                         {venueId && venueSurfaces.length > 0 && (
                             <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
                                 <TextField
@@ -1084,6 +1247,7 @@ export function PracticeSessionEditor({
                                     fullWidth
                                     value={surfaceId}
                                     onChange={(event) => handleSurfaceChange(event.target.value)}
+                                    sx={{ "& .MuiInputBase-root": { minHeight: 44 } }}
                                 >
                                     <MenuItem value="">Any surface</MenuItem>
                                     {venueSurfaces.map((surface) => (
@@ -1099,6 +1263,7 @@ export function PracticeSessionEditor({
                                         fullWidth
                                         value={segmentId}
                                         onChange={(event) => handleSegmentChange(event.target.value)}
+                                        sx={{ "& .MuiInputBase-root": { minHeight: 44 } }}
                                     >
                                         <MenuItem value="">{wholeSurfaceLabel}</MenuItem>
                                         {surfaceSegments.map((segment) => (
@@ -1109,6 +1274,8 @@ export function PracticeSessionEditor({
                                     </TextField>
                                 )}
                             </Stack>
+                        )}
+                            </>
                         )}
                     </Stack>
                 </Paper>
@@ -1223,11 +1390,15 @@ export function PracticeSessionEditor({
                             action={
                                 <Button
                                     color="inherit"
-                                    size="small"
-                                    disabled={isSaving || isSharing}
+                                    disabled={
+                                        isSaving
+                                        || isSharing
+                                        || !overrideReason.trim()
+                                    }
                                     onClick={() => handleSave(true)}
+                                    sx={{ minHeight: 44 }}
                                 >
-                                    Book anyway
+                                    Override conflict
                                 </Button>
                             }
                         >
@@ -1244,6 +1415,30 @@ export function PracticeSessionEditor({
                                         : ""}
                                 </Typography>
                             ))}
+                            <TextField
+                                label="Override reason"
+                                value={overrideReason}
+                                onChange={(event) => {
+                                    setOverrideReason(event.target.value);
+                                    if (validationErrors.overrideReason) {
+                                        setValidationErrors((previous) => {
+                                            const next = { ...previous };
+                                            delete next.overrideReason;
+                                            return next;
+                                        });
+                                    }
+                                }}
+                                required
+                                fullWidth
+                                multiline
+                                minRows={2}
+                                error={Boolean(validationErrors.overrideReason)}
+                                helperText={
+                                    validationErrors.overrideReason
+                                    || "Required for the audit trail"
+                                }
+                                sx={{ mt: 2, "& .MuiInputBase-root": { minHeight: 44 } }}
+                            />
                         </Alert>
                     )}
 

--- a/components/features/venue-admin/AvailableIceBrowser.tsx
+++ b/components/features/venue-admin/AvailableIceBrowser.tsx
@@ -1,13 +1,36 @@
 import { Button, Card, CardContent, Stack, Typography } from "@mui/material";
+import { formatDateTimeInZone } from "@/lib/utils/date";
 
 interface AvailableIceBlock {
   id: string;
   title: string;
   startsAt: Date | string;
   endsAt: Date | string;
+  surfaceName?: string | null;
+  occupancy?: Array<{ startsAt: Date | string; endsAt: Date | string }>;
+  remainingSlices?: Array<{ startsAt: Date | string; endsAt: Date | string }>;
 }
 
-export function AvailableIceBrowser({ blocks }: { blocks: AvailableIceBlock[] }) {
+function formatRange(
+  startsAt: Date | string,
+  endsAt: Date | string,
+  timeZone: string,
+): string {
+  return `${formatDateTimeInZone(startsAt, timeZone)} – ${formatDateTimeInZone(
+    endsAt,
+    timeZone,
+  )}`;
+}
+
+export function AvailableIceBrowser({
+  blocks,
+  timeZone,
+  mode,
+}: {
+  blocks: AvailableIceBlock[];
+  timeZone: string;
+  mode: "public" | "staff";
+}) {
   return (
     <Stack spacing={2}>
       <Typography variant="h5">Available ice</Typography>
@@ -20,11 +43,41 @@ export function AvailableIceBrowser({ blocks }: { blocks: AvailableIceBlock[] })
               <Stack spacing={1}>
                 <Typography variant="h6">{block.title}</Typography>
                 <Typography variant="body2" color="text.secondary">
-                  {new Date(block.startsAt).toLocaleString()} - {new Date(block.endsAt).toLocaleString()}
+                  {formatRange(block.startsAt, block.endsAt, timeZone)}
                 </Typography>
-                <Button href={`#request-${block.id}`} variant="outlined">
-                  Request this ice
-                </Button>
+                {block.surfaceName && <Typography variant="body2">{block.surfaceName}</Typography>}
+                {mode === "staff" ? (
+                  <Typography variant="body2" color="text.secondary">
+                    Occupancy: {block.occupancy?.length
+                      ? block.occupancy
+                          .map((slice) =>
+                            formatRange(slice.startsAt, slice.endsAt, timeZone),
+                          )
+                          .join(", ")
+                      : "None"}
+                  </Typography>
+                ) : null}
+                <Typography variant="body2" color="text.secondary">
+                  Remaining: {block.remainingSlices?.length
+                    ? block.remainingSlices
+                        .map((slice) =>
+                          formatRange(slice.startsAt, slice.endsAt, timeZone),
+                        )
+                        .join(", ")
+                    : "No remaining slices"}
+                </Typography>
+                {mode === "public"
+                  ? block.remainingSlices?.map((slice, index) => (
+                      <Button
+                        key={`${new Date(slice.startsAt).toISOString()}-${new Date(slice.endsAt).toISOString()}`}
+                        href={`#request-${block.id}-${index}`}
+                        variant="outlined"
+                        sx={{ minHeight: 44, alignSelf: "flex-start" }}
+                      >
+                        Request this ice
+                      </Button>
+                    ))
+                  : null}
               </Stack>
             </CardContent>
           </Card>

--- a/components/features/venue-admin/IceTimeRequestForm.tsx
+++ b/components/features/venue-admin/IceTimeRequestForm.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/lib/utils/date";
 
 interface IceTimeRequestFormProps {
+  anchorId?: string;
   scheduleBlockId: string;
   venueId: string;
   venueName: string;
@@ -22,7 +23,7 @@ interface IceTimeRequestFormProps {
 
 type FormMessage = { severity: "success" | "error"; text: string };
 
-export function IceTimeRequestForm({ scheduleBlockId, venueId, venueName, startsAt, endsAt, timezone }: IceTimeRequestFormProps) {
+export function IceTimeRequestForm({ anchorId, scheduleBlockId, venueId, venueName, startsAt, endsAt, timezone }: IceTimeRequestFormProps) {
   const [message, setMessage] = useState<FormMessage | null>(null);
   const [isPending, startTransition] = useTransition();
   const tz = useMemo(() => resolveTimeZone(timezone), [timezone]);
@@ -70,7 +71,7 @@ export function IceTimeRequestForm({ scheduleBlockId, venueId, venueName, starts
   };
 
   return (
-    <Stack id={`request-${scheduleBlockId}`} component="form" spacing={2} sx={{ maxWidth: 560 }} onSubmit={handleSubmit}>
+    <Stack id={anchorId ?? `request-${scheduleBlockId}`} component="form" spacing={2} sx={{ maxWidth: 560 }} onSubmit={handleSubmit}>
       <Typography variant="h5">Request ice time</Typography>
       <Alert severity="info">Requesting ice at {venueName}</Alert>
       {message ? <Alert severity={message.severity}>{message.text}</Alert> : null}

--- a/components/features/venue-admin/IceTimeRequestQueue.tsx
+++ b/components/features/venue-admin/IceTimeRequestQueue.tsx
@@ -1,4 +1,38 @@
-import { Card, CardContent, Chip, Stack, Typography } from "@mui/material";
+"use client";
+
+import { useMemo, useState } from "react";
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Checkbox,
+  Chip,
+  FormControlLabel,
+  MenuItem,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import {
+  annotateIceTimeRequest,
+  cancelIceTimeRequest,
+  decideIceTimeRequest,
+  expireIceTimeRequest,
+} from "@/lib/actions/venue-requests";
+import {
+  formatDateTimeInZone,
+  formatDateTimeLocalInput,
+  parseDateTimeLocalToUtc,
+} from "@/lib/utils/date";
+
+interface SurfaceOption {
+  id: string;
+  name: string;
+  wholeLabel: string;
+  segments: Array<{ id: string; name: string }>;
+}
 
 interface RequestSummary {
   id: string;
@@ -7,32 +41,618 @@ interface RequestSummary {
   status: string;
   requestedStartAt: Date | string;
   requestedEndAt: Date | string;
+  approvedStartAt?: Date | string | null;
+  approvedEndAt?: Date | string | null;
+  timezone?: string;
+  requestedSurfaceId?: string | null;
+  requestedSurfaceName?: string | null;
+  requestedSegmentId?: string | null;
+  requestedSegmentName?: string | null;
+  approvedSurfaceId?: string | null;
+  approvedSurfaceName?: string | null;
+  approvedSegmentId?: string | null;
+  approvedSegmentName?: string | null;
+  reservation?: {
+    id: string;
+    status: string;
+    venueName?: string | null;
+    surfaceName?: string | null;
+    segmentName?: string | null;
+  } | null;
 }
 
-export function IceTimeRequestQueue({ requests }: { requests: RequestSummary[] }) {
+interface ApprovalDraft {
+  requestId: string;
+  approvedStart: string;
+  approvedEnd: string;
+  approvedSurfaceId: string;
+  approvedSegmentId: string;
+  intentionalVenueWideClaim: boolean;
+  overrideConflicts: boolean;
+  overrideReason: string;
+}
+
+function toLocalInput(value: Date | string, timezone: string) {
+  return formatDateTimeLocalInput(new Date(value), timezone);
+}
+
+function resolveTimeZone(venueTimeZone: string | undefined, request: RequestSummary) {
+  return request.timezone ?? venueTimeZone ?? "America/New_York";
+}
+
+function formatInterval(startAt: Date | string, endAt: Date | string, timeZone: string) {
+  return `${formatDateTimeInZone(startAt, timeZone)} – ${formatDateTimeInZone(endAt, timeZone)}`;
+}
+
+function requestedSpaceLabel(request: RequestSummary) {
+  if (!request.requestedSurfaceId) return "Venue-wide";
+  if (request.requestedSegmentName) {
+    return `${request.requestedSurfaceName ?? "Surface"} / ${request.requestedSegmentName}`;
+  }
+  return request.requestedSurfaceName ?? "Whole surface";
+}
+
+function approvedSpaceLabel(request: RequestSummary) {
+  if (request.reservation) {
+    if (!request.reservation.surfaceName) return "Venue-wide";
+    if (request.reservation.segmentName) {
+      return `${request.reservation.surfaceName} / ${request.reservation.segmentName}`;
+    }
+    return request.reservation.surfaceName;
+  }
+  if (request.approvedSurfaceId === null) return "Venue-wide";
+  if (request.approvedSegmentName) {
+    return `${request.approvedSurfaceName ?? "Surface"} / ${request.approvedSegmentName}`;
+  }
+  return request.approvedSurfaceName ?? null;
+}
+
+export function IceTimeRequestQueue({
+  organizationId,
+  venueId,
+  venueName,
+  venueTimeZone,
+  surfaceOptions = [],
+  requests,
+}: {
+  organizationId: string;
+  venueId: string;
+  venueName?: string;
+  venueTimeZone?: string;
+  surfaceOptions?: SurfaceOption[];
+  requests: RequestSummary[];
+}) {
+  const [approvalDraft, setApprovalDraft] = useState<ApprovalDraft | null>(null);
+  const [declineFor, setDeclineFor] = useState<string | null>(null);
+  const [declineMessage, setDeclineMessage] = useState("");
+  const [noteByRequestId, setNoteByRequestId] = useState<Record<string, string>>({});
+  const [unassignFor, setUnassignFor] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [approvalValidationError, setApprovalValidationError] = useState<string | null>(null);
+
+  async function runDecision(
+    request: RequestSummary,
+    status: "ACCEPTED" | "PARTIALLY_ACCEPTED" | "DECLINED",
+    extras: Record<string, unknown> = {},
+  ) {
+    setActionError(null);
+    const result = await decideIceTimeRequest({
+      organizationId,
+      venueId,
+      requestId: request.id,
+      status,
+      ...extras,
+    });
+    if (!result.success) {
+      setActionError(result.error);
+    }
+    return result;
+  }
+
+  async function changeRequestStatus(
+    request: RequestSummary,
+    action: typeof cancelIceTimeRequest | typeof expireIceTimeRequest,
+  ) {
+    setActionError(null);
+    const result = await action({
+      organizationId,
+      venueId,
+      requestId: request.id,
+      linkedActivityDisposition:
+        unassignFor === request.id ? "UNASSIGN" : undefined,
+    });
+    if (!result.success) {
+      setActionError(result.error);
+    }
+    return result;
+  }
+
+  function openApprovalEditor(request: RequestSummary) {
+    const timeZone = resolveTimeZone(venueTimeZone, request);
+    setActionError(null);
+    setApprovalValidationError(null);
+    setApprovalDraft({
+      requestId: request.id,
+      approvedStart: toLocalInput(
+        request.approvedStartAt ?? request.requestedStartAt,
+        timeZone,
+      ),
+      approvedEnd: toLocalInput(
+        request.approvedEndAt ?? request.requestedEndAt,
+        timeZone,
+      ),
+      approvedSurfaceId:
+        request.status === "SUBMITTED" || request.status === "UNDER_REVIEW"
+          ? (request.requestedSurfaceId ?? "")
+          : (request.approvedSurfaceId ?? ""),
+      approvedSegmentId:
+        request.status === "SUBMITTED" || request.status === "UNDER_REVIEW"
+          ? (request.requestedSegmentId ?? "")
+          : (request.approvedSegmentId ?? ""),
+      intentionalVenueWideClaim: false,
+      overrideConflicts: false,
+      overrideReason: "",
+    });
+  }
+
+  const activeRequest = useMemo(
+    () => requests.find((request) => request.id === approvalDraft?.requestId) ?? null,
+    [approvalDraft, requests],
+  );
+
+  const activeTimeZone = activeRequest
+    ? resolveTimeZone(venueTimeZone, activeRequest)
+    : venueTimeZone ?? "America/New_York";
+  const approvalSurfaceOptions = activeRequest?.requestedSurfaceId
+    ? surfaceOptions.filter(
+        (surface) => surface.id === activeRequest.requestedSurfaceId,
+      )
+    : surfaceOptions;
+  const selectedSurface = approvalDraft
+    ? approvalSurfaceOptions.find(
+        (surface) => surface.id === approvalDraft.approvedSurfaceId,
+      ) ?? null
+    : null;
+  const segmentOptions = activeRequest?.requestedSegmentId
+    ? (selectedSurface?.segments ?? []).filter(
+        (segment) => segment.id === activeRequest.requestedSegmentId,
+      )
+    : selectedSurface?.segments ?? [];
+  const venueWideAllowed = activeRequest?.requestedSurfaceId == null;
+
+  const approvalPreview = approvalDraft && activeRequest
+    ? (() => {
+        const approvedStartAt = parseDateTimeLocalToUtc(
+          approvalDraft.approvedStart,
+          activeTimeZone,
+        );
+        const approvedEndAt = parseDateTimeLocalToUtc(
+          approvalDraft.approvedEnd,
+          activeTimeZone,
+        );
+        const exactInterval =
+          approvedStartAt?.getTime() === new Date(activeRequest.requestedStartAt).getTime()
+          && approvedEndAt?.getTime() === new Date(activeRequest.requestedEndAt).getTime();
+        const exactSpace =
+          (approvalDraft.approvedSurfaceId || null) === (activeRequest.requestedSurfaceId ?? null)
+          && (approvalDraft.approvedSegmentId || null) === (activeRequest.requestedSegmentId ?? null);
+        return {
+          exactInterval,
+          exactSpace,
+          finalStatus: exactInterval && exactSpace ? "ACCEPTED" : "PARTIALLY_ACCEPTED",
+        };
+      })()
+    : null;
+
   return (
     <Stack spacing={2}>
-      <Typography variant="h5">Request queue</Typography>
+      <Stack spacing={0.5}>
+        <Typography variant="h5">Request queue</Typography>
+        {venueName ? (
+          <Typography color="text.secondary" variant="body2">
+            Times in this queue use {venueTimeZone ?? "the venue timezone"} for {venueName}.
+          </Typography>
+        ) : null}
+      </Stack>
+      {actionError ? <Alert severity="error">{actionError}</Alert> : null}
       {requests.length === 0 ? (
         <Typography color="text.secondary">No ice time requests yet.</Typography>
-      ) : (
-        requests.map((request) => (
+      ) : requests.map((request) => {
+        const timeZone = resolveTimeZone(venueTimeZone, request);
+        const isApproving = approvalDraft?.requestId === request.id;
+        const isDeclining = declineFor === request.id;
+        const approvalLabel = approvedSpaceLabel(request);
+
+        return (
           <Card key={request.id}>
             <CardContent>
-              <Stack spacing={1}>
+              <Stack spacing={1.5}>
                 <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap" useFlexGap>
                   <Typography variant="h6">{request.contactName}</Typography>
                   <Chip label={request.status} size="small" />
                 </Stack>
                 <Typography>{request.contactEmail}</Typography>
                 <Typography variant="body2" color="text.secondary">
-                  {new Date(request.requestedStartAt).toLocaleString()} - {new Date(request.requestedEndAt).toLocaleString()}
+                  Requested interval: {formatInterval(request.requestedStartAt, request.requestedEndAt, timeZone)}
                 </Typography>
+                <Typography variant="body2" color="text.secondary">
+                  Requested space: {requestedSpaceLabel(request)}
+                </Typography>
+                {request.approvedStartAt && request.approvedEndAt && approvalLabel ? (
+                  <Typography variant="body2">
+                    Approved: {approvalLabel}, {formatInterval(request.approvedStartAt, request.approvedEndAt, timeZone)}
+                  </Typography>
+                ) : null}
+                <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+                  <Button
+                    sx={{ minHeight: 44 }}
+                    variant="contained"
+                    onClick={() => {
+                      if ((request.requestedSurfaceId ?? null) === null) {
+                        openApprovalEditor(request);
+                        return;
+                      }
+                      void runDecision(request, "ACCEPTED", {
+                        approvedStartAt: new Date(request.requestedStartAt),
+                        approvedEndAt: new Date(request.requestedEndAt),
+                        approvedSurfaceId: request.requestedSurfaceId ?? null,
+                        approvedSegmentId: request.requestedSegmentId ?? null,
+                      });
+                    }}
+                  >
+                    Approve in full
+                  </Button>
+                  <Button sx={{ minHeight: 44 }} onClick={() => openApprovalEditor(request)}>
+                    Partially approve
+                  </Button>
+                  <Button
+                    sx={{ minHeight: 44 }}
+                    color="warning"
+                    onClick={() => {
+                      setActionError(null);
+                      setDeclineMessage("");
+                      setDeclineFor(request.id);
+                    }}
+                  >
+                    Decline
+                  </Button>
+                  <Button
+                    sx={{ minHeight: 44 }}
+                    color="error"
+                    onClick={() => void changeRequestStatus(request, cancelIceTimeRequest)}
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    sx={{ minHeight: 44 }}
+                    color="error"
+                    variant="outlined"
+                    onClick={() => void changeRequestStatus(request, expireIceTimeRequest)}
+                  >
+                    Expire
+                  </Button>
+                </Stack>
+                {request.reservation ? (
+                  <FormControlLabel
+                    control={
+                      <Checkbox
+                        checked={unassignFor === request.id}
+                        onChange={(event) =>
+                          setUnassignFor(event.target.checked ? request.id : null)
+                        }
+                        sx={{ minWidth: 44, minHeight: 44 }}
+                      />
+                    }
+                    label="Unassign linked activity before canceling or expiring"
+                  />
+                ) : null}
+                {isApproving && approvalDraft && activeRequest ? (
+                  <Stack spacing={1.5} sx={{ pt: 1 }}>
+                    <Alert severity={approvalPreview?.finalStatus === "ACCEPTED" ? "success" : "info"}>
+                      {approvalPreview?.finalStatus === "ACCEPTED"
+                        ? "These approved details exactly match the request and will stay a full acceptance."
+                        : "Changing the interval or space makes this a partial acceptance."}
+                    </Alert>
+                    {approvalValidationError ? <Alert severity="error">{approvalValidationError}</Alert> : null}
+                    <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
+                      <TextField
+                        fullWidth
+                        label="Approved start"
+                        type="datetime-local"
+                        value={approvalDraft.approvedStart}
+                        onChange={(event) => {
+                          setApprovalValidationError(null);
+                          setApprovalDraft((current) =>
+                            current
+                              ? { ...current, approvedStart: event.target.value }
+                              : current,
+                          );
+                        }}
+                        helperText={`Times are in ${activeTimeZone}`}
+                        slotProps={{ inputLabel: { shrink: true } }}
+                      />
+                      <TextField
+                        fullWidth
+                        label="Approved end"
+                        type="datetime-local"
+                        value={approvalDraft.approvedEnd}
+                        onChange={(event) => {
+                          setApprovalValidationError(null);
+                          setApprovalDraft((current) =>
+                            current
+                              ? { ...current, approvedEnd: event.target.value }
+                              : current,
+                          );
+                        }}
+                        helperText={`Times are in ${activeTimeZone}`}
+                        slotProps={{ inputLabel: { shrink: true } }}
+                      />
+                    </Stack>
+                    <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
+                      <TextField
+                        select
+                        fullWidth
+                        label="Approved surface"
+                        value={approvalDraft.approvedSurfaceId}
+                        onChange={(event) => {
+                          setActionError(null);
+                          setApprovalValidationError(null);
+                          const nextSurfaceId = event.target.value;
+                          setApprovalDraft((current) =>
+                            current
+                              ? {
+                                  ...current,
+                                  approvedSurfaceId: nextSurfaceId,
+                                  approvedSegmentId: "",
+                                  intentionalVenueWideClaim:
+                                    nextSurfaceId === "" ? current.intentionalVenueWideClaim : false,
+                                }
+                              : current,
+                          );
+                        }}
+                      >
+                        {venueWideAllowed ? (
+                          <MenuItem value="">Venue-wide</MenuItem>
+                        ) : null}
+                        {approvalSurfaceOptions.map((surface) => (
+                          <MenuItem key={surface.id} value={surface.id}>
+                            {surface.name}
+                          </MenuItem>
+                        ))}
+                      </TextField>
+                      {selectedSurface ? (
+                        <TextField
+                          select
+                          fullWidth
+                          label="Approved segment"
+                          value={approvalDraft.approvedSegmentId}
+                          onChange={(event) => {
+                            setApprovalValidationError(null);
+                            setApprovalDraft((current) =>
+                              current
+                                ? { ...current, approvedSegmentId: event.target.value }
+                                : current,
+                            );
+                          }}
+                          helperText={`Leave blank for ${selectedSurface.wholeLabel}.`}
+                        >
+                          {activeRequest.requestedSegmentId ? null : (
+                            <MenuItem value="">{selectedSurface.wholeLabel}</MenuItem>
+                          )}
+                          {segmentOptions.map((segment) => (
+                            <MenuItem key={segment.id} value={segment.id}>
+                              {segment.name}
+                            </MenuItem>
+                          ))}
+                        </TextField>
+                      ) : venueWideAllowed ? (
+                        <Box sx={{ flex: 1 }}>
+                          <Alert severity="warning">
+                            Venue-wide claims block every surface at this venue and require venue-manager authorization.
+                          </Alert>
+                        </Box>
+                      ) : null}
+                    </Stack>
+                    {venueWideAllowed && approvalDraft.approvedSurfaceId === "" ? (
+                      <FormControlLabel
+                        control={
+                          <Checkbox
+                            checked={approvalDraft.intentionalVenueWideClaim}
+                            onChange={(event) =>
+                              setApprovalDraft((current) =>
+                                current
+                                  ? {
+                                      ...current,
+                                      intentionalVenueWideClaim: event.target.checked,
+                                    }
+                                  : current,
+                              )
+                            }
+                            sx={{ minWidth: 44, minHeight: 44 }}
+                          />
+                        }
+                        label="I intentionally want a venue-wide claim that blocks every surface for this interval"
+                      />
+                    ) : null}
+                    <FormControlLabel
+                      control={
+                        <Checkbox
+                          checked={approvalDraft.overrideConflicts}
+                          onChange={(event) =>
+                            setApprovalDraft((current) =>
+                              current
+                                ? { ...current, overrideConflicts: event.target.checked }
+                                : current,
+                            )
+                          }
+                          sx={{ minWidth: 44, minHeight: 44 }}
+                        />
+                      }
+                      label="Override conflicts if the final availability check finds a clash"
+                    />
+                    {(approvalDraft.overrideConflicts || approvalDraft.approvedSurfaceId === "") ? (
+                      <TextField
+                        fullWidth
+                        label="Reason"
+                        value={approvalDraft.overrideReason}
+                        onChange={(event) => {
+                          setApprovalValidationError(null);
+                          setApprovalDraft((current) =>
+                            current
+                              ? { ...current, overrideReason: event.target.value }
+                              : current,
+                          );
+                        }}
+                        helperText={approvalDraft.approvedSurfaceId === ""
+                          ? "Required for intentional venue-wide claims and reused if a conflict override is needed."
+                          : "Required when overriding conflicts."}
+                        multiline
+                        minRows={2}
+                      />
+                    ) : null}
+                    <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+                      <Button
+                        sx={{ minHeight: 44 }}
+                        variant="contained"
+                        onClick={() => {
+                          const approvedStartAt = parseDateTimeLocalToUtc(
+                            approvalDraft.approvedStart,
+                            activeTimeZone,
+                          );
+                          const approvedEndAt = parseDateTimeLocalToUtc(
+                            approvalDraft.approvedEnd,
+                            activeTimeZone,
+                          );
+                          if (!approvedStartAt || !approvedEndAt) {
+                            setApprovalValidationError("Enter a valid approved interval.");
+                            return;
+                          }
+                          if (
+                            approvalDraft.approvedSurfaceId === ""
+                            && !approvalDraft.intentionalVenueWideClaim
+                          ) {
+                            setApprovalValidationError(
+                              "Confirm the intentional venue-wide claim before approving without a surface.",
+                            );
+                            return;
+                          }
+                          if (
+                            (approvalDraft.overrideConflicts || approvalDraft.approvedSurfaceId === "")
+                            && !approvalDraft.overrideReason.trim()
+                          ) {
+                            setApprovalValidationError("Enter a reason for this approval.");
+                            return;
+                          }
+                          void runDecision(
+                            activeRequest,
+                            approvalPreview?.finalStatus === "ACCEPTED"
+                              ? "ACCEPTED"
+                              : "PARTIALLY_ACCEPTED",
+                            {
+                              approvedStartAt,
+                              approvedEndAt,
+                              approvedSurfaceId: approvalDraft.approvedSurfaceId || null,
+                              approvedSegmentId: approvalDraft.approvedSegmentId || null,
+                              intentionalVenueWideClaim:
+                                approvalDraft.intentionalVenueWideClaim,
+                              overrideConflicts: approvalDraft.overrideConflicts,
+                              overrideReason: approvalDraft.overrideReason.trim() || undefined,
+                            },
+                          ).then((result) => {
+                            if (result.success) {
+                              setApprovalDraft(null);
+                              setApprovalValidationError(null);
+                            }
+                          });
+                        }}
+                      >
+                        {approvalPreview?.finalStatus === "ACCEPTED"
+                          ? "Confirm full approval"
+                          : "Confirm partial approval"}
+                      </Button>
+                      <Button
+                        sx={{ minHeight: 44 }}
+                        onClick={() => {
+                          setApprovalDraft(null);
+                          setApprovalValidationError(null);
+                        }}
+                      >
+                        Cancel approval edit
+                      </Button>
+                    </Stack>
+                  </Stack>
+                ) : null}
+                {isDeclining ? (
+                  <Stack spacing={1}>
+                    <TextField
+                      label="Decision message"
+                      value={declineMessage}
+                      onChange={(event) => setDeclineMessage(event.target.value)}
+                    />
+                    <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+                      <Button
+                        sx={{ minHeight: 44 }}
+                        onClick={() => {
+                          void runDecision(request, "DECLINED", {
+                            decisionMessage: declineMessage,
+                          }).then((result) => {
+                            if (result.success) {
+                              setDeclineFor(null);
+                              setDeclineMessage("");
+                            }
+                          });
+                        }}
+                      >
+                        Confirm decline
+                      </Button>
+                      <Button
+                        sx={{ minHeight: 44 }}
+                        onClick={() => {
+                          setDeclineFor(null);
+                          setDeclineMessage("");
+                        }}
+                      >
+                        Cancel decline
+                      </Button>
+                    </Stack>
+                  </Stack>
+                ) : null}
+                {request.status !== "SUBMITTED" ? (
+                  <Stack direction={{ xs: "column", sm: "row" }} spacing={1} alignItems={{ sm: "center" }}>
+                    <TextField
+                      fullWidth
+                      label="Internal note"
+                      value={noteByRequestId[request.id] ?? ""}
+                      onChange={(event) =>
+                        setNoteByRequestId((current) => ({
+                          ...current,
+                          [request.id]: event.target.value,
+                        }))
+                      }
+                    />
+                    <Button
+                      sx={{ minHeight: 44, minWidth: { sm: 120 } }}
+                      onClick={() => {
+                        setActionError(null);
+                        void annotateIceTimeRequest({
+                          organizationId,
+                          venueId,
+                          requestId: request.id,
+                          decisionMessage: noteByRequestId[request.id] ?? "",
+                        }).then((result) => {
+                          if (!result.success) setActionError(result.error);
+                        });
+                      }}
+                    >
+                      Save note
+                    </Button>
+                  </Stack>
+                ) : null}
               </Stack>
             </CardContent>
           </Card>
-        ))
-      )}
+        );
+      })}
     </Stack>
   );
 }

--- a/lib/actions/practice-sessions.ts
+++ b/lib/actions/practice-sessions.ts
@@ -2,7 +2,11 @@
 
 import { z } from "zod";
 import { prisma } from "@/lib/db/prisma";
-import { requireTeamAdmin, requireTeamMember } from "@/lib/auth/session";
+import {
+    requireLeagueRole,
+    requireTeamAdmin,
+    requireTeamMember,
+} from "@/lib/auth/session";
 import { revalidatePath } from "next/cache";
 import type { Prisma } from "@prisma/client";
 import {
@@ -19,14 +23,307 @@ import {
     type GetPracticeSessionsByTeamInput,
     type SharePracticeSessionInput,
 } from "@/lib/utils/validation";
-import { findBookingConflicts } from "@/lib/utils/availability";
-import { canUserAccessVenue } from "@/lib/actions/venues";
-import type { BookingConflict } from "@/types/segments";
 import type { PlayData } from "@/types/practice-planner";
+import {
+    assignVenueReservation,
+    createVenueReservation,
+    VenueReservationConflictError,
+    VenueReservationLifecycleError,
+} from "@/lib/services/venue-reservations";
+import { runVenueReservationTransaction } from "@/lib/services/venue-reservation-transaction";
+import { FALLBACK_TIME_ZONE } from "@/lib/utils/date";
 
 export type ActionResult<T> =
     | { success: true; data: T }
     | { success: false; error: string; details?: unknown };
+
+type PracticeReservationFields = {
+    reservationId?: string | null;
+    overrideReason?: string;
+};
+
+type CreatePracticeSessionActionInput =
+    CreatePracticeSessionInput & PracticeReservationFields;
+type UpdatePracticeSessionActionInput =
+    UpdatePracticeSessionInput & PracticeReservationFields;
+
+const practiceReservationFieldsSchema = z.object({
+    reservationId: z.string().cuid("Invalid venue reservation ID").nullable().optional(),
+    overrideReason: z.string().trim().min(1).max(1000).optional(),
+});
+
+type ConfirmedPracticeReservation = {
+    id: string;
+    status: string;
+    startsAt: Date;
+    endsAt: Date;
+    timezone: string;
+    venueId: string;
+    surfaceId: string | null;
+    segmentId: string | null;
+    ownerTeamId: string | null;
+    ownerLeagueId: string | null;
+    ownerVenueOrganizationId: string | null;
+    venue?: { name: string; timezone: string } | null;
+};
+
+function reservationFields(input: PracticeReservationFields) {
+    return practiceReservationFieldsSchema.parse({
+        reservationId: input.reservationId,
+        overrideReason: input.overrideReason,
+    });
+}
+
+async function requirePracticeScheduler(
+    teamId: string,
+    reservationId?: string | null,
+): Promise<string> {
+    let teamActorId: string | null = null;
+    let teamError: unknown;
+    try {
+        teamActorId = await requireTeamAdmin(teamId);
+    } catch (error) {
+        teamError = error;
+    }
+    if (!reservationId) {
+        if (teamActorId) return teamActorId;
+        throw teamError;
+    }
+
+    const reservation = await prisma.venueReservation.findUnique({
+        where: { id: reservationId },
+        select: { ownerLeagueId: true },
+    });
+    if (!reservation?.ownerLeagueId) {
+        if (teamActorId) return teamActorId;
+        throw teamError;
+    }
+
+    const team = await prisma.team.findUnique({
+        where: { id: teamId },
+        select: { leagueId: true },
+    });
+    if (team?.leagueId !== reservation.ownerLeagueId) {
+        throw teamError ?? new Error("Unauthorized");
+    }
+    return requireLeagueRole(team.leagueId, "LEAGUE_ADMIN");
+}
+
+async function loadConfirmedPracticeReservation(
+    tx: Prisma.TransactionClient,
+    reservationId: string,
+    teamId: string,
+    expectedStart: Date,
+    expectedDuration: number,
+): Promise<ConfirmedPracticeReservation> {
+    const reservation = await tx.venueReservation.findUnique({
+        where: { id: reservationId },
+        include: { venue: { select: { name: true, timezone: true } } },
+    }) as ConfirmedPracticeReservation | null;
+    if (!reservation || reservation.status !== "CONFIRMED") {
+        throw new VenueReservationLifecycleError(
+            "Select a confirmed venue reservation.",
+        );
+    }
+
+    if (reservation.ownerTeamId) {
+        if (reservation.ownerTeamId !== teamId) {
+            throw new VenueReservationLifecycleError(
+                "The venue reservation is outside this team's scope.",
+            );
+        }
+    } else if (reservation.ownerLeagueId) {
+        const team = await tx.team.findUnique({
+            where: { id: teamId },
+            select: { leagueId: true },
+        });
+        if (team?.leagueId !== reservation.ownerLeagueId) {
+            throw new VenueReservationLifecycleError(
+                "The venue reservation is outside this league's scope.",
+            );
+        }
+    } else {
+        throw new VenueReservationLifecycleError(
+            "Venue-owned inventory cannot be assigned to this practice.",
+        );
+    }
+
+    const expectedEnd = new Date(
+        expectedStart.getTime() + expectedDuration * 60_000,
+    );
+    if (
+        reservation.startsAt.getTime() !== expectedStart.getTime()
+        || reservation.endsAt.getTime() !== expectedEnd.getTime()
+    ) {
+        throw new VenueReservationLifecycleError(
+            "The practice time and duration must match the selected venue reservation.",
+        );
+    }
+    return reservation;
+}
+
+async function assertExactTeamAdminInTransaction(
+    tx: Prisma.TransactionClient,
+    input: { teamId: string; actorId: string },
+): Promise<void> {
+    const teamAdmin = await tx.teamMember.findFirst({
+        where: {
+            userId: input.actorId,
+            teamId: input.teamId,
+            role: "ADMIN",
+        },
+        select: { id: true },
+    });
+    if (!teamAdmin) {
+        throw new VenueReservationLifecycleError(
+            "Practice updates require exact team-admin authority.",
+        );
+    }
+}
+
+async function assertPracticeReservationActorInTransaction(
+    tx: Prisma.TransactionClient,
+    input: {
+        reservationId: string;
+        teamId: string;
+        actorId: string;
+    },
+): Promise<void> {
+    const reservation = await tx.venueReservation.findUnique({
+        where: { id: input.reservationId },
+        select: { ownerLeagueId: true, ownerTeamId: true },
+    });
+    if (!reservation) {
+        throw new VenueReservationLifecycleError(
+            "Venue reservation not found.",
+        );
+    }
+    if (reservation.ownerTeamId) {
+        if (reservation.ownerTeamId !== input.teamId) {
+            throw new VenueReservationLifecycleError(
+                "The venue reservation is outside this team's scope.",
+            );
+        }
+        const teamAdmin = await tx.teamMember.findFirst({
+            where: {
+                userId: input.actorId,
+                teamId: input.teamId,
+                role: "ADMIN",
+            },
+            select: { id: true },
+        });
+        if (!teamAdmin) {
+            throw new VenueReservationLifecycleError(
+                "Team-owned reservations require exact team-admin authority.",
+            );
+        }
+        return;
+    }
+    if (reservation.ownerLeagueId) {
+        const team = await tx.team.findUnique({
+            where: { id: input.teamId },
+            select: { leagueId: true },
+        });
+        const scheduler = await tx.leagueUser.findFirst({
+            where: {
+                userId: input.actorId,
+                leagueId: reservation.ownerLeagueId,
+                role: "LEAGUE_ADMIN",
+            },
+            select: { id: true },
+        });
+        if (
+            team?.leagueId !== reservation.ownerLeagueId
+            || !scheduler
+        ) {
+            throw new VenueReservationLifecycleError(
+                "League-owned reservations require same-league scheduler authority.",
+            );
+        }
+        return;
+    }
+    throw new VenueReservationLifecycleError(
+        "Venue-owned inventory cannot be assigned to this practice.",
+    );
+}
+
+function practiceDataFromReservation(
+    reservation: ConfirmedPracticeReservation,
+): PracticeAttachment {
+    return {
+        venueId: reservation.venueId,
+        surfaceId: reservation.surfaceId,
+        segmentId: reservation.segmentId,
+        startAt: reservation.startsAt,
+    };
+}
+
+async function createPracticeEventAndRsvps(
+    tx: Prisma.TransactionClient,
+    input: {
+        eventId?: string;
+        title: string;
+        teamId: string;
+        reservation: ConfirmedPracticeReservation;
+        actorId: string;
+        overrideReason?: string;
+        assignEventReservation?: boolean;
+    },
+): Promise<string> {
+    const eventData = {
+        type: "PRACTICE" as const,
+        title: input.title,
+        startAt: input.reservation.startsAt,
+        endAt: input.reservation.endsAt,
+        timezone:
+            input.reservation.timezone
+            || input.reservation.venue?.timezone
+            || FALLBACK_TIME_ZONE,
+        location: input.reservation.venue?.name || "Venue",
+        venueId: input.reservation.venueId,
+        opponent: null,
+        notes: null,
+        teamId: input.teamId,
+        leagueId: null,
+    };
+    const event = input.eventId
+        ? await tx.event.update({
+            where: { id: input.eventId },
+            data: eventData,
+            select: { id: true },
+        })
+        : await tx.event.create({
+            data: eventData,
+            select: { id: true },
+        });
+
+    if (input.assignEventReservation !== false) {
+        await assignVenueReservation(tx, {
+            reservationId: input.reservation.id,
+            targetType: "EVENT",
+            targetId: event.id,
+            actorId: input.actorId,
+            overrideReason: input.overrideReason,
+        });
+    }
+
+    const members = await tx.teamMember.findMany({
+        where: { teamId: input.teamId },
+        select: { userId: true },
+    });
+    const userIds = [...new Set(members.map(({ userId }) => userId))];
+    if (userIds.length > 0) {
+        await tx.rSVP.createMany({
+            data: userIds.map((userId) => ({
+                eventId: event.id,
+                userId,
+                status: "NO_RESPONSE" as const,
+            })),
+            skipDuplicates: true,
+        });
+    }
+    return event.id;
+}
 
 /**
  * Sanitize text input by removing control characters and trimming
@@ -129,110 +426,21 @@ function normalizePracticeAttachment(validated: {
 }
 
 /**
- * Verify attachment references: the venue is active and accessible to this
- * user (visibility rules — public, or scoped to a team/league the user
- * belongs to), the surface is active and belongs to the venue, and the
- * segment is active and belongs to the surface (same checks as events and
- * season-games, 006 FR). Returns an error message or null.
- */
-async function validatePracticeAttachment(
-    userId: string,
-    attachment: PracticeAttachment
-): Promise<string | null> {
-    const { venueId, surfaceId, segmentId } = attachment;
-    if (!venueId) return null;
-
-    const venue = await prisma.venue.findUnique({
-        where: { id: venueId },
-        select: { id: true, isActive: true, visibility: true, teamId: true, leagueId: true },
-    });
-    if (!venue || !venue.isActive || !(await canUserAccessVenue(userId, venue))) {
-        return "Venue not found or unavailable";
-    }
-
-    if (surfaceId) {
-        const surface = await prisma.iceSurface.findFirst({
-            where: { id: surfaceId, venueId, isActive: true },
-            select: { id: true },
-        });
-        if (!surface) {
-            return "Select an active surface at the chosen venue";
-        }
-    }
-
-    if (segmentId) {
-        if (!surfaceId) {
-            return "Pick a surface before choosing a segment";
-        }
-        const segment = await prisma.surfaceSegment.findFirst({
-            where: { id: segmentId, surfaceId, isActive: true },
-            select: { id: true },
-        });
-        if (!segment) {
-            return "Select an active segment on the chosen surface";
-        }
-    }
-
-    return null;
-}
-
-function practiceConflictFailure(conflicts: BookingConflict[]): {
-    success: false;
-    error: string;
-    details: { conflicts: BookingConflict[] };
-} {
-    return {
-        success: false,
-        error: `This time overlaps ${conflicts.length} existing booking${conflicts.length > 1 ? "s" : ""} at the venue`,
-        details: { conflicts },
-    };
-}
-
-/**
- * Run the unified availability check for an attached practice (FR-019).
- * Returns the conflicts found; the caller decides warn-vs-proceed based on
- * overrideConflicts. Unattached practices (no venue/startAt) never conflict.
- */
-async function findPracticeConflicts(
-    attachment: PracticeAttachment,
-    duration: number,
-    excludePracticeId?: string
-): Promise<BookingConflict[]> {
-    if (!attachment.venueId || !attachment.startAt) return [];
-    const endAt = new Date(attachment.startAt.getTime() + duration * 60_000);
-    return findBookingConflicts({
-        venueId: attachment.venueId,
-        surfaceId: attachment.surfaceId,
-        segmentId: attachment.segmentId,
-        startAt: attachment.startAt,
-        endAt,
-        excludePracticeId,
-    });
-}
-
-/**
  * Create a new practice session
  * Only ADMIN role can create sessions
  * Requirements: 2.1, 2.2, 2.5
  */
 export async function createPracticeSession(
-    input: CreatePracticeSessionInput
+    input: CreatePracticeSessionActionInput
 ): Promise<ActionResult<{ id: string; title: string; date: Date; conflictsOverridden: boolean }>> {
     try {
-        // Validate input
         const validated = createPracticeSessionSchema.parse(input);
+        const reservationInput = reservationFields(input);
+        const userId = await requirePracticeScheduler(
+            validated.teamId,
+            reservationInput.reservationId,
+        );
 
-        // Check authentication and authorization - only ADMIN can create sessions
-        const userId = await requireTeamAdmin(validated.teamId);
-
-        // Optional venue attachment (FR-019, feature 006)
-        const attachment = normalizePracticeAttachment(validated);
-        const attachmentError = await validatePracticeAttachment(userId, attachment);
-        if (attachmentError) {
-            return { success: false, error: attachmentError };
-        }
-
-        // Validate play sequence integrity
         if (validated.plays && validated.plays.length > 0) {
             const sequenceValidation = validatePlaySequence(validated.plays);
             if (!sequenceValidation.valid) {
@@ -242,7 +450,6 @@ export async function createPracticeSession(
                 };
             }
 
-            // Validate total duration
             const durationValidation = validateTotalDuration(validated.duration, validated.plays);
             if (!durationValidation.valid) {
                 return {
@@ -251,7 +458,6 @@ export async function createPracticeSession(
                 };
             }
 
-            // Verify all plays exist and belong to the team
             const playIds = validated.plays.map(p => p.playId);
             const plays = await prisma.play.findMany({
                 where: {
@@ -269,54 +475,137 @@ export async function createPracticeSession(
             }
         }
 
-        // Venue availability (FR-019): warn on conflicts and require an
-        // explicit override to proceed; the override is recorded on the row
-        // (conflictOverriddenBy/At), matching SeasonGame/EventGame.
-        const conflicts = await findPracticeConflicts(attachment, validated.duration);
-        if (conflicts.length > 0 && !validated.overrideConflicts) {
-            return practiceConflictFailure(conflicts);
+        const requestedAttachment = normalizePracticeAttachment(validated);
+        if (
+            !reservationInput.reservationId
+            && requestedAttachment.venueId
+            && validated.overrideConflicts
+            && !reservationInput.overrideReason
+        ) {
+            return {
+                success: false,
+                error: "Explain why this venue conflict should be overridden.",
+            };
         }
-        const conflictsOverridden = conflicts.length > 0;
 
-        // Create practice session with plays
-        const session = await prisma.practiceSession.create({
-            data: {
-                title: validated.title,
-                date: validated.date,
-                duration: validated.duration,
-                isShared: false,
-                teamId: validated.teamId,
-                createdById: userId,
-                venueId: attachment.venueId,
-                surfaceId: attachment.surfaceId,
-                segmentId: attachment.segmentId,
-                startAt: attachment.startAt,
-                ...(conflictsOverridden && {
-                    conflictOverriddenById: userId,
-                    conflictOverriddenAt: new Date(),
-                }),
-                plays: validated.plays && validated.plays.length > 0 ? {
-                    create: validated.plays.map(play => ({
-                        playId: play.playId,
-                        sequence: play.sequence,
-                        duration: play.duration,
-                        instructions: play.instructions ? sanitizeText(play.instructions, 2000) : null,
-                    })),
-                } : undefined,
-            },
-            select: {
-                id: true,
-                title: true,
-                date: true,
-            },
+        const session = await runVenueReservationTransaction(async (tx) => {
+            let reservation: ConfirmedPracticeReservation | null = null;
+
+            if (reservationInput.reservationId) {
+                reservation = await loadConfirmedPracticeReservation(
+                    tx,
+                    reservationInput.reservationId,
+                    validated.teamId,
+                    validated.date,
+                    validated.duration,
+                );
+            } else if (requestedAttachment.venueId && requestedAttachment.startAt) {
+                const venue = await tx.venue.findUnique({
+                    where: { id: requestedAttachment.venueId },
+                    select: { name: true, timezone: true },
+                });
+                if (!venue) {
+                    throw new VenueReservationLifecycleError(
+                        "Venue not found or unavailable.",
+                    );
+                }
+                const created = await createVenueReservation(tx, {
+                    venueId: requestedAttachment.venueId,
+                    surfaceId: requestedAttachment.surfaceId,
+                    segmentId: requestedAttachment.segmentId,
+                    startsAt: requestedAttachment.startAt,
+                    endsAt: new Date(
+                        requestedAttachment.startAt.getTime()
+                            + validated.duration * 60_000,
+                    ),
+                    timezone: venue.timezone,
+                    ownerTeamId: validated.teamId,
+                    actorId: userId,
+                    status: "CONFIRMED",
+                    overrideReason: reservationInput.overrideReason,
+                });
+                reservation = {
+                    ...created,
+                    startsAt: requestedAttachment.startAt,
+                    endsAt: new Date(
+                        requestedAttachment.startAt.getTime()
+                            + validated.duration * 60_000,
+                    ),
+                    timezone: venue.timezone,
+                    venueId: requestedAttachment.venueId,
+                    surfaceId: requestedAttachment.surfaceId,
+                    segmentId: requestedAttachment.segmentId,
+                    ownerTeamId: validated.teamId,
+                    ownerLeagueId: null,
+                    ownerVenueOrganizationId: null,
+                    venue,
+                };
+            }
+
+            const canonical = reservation
+                ? practiceDataFromReservation(reservation)
+                : requestedAttachment;
+            const createdSession = await tx.practiceSession.create({
+                data: {
+                    title: validated.title,
+                    date: reservation ? reservation.startsAt : validated.date,
+                    duration: reservation
+                        ? Math.round(
+                            (
+                                reservation.endsAt.getTime()
+                                - reservation.startsAt.getTime()
+                            ) / 60_000,
+                        )
+                        : validated.duration,
+                    isShared: false,
+                    teamId: validated.teamId,
+                    createdById: userId,
+                    venueId: canonical.venueId,
+                    surfaceId: canonical.surfaceId,
+                    segmentId: canonical.segmentId,
+                    startAt: canonical.startAt,
+                    plays: validated.plays.length > 0 ? {
+                        create: validated.plays.map(play => ({
+                            playId: play.playId,
+                            sequence: play.sequence,
+                            duration: play.duration,
+                            instructions: play.instructions
+                                ? sanitizeText(play.instructions, 2000)
+                                : null,
+                        })),
+                    } : undefined,
+                },
+                select: { id: true, title: true, date: true },
+            });
+
+            if (reservation) {
+                await assignVenueReservation(tx, {
+                    reservationId: reservation.id,
+                    targetType: "PRACTICE",
+                    targetId: createdSession.id,
+                    actorId: userId,
+                    overrideReason: reservationInput.overrideReason,
+                });
+                await createPracticeEventAndRsvps(tx, {
+                    title: validated.title,
+                    teamId: validated.teamId,
+                    reservation,
+                    actorId: userId,
+                    overrideReason: reservationInput.overrideReason,
+                });
+            }
+            return createdSession;
         });
 
-        // Revalidate practice planner pages
         revalidatePath("/practice-planner");
+        revalidatePath("/calendar");
 
         return {
             success: true,
-            data: { ...session, conflictsOverridden },
+            data: {
+                ...session,
+                conflictsOverridden: Boolean(reservationInput.overrideReason),
+            },
         };
     } catch (error) {
         if (error instanceof z.ZodError) {
@@ -324,6 +613,21 @@ export async function createPracticeSession(
                 success: false,
                 error: "Invalid input",
                 details: error.issues,
+            };
+        }
+
+        if (
+            error instanceof VenueReservationConflictError
+            || error instanceof VenueReservationLifecycleError
+        ) {
+            return {
+                success: false,
+                error: error.message,
+                ...(
+                    error instanceof VenueReservationConflictError
+                        ? { details: { conflicts: error.conflicts } }
+                        : {}
+                ),
             };
         }
 
@@ -348,16 +652,20 @@ export async function createPracticeSession(
  * Requirements: 2.1, 2.2, 2.5
  */
 export async function updatePracticeSession(
-    input: UpdatePracticeSessionInput
+    input: UpdatePracticeSessionActionInput
 ): Promise<ActionResult<{ id: string; title: string; date: Date; conflictsOverridden: boolean }>> {
     try {
-        // Validate input
         const validated = updatePracticeSessionSchema.parse(input);
+        const parsedReservation = reservationFields(input);
+        const reservationWasSubmitted = Object.hasOwn(input, "reservationId");
 
-        // First fetch the existing session to get its actual teamId for authorization
         const existingSession = await prisma.practiceSession.findUnique({
             where: { id: validated.id },
-            select: { teamId: true, isShared: true },
+            select: {
+                teamId: true,
+                isShared: true,
+                venueReservationId: true,
+            },
         });
 
         if (!existingSession) {
@@ -367,42 +675,49 @@ export async function updatePracticeSession(
             };
         }
 
-        // Authorize against the session's actual teamId
-        const userId = await requireTeamAdmin(existingSession.teamId);
-
-        // Verify the teamId in the request matches the session's actual teamId
         if (existingSession.teamId !== validated.teamId) {
             return {
                 success: false,
                 error: "Unauthorized: Practice session does not belong to this team",
             };
         }
-
-        // Optional venue attachment (FR-019, feature 006). The editor submits
-        // the full session state, so the attachment is replaced wholesale:
-        // omitting/clearing venueId detaches the practice (clears surface,
-        // segment, and startAt — no availability footprint).
-        const attachment = normalizePracticeAttachment(validated);
-        const attachmentError = await validatePracticeAttachment(userId, attachment);
-        if (attachmentError) {
-            return { success: false, error: attachmentError };
+        const selectedReservationId = reservationWasSubmitted
+            ? parsedReservation.reservationId ?? null
+            : existingSession.venueReservationId;
+        const requestedAttachment = normalizePracticeAttachment(validated);
+        const createsDirectReservation =
+            !selectedReservationId
+            && Boolean(
+                requestedAttachment.venueId
+                && requestedAttachment.startAt,
+            );
+        const reservationRelationChanged =
+            selectedReservationId !== existingSession.venueReservationId
+            || createsDirectReservation;
+        let userId: string;
+        if (!reservationRelationChanged) {
+            userId = await requireTeamAdmin(existingSession.teamId);
+        } else {
+            const actorIds: string[] = [];
+            if (existingSession.venueReservationId) {
+                actorIds.push(await requirePracticeScheduler(
+                    existingSession.teamId,
+                    existingSession.venueReservationId,
+                ));
+            }
+            if (selectedReservationId) {
+                actorIds.push(await requirePracticeScheduler(
+                    existingSession.teamId,
+                    selectedReservationId,
+                ));
+            }
+            if (createsDirectReservation) {
+                actorIds.push(await requireTeamAdmin(existingSession.teamId));
+            }
+            userId = actorIds[actorIds.length - 1]
+                ?? await requireTeamAdmin(existingSession.teamId);
         }
 
-        // Venue availability (FR-019): warn on conflicts and require an
-        // explicit override to proceed, excluding this practice's own slot;
-        // the override is recorded on the row (conflictOverriddenBy/At),
-        // matching SeasonGame/EventGame.
-        const conflicts = await findPracticeConflicts(
-            attachment,
-            validated.duration,
-            validated.id
-        );
-        if (conflicts.length > 0 && !validated.overrideConflicts) {
-            return practiceConflictFailure(conflicts);
-        }
-        const conflictsOverridden = conflicts.length > 0;
-
-        // Validate play sequence integrity
         if (validated.plays && validated.plays.length > 0) {
             const sequenceValidation = validatePlaySequence(validated.plays);
             if (!sequenceValidation.valid) {
@@ -412,7 +727,6 @@ export async function updatePracticeSession(
                 };
             }
 
-            // Validate total duration
             const durationValidation = validateTotalDuration(validated.duration, validated.plays);
             if (!durationValidation.valid) {
                 return {
@@ -421,7 +735,6 @@ export async function updatePracticeSession(
                 };
             }
 
-            // Verify all plays exist and belong to the team
             const playIds = validated.plays.map(p => p.playId);
             const plays = await prisma.play.findMany({
                 where: {
@@ -439,31 +752,172 @@ export async function updatePracticeSession(
             }
         }
 
-        // Update session - delete existing plays and recreate
-        const session = await prisma.$transaction(async (tx) => {
-            // Delete existing plays
+        if (
+            !selectedReservationId
+            && requestedAttachment.venueId
+            && validated.overrideConflicts
+            && !parsedReservation.overrideReason
+        ) {
+            return {
+                success: false,
+                error: "Explain why this venue conflict should be overridden.",
+            };
+        }
+
+        const session = await runVenueReservationTransaction(async (tx) => {
+            const current = await tx.practiceSession.findUnique({
+                where: { id: validated.id },
+                select: {
+                    id: true,
+                    teamId: true,
+                    venueReservationId: true,
+                },
+            });
+            if (!current || current.teamId !== validated.teamId) {
+                throw new VenueReservationLifecycleError(
+                    "Practice session not found.",
+                );
+            }
+            if (!reservationRelationChanged) {
+                if (
+                    current.venueReservationId
+                    !== existingSession.venueReservationId
+                ) {
+                    throw new VenueReservationLifecycleError(
+                        "The practice reservation changed while the update was in progress.",
+                    );
+                }
+                await assertExactTeamAdminInTransaction(tx, {
+                    teamId: current.teamId,
+                    actorId: userId,
+                });
+            } else if (current.venueReservationId) {
+                await assertPracticeReservationActorInTransaction(tx, {
+                    reservationId: current.venueReservationId,
+                    teamId: current.teamId,
+                    actorId: userId,
+                });
+            }
+            if (createsDirectReservation) {
+                await assertExactTeamAdminInTransaction(tx, {
+                    teamId: current.teamId,
+                    actorId: userId,
+                });
+            }
+
+            const oldEvent = current.venueReservationId
+                ? await tx.event.findUnique({
+                    where: { venueReservationId: current.venueReservationId },
+                    select: { id: true },
+                })
+                : null;
+
+            let reservation: ConfirmedPracticeReservation | null = null;
+            if (selectedReservationId) {
+                reservation = await loadConfirmedPracticeReservation(
+                    tx,
+                    selectedReservationId,
+                    validated.teamId,
+                    validated.date,
+                    validated.duration,
+                );
+                if (reservationRelationChanged) {
+                    await assertPracticeReservationActorInTransaction(tx, {
+                        reservationId: reservation.id,
+                        teamId: validated.teamId,
+                        actorId: userId,
+                    });
+                }
+            } else if (requestedAttachment.venueId && requestedAttachment.startAt) {
+                const venue = await tx.venue.findUnique({
+                    where: { id: requestedAttachment.venueId },
+                    select: { name: true, timezone: true },
+                });
+                if (!venue) {
+                    throw new VenueReservationLifecycleError(
+                        "Venue not found or unavailable.",
+                    );
+                }
+                const created = await createVenueReservation(tx, {
+                    venueId: requestedAttachment.venueId,
+                    surfaceId: requestedAttachment.surfaceId,
+                    segmentId: requestedAttachment.segmentId,
+                    startsAt: requestedAttachment.startAt,
+                    endsAt: new Date(
+                        requestedAttachment.startAt.getTime()
+                            + validated.duration * 60_000,
+                    ),
+                    timezone: venue.timezone,
+                    ownerTeamId: validated.teamId,
+                    actorId: userId,
+                    status: "CONFIRMED",
+                    overrideReason: parsedReservation.overrideReason,
+                });
+                reservation = {
+                    ...created,
+                    startsAt: requestedAttachment.startAt,
+                    endsAt: new Date(
+                        requestedAttachment.startAt.getTime()
+                            + validated.duration * 60_000,
+                    ),
+                    timezone: venue.timezone,
+                    venueId: requestedAttachment.venueId,
+                    surfaceId: requestedAttachment.surfaceId,
+                    segmentId: requestedAttachment.segmentId,
+                    ownerTeamId: validated.teamId,
+                    ownerLeagueId: null,
+                    ownerVenueOrganizationId: null,
+                    venue,
+                };
+            }
+
+            if (
+                current.venueReservationId
+                && current.venueReservationId !== reservation?.id
+            ) {
+                if (oldEvent) {
+                    await tx.event.update({
+                        where: { id: oldEvent.id },
+                        data: { venueReservationId: null },
+                    });
+                }
+                await tx.practiceSession.update({
+                    where: { id: current.id },
+                    data: { venueReservationId: null },
+                });
+            }
+
             await tx.practiceSessionPlay.deleteMany({
                 where: { sessionId: validated.id },
             });
 
-            // Update session with new plays
-            return await tx.practiceSession.update({
+            const canonical = reservation
+                ? practiceDataFromReservation(reservation)
+                : requestedAttachment;
+            const updated = await tx.practiceSession.update({
                 where: { id: validated.id },
                 data: {
                     title: validated.title,
-                    date: validated.date,
-                    duration: validated.duration,
-                    venueId: attachment.venueId,
-                    surfaceId: attachment.surfaceId,
-                    segmentId: attachment.segmentId,
-                    startAt: attachment.startAt,
-                    // The conflict check re-ran above whenever a venue is
-                    // attached (and a detached practice has no footprint), so
-                    // always write the override audit fields: stale metadata
-                    // must not survive a reschedule to a clean slot.
-                    conflictOverriddenById: conflictsOverridden ? userId : null,
-                    conflictOverriddenAt: conflictsOverridden ? new Date() : null,
-                    plays: validated.plays && validated.plays.length > 0 ? {
+                    date: reservation ? reservation.startsAt : validated.date,
+                    duration: reservation
+                        ? Math.round(
+                            (
+                                reservation.endsAt.getTime()
+                                - reservation.startsAt.getTime()
+                            ) / 60_000,
+                        )
+                        : validated.duration,
+                    venueId: canonical.venueId,
+                    surfaceId: canonical.surfaceId,
+                    segmentId: canonical.segmentId,
+                    startAt: canonical.startAt,
+                    conflictOverriddenById: parsedReservation.overrideReason
+                        ? userId
+                        : null,
+                    conflictOverriddenAt: parsedReservation.overrideReason
+                        ? new Date()
+                        : null,
+                    plays: validated.plays.length > 0 ? {
                         create: validated.plays.map(play => ({
                             playId: play.playId,
                             sequence: play.sequence,
@@ -478,11 +932,39 @@ export async function updatePracticeSession(
                     date: true,
                 },
             });
+
+            if (!reservation) {
+                if (oldEvent) {
+                    await tx.event.delete({ where: { id: oldEvent.id } });
+                }
+                return updated;
+            }
+
+            if (reservationRelationChanged) {
+                await assignVenueReservation(tx, {
+                    reservationId: reservation.id,
+                    targetType: "PRACTICE",
+                    targetId: updated.id,
+                    actorId: userId,
+                    overrideReason: parsedReservation.overrideReason,
+                });
+            }
+            await createPracticeEventAndRsvps(tx, {
+                eventId: oldEvent?.id,
+                title: validated.title,
+                teamId: validated.teamId,
+                reservation,
+                actorId: userId,
+                overrideReason: parsedReservation.overrideReason,
+                assignEventReservation:
+                    reservationRelationChanged || !oldEvent,
+            });
+            return updated;
         });
 
-        // Revalidate practice planner pages
         revalidatePath("/practice-planner");
         revalidatePath(`/practice-planner/${validated.id}`);
+        revalidatePath("/calendar");
 
         // Send update notifications if session is shared (Requirements: 6.3)
         if (existingSession.isShared) {
@@ -495,7 +977,10 @@ export async function updatePracticeSession(
 
         return {
             success: true,
-            data: { ...session, conflictsOverridden },
+            data: {
+                ...session,
+                conflictsOverridden: Boolean(parsedReservation.overrideReason),
+            },
         };
     } catch (error) {
         if (error instanceof z.ZodError) {
@@ -503,6 +988,21 @@ export async function updatePracticeSession(
                 success: false,
                 error: "Invalid input",
                 details: error.issues,
+            };
+        }
+
+        if (
+            error instanceof VenueReservationConflictError
+            || error instanceof VenueReservationLifecycleError
+        ) {
+            return {
+                success: false,
+                error: error.message,
+                ...(
+                    error instanceof VenueReservationConflictError
+                        ? { details: { conflicts: error.conflicts } }
+                        : {}
+                ),
             };
         }
 
@@ -536,7 +1036,7 @@ export async function deletePracticeSession(
         // First fetch the existing session to get its actual teamId for authorization
         const existingSession = await prisma.practiceSession.findUnique({
             where: { id: validated.id },
-            select: { teamId: true },
+            select: { teamId: true, venueReservationId: true },
         });
 
         if (!existingSession) {
@@ -546,9 +1046,6 @@ export async function deletePracticeSession(
             };
         }
 
-        // Authorize against the session's actual teamId
-        await requireTeamAdmin(existingSession.teamId);
-
         // Verify the teamId in the request matches the session's actual teamId
         if (existingSession.teamId !== validated.teamId) {
             return {
@@ -557,13 +1054,56 @@ export async function deletePracticeSession(
             };
         }
 
-        // Delete session (cascade will remove associated PracticeSessionPlay records)
-        await prisma.practiceSession.delete({
-            where: { id: validated.id },
+        const actorId = await requirePracticeScheduler(
+            existingSession.teamId,
+            existingSession.venueReservationId,
+        );
+
+        await runVenueReservationTransaction(async (tx) => {
+            const practice = await tx.practiceSession.findUnique({
+                where: { id: validated.id },
+                select: {
+                    id: true,
+                    teamId: true,
+                    venueReservationId: true,
+                },
+            });
+            if (!practice || practice.teamId !== validated.teamId) {
+                throw new VenueReservationLifecycleError(
+                    "Practice session not found.",
+                );
+            }
+            if (practice.venueReservationId) {
+                await assertPracticeReservationActorInTransaction(tx, {
+                    reservationId: practice.venueReservationId,
+                    teamId: practice.teamId,
+                    actorId,
+                });
+                const participantEvent = await tx.event.findUnique({
+                    where: {
+                        venueReservationId: practice.venueReservationId,
+                    },
+                    select: { id: true, type: true, teamId: true },
+                });
+                if (
+                    participantEvent?.type === "PRACTICE"
+                    && participantEvent.teamId === practice.teamId
+                ) {
+                    // Event deletion cascades its participant RSVP rows.
+                    await tx.event.delete({
+                        where: { id: participantEvent.id },
+                    });
+                }
+            }
+            // The confirmed reservation remains valid, unassigned inventory.
+            await tx.practiceSession.delete({
+                where: { id: practice.id },
+            });
         });
 
         // Revalidate practice planner pages
         revalidatePath("/practice-planner");
+        revalidatePath("/calendar");
 
         return {
             success: true,

--- a/lib/actions/venue-requests.ts
+++ b/lib/actions/venue-requests.ts
@@ -12,7 +12,6 @@ import {
 } from "@/lib/auth/session";
 import type { ActionResult } from "@/lib/actions/venue-organizations";
 import {
-  decideIceTimeRequestSchema,
   submitIceTimeRequestSchema,
   type SubmitIceTimeRequestInput,
 } from "@/lib/utils/validation";
@@ -20,16 +19,479 @@ import {
   sendIceTimeRequestDecisionEmail,
   sendIceTimeRequestSubmittedEmail,
 } from "@/lib/email/templates";
+import {
+  createVenueReservation,
+  transitionVenueReservation,
+  VenueReservationConflictError,
+  VenueReservationLifecycleError,
+} from "@/lib/services/venue-reservations";
+import {
+  approvedSpaceWithinRequestedSpace,
+  findLegacyAcceptedRequestConflicts,
+} from "@/lib/services/venue-reservation-availability";
+import { runVenueReservationTransaction } from "@/lib/services/venue-reservation-transaction";
+import { assertAssociationOperationsNotificationEvent } from "@/lib/services/association-operations-notification-registry";
+import { getWholeSurfaceDefaultLabel } from "@/lib/utils/segment-presets";
+import { expandRecurrenceWindow } from "@/lib/utils/venue-schedule";
 
 const requestCommandSchema = z.object({
   organizationId: z.string().cuid("Invalid organization ID format"),
   venueId: z.string().cuid("Invalid venue ID format"),
   requestId: z.string().cuid("Invalid request ID format"),
+  linkedActivityDisposition: z.enum(["UNASSIGN"]).optional(),
 });
 
-const decisionSchema = decideIceTimeRequestSchema.extend({
-  status: z.enum(["UNDER_REVIEW", "ACCEPTED", "DECLINED"]),
+const decisionSchema = z.object({
+  organizationId: z.string().cuid("Invalid organization ID format"),
+  venueId: z.string().cuid("Invalid venue ID format"),
+  requestId: z.string().cuid("Invalid request ID format"),
+  status: z.enum(["UNDER_REVIEW", "ACCEPTED", "PARTIALLY_ACCEPTED", "DECLINED"]),
+  approvedStartAt: z.coerce.date().optional(),
+  approvedEndAt: z.coerce.date().optional(),
+  approvedSurfaceId: z.string().cuid().nullable().optional(),
+  approvedSegmentId: z.string().cuid().nullable().optional(),
+  intentionalVenueWideClaim: z.boolean().default(false),
+  decisionMessage: z.string().max(1000).optional(),
+  overrideConflicts: z.boolean().default(false),
+  overrideReason: z.string().max(1000).optional(),
+}).superRefine((value, context) => {
+  if (value.overrideConflicts && !value.overrideReason?.trim()) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "A reason is required to override conflicts",
+      path: ["overrideReason"],
+    });
+  }
 });
+
+const annotationSchema = requestCommandSchema.pick({
+  organizationId: true,
+  venueId: true,
+  requestId: true,
+}).extend({
+  decisionMessage: z.string().trim().min(1).max(1000),
+});
+
+async function assertVenueRequestManagerInTransaction(
+  tx: Prisma.TransactionClient,
+  input: {
+    actorId: string;
+    organizationId: string;
+    venueId: string;
+  },
+) {
+  const staff = await tx.venueStaff.findFirst({
+    where: {
+      userId: input.actorId,
+      organizationId: input.organizationId,
+      status: "ACTIVE",
+      role: { in: ["OWNER", "MANAGER", "REQUEST_MANAGER"] },
+      OR: [{ venueId: null }, { venueId: input.venueId }],
+    },
+    select: { id: true },
+  });
+  if (!staff) {
+    throw new VenueReservationLifecycleError(
+      "You are not authorized to decide requests for this venue.",
+    );
+  }
+}
+
+async function assertVenueConflictOverrideInTransaction(
+  tx: Prisma.TransactionClient,
+  input: {
+    actorId: string;
+    organizationId: string;
+    venueId: string;
+  },
+) {
+  const manager = await tx.venueStaff.findFirst({
+    where: {
+      userId: input.actorId,
+      organizationId: input.organizationId,
+      status: "ACTIVE",
+      role: { in: ["OWNER", "MANAGER"] },
+      OR: [{ venueId: null }, { venueId: input.venueId }],
+    },
+    select: { id: true },
+  });
+  if (!manager) {
+    throw new VenueReservationLifecycleError(
+      "Conflict overrides require venue-manager authorization.",
+    );
+  }
+}
+
+export type DecideIceTimeRequestTransactionHooks = {
+  beforeCreateReservation?: () => Promise<void>;
+};
+
+export async function decideIceTimeRequestInTransaction(
+  tx: Prisma.TransactionClient,
+  validated: z.infer<typeof decisionSchema>,
+  userId: string,
+  hooks: DecideIceTimeRequestTransactionHooks = {},
+) {
+  await assertVenueRequestManagerInTransaction(tx, {
+    actorId: userId,
+    organizationId: validated.organizationId,
+    venueId: validated.venueId,
+  });
+  const request = await tx.iceTimeRequest.findFirst({
+    where: {
+      id: validated.requestId,
+      venueId: validated.venueId,
+      venue: { organizationId: validated.organizationId },
+    },
+    select: {
+      id: true,
+      contactEmail: true,
+      scheduleBlockId: true,
+      requestedStartAt: true,
+      requestedEndAt: true,
+      requesterTeamId: true,
+      requesterTeam: { select: { leagueId: true } },
+      requesterLeagueId: true,
+      requesterUserId: true,
+      status: true,
+      decidedAt: true,
+      approvedStartAt: true,
+      approvedEndAt: true,
+      approvedSurfaceId: true,
+      approvedSegmentId: true,
+      venueReservation: {
+        select: {
+          id: true,
+          status: true,
+          startsAt: true,
+          endsAt: true,
+          surfaceId: true,
+          segmentId: true,
+        },
+      },
+      scheduleBlock: {
+        select: { id: true, surfaceId: true, segmentId: true, intent: true },
+      },
+      venue: {
+        select: {
+          id: true,
+          name: true,
+          organizationId: true,
+          slug: true,
+          timezone: true,
+          leagueId: true,
+          team: { select: { leagueId: true } },
+        },
+      },
+    },
+  });
+
+  if (!request) {
+    return { success: false as const, error: "Ice time request not found" };
+  }
+
+  const approves = validated.status === "ACCEPTED"
+    || validated.status === "PARTIALLY_ACCEPTED";
+  const requestedSurfaceId = request.scheduleBlock?.surfaceId ?? null;
+  const requestedSegmentId = request.scheduleBlock?.segmentId ?? null;
+  const approvedStartAt = validated.approvedStartAt
+    ?? (validated.status === "ACCEPTED" ? request.requestedStartAt : undefined);
+  const approvedEndAt = validated.approvedEndAt
+    ?? (validated.status === "ACCEPTED" ? request.requestedEndAt : undefined);
+  // `null` is an intentional venue-wide / whole-surface selection. Only an
+  // omitted field inherits the offered space.
+  const approvedSurfaceId = validated.approvedSurfaceId === undefined
+    ? requestedSurfaceId
+    : validated.approvedSurfaceId;
+  const approvedSegmentId = validated.approvedSegmentId === undefined
+    ? requestedSegmentId
+    : validated.approvedSegmentId;
+  const exactInterval =
+    approvedStartAt?.getTime() === request.requestedStartAt.getTime()
+    && approvedEndAt?.getTime() === request.requestedEndAt.getTime();
+  const exactSpace =
+    approvedSurfaceId === requestedSurfaceId
+    && approvedSegmentId === requestedSegmentId;
+  const venueWideApproval = approves && approvedSurfaceId === null;
+  const hasCompleteApprovalSnapshot =
+    request.approvedStartAt !== null && request.approvedEndAt !== null;
+  const approvalMatchesExistingSnapshot =
+    hasCompleteApprovalSnapshot
+    &&
+    request.approvedStartAt?.getTime() === approvedStartAt?.getTime()
+    && request.approvedEndAt?.getTime() === approvedEndAt?.getTime()
+    && request.approvedSurfaceId === approvedSurfaceId
+    && request.approvedSegmentId === approvedSegmentId;
+  const nextStatus = approves
+    ? exactInterval && exactSpace
+      ? "ACCEPTED"
+      : "PARTIALLY_ACCEPTED"
+    : validated.status;
+  const terminalStatuses = [
+    "ACCEPTED",
+    "PARTIALLY_ACCEPTED",
+    "DECLINED",
+  ] as const;
+  const alreadyTerminal = terminalStatuses.includes(
+    request.status as (typeof terminalStatuses)[number],
+  );
+  const idempotentApproval =
+    approves
+    && request.status === nextStatus
+    && request.venueReservation?.status === "CONFIRMED"
+    && request.approvedStartAt?.getTime() === approvedStartAt?.getTime()
+    && request.approvedEndAt?.getTime() === approvedEndAt?.getTime()
+    && request.approvedSurfaceId === approvedSurfaceId
+    && request.approvedSegmentId === approvedSegmentId
+    && request.venueReservation.startsAt.getTime()
+      === approvedStartAt?.getTime()
+    && request.venueReservation.endsAt.getTime()
+      === approvedEndAt?.getTime()
+    && request.venueReservation.surfaceId === approvedSurfaceId
+    && request.venueReservation.segmentId === approvedSegmentId;
+  const idempotentDecline =
+    validated.status === "DECLINED"
+    && request.status === "DECLINED"
+    && request.venueReservation === null;
+  const idempotentDecision = idempotentApproval || idempotentDecline;
+  const legacyApprovalMaterialization =
+    approves
+    && request.venueReservation === null
+    && ["ACCEPTED", "PARTIALLY_ACCEPTED"].includes(request.status)
+    && request.status === nextStatus
+    && (
+      !hasCompleteApprovalSnapshot
+      || approvalMatchesExistingSnapshot
+    );
+  const repairsLegacyApprovalSnapshot =
+    legacyApprovalMaterialization && !hasCompleteApprovalSnapshot;
+  if (
+    ["CANCELED", "EXPIRED"].includes(request.status)
+    || (
+      alreadyTerminal
+      && !idempotentDecision
+      && !legacyApprovalMaterialization
+    )
+  ) {
+    return {
+      success: false as const,
+      error:
+        "This ice time request already has a different final decision.",
+    };
+  }
+
+  let legacyAcceptedConflicts: Array<{ id: string }> = [];
+  if (approves && !idempotentDecision) {
+    if (
+      !approvedStartAt
+      || !approvedEndAt
+      || approvedEndAt <= approvedStartAt
+      || approvedStartAt < request.requestedStartAt
+      || approvedEndAt > request.requestedEndAt
+    ) {
+      return { success: false as const, error: "Approved time must be within the original request" };
+    }
+    if (approvedSegmentId && !approvedSurfaceId) {
+      return { success: false as const, error: "An approved segment requires an approved surface" };
+    }
+    if (!approvedSpaceWithinRequestedSpace(
+      { surfaceId: requestedSurfaceId, segmentId: requestedSegmentId },
+      { surfaceId: approvedSurfaceId ?? null, segmentId: approvedSegmentId ?? null },
+    )) {
+      return {
+        success: false as const,
+        error:
+          "Approved space must stay within the requested venue, surface, and segment.",
+      };
+    }
+    if (venueWideApproval && !validated.intentionalVenueWideClaim) {
+      return {
+        success: false as const,
+        error:
+          "Confirm the intentional venue-wide claim before approving without a surface.",
+      };
+    }
+    if (venueWideApproval && !validated.overrideReason?.trim()) {
+      return {
+        success: false as const,
+        error:
+          "A reason is required for an intentional venue-wide claim.",
+      };
+    }
+    if (request.scheduleBlock?.intent && request.scheduleBlock.intent !== "OFFERING") {
+      return { success: false as const, error: "The source block is not a requestable offering" };
+    }
+    legacyAcceptedConflicts = await findLegacyAcceptedRequestConflicts(
+      tx,
+      {
+        venueId: request.venue.id,
+        surfaceId: approvedSurfaceId,
+        segmentId: approvedSegmentId,
+        startsAt: approvedStartAt,
+        endsAt: approvedEndAt,
+        excludeRequestId: request.id,
+      },
+    );
+    if (legacyAcceptedConflicts.length > 0 && !validated.overrideConflicts) {
+      return { success: false as const, error: "That ice time has already been accepted for another request" };
+    }
+    if (legacyAcceptedConflicts.length > 0) {
+      await assertVenueConflictOverrideInTransaction(tx, {
+        actorId: userId,
+        organizationId: validated.organizationId,
+        venueId: validated.venueId,
+      });
+    }
+  }
+
+  const decidedAt =
+    validated.status === "UNDER_REVIEW" ? null : new Date();
+  const updated = idempotentDecision
+    || (legacyApprovalMaterialization && !repairsLegacyApprovalSnapshot)
+    ? {
+        id: request.id,
+        status: request.status,
+        decidedAt: request.decidedAt,
+      }
+    : await tx.iceTimeRequest.update({
+        where: { id: request.id },
+        data: repairsLegacyApprovalSnapshot
+          ? {
+              approvedStartAt,
+              approvedEndAt,
+              approvedSurfaceId,
+              approvedSegmentId,
+            }
+          : {
+              status: nextStatus,
+              decisionMessage: validated.decisionMessage || null,
+              decidedAt,
+              decidedById: userId,
+              ...(approves
+                ? {
+                    approvedStartAt,
+                    approvedEndAt,
+                    approvedSurfaceId,
+                    approvedSegmentId,
+                  }
+                : {}),
+            },
+        select: { id: true, status: true, decidedAt: true },
+      });
+
+  let reservationId = request.venueReservation?.id ?? null;
+  if (approves && !reservationId) {
+    await hooks.beforeCreateReservation?.();
+
+    const owner = request.requesterTeamId
+      ? { ownerTeamId: request.requesterTeamId }
+      : request.requesterLeagueId
+        ? { ownerLeagueId: request.requesterLeagueId }
+        : request.venue.organizationId
+          ? { ownerVenueOrganizationId: request.venue.organizationId }
+          : null;
+    if (!owner) {
+      throw new VenueReservationLifecycleError(
+        "The venue must belong to a venue organization before approving a public request.",
+      );
+    }
+    const reservation = await createVenueReservation(tx, {
+      ...owner,
+      venueId: request.venue.id,
+      surfaceId: approvedSurfaceId,
+      segmentId: approvedSegmentId,
+      startsAt: approvedStartAt!,
+      endsAt: approvedEndAt!,
+      timezone: request.venue.timezone ?? "America/New_York",
+      status: "CONFIRMED",
+      sourceRequestId: request.id,
+      offeringBlockId: request.scheduleBlockId,
+      actorId: userId,
+      overrideReason:
+        validated.overrideConflicts || venueWideApproval
+          ? validated.overrideReason?.trim()
+          : undefined,
+    });
+    reservationId = reservation?.id ?? null;
+    if (
+      reservationId
+      && legacyAcceptedConflicts.length > 0
+      && validated.overrideReason?.trim()
+    ) {
+      await tx.venueReservationOverride.create({
+        data: {
+          reservationId,
+          actorId: userId,
+          reason: validated.overrideReason.trim(),
+          conflictingReservationIds: [],
+          candidateSnapshot: {
+            source: "LEGACY_ACCEPTED_REQUESTS",
+            requestId: request.id,
+            legacyAcceptedRequestIds: legacyAcceptedConflicts.map(({ id }) => id),
+            venueId: request.venue.id,
+            surfaceId: approvedSurfaceId,
+            segmentId: approvedSegmentId,
+            startsAt: approvedStartAt!.toISOString(),
+            endsAt: approvedEndAt!.toISOString(),
+          },
+        },
+      });
+    }
+  }
+
+  const notificationIds: string[] = [];
+  const notificationLeagueId =
+    request.requesterLeagueId
+    ?? request.requesterTeam?.leagueId
+    ?? request.venue.leagueId
+    ?? request.venue.team?.leagueId
+    ?? null;
+  if (validated.status !== "UNDER_REVIEW" && notificationLeagueId) {
+    const eventType = nextStatus === "ACCEPTED"
+      ? "association.venue_request.approved"
+      : nextStatus === "PARTIALLY_ACCEPTED"
+        ? "association.venue_request.partially_approved"
+        : "association.venue_request.declined";
+    const event = assertAssociationOperationsNotificationEvent({
+      eventType,
+      aggregateType: "VENUE_REQUEST",
+      aggregateId: request.id,
+      payload: { kind: "VENUE_REQUEST", data: { requestId: request.id } },
+    });
+    const dedupeKey = `${event.type}:${request.id}:${updated.status}`;
+    const notification = await tx.notificationOutbox.upsert({
+      where: {
+        leagueId_dedupeKey: {
+          leagueId: notificationLeagueId,
+          dedupeKey,
+        },
+      },
+      create: {
+        leagueId: notificationLeagueId,
+        recipientUserId: request.requesterUserId,
+        recipientEmail: request.contactEmail.trim().toLowerCase(),
+        eventType: event.type,
+        aggregateType: event.aggregateType,
+        aggregateId: event.aggregateId,
+        payload: { kind: "VENUE_REQUEST", data: { requestId: request.id } },
+        dedupeKey,
+      },
+      update: {},
+      select: { id: true },
+    });
+    notificationIds.push(notification.id);
+  }
+
+  return {
+    success: true as const,
+    request,
+    updated,
+    reservationId,
+    notificationIds,
+    notificationLeagueId,
+    idempotentDecision,
+  };
+}
 
 export async function submitIceTimeRequest(
   input: SubmitIceTimeRequestInput
@@ -61,12 +523,15 @@ export async function submitIceTimeRequest(
         endsAt: true,
         title: true,
         registrationMode: true,
+        recurrenceRule: true,
+        recurrenceEndDate: true,
         venue: {
           select: {
             id: true,
             name: true,
             organizationId: true,
             slug: true,
+            timezone: true,
           },
         },
       },
@@ -80,22 +545,26 @@ export async function submitIceTimeRequest(
       return { success: false, error: "That ice block is not accepting ice time requests" };
     }
 
-    if (validated.requestedStartAt < block.startsAt || validated.requestedEndAt > block.endsAt) {
+    const offeringOccurrences = block.recurrenceRule
+      ? expandRecurrenceWindow(
+          {
+            startAt: block.startsAt,
+            endAt: block.endsAt,
+            recurrenceRule: block.recurrenceRule,
+            recurrenceEndAt: block.recurrenceEndDate,
+            timezone: block.venue.timezone,
+          },
+          validated.requestedStartAt,
+          validated.requestedEndAt,
+        )
+      : [{ startAt: block.startsAt, endAt: block.endsAt }];
+    const requestedWithinOffering = offeringOccurrences.some(
+      (occurrence) =>
+        validated.requestedStartAt >= occurrence.startAt
+        && validated.requestedEndAt <= occurrence.endAt,
+    );
+    if (!requestedWithinOffering) {
       return { success: false, error: "Requested time must be within the published available ice block" };
-    }
-
-    const existingAccepted = await prisma.iceTimeRequest.findFirst({
-      where: {
-        scheduleBlockId: block.id,
-        status: "ACCEPTED",
-        requestedStartAt: { lt: validated.requestedEndAt },
-        requestedEndAt: { gt: validated.requestedStartAt },
-      },
-      select: { id: true },
-    });
-
-    if (existingAccepted) {
-      return { success: false, error: "That ice time has already been accepted for another request" };
     }
 
     const request = await prisma.iceTimeRequest.create({
@@ -144,75 +613,18 @@ export async function submitIceTimeRequest(
 
 export async function decideIceTimeRequest(
   input: z.input<typeof decisionSchema>
-): Promise<ActionResult<{ requestId: string; status: string; decidedAt: Date | null }>> {
+): Promise<ActionResult<{
+  requestId: string;
+  status: string;
+  decidedAt: Date | null;
+  reservationId: string | null;
+  notificationIds: string[];
+}>> {
   try {
     const validated = decisionSchema.parse(input);
     const userId = await requireVenueRequestManager(validated.organizationId, validated.venueId);
-    const decision = await prisma.$transaction(
-      async (tx) => {
-        const request = await tx.iceTimeRequest.findFirst({
-          where: {
-            id: validated.requestId,
-            venueId: validated.venueId,
-            venue: { organizationId: validated.organizationId },
-          },
-          select: {
-            id: true,
-            contactEmail: true,
-            scheduleBlockId: true,
-            requestedStartAt: true,
-            requestedEndAt: true,
-            venue: {
-              select: {
-                id: true,
-                name: true,
-                organizationId: true,
-                slug: true,
-              },
-            },
-          },
-        });
-
-        if (!request) {
-          return { success: false as const, error: "Ice time request not found" };
-        }
-
-        if (validated.status === "ACCEPTED") {
-          const acceptedConflict = await tx.iceTimeRequest.findFirst({
-            where: {
-              id: { not: request.id },
-              scheduleBlockId: request.scheduleBlockId,
-              status: "ACCEPTED",
-              requestedStartAt: { lt: request.requestedEndAt },
-              requestedEndAt: { gt: request.requestedStartAt },
-            },
-            select: { id: true },
-          });
-
-          if (acceptedConflict) {
-            return {
-              success: false as const,
-              error: "That ice time has already been accepted for another request",
-            };
-          }
-        }
-
-        const decidedAt = validated.status === "UNDER_REVIEW" ? null : new Date();
-        const updated = await tx.iceTimeRequest.update({
-          where: { id: request.id },
-          data: {
-            status: validated.status,
-            decisionMessage: validated.decisionMessage || null,
-            decidedAt,
-            decidedById: userId,
-          },
-          select: { id: true, status: true, decidedAt: true },
-        });
-
-        return { success: true as const, request, updated };
-      },
-      { isolationLevel: Prisma.TransactionIsolationLevel.Serializable }
-    );
+    const decision = await runVenueReservationTransaction((tx) =>
+      decideIceTimeRequestInTransaction(tx, validated, userId));
 
     if (!decision.success) {
       return { success: false, error: decision.error };
@@ -220,23 +632,43 @@ export async function decideIceTimeRequest(
 
     const { request, updated } = decision;
 
-    if (validated.status !== "UNDER_REVIEW") {
+    if (
+      validated.status !== "UNDER_REVIEW"
+      && decision.notificationIds.length === 0
+      && !decision.idempotentDecision
+    ) {
       await sendIceTimeRequestDecisionEmail({
         contactEmail: request.contactEmail,
         venueName: request.venue.name,
-        status: validated.status,
+        status: updated.status as "ACCEPTED" | "PARTIALLY_ACCEPTED" | "DECLINED",
         decisionMessage: validated.decisionMessage || null,
       });
     }
 
     revalidateRequestPaths(validated.organizationId, validated.venueId, request.venue.slug);
+    if (decision.notificationLeagueId) {
+      revalidatePath(`/league/${decision.notificationLeagueId}/operations`);
+      revalidatePath(
+        `/league/${decision.notificationLeagueId}/venue-reservations`,
+      );
+    }
+    if (request.requesterTeamId) revalidatePath(`/teams/${request.requesterTeamId}`);
     return {
       success: true,
-      data: { requestId: updated.id, status: updated.status, decidedAt: updated.decidedAt },
+      data: {
+        requestId: updated.id,
+        status: updated.status,
+        decidedAt: updated.decidedAt,
+        reservationId: decision.reservationId,
+        notificationIds: decision.notificationIds,
+      },
     };
   } catch (error) {
     if (error instanceof Error && error.message.includes("NEXT_REDIRECT")) {
       throw error;
+    }
+    if (error instanceof VenueReservationConflictError || error instanceof VenueReservationLifecycleError) {
+      return { success: false, error: error.message };
     }
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2034") {
       return {
@@ -260,39 +692,225 @@ export async function expireIceTimeRequest(
   return setRequestStatus(input, "EXPIRED");
 }
 
+export async function annotateIceTimeRequest(
+  input: z.input<typeof annotationSchema>,
+): Promise<ActionResult<{ requestId: string; decisionMessage: string }>> {
+  try {
+    const validated = annotationSchema.parse(input);
+    const actorId = await requireVenueRequestManager(
+      validated.organizationId,
+      validated.venueId,
+    );
+    const updated = await runVenueReservationTransaction(async (tx) => {
+      await assertVenueRequestManagerInTransaction(tx, {
+        actorId,
+        organizationId: validated.organizationId,
+        venueId: validated.venueId,
+      });
+      const request = await tx.iceTimeRequest.findFirst({
+        where: {
+          id: validated.requestId,
+          venueId: validated.venueId,
+          venue: { organizationId: validated.organizationId },
+        },
+        select: { id: true, venue: { select: { slug: true } } },
+      });
+      if (!request) return null;
+      const row = await tx.iceTimeRequest.update({
+        where: { id: request.id },
+        data: {
+          decisionMessage: validated.decisionMessage,
+          decidedById: actorId,
+        },
+        select: { id: true, decisionMessage: true },
+      });
+      return { ...row, slug: request.venue.slug };
+    });
+    if (!updated?.decisionMessage) {
+      return { success: false, error: "Ice time request not found" };
+    }
+    revalidateRequestPaths(
+      validated.organizationId,
+      validated.venueId,
+      updated.slug,
+    );
+    return {
+      success: true,
+      data: {
+        requestId: updated.id,
+        decisionMessage: updated.decisionMessage,
+      },
+    };
+  } catch (error) {
+    if (error instanceof Error && error.message.includes("NEXT_REDIRECT")) {
+      throw error;
+    }
+    if (error instanceof VenueReservationLifecycleError) {
+      return { success: false, error: error.message };
+    }
+    return { success: false, error: "Failed to annotate ice time request." };
+  }
+}
+
 export async function getVenueRequestQueue(
   organizationId: string,
   venueId: string
 ): Promise<
   ActionResult<{
     venueId: string;
+    venueName: string;
+    timezone: string;
+    surfaceOptions: Array<{
+      id: string;
+      name: string;
+      wholeLabel: string;
+      segments: Array<{ id: string; name: string }>;
+    }>;
     requests: Array<{
       id: string;
       contactName: string;
       contactEmail: string;
       status: string;
+      timezone: string;
       requestedStartAt: Date;
       requestedEndAt: Date;
+      approvedStartAt: Date | null;
+      approvedEndAt: Date | null;
+      requestedSurfaceId: string | null;
+      requestedSurfaceName: string | null;
+      requestedSegmentId: string | null;
+      requestedSegmentName: string | null;
+      approvedSurfaceId: string | null;
+      approvedSurfaceName: string | null;
+      approvedSegmentId: string | null;
+      approvedSegmentName: string | null;
+      reservation: {
+        id: string;
+        status: string;
+        venueName: string;
+        surfaceName: string | null;
+        segmentName: string | null;
+      } | null;
     }>;
   }>
 > {
   try {
     await requireVenueRequestManager(organizationId, venueId);
+    const venue = await prisma.venue.findFirst({
+      where: {
+        id: venueId,
+        organizationId,
+      },
+      select: {
+        id: true,
+        name: true,
+        timezone: true,
+        surfaces: {
+          where: { isActive: true },
+          select: {
+            id: true,
+            name: true,
+            surfaceType: true,
+            wholeLabel: true,
+            segments: {
+              where: { isActive: true },
+              select: { id: true, name: true },
+              orderBy: [{ createdAt: "asc" }, { name: "asc" }],
+            },
+          },
+          orderBy: [{ displayOrder: "asc" }, { name: "asc" }],
+        },
+      },
+    });
 
-    const requests = await prisma.iceTimeRequest.findMany({
-      where: { venueId },
+    if (!venue) {
+      return { success: false, error: "Venue not found" };
+    }
+
+    const requests = await (prisma.iceTimeRequest.findMany as any)({
+      where: {
+        venueId,
+        venue: { organizationId },
+      },
       select: {
         id: true,
         contactName: true,
         contactEmail: true,
         status: true,
+        venue: { select: { timezone: true } },
         requestedStartAt: true,
         requestedEndAt: true,
+        approvedStartAt: true,
+        approvedEndAt: true,
+        approvedSurfaceId: true,
+        approvedSegmentId: true,
+        approvedSurface: { select: { name: true } },
+        approvedSegment: { select: { name: true } },
+        scheduleBlock: {
+          select: {
+            surfaceId: true,
+            segmentId: true,
+            surface: { select: { name: true } },
+            segment: { select: { name: true } },
+          },
+        },
+        venueReservation: {
+          select: {
+            id: true,
+            status: true,
+            venue: { select: { name: true } },
+            surface: { select: { name: true } },
+            segment: { select: { name: true } },
+          },
+        },
       },
       orderBy: [{ status: "asc" }, { createdAt: "desc" }],
-    });
+    }).then((rows: any[]) => rows.map(({
+      venueReservation,
+      venue: requestVenue,
+      scheduleBlock,
+      approvedSurface,
+      approvedSegment,
+      ...request
+    }) => ({
+      ...request,
+      timezone: requestVenue.timezone,
+      requestedSurfaceId: scheduleBlock?.surfaceId ?? null,
+      requestedSurfaceName: scheduleBlock?.surface?.name ?? null,
+      requestedSegmentId: scheduleBlock?.segmentId ?? null,
+      requestedSegmentName: scheduleBlock?.segment?.name ?? null,
+      approvedSurfaceName: approvedSurface?.name ?? null,
+      approvedSegmentName: approvedSegment?.name ?? null,
+      reservation: venueReservation
+        ? {
+            id: venueReservation.id,
+            status: venueReservation.status,
+            venueName: venueReservation.venue.name,
+            surfaceName: venueReservation.surface?.name ?? null,
+            segmentName: venueReservation.segment?.name ?? null,
+          }
+        : null,
+    })));
 
-    return { success: true, data: { venueId, requests } };
+    return {
+      success: true,
+      data: {
+        venueId,
+        venueName: venue.name,
+        timezone: venue.timezone,
+        surfaceOptions: venue.surfaces.map((surface) => ({
+          id: surface.id,
+          name: surface.name,
+          wholeLabel:
+            surface.wholeLabel ?? getWholeSurfaceDefaultLabel(surface.surfaceType),
+          segments: surface.segments.map((segment) => ({
+            id: segment.id,
+            name: segment.name,
+          })),
+        })),
+        requests,
+      },
+    };
   } catch (error) {
     if (error instanceof Error && error.message.includes("NEXT_REDIRECT")) {
       throw error;
@@ -307,23 +925,113 @@ async function setRequestStatus(
 ): Promise<ActionResult<{ requestId: string; status: string }>> {
   try {
     const validated = requestCommandSchema.parse(input);
-    await requireVenueRequestManager(validated.organizationId, validated.venueId);
-    const request = await findManagedRequest(validated.organizationId, validated.venueId, validated.requestId);
-    if (!request) {
-      return { success: false, error: "Ice time request not found" };
-    }
-
-    const updated = await prisma.iceTimeRequest.update({
-      where: { id: request.id },
-      data: { status },
-      select: { id: true, status: true },
+    const actorId = await requireVenueRequestManager(
+      validated.organizationId,
+      validated.venueId,
+    );
+    const updated = await runVenueReservationTransaction(async (tx) => {
+      await assertVenueRequestManagerInTransaction(tx, {
+        actorId,
+        organizationId: validated.organizationId,
+        venueId: validated.venueId,
+      });
+      const request = await tx.iceTimeRequest.findFirst({
+        where: {
+          id: validated.requestId,
+          venueId: validated.venueId,
+          venue: { organizationId: validated.organizationId },
+        },
+        select: {
+          id: true,
+          status: true,
+          venue: { select: { slug: true } },
+          venueReservation: { select: { id: true, status: true } },
+        },
+      });
+      if (!request) return null;
+      if (request.status === status) {
+        return { id: request.id, status: request.status, slug: request.venue.slug };
+      }
+      if (
+        ["DECLINED", "CANCELED", "EXPIRED"].includes(request.status)
+      ) {
+        throw new VenueReservationLifecycleError(
+          "This ice time request already has a different final status.",
+        );
+      }
+      if (
+        request.venueReservation
+        && ["CONFIRMED", "HELD"].includes(request.venueReservation.status)
+      ) {
+        if (validated.linkedActivityDisposition === "UNASSIGN") {
+          const linked = await tx.venueReservation.findUnique({
+            where: { id: request.venueReservation.id },
+            select: {
+              events: { select: { id: true, type: true } },
+              seasonGames: { select: { id: true } },
+              eventGames: { select: { id: true } },
+              signupEvents: { select: { id: true } },
+              proposalEntries: { select: { id: true } },
+            },
+          });
+          const unsupportedLinks =
+            (linked?.seasonGames.length ?? 0)
+            + (linked?.eventGames.length ?? 0)
+            + (linked?.signupEvents.length ?? 0)
+            + (linked?.proposalEntries.length ?? 0);
+          if (
+            unsupportedLinks > 0
+            || linked?.events.some(({ type }) => type !== "PRACTICE")
+          ) {
+            throw new VenueReservationLifecycleError(
+              "Use the linked activity workflow to dispose of non-practice assignments.",
+            );
+          }
+          const linkedWhere = {
+            venueReservationId: request.venueReservation.id,
+          };
+          await Promise.all([
+            tx.event.deleteMany({
+              where: { ...linkedWhere, type: "PRACTICE" },
+            }),
+            tx.practiceSession.updateMany({
+              where: linkedWhere,
+              data: {
+                venueReservationId: null,
+                venueId: null,
+                surfaceId: null,
+                segmentId: null,
+                startAt: null,
+                conflictOverriddenById: null,
+                conflictOverriddenAt: null,
+              },
+            }),
+          ]);
+        }
+        await transitionVenueReservation(tx, {
+          reservationId: request.venueReservation.id,
+          nextStatus: "RELEASED",
+          actorId,
+          reason: `Source ice time request ${status.toLowerCase()}`,
+          allowAssignedDisposition: false,
+        });
+      }
+      const row = await tx.iceTimeRequest.update({
+        where: { id: request.id },
+        data: { status },
+        select: { id: true, status: true },
+      });
+      return { ...row, slug: request.venue.slug };
     });
-
-    revalidateRequestPaths(validated.organizationId, validated.venueId, request.venue.slug);
+    if (!updated) return { success: false, error: "Ice time request not found" };
+    revalidateRequestPaths(validated.organizationId, validated.venueId, updated.slug);
     return { success: true, data: { requestId: updated.id, status: updated.status } };
   } catch (error) {
     if (error instanceof Error && error.message.includes("NEXT_REDIRECT")) {
       throw error;
+    }
+    if (error instanceof VenueReservationLifecycleError) {
+      return { success: false, error: error.message };
     }
     return { success: false, error: "Failed to update ice time request." };
   }
@@ -380,4 +1088,7 @@ function revalidateRequestPaths(organizationId: string | null, venueId: string, 
   if (slug) {
     revalidatePath(`/rinks/${slug}/schedule`);
   }
+  revalidatePath(`/venues/${venueId}/schedule`);
+  revalidatePath("/operations");
+  revalidatePath("/venue-reservations");
 }

--- a/lib/actions/venue-reservations.ts
+++ b/lib/actions/venue-reservations.ts
@@ -1,0 +1,680 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+import { prisma } from "@/lib/db/prisma";
+import {
+  requireLeagueRole,
+  requireTeamAdmin,
+  requireUserId,
+  requireVenueScheduleManager,
+} from "@/lib/auth/session";
+import type { ActionResult } from "@/lib/actions/venue-organizations";
+import {
+  assignVenueReservationSchema,
+  venueReservationLifecycleSchema,
+} from "@/lib/utils/validation";
+import {
+  assignVenueReservation as assignReservation,
+  assertGenericRescheduleAllowed,
+  createVenueReservation,
+  transitionVenueReservation,
+  VenueReservationConflictError,
+  VenueReservationLifecycleError,
+} from "@/lib/services/venue-reservations";
+import {
+  findVenueReservationAvailability,
+  subtractVenueReservationOccupancy,
+} from "@/lib/services/venue-reservation-availability";
+import { runVenueReservationTransaction } from "@/lib/services/venue-reservation-transaction";
+import { publicPublishedVenueWhere } from "@/lib/utils/public-venues";
+
+const lifecycleSchema = venueReservationLifecycleSchema.extend({
+  allowAssignedDisposition: z.boolean().optional(),
+  linkedActivityDisposition: z.enum(["UNASSIGN"]).optional(),
+  overrideReason: z.string().min(1).max(1000).optional(),
+});
+
+const rescheduleSchema = z.object({
+  reservationId: z.string().cuid(),
+  startsAt: z.coerce.date(),
+  endsAt: z.coerce.date(),
+  reason: z.string().min(1).max(1000),
+  overrideReason: z.string().min(1).max(1000).optional(),
+}).refine((value) => value.endsAt > value.startsAt, {
+  message: "End time must be after start time",
+  path: ["endsAt"],
+});
+
+const unassignSchema = z.object({
+  reservationId: z.string().cuid(),
+  targetId: z.string().cuid(),
+  targetType: z.enum(["SEASON_GAME", "PRACTICE", "EVENT", "SIGNUP_EVENT", "EVENT_GAME"]),
+  reason: z.string().min(1).max(1000),
+});
+const availabilityInputSchema = z.object({
+  venueId: z.string().cuid(),
+  surfaceId: z.string().cuid().nullable().optional(),
+  segmentId: z.string().cuid().nullable().optional(),
+  startsAt: z.coerce.date(),
+  endsAt: z.coerce.date(),
+  excludeReservationId: z.string().cuid().optional(),
+  includeOfferings: z.boolean().default(true),
+  mode: z.enum(["PUBLIC", "STAFF"]),
+}).refine((value) => value.endsAt > value.startsAt, {
+  message: "End time must be after start time",
+  path: ["endsAt"],
+});
+
+type ReservationSummary = {
+  id: string;
+  venueId: string;
+  status: string;
+  venue: { organizationId: string | null };
+  ownerTeamId?: string | null;
+  ownerLeagueId?: string | null;
+  ownerVenueOrganizationId?: string | null;
+};
+
+async function loadReservation(reservationId: string): Promise<ReservationSummary | null> {
+  return prisma.venueReservation.findUnique({
+    where: { id: reservationId },
+    select: {
+      id: true,
+      venueId: true,
+      status: true,
+      ownerTeamId: true,
+      ownerLeagueId: true,
+      ownerVenueOrganizationId: true,
+      venue: { select: { organizationId: true } },
+    },
+  }) as Promise<ReservationSummary | null>;
+}
+
+async function authorizeVenueReservation(reservationId: string): Promise<{ actorId: string; reservation: ReservationSummary }> {
+  const reservation = await loadReservation(reservationId);
+  if (!reservation) throw new VenueReservationLifecycleError("Venue reservation not found.");
+  try {
+    if (reservation.ownerLeagueId) {
+      return {
+        actorId: await requireLeagueRole(
+          reservation.ownerLeagueId,
+          "LEAGUE_ADMIN",
+        ),
+        reservation,
+      };
+    }
+    if (reservation.ownerTeamId) {
+      return {
+        actorId: await requireTeamAdmin(reservation.ownerTeamId),
+        reservation,
+      };
+    }
+  } catch {
+    // Exact venue staff remain authorized by the service contract below.
+  }
+  return {
+    actorId: await requireVenueScheduleManager(
+      reservation.venue.organizationId!,
+      reservation.venueId,
+    ),
+    reservation,
+  };
+}
+
+async function authorizeVenueReservationAssignment(
+  reservationId: string,
+): Promise<{ actorId: string; reservation: ReservationSummary }> {
+  const reservation = await loadReservation(reservationId);
+  if (!reservation) throw new VenueReservationLifecycleError("Venue reservation not found.");
+
+  if (reservation.ownerLeagueId) {
+    const actorId = await requireLeagueRole(reservation.ownerLeagueId, "LEAGUE_ADMIN");
+    return { actorId, reservation };
+  }
+  if (reservation.ownerTeamId) {
+    const actorId = await requireTeamAdmin(reservation.ownerTeamId);
+    return { actorId, reservation };
+  }
+
+  const actorId = await requireVenueScheduleManager(
+    reservation.venue.organizationId!,
+    reservation.venueId,
+  );
+  return { actorId, reservation };
+}
+
+function revalidateReservationPaths(reservation: ReservationSummary) {
+  revalidatePath(`/venues/${reservation.venueId}/schedule`);
+  revalidatePath(`/venue-admin/${reservation.venue.organizationId}/venues/${reservation.venueId}/requests`);
+  revalidatePath("/operations");
+  revalidatePath("/venue-reservations");
+  if (reservation.ownerLeagueId) {
+    revalidatePath(`/league/${reservation.ownerLeagueId}/operations`);
+    revalidatePath(`/league/${reservation.ownerLeagueId}/venue-reservations`);
+  }
+  if (reservation.ownerTeamId) revalidatePath(`/teams/${reservation.ownerTeamId}`);
+}
+
+function actionError(error: unknown): ActionResult<never> {
+  if (error instanceof VenueReservationConflictError || error instanceof VenueReservationLifecycleError) {
+    return { success: false, error: error.message };
+  }
+  return { success: false, error: "Unable to update venue reservation." };
+}
+
+export async function assignVenueReservation(
+  input: z.input<typeof assignVenueReservationSchema>,
+): Promise<ActionResult<unknown>> {
+  try {
+    const validated = assignVenueReservationSchema.parse(input);
+    const { actorId, reservation } = await authorizeVenueReservationAssignment(validated.reservationId);
+    const result = await runVenueReservationTransaction(async (tx) => {
+      const assigned = await assignReservation(tx, {
+        reservationId: validated.reservationId,
+        targetType: validated.targetType,
+        targetId: validated.targetId,
+        actorId,
+        overrideReason: validated.overrideConflicts
+          ? validated.overrideReason
+          : undefined,
+      });
+      if (validated.targetType !== "PRACTICE") return assigned;
+
+      const [practice, canonicalReservation] = await Promise.all([
+        tx.practiceSession.findUnique({
+          where: { id: validated.targetId },
+          include: { team: { select: { leagueId: true } } },
+        }),
+        tx.venueReservation.findUnique({
+          where: { id: validated.reservationId },
+          include: { venue: { select: { name: true } } },
+        }),
+      ]);
+      if (!practice || !canonicalReservation) {
+        throw new VenueReservationLifecycleError(
+          "The practice assignment could not be reloaded.",
+        );
+      }
+
+      const existingEvent = await tx.event.findUnique({
+        where: { venueReservationId: canonicalReservation.id },
+        select: { id: true, teamId: true, type: true },
+      });
+      if (
+        existingEvent
+        && (
+          existingEvent.teamId !== practice.teamId
+          || existingEvent.type !== "PRACTICE"
+        )
+      ) {
+        throw new VenueReservationLifecycleError(
+          "The reservation is linked to another participant activity.",
+        );
+      }
+      const eventData = {
+        type: "PRACTICE" as const,
+        title: practice.title,
+        startAt: canonicalReservation.startsAt,
+        endAt: canonicalReservation.endsAt,
+        timezone: canonicalReservation.timezone,
+        location: canonicalReservation.venue.name,
+        venueId: canonicalReservation.venueId,
+        teamId: practice.teamId,
+        leagueId: null,
+        opponent: null,
+        notes: null,
+      };
+      const event = existingEvent
+        ? await tx.event.update({
+            where: { id: existingEvent.id },
+            data: eventData,
+            select: { id: true },
+          })
+        : await tx.event.create({
+            data: eventData,
+            select: { id: true },
+          });
+      if (!existingEvent) {
+        await assignReservation(tx, {
+          reservationId: canonicalReservation.id,
+          targetType: "EVENT",
+          targetId: event.id,
+          actorId,
+        });
+      }
+
+      const members = await tx.teamMember.findMany({
+        where: { teamId: practice.teamId },
+        select: { userId: true },
+      });
+      const userIds = [...new Set(members.map(({ userId }) => userId))];
+      if (userIds.length > 0) {
+        await tx.rSVP.createMany({
+          data: userIds.map((userId) => ({
+            eventId: event.id,
+            userId,
+            status: "NO_RESPONSE" as const,
+          })),
+          skipDuplicates: true,
+        });
+      }
+      return {
+        reservation: assigned,
+        primaryActivity: practice,
+        participantEvent: event,
+        rsvpCount: userIds.length,
+        canonicalScheduleId: `reservation:${canonicalReservation.id}`,
+      };
+    });
+    revalidateReservationPaths(reservation);
+    return { success: true, data: result };
+  } catch (error) {
+    return actionError(error);
+  }
+}
+
+async function transition(
+  input: z.input<typeof lifecycleSchema>,
+  nextStatus: "RELEASED" | "CANCELED" | "COMPLETED",
+  usageStatus?: "USED" | "UNUSED",
+): Promise<ActionResult<unknown>> {
+  try {
+    const validated = lifecycleSchema.parse({ ...input, nextStatus, usageStatus: usageStatus ?? input.usageStatus });
+    const { actorId, reservation } = await authorizeVenueReservation(validated.reservationId);
+    const updated = await runVenueReservationTransaction(async (tx) => {
+      const current = await tx.venueReservation.findUnique({
+        where: { id: validated.reservationId },
+        include: {
+          events: { select: { id: true, type: true } },
+          seasonGames: { select: { id: true } },
+          eventGames: { select: { id: true } },
+          signupEvents: { select: { id: true } },
+          practiceSessions: { select: { id: true } },
+          proposalEntries: { select: { id: true } },
+        },
+      });
+      const assigned = current && (
+        (current.events?.length ?? 0)
+        + (current.seasonGames?.length ?? 0)
+        + (current.eventGames?.length ?? 0)
+        + (current.signupEvents?.length ?? 0)
+        + (current.practiceSessions?.length ?? 0)
+        + (current.proposalEntries?.length ?? 0)
+      ) > 0;
+      const disposition = validated.linkedActivityDisposition
+        ?? (validated.allowAssignedDisposition ? "UNASSIGN" : undefined);
+      if (
+        assigned
+        && ["RELEASED", "CANCELED"].includes(nextStatus)
+        && !disposition
+      ) {
+        throw new VenueReservationLifecycleError(
+          "Resolve linked activities before releasing or canceling this venue reservation.",
+        );
+      }
+      if (
+        assigned
+        && ["RELEASED", "CANCELED"].includes(nextStatus)
+        && disposition === "UNASSIGN"
+      ) {
+        const unsupportedLinks =
+          (current?.seasonGames?.length ?? 0)
+          + (current?.eventGames?.length ?? 0)
+          + (current?.signupEvents?.length ?? 0)
+          + (current?.proposalEntries?.length ?? 0);
+        const hasNonPracticeEvent = current?.events?.some(
+          ({ type }) => type !== "PRACTICE",
+        );
+        if (unsupportedLinks > 0 || hasNonPracticeEvent) {
+          throw new VenueReservationLifecycleError(
+            "Use the linked activity workflow to dispose of non-practice assignments.",
+          );
+        }
+        const linkedWhere = {
+          venueReservationId: validated.reservationId,
+        };
+        await Promise.all([
+          // Participant Event deletion cascades its RSVP rows.
+          tx.event.deleteMany({
+            where: { ...linkedWhere, type: "PRACTICE" },
+          }),
+          tx.practiceSession.updateMany({
+            where: linkedWhere,
+            data: {
+              venueReservationId: null,
+              venueId: null,
+              surfaceId: null,
+              segmentId: null,
+              startAt: null,
+              conflictOverriddenById: null,
+              conflictOverriddenAt: null,
+            },
+          }),
+        ]);
+      }
+      return transitionVenueReservation(tx, {
+        ...validated,
+        nextStatus,
+        usageStatus: usageStatus ?? validated.usageStatus,
+        actorId,
+        allowAssignedDisposition: false,
+      });
+    });
+    revalidateReservationPaths(reservation);
+    return { success: true, data: updated };
+  } catch (error) {
+    return actionError(error);
+  }
+}
+
+export async function releaseVenueReservation(input: z.input<typeof lifecycleSchema>) {
+  return transition(input, "RELEASED");
+}
+
+export async function cancelVenueReservation(input: z.input<typeof lifecycleSchema>) {
+  return transition(input, "CANCELED");
+}
+
+export async function completeVenueReservation(input: z.input<typeof lifecycleSchema>) {
+  return transition(input, "COMPLETED", "USED");
+}
+
+export async function markVenueReservationUnused(
+  input: Omit<z.input<typeof lifecycleSchema>, "nextStatus" | "usageStatus">,
+) {
+  return transition(input as z.input<typeof lifecycleSchema>, "COMPLETED", "UNUSED");
+}
+
+export async function rescheduleVenueReservation(
+  input: z.input<typeof rescheduleSchema>,
+): Promise<ActionResult<unknown>> {
+  try {
+    const validated = rescheduleSchema.parse(input);
+    const { actorId, reservation } = await authorizeVenueReservation(validated.reservationId);
+    const replacement = await runVenueReservationTransaction(async (tx) => {
+      const current = await tx.venueReservation.findUnique({
+        where: { id: validated.reservationId },
+        select: {
+          id: true,
+          status: true,
+          venueId: true,
+          surfaceId: true,
+          segmentId: true,
+          startsAt: true,
+          endsAt: true,
+          timezone: true,
+          ownerLeagueId: true,
+          ownerTeamId: true,
+          ownerVenueOrganizationId: true,
+          offeringBlockId: true,
+          sourceRequestId: true,
+        },
+      });
+      if (!current) throw new VenueReservationLifecycleError("Venue reservation not found.");
+      assertGenericRescheduleAllowed(current);
+      if (current.status !== "CONFIRMED") {
+        throw new VenueReservationLifecycleError(
+          "Only a confirmed venue reservation can be rescheduled.",
+        );
+      }
+      await transitionVenueReservation(tx, {
+        reservationId: current.id,
+        nextStatus: "RELEASED",
+        actorId,
+        reason: validated.reason,
+        allowAssignedDisposition: false,
+      });
+      return createVenueReservation(tx, {
+        venueId: current.venueId,
+        surfaceId: current.surfaceId,
+        segmentId: current.segmentId,
+        startsAt: validated.startsAt,
+        endsAt: validated.endsAt,
+        timezone: current.timezone,
+        ownerLeagueId: current.ownerLeagueId,
+        ownerTeamId: current.ownerTeamId,
+        ownerVenueOrganizationId: current.ownerVenueOrganizationId,
+        sourceRequestId: null,
+        offeringBlockId: current.offeringBlockId,
+        actorId,
+        status: "CONFIRMED",
+        overrideReason: validated.overrideReason,
+      });
+    });
+    revalidateReservationPaths(reservation);
+    return { success: true, data: replacement };
+  } catch (error) {
+    return actionError(error);
+  }
+}
+
+export async function unassignVenueReservation(
+  input: z.input<typeof unassignSchema>,
+): Promise<ActionResult<{ reservationId: string; targetId: string }>> {
+  try {
+    const validated = unassignSchema.parse(input);
+    const { actorId, reservation } =
+      await authorizeVenueReservationAssignment(validated.reservationId);
+    await runVenueReservationTransaction(async (tx) => {
+      const current = await tx.venueReservation.findUnique({
+        where: { id: validated.reservationId },
+        select: {
+          id: true,
+          venueId: true,
+          ownerLeagueId: true,
+          ownerTeamId: true,
+          ownerVenueOrganizationId: true,
+        },
+      });
+      if (!current) {
+        throw new VenueReservationLifecycleError(
+          "Venue reservation not found.",
+        );
+      }
+      const actorStillAuthorized = current.ownerLeagueId
+        ? await tx.leagueUser.findFirst({
+            where: {
+              userId: actorId,
+              leagueId: current.ownerLeagueId,
+              role: "LEAGUE_ADMIN",
+            },
+            select: { id: true },
+          })
+        : current.ownerTeamId
+          ? await tx.teamMember.findFirst({
+              where: {
+                userId: actorId,
+                teamId: current.ownerTeamId,
+                role: "ADMIN",
+              },
+              select: { id: true },
+            })
+          : await tx.venueStaff.findFirst({
+              where: {
+                userId: actorId,
+                organizationId: current.ownerVenueOrganizationId!,
+                status: "ACTIVE",
+                role: { in: ["OWNER", "MANAGER", "SCHEDULER"] },
+                OR: [{ venueId: null }, { venueId: current.venueId }],
+              },
+              select: { id: true },
+            });
+      if (!actorStillAuthorized) {
+        throw new VenueReservationLifecycleError(
+          "The actor is no longer authorized for this reservation owner.",
+        );
+      }
+
+      if (validated.targetType === "PRACTICE") {
+        const practice = await tx.practiceSession.findFirst({
+          where: {
+            id: validated.targetId,
+            venueReservationId: validated.reservationId,
+          },
+          select: {
+            id: true,
+            teamId: true,
+            venueId: true,
+            startAt: true,
+            duration: true,
+          },
+        });
+        if (!practice) {
+          throw new VenueReservationLifecycleError(
+            "Reservation assignment not found.",
+          );
+        }
+        const practiceEnd = practice.startAt
+          ? new Date(practice.startAt.getTime() + practice.duration * 60_000)
+          : null;
+        await tx.event.deleteMany({
+          where: {
+            venueReservationId: validated.reservationId,
+            type: "PRACTICE",
+            teamId: practice.teamId,
+            venueId: practice.venueId,
+            ...(practice.startAt ? { startAt: practice.startAt } : {}),
+            ...(practiceEnd ? { endAt: practiceEnd } : {}),
+          },
+        });
+        await tx.practiceSession.update({
+          where: { id: practice.id },
+          data: {
+            venueReservationId: null,
+            venueId: null,
+            surfaceId: null,
+            segmentId: null,
+            startAt: null,
+            conflictOverriddenById: null,
+            conflictOverriddenAt: null,
+          },
+        });
+      } else {
+      const delegates = {
+        EVENT: "event",
+        SEASON_GAME: "seasonGame",
+        SIGNUP_EVENT: "signupEvent",
+        EVENT_GAME: "eventGame",
+      } as const;
+      const delegate = (tx as unknown as Record<string, {
+        updateMany?: (args: unknown) => Promise<{ count: number }>;
+      }>)[delegates[validated.targetType]];
+      // updateMany binds both IDs, so another tenant's target cannot be cleared.
+      if (delegate?.updateMany) {
+        const update = await delegate.updateMany({
+          where: { id: validated.targetId, venueReservationId: validated.reservationId },
+          data: { venueReservationId: null },
+        });
+        if (update.count === 0) throw new VenueReservationLifecycleError("Reservation assignment not found.");
+      }
+      }
+      await tx.auditLog.create({
+        data: {
+          action: "VENUE_RESERVATION_UNASSIGNED",
+          userId: actorId,
+          leagueId: current.ownerLeagueId,
+          teamId: current.ownerTeamId,
+          resourceId: current.id,
+          resourceType: "VenueReservation",
+          details: {
+            targetType: validated.targetType,
+            targetId: validated.targetId,
+            reason: validated.reason,
+          },
+        },
+      });
+    });
+    revalidateReservationPaths(reservation);
+    return { success: true, data: { reservationId: validated.reservationId, targetId: validated.targetId } };
+  } catch (error) {
+    return actionError(error) as ActionResult<{ reservationId: string; targetId: string }>;
+  }
+}
+
+export async function checkVenueReservationAvailability(
+  input: z.input<typeof availabilityInputSchema>,
+): Promise<ActionResult<unknown>> {
+  try {
+    const validated = availabilityInputSchema.parse(input);
+    const actorId = validated.mode === "STAFF" ? await requireUserId() : null;
+    const result = await runVenueReservationTransaction(async (tx) => {
+      const venue = validated.mode === "PUBLIC"
+        ? await tx.venue.findFirst({
+            where: {
+              ...publicPublishedVenueWhere,
+              id: validated.venueId,
+            },
+            select: { organizationId: true },
+          })
+        : await tx.venue.findUnique({
+            where: { id: validated.venueId },
+            select: { organizationId: true },
+          });
+      if (!venue) {
+        throw new Error("Venue is not available in this view.");
+      }
+
+      const staff = actorId && venue.organizationId
+        ? await tx.venueStaff.findFirst({
+            where: {
+              userId: actorId,
+              organizationId: venue.organizationId,
+              status: "ACTIVE",
+              OR: [{ venueId: null }, { venueId: validated.venueId }],
+            },
+            select: { id: true, role: true },
+          })
+        : null;
+      if (validated.mode === "STAFF" && !staff) {
+        throw new Error("Venue staff access is required.");
+      }
+
+      const availability = await findVenueReservationAvailability(tx, {
+        venueId: validated.venueId,
+        surfaceId: validated.surfaceId,
+        segmentId: validated.segmentId,
+        startsAt: validated.startsAt,
+        endsAt: validated.endsAt,
+        excludeReservationId: validated.excludeReservationId,
+        includeOfferings: validated.includeOfferings,
+        offeringAccess: validated.mode,
+      });
+      if (validated.mode === "PUBLIC") {
+        return {
+          mode: validated.mode,
+          offerings: availability.offerings,
+          availableSlices: subtractVenueReservationOccupancy(
+            {
+              startsAt: validated.startsAt,
+              endsAt: validated.endsAt,
+            },
+            availability.occupancy,
+          ).remainingSlices,
+          canOverride: false,
+        };
+      }
+
+      return {
+        mode: validated.mode,
+        availability,
+        canOverride: staff?.role === "OWNER" || staff?.role === "MANAGER",
+      };
+    });
+    return {
+      success: true,
+      data: result.mode === "PUBLIC"
+        ? {
+            offerings: result.offerings,
+            availableSlices: result.availableSlices,
+            canOverride: false,
+          }
+        : {
+            ...result.availability,
+            canOverride: result.canOverride,
+          },
+    };
+  } catch {
+    return { success: false, error: "Unable to check venue availability." };
+  }
+}

--- a/lib/actions/venue-schedules.ts
+++ b/lib/actions/venue-schedules.ts
@@ -21,6 +21,10 @@ import {
 import { findBookingConflicts, getVenueBookings } from "@/lib/utils/availability";
 import { expandRecurrenceWindow } from "@/lib/utils/venue-schedule";
 import type { BookingConflict, VenueBookingView } from "@/types/segments";
+import {
+  populateVenueOfferingAvailability,
+  type VenueReservationOfferingWithAvailability,
+} from "@/lib/services/venue-reservation-availability";
 
 type VenueContext = {
   id: string;
@@ -110,6 +114,7 @@ export async function getVenueScheduleAdminData(
       status: string;
       surfaceId: string | null;
     }>;
+    availableIce: VenueReservationOfferingWithAvailability[];
   }>
 > {
   try {
@@ -150,15 +155,48 @@ export async function getVenueScheduleAdminData(
           endsAt: true,
           activityType: true,
           status: true,
+          intent: true,
+          registrationMode: true,
           surfaceId: true,
+          segmentId: true,
+          recurrenceRule: true,
+          recurrenceEndDate: true,
+          surface: { select: { name: true } },
         },
         orderBy: { startsAt: "asc" },
       }),
     ]);
+    const availabilityFrom = new Date();
+    const availabilityTo = new Date(
+      availabilityFrom.getTime() + OFFERING_AVAILABILITY_HORIZON_MS,
+    );
+    const availableIce = await populateVenueOfferingAvailability(prisma, {
+      venueId,
+      offerings: expandRequestableOfferingOccurrences(
+        scheduleBlocks.filter(
+          (block) =>
+            block.status === "PUBLISHED"
+            && block.intent === "OFFERING"
+            && block.registrationMode === "REQUEST_REQUIRED",
+        ),
+        venue.timezone,
+        availabilityFrom,
+        availabilityTo,
+      ),
+      now: availabilityFrom,
+      mode: "STAFF",
+    });
 
     return {
       success: true,
-      data: { venueId, timezone: venue.timezone, surfaces, operatingHours, scheduleBlocks },
+      data: {
+        venueId,
+        timezone: venue.timezone,
+        surfaces,
+        operatingHours,
+        scheduleBlocks,
+        availableIce,
+      },
     };
   } catch (error) {
     if (error instanceof Error && error.message.includes("NEXT_REDIRECT")) {
@@ -593,13 +631,68 @@ interface PublicVenueScheduleFilters {
   skillLevelIds?: string[];
 }
 
+const OFFERING_AVAILABILITY_HORIZON_MS = 366 * 24 * 60 * 60 * 1000;
+
+type RequestableOfferingBlock = {
+  id: string;
+  title: string;
+  startsAt: Date;
+  endsAt: Date;
+  surfaceId: string | null;
+  segmentId: string | null;
+  recurrenceRule: string | null;
+  recurrenceEndDate: Date | null;
+  surface: { name: string } | null;
+};
+
+function expandRequestableOfferingOccurrences(
+  blocks: RequestableOfferingBlock[],
+  timeZone: string,
+  from: Date,
+  to: Date,
+) {
+  return blocks.flatMap((block) => {
+    const occurrences = block.recurrenceRule
+      ? expandRecurrenceWindow(
+          {
+            startAt: block.startsAt,
+            endAt: block.endsAt,
+            recurrenceRule: block.recurrenceRule,
+            recurrenceEndAt: block.recurrenceEndDate,
+            timezone: timeZone,
+          },
+          from,
+          to,
+        )
+      : block.startsAt < to && block.endsAt > from
+        ? [{ startAt: block.startsAt, endAt: block.endsAt }]
+        : [];
+
+    return occurrences.map((occurrence) => ({
+      id: block.recurrenceRule
+        ? `${block.id}:${occurrence.startAt.toISOString()}`
+        : block.id,
+      offeringBlockId: block.id,
+      title: block.title,
+      startsAt: occurrence.startAt,
+      endsAt: occurrence.endAt,
+      surfaceId: block.surfaceId,
+      segmentId: block.segmentId,
+      surfaceName: block.surface?.name ?? null,
+    }));
+  });
+}
+
 export async function getPublicVenueSchedule(slug: string, filters: PublicVenueScheduleFilters = {}) {
   const now = new Date();
+  const availabilityEnd = new Date(
+    now.getTime() + OFFERING_AVAILABILITY_HORIZON_MS,
+  );
   const skillLevelWhere = filters.skillLevelIds?.length
     ? { skillLevels: { some: { id: { in: filters.skillLevelIds } } } }
     : {};
 
-  return prisma.venue.findFirst({
+  const venue = await prisma.venue.findFirst({
     where: {
       ...publicPublishedVenueWhere,
       slug,
@@ -613,7 +706,18 @@ export async function getPublicVenueSchedule(slug: string, filters: PublicVenueS
         where: {
           status: "PUBLISHED",
           visibility: "PUBLIC",
-          startsAt: { gte: now },
+          audience: "PUBLIC",
+          startsAt: { lt: availabilityEnd },
+          OR: [
+            { recurrenceRule: null, endsAt: { gt: now } },
+            {
+              recurrenceRule: { not: null },
+              OR: [
+                { recurrenceEndDate: null },
+                { recurrenceEndDate: { gte: now } },
+              ],
+            },
+          ],
           ...skillLevelWhere,
         },
         select: {
@@ -629,8 +733,19 @@ export async function getPublicVenueSchedule(slug: string, filters: PublicVenueS
           priceCurrency: true,
           priceLabel: true,
           registrationMode: true,
+          intent: true,
           externalRegistrationUrl: true,
+          surfaceId: true,
+          segmentId: true,
+          recurrenceRule: true,
+          recurrenceEndDate: true,
           surface: {
+            select: {
+              id: true,
+              name: true,
+            },
+          },
+          segment: {
             select: {
               id: true,
               name: true,
@@ -676,6 +791,29 @@ export async function getPublicVenueSchedule(slug: string, filters: PublicVenueS
       },
     },
   });
+  if (!venue) return null;
+
+  const requestableOfferings = expandRequestableOfferingOccurrences(
+    venue.scheduleBlocks.filter(
+      (block) =>
+        block.registrationMode === "REQUEST_REQUIRED"
+        && block.intent === "OFFERING",
+    ),
+    venue.timezone,
+    now,
+    availabilityEnd,
+  );
+  const availableIce = await populateVenueOfferingAvailability(prisma, {
+    venueId: venue.id,
+    offerings: requestableOfferings,
+    now,
+    mode: "PUBLIC",
+  });
+
+  return {
+    ...venue,
+    availableIce,
+  };
 }
 
 async function setScheduleBlockStatus(

--- a/lib/data/calendar.ts
+++ b/lib/data/calendar.ts
@@ -60,7 +60,7 @@ export async function getUserCalendarItems(window: CalendarWindow): Promise<Cale
   ]);
 
   // ISO-8601 UTC strings sort correctly lexicographically.
-  return dedupeItems([...events, ...practices, ...signups, ...venueBlocks]).sort((a, b) =>
+  return deduplicateCalendarItems([...events, ...practices, ...signups, ...venueBlocks]).sort((a, b) =>
     a.startAt.localeCompare(b.startAt)
   );
 }
@@ -84,15 +84,36 @@ function normalizeWindow(window: CalendarWindow): { from: Date; to: Date } {
 /**
  * Two scopes can reach the same row (e.g. a team event in the viewer's league),
  * and recurring venue blocks emit one item per occurrence under the block's id,
- * so the identity key is source + id + startAt.
+ * Linked activity aliases share the reservation identity. Legacy rows retain a
+ * source + id + startAt identity so recurring occurrences remain distinct.
  */
-function dedupeItems(items: CalendarItem[]): CalendarItem[] {
+export function deduplicateCalendarItems(items: CalendarItem[]): CalendarItem[] {
   const seen = new Map<string, CalendarItem>();
+  const participantEventHrefs = new Map<string, string>();
   for (const item of items) {
-    const key = `${item.source}:${item.id}:${item.startAt}`;
-    if (!seen.has(key)) seen.set(key, item);
+    const key = item.venueReservationId
+      ? `reservation:${item.venueReservationId}`
+      : `${item.source}:${item.id}:${item.startAt}`;
+    if (item.venueReservationId && item.source === "event") {
+      const currentHref = participantEventHrefs.get(key);
+      if (!currentHref || item.href.localeCompare(currentHref) < 0) {
+        participantEventHrefs.set(key, item.href);
+      }
+    }
+    const current = seen.get(key);
+    if (
+      !current
+      || (item.source === "practice" && current.source === "event")
+    ) {
+      seen.set(key, item);
+    }
   }
-  return [...seen.values()];
+  return [...seen.entries()].map(([key, item]) => {
+    const participantEventHref = participantEventHrefs.get(key);
+    return participantEventHref
+      ? { ...item, href: participantEventHref }
+      : item;
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -129,6 +150,7 @@ async function fetchTeamAndLeagueEvents(params: {
       startAt: true,
       endAt: true,
       timezone: true,
+      venueReservationId: true,
       team: { select: { id: true, name: true } },
       league: { select: { id: true, name: true } },
     },
@@ -149,6 +171,7 @@ async function fetchTeamAndLeagueEvents(params: {
       },
       href: `/events/${event.id}`,
       eventType: event.type,
+      venueReservationId: event.venueReservationId,
     })
   );
 }
@@ -174,6 +197,8 @@ async function fetchPracticeSessions(params: {
       // Venue-attached sessions carry an exact startAt; `date` is the fallback.
       startAt: true,
       duration: true,
+      venueReservationId: true,
+      venueReservation: { select: { timezone: true } },
       teamId: true,
       team: { select: { name: true } },
     },
@@ -189,6 +214,8 @@ async function fetchPracticeSessions(params: {
       endAt: new Date(start.getTime() + practice.duration * 60_000).toISOString(),
       scope: { teamId: practice.teamId, teamName: practice.team.name },
       href: `/practice-planner/${practice.id}`,
+      venueReservationId: practice.venueReservationId,
+      timezone: practice.venueReservation?.timezone,
     };
   });
 }

--- a/lib/data/schedule-items.ts
+++ b/lib/data/schedule-items.ts
@@ -37,6 +37,7 @@ export function deduplicateAssociationScheduleItems<
   T extends AssociationScheduleItemView,
 >(items: readonly T[]): T[] {
   const chosen = new Map<string, T>();
+  const participantEventHrefs = new Map<string, string>();
   for (const item of items) {
     const identity = canonicalScheduleIdentity({
       venueReservationId: item.venueReservationId,
@@ -44,6 +45,12 @@ export function deduplicateAssociationScheduleItems<
       sourceId: item.sourceId,
       startsAt: item.startsAt,
     });
+    if (item.venueReservationId && item.source === "event" && item.href) {
+      const currentHref = participantEventHrefs.get(identity);
+      if (!currentHref || item.href.localeCompare(currentHref) < 0) {
+        participantEventHrefs.set(identity, item.href);
+      }
+    }
     const current = chosen.get(identity);
     if (
       !current
@@ -52,7 +59,12 @@ export function deduplicateAssociationScheduleItems<
       chosen.set(identity, { ...item, canonicalScheduleId: identity });
     }
   }
-  return [...chosen.values()].sort(
+  return [...chosen.entries()].map(([identity, item]) => {
+    const participantEventHref = participantEventHrefs.get(identity);
+    return participantEventHref
+      ? { ...item, href: participantEventHref }
+      : item;
+  }).sort(
     (a, b) =>
       a.startsAt.getTime() - b.startsAt.getTime()
       || a.canonicalScheduleId.localeCompare(b.canonicalScheduleId),

--- a/lib/email/templates.ts
+++ b/lib/email/templates.ts
@@ -413,14 +413,19 @@ export async function sendIceTimeRequestSubmittedEmail(
 interface IceTimeRequestDecisionEmailData {
   contactEmail: string;
   venueName: string;
-  status: "ACCEPTED" | "DECLINED";
+  status: "ACCEPTED" | "PARTIALLY_ACCEPTED" | "DECLINED";
   decisionMessage?: string | null;
 }
 
 export async function sendIceTimeRequestDecisionEmail(
   data: IceTimeRequestDecisionEmailData
 ): Promise<void> {
-  const statusLabel = data.status === "ACCEPTED" ? "accepted" : "declined";
+  const statusLabel =
+    data.status === "ACCEPTED"
+      ? "accepted"
+      : data.status === "PARTIALLY_ACCEPTED"
+        ? "partially accepted"
+        : "declined";
 
   await sendEmail({
     subject: `Your ice time request was ${statusLabel}`,

--- a/lib/services/venue-reservation-availability.ts
+++ b/lib/services/venue-reservation-availability.ts
@@ -11,7 +11,6 @@ export type VenueReservationAvailabilityCandidate = {
   endsAt: Date;
   now?: Date;
   excludeReservationId?: string;
-  publicView?: boolean;
 };
 
 export type VenueReservationConflict = {
@@ -40,7 +39,7 @@ function pairKey(a: string, b: string): string {
   return a < b ? `${a}\0${b}` : `${b}\0${a}`;
 }
 
-function scopesConflict(
+export function venueReservationScopesConflict(
   candidateSurfaceId: string | null,
   candidateSegmentId: string | null,
   existing: { surfaceId: string | null; segmentId: string | null },
@@ -51,6 +50,16 @@ function scopesConflict(
   if (candidateSegmentId === null || existing.segmentId === null) return true;
   if (candidateSegmentId === existing.segmentId) return true;
   return !coexistence.has(pairKey(candidateSegmentId, existing.segmentId));
+}
+
+export function approvedSpaceWithinRequestedSpace(
+  requested: { surfaceId: string | null; segmentId: string | null },
+  approved: { surfaceId: string | null; segmentId: string | null },
+): boolean {
+  if (requested.surfaceId === null) return true;
+  if (approved.surfaceId !== requested.surfaceId) return false;
+  if (requested.segmentId === null) return true;
+  return approved.segmentId === requested.segmentId;
 }
 
 async function loadCoexistence(
@@ -127,20 +136,72 @@ export async function findVenueReservationConflicts(
       : new Set<string>();
 
   return (rows as ReservationRow[])
-    .filter((row) => scopesConflict(surfaceId, segmentId, row, coexistence))
-    .map((row) => {
-      if (!candidate.publicView) return row;
-      return {
-        id: row.id,
-        status: row.status,
-        startsAt: row.startsAt,
-        endsAt: row.endsAt,
-        timezone: row.timezone,
-        venueId: row.venueId,
-        surfaceId: row.surfaceId,
-        segmentId: row.segmentId,
-      };
-    });
+    .filter((row) =>
+      venueReservationScopesConflict(surfaceId, segmentId, row, coexistence)
+    )
+    .map((row) => row);
+}
+
+export async function findLegacyAcceptedRequestConflicts(
+  tx: Prisma.TransactionClient,
+  candidate: VenueReservationAvailabilityCandidate & {
+    excludeRequestId?: string;
+  },
+): Promise<Array<{ id: string }>> {
+  const surfaceId = candidate.surfaceId ?? null;
+  const segmentId = surfaceId ? candidate.segmentId ?? null : null;
+  const rows = await tx.iceTimeRequest.findMany({
+    where: {
+      id: candidate.excludeRequestId
+        ? { not: candidate.excludeRequestId }
+        : undefined,
+      venueId: candidate.venueId,
+      status: { in: ["ACCEPTED", "PARTIALLY_ACCEPTED"] },
+      venueReservation: null,
+      requestedStartAt: { lt: candidate.endsAt },
+      requestedEndAt: { gt: candidate.startsAt },
+    },
+    select: {
+      id: true,
+      requestedStartAt: true,
+      requestedEndAt: true,
+      approvedStartAt: true,
+      approvedEndAt: true,
+      approvedSurfaceId: true,
+      approvedSegmentId: true,
+      scheduleBlock: {
+        select: { surfaceId: true, segmentId: true },
+      },
+    },
+  });
+  const coexistence =
+    surfaceId && segmentId
+      ? await loadCoexistence(tx, surfaceId)
+      : new Set<string>();
+
+  return rows.filter((row) => {
+    const hasApprovalSnapshot =
+      row.approvedStartAt !== null && row.approvedEndAt !== null;
+    const startsAt = row.approvedStartAt ?? row.requestedStartAt;
+    const endsAt = row.approvedEndAt ?? row.requestedEndAt;
+    const legacySurfaceId = hasApprovalSnapshot
+      ? row.approvedSurfaceId
+      : row.scheduleBlock.surfaceId;
+    const legacySegmentId = hasApprovalSnapshot
+      ? row.approvedSegmentId
+      : row.scheduleBlock.segmentId;
+    return startsAt < candidate.endsAt
+      && endsAt > candidate.startsAt
+      && venueReservationScopesConflict(
+        surfaceId,
+        segmentId,
+        {
+          surfaceId: legacySurfaceId,
+          segmentId: legacySegmentId,
+        },
+        coexistence,
+      );
+  }).map(({ id }) => ({ id }));
 }
 
 export type VenueReservationOffering = {
@@ -152,9 +213,148 @@ export type VenueReservationOffering = {
   segmentId: string | null;
 };
 
+export type VenueReservationAvailabilitySlice = {
+  startsAt: Date;
+  endsAt: Date;
+};
+
+export type VenueReservationOfferingOccurrence = VenueReservationOffering & {
+  offeringBlockId?: string;
+  surfaceName?: string | null;
+};
+
+export type VenueReservationOfferingWithAvailability =
+  VenueReservationOfferingOccurrence & {
+    occupancy: VenueReservationAvailabilitySlice[];
+    remainingSlices: VenueReservationAvailabilitySlice[];
+  };
+
+export type PublicVenueReservationOfferingAvailability =
+  VenueReservationOfferingOccurrence & {
+    remainingSlices: VenueReservationAvailabilitySlice[];
+  };
+
+/**
+ * Subtract canonical, scope-compatible occupancy from one concrete offering
+ * occurrence. Intervals are clipped to the offering and merged before
+ * subtraction so overlapping reservations cannot create duplicate or negative
+ * slices.
+ */
+export function subtractVenueReservationOccupancy(
+  offering: Pick<VenueReservationOfferingOccurrence, "startsAt" | "endsAt">,
+  occupancy: Array<Pick<VenueReservationConflict, "startsAt" | "endsAt">>,
+): {
+  occupancy: VenueReservationAvailabilitySlice[];
+  remainingSlices: VenueReservationAvailabilitySlice[];
+} {
+  const start = offering.startsAt.getTime();
+  const end = offering.endsAt.getTime();
+  const clipped = occupancy
+    .map((item) => ({
+      startsAt: new Date(Math.max(start, item.startsAt.getTime())),
+      endsAt: new Date(Math.min(end, item.endsAt.getTime())),
+    }))
+    .filter((item) => item.startsAt < item.endsAt)
+    .sort(
+      (left, right) =>
+        left.startsAt.getTime() - right.startsAt.getTime()
+        || left.endsAt.getTime() - right.endsAt.getTime(),
+    );
+
+  const merged: VenueReservationAvailabilitySlice[] = [];
+  for (const item of clipped) {
+    const previous = merged.at(-1);
+    if (previous && item.startsAt <= previous.endsAt) {
+      if (item.endsAt > previous.endsAt) previous.endsAt = item.endsAt;
+      continue;
+    }
+    merged.push({ ...item });
+  }
+
+  const remainingSlices: VenueReservationAvailabilitySlice[] = [];
+  let cursor = start;
+  for (const item of merged) {
+    if (cursor < item.startsAt.getTime()) {
+      remainingSlices.push({
+        startsAt: new Date(cursor),
+        endsAt: item.startsAt,
+      });
+    }
+    cursor = Math.max(cursor, item.endsAt.getTime());
+  }
+  if (cursor < end) {
+    remainingSlices.push({ startsAt: new Date(cursor), endsAt: new Date(end) });
+  }
+
+  return { occupancy: merged, remainingSlices };
+}
+
+/**
+ * Resolve concrete requestable offering occurrences against canonical
+ * reservation occupancy. Conflict lookup applies venue-wide, whole-surface,
+ * segment, and coexistence rules before interval subtraction. Public mode
+ * returns remaining slices only; authenticated staff mode also returns the
+ * merged occupancy intervals needed for venue operations.
+ */
+export async function populateVenueOfferingAvailability(
+  tx: Prisma.TransactionClient,
+  input: {
+    venueId: string;
+    offerings: VenueReservationOfferingOccurrence[];
+    now?: Date;
+    mode: "PUBLIC";
+  },
+): Promise<PublicVenueReservationOfferingAvailability[]>;
+export async function populateVenueOfferingAvailability(
+  tx: Prisma.TransactionClient,
+  input: {
+    venueId: string;
+    offerings: VenueReservationOfferingOccurrence[];
+    now?: Date;
+    mode: "STAFF";
+  },
+): Promise<VenueReservationOfferingWithAvailability[]>;
+export async function populateVenueOfferingAvailability(
+  tx: Prisma.TransactionClient,
+  input: {
+    venueId: string;
+    offerings: VenueReservationOfferingOccurrence[];
+    now?: Date;
+    mode: "PUBLIC" | "STAFF";
+  },
+): Promise<
+  Array<
+    | VenueReservationOfferingWithAvailability
+    | PublicVenueReservationOfferingAvailability
+  >
+> {
+  return Promise.all(
+    input.offerings.map(async (offering) => {
+      const conflicts = await findVenueReservationConflicts(tx, {
+        venueId: input.venueId,
+        surfaceId: offering.surfaceId,
+        segmentId: offering.segmentId,
+        startsAt: offering.startsAt,
+        endsAt: offering.endsAt,
+        now: input.now,
+      });
+      const availability = subtractVenueReservationOccupancy(offering, conflicts);
+      return {
+        ...offering,
+        ...(input.mode === "STAFF"
+          ? availability
+          : { remainingSlices: availability.remainingSlices }),
+      };
+    }),
+  );
+}
+
 export async function findVenueReservationAvailability(
   tx: Prisma.TransactionClient,
-  input: VenueReservationAvailabilityCandidate & { includeOfferings?: boolean },
+  input: VenueReservationAvailabilityCandidate & {
+    includeOfferings?: boolean;
+    offeringAccess?: "PUBLIC" | "STAFF";
+  },
 ): Promise<{
   offerings: VenueReservationOffering[];
   occupancy: VenueReservationConflict[];
@@ -167,6 +367,9 @@ export async function findVenueReservationAvailability(
           venueId: input.venueId,
           intent: "OFFERING",
           status: "PUBLISHED",
+          ...(input.offeringAccess === "PUBLIC"
+            ? { audience: "PUBLIC", visibility: "PUBLIC" }
+            : {}),
           startsAt: { lt: input.endsAt },
           AND: [
             {

--- a/lib/services/venue-reservations.ts
+++ b/lib/services/venue-reservations.ts
@@ -8,6 +8,7 @@ import {
   type AssociationOperationsNotificationEventType,
 } from "@/lib/services/association-operations-notification-registry";
 import {
+  approvedSpaceWithinRequestedSpace,
   findVenueReservationConflicts,
   type VenueReservationConflict,
 } from "@/lib/services/venue-reservation-availability";
@@ -26,6 +27,16 @@ export class VenueReservationLifecycleError extends Error {
   constructor(message: string) {
     super(message);
     this.name = "VenueReservationLifecycleError";
+  }
+}
+
+export function assertGenericRescheduleAllowed(
+  reservation: { sourceRequestId: string | null },
+): void {
+  if (reservation.sourceRequestId) {
+    throw new VenueReservationLifecycleError(
+      "Request-backed reservations cannot be generically rescheduled. Venue staff must cancel or amend the approved request and approve a new request.",
+    );
   }
 }
 
@@ -416,15 +427,18 @@ async function assertCreateAuthorizationAndSources(
       (occurrence) =>
         occurrence.startAt <= input.startsAt && occurrence.endAt >= input.endsAt,
     );
-    const offeringContainsSpace =
-      offering?.surfaceId === null
-      || (
-        offering?.surfaceId === (input.surfaceId ?? null)
-        && (
-          offering.segmentId === null
-          || offering.segmentId === (input.segmentId ?? null)
+    const offeringContainsSpace = offering
+      ? approvedSpaceWithinRequestedSpace(
+          {
+            surfaceId: offering.surfaceId,
+            segmentId: offering.segmentId,
+          },
+          {
+            surfaceId: input.surfaceId ?? null,
+            segmentId: input.segmentId ?? null,
+          },
         )
-      );
+      : false;
     if (
       !offering
       || !offeringContainsInterval
@@ -468,7 +482,11 @@ async function assertCreateAuthorizationAndSources(
     : input.ownerLeagueId
       ? request?.requesterLeagueId === input.ownerLeagueId
         && request.requesterTeamId === null
-      : false;
+      : input.ownerVenueOrganizationId
+        ? request?.requesterLeagueId === null
+          && request.requesterTeamId === null
+          && venue.organizationId === input.ownerVenueOrganizationId
+        : false;
   if (
     !request
     || !["ACCEPTED", "PARTIALLY_ACCEPTED"].includes(request.status)
@@ -674,6 +692,7 @@ export async function transitionVenueReservation(
     usageStatus?: VenueReservationUsageStatus;
     allowAssignedDisposition?: boolean;
     overrideReason?: string;
+    snapshot?: Prisma.InputJsonValue;
   },
 ) {
   const reservation = await tx.venueReservation.findUnique({
@@ -811,6 +830,7 @@ export async function transitionVenueReservation(
           nextStatus: input.nextStatus,
           actorId: input.actorId,
           reason: input.reason.trim(),
+          snapshot: input.snapshot,
         },
       },
       ...(confirmationConflicts.length > 0
@@ -885,6 +905,14 @@ async function assertAssignmentScope(
   scope: AssignmentScope,
   actorId: string,
 ): Promise<void> {
+  if (
+    reservation.ownerVenueOrganizationId
+    && scope.authorization.type !== "ORGANIZATION"
+  ) {
+    throw new VenueReservationLifecycleError(
+      "Venue-organization-owned public request reservations cannot be assigned to association or team activities.",
+    );
+  }
   const ownerMatches = reservation.ownerLeagueId
     ? scope.leagueId === reservation.ownerLeagueId
     : reservation.ownerTeamId
@@ -964,6 +992,7 @@ export async function assignVenueReservation(
       | "EVENT_GAME";
     targetId: string;
     actorId: string;
+    overrideReason?: string | null;
   },
 ) {
   const reservation = await tx.venueReservation.findUnique({
@@ -1008,6 +1037,19 @@ export async function assignVenueReservation(
     + reservation.signupEvents.length
     + reservation.practiceSessions.length
     + reservation.proposalEntries.length;
+  const assignmentConflicts = totalLinkCount === 0
+    ? await findVenueReservationConflicts(tx, {
+        venueId: reservation.venueId,
+        surfaceId: reservation.surfaceId,
+        segmentId: reservation.segmentId,
+        startsAt: reservation.startsAt,
+        endsAt: reservation.endsAt,
+        excludeReservationId: reservation.id,
+      })
+    : [];
+  if (assignmentConflicts.length > 0 && !input.overrideReason?.trim()) {
+    throw new VenueReservationConflictError(assignmentConflicts);
+  }
   const targetSpaceMatches = (target: {
     surfaceId: string | null;
     segmentId: string | null;
@@ -1416,7 +1458,31 @@ export async function assignVenueReservation(
 
   const updated = await tx.venueReservation.update({
     where: { id: reservation.id },
-    data: { assignedById: input.actorId },
+    data: {
+      assignedById: input.actorId,
+      ...(assignmentConflicts.length > 0
+        ? {
+            overrides: {
+              create: {
+                actorId: input.actorId,
+                reason: input.overrideReason!.trim(),
+                candidateSnapshot: {
+                  venueId: reservation.venueId,
+                  surfaceId: reservation.surfaceId,
+                  segmentId: reservation.segmentId,
+                  startsAt: reservation.startsAt.toISOString(),
+                  endsAt: reservation.endsAt.toISOString(),
+                  targetType: input.targetType,
+                  targetId: input.targetId,
+                },
+                conflictingReservationIds: assignmentConflicts.map(
+                  ({ id }) => id,
+                ),
+              },
+            },
+          }
+        : {}),
+    },
   });
   const leagueId = await reservationLeagueId(tx, reservation);
   await tx.auditLog.create({
@@ -1427,7 +1493,11 @@ export async function assignVenueReservation(
       teamId: reservation.ownerTeamId,
       resourceId: reservation.id,
       resourceType: "VenueReservation",
-      details: { targetType: input.targetType, targetId: input.targetId },
+      details: {
+        targetType: input.targetType,
+        targetId: input.targetId,
+        conflictOverrideCount: assignmentConflicts.length,
+      },
     },
   });
 

--- a/lib/utils/validation.ts
+++ b/lib/utils/validation.ts
@@ -2547,7 +2547,7 @@ export const venueReservationLifecycleSchema = z.object({
 export const venueReservationAvailabilitySchema = venueReservationIntervalSchema.extend({
   excludeReservationId: associationCuidSchema.optional(),
   includeOfferings: z.boolean().default(true),
-  publicView: z.boolean().default(false),
+  mode: z.enum(["PUBLIC", "STAFF"]),
 });
 
 export const associationProfileSchema = z.object({

--- a/prisma/migrations/20260817130000_add_canonical_venue_reservations/migration.sql
+++ b/prisma/migrations/20260817130000_add_canonical_venue_reservations/migration.sql
@@ -412,6 +412,18 @@ BEGIN
           AND request."requesterLeagueId" IS NOT NULL
           AND NEW."ownerLeagueId" = request."requesterLeagueId"
         )
+        OR (
+          request."requesterTeamId" IS NULL
+          AND request."requesterLeagueId" IS NULL
+          AND NEW."ownerVenueOrganizationId" IS NOT NULL
+          AND EXISTS (
+            SELECT 1
+            FROM "venues" request_venue
+            WHERE request_venue."id" = request."venueId"
+              AND request_venue."organizationId" =
+                NEW."ownerVenueOrganizationId"
+          )
+        )
       )
   ) THEN
     RAISE EXCEPTION 'venue reservation source request approval or owner does not match'
@@ -468,8 +480,10 @@ LANGUAGE plpgsql
 AS $$
 BEGIN
   IF NOT EXISTS (
-    SELECT 1 FROM "venue_schedule_blocks"
-    WHERE "id" = NEW."scheduleBlockId" AND "venueId" = NEW."venueId"
+    SELECT 1
+    FROM "venue_schedule_blocks" block
+    WHERE block."id" = NEW."scheduleBlockId"
+      AND block."venueId" = NEW."venueId"
   ) THEN
     RAISE EXCEPTION 'ice time request block does not belong to request venue'
       USING ERRCODE = '23514';
@@ -492,12 +506,52 @@ BEGIN
       USING ERRCODE = '23514';
   END IF;
 
+  IF (
+    NEW."approvedStartAt" IS NOT NULL
+    OR NEW."status" IN ('ACCEPTED', 'PARTIALLY_ACCEPTED')
+  ) AND (
+    NEW."approvedSurfaceId" IS NOT NULL
+    OR NEW."approvedSegmentId" IS NOT NULL
+  ) AND NOT EXISTS (
+    SELECT 1
+    FROM "venue_schedule_blocks" block
+    WHERE block."id" = NEW."scheduleBlockId"
+      AND block."venueId" = NEW."venueId"
+      AND (
+        block."surfaceId" IS NULL
+        OR (
+          NEW."approvedSurfaceId" = block."surfaceId"
+          AND (
+            block."segmentId" IS NULL
+            OR NEW."approvedSegmentId" = block."segmentId"
+          )
+        )
+      )
+  ) THEN
+    RAISE EXCEPTION 'approved space widens or leaves requested space'
+      USING ERRCODE = '23514';
+  END IF;
+
+  IF (
+    NEW."approvedStartAt" IS NOT NULL
+    OR NEW."status" IN ('ACCEPTED', 'PARTIALLY_ACCEPTED')
+  ) AND NEW."approvedSurfaceId" IS NULL AND EXISTS (
+    SELECT 1
+    FROM "venue_schedule_blocks" block
+    WHERE block."id" = NEW."scheduleBlockId"
+      AND block."surfaceId" IS NOT NULL
+  ) THEN
+    RAISE EXCEPTION 'approved space widens requested surface to venue'
+      USING ERRCODE = '23514';
+  END IF;
+
   RETURN NEW;
 END;
 $$;
 
 CREATE TRIGGER "ice_time_requests_approval_ancestry_trigger"
-BEFORE INSERT OR UPDATE OF "scheduleBlockId", "venueId", "approvedSurfaceId", "approvedSegmentId"
+BEFORE INSERT OR UPDATE OF "scheduleBlockId", "venueId", "status",
+  "approvedStartAt", "approvedEndAt", "approvedSurfaceId", "approvedSegmentId"
 ON "ice_time_requests"
 FOR EACH ROW EXECUTE FUNCTION "validate_ice_time_request_approval_ancestry"();
 

--- a/scripts/backfill-venue-reservations.ts
+++ b/scripts/backfill-venue-reservations.ts
@@ -978,7 +978,7 @@ export async function backfillVenueReservations(
           requesterTeamId: true,
           requesterLeagueId: true,
           venueId: true,
-          venue: { select: { timezone: true } },
+          venue: { select: { timezone: true, organizationId: true } },
           venueReservation: { select: { id: true } },
           scheduleBlockId: true,
         },
@@ -1003,7 +1003,10 @@ export async function backfillVenueReservations(
           ? null
           : request.requesterLeagueId,
         ownerTeamId: request.requesterTeamId,
-        ownerVenueOrganizationId: null,
+        ownerVenueOrganizationId:
+          request.requesterTeamId || request.requesterLeagueId
+            ? null
+            : request.venue.organizationId,
         sourceRequestId: request.id,
         offeringBlockId: request.scheduleBlockId,
         aliasIds: {},

--- a/specs/007-association-operations/tasks.md
+++ b/specs/007-association-operations/tasks.md
@@ -56,27 +56,27 @@ description: "Dependency-ordered implementation backlog for association operatio
 
 ### Tests
 
-- [ ] T017 [P] [US1] Add full, partial, declined, canceled, idempotent approval, durable notification-ID, and registry-validation contract tests to `__tests__/lib/actions/venue-requests.test.ts`
-- [ ] T018 [P] [US1] Add simultaneous overlapping approval and documented-scale p95 performance tests to `__tests__/integration/venue-reservation-concurrency.test.ts` and `__tests__/performance/venue-reservation-availability.test.ts`
-- [ ] T019 [P] [US1] Add venue-reservation assignment and lifecycle action tests to `__tests__/lib/actions/venue-reservations.test.ts`
-- [ ] T020 [P] [US1] Add practice reservation, Event/RSVP linkage, and override tests to `__tests__/lib/actions/practice-sessions.test.ts`
-- [ ] T021 [P] [US1] Add canonical schedule deduplication tests to `__tests__/lib/data/schedule-items.test.ts`
-- [ ] T022 [P] [US1] Add venue request decision-control component tests to `__tests__/components/features/venue-admin/IceTimeRequestQueue.test.tsx`
+- [x] T017 [P] [US1] Add full, partial, declined, canceled, idempotent approval, durable notification-ID, and registry-validation contract tests to `__tests__/lib/actions/venue-requests.test.ts`
+- [x] T018 [P] [US1] Add simultaneous overlapping approval and documented-scale p95 performance tests to `__tests__/integration/venue-reservation-concurrency.test.ts` and `__tests__/performance/venue-reservation-availability.test.ts`
+- [x] T019 [P] [US1] Add venue-reservation assignment and lifecycle action tests to `__tests__/lib/actions/venue-reservations.test.ts`
+- [x] T020 [P] [US1] Add practice reservation, Event/RSVP linkage, and override tests to `__tests__/lib/actions/practice-sessions.test.ts`
+- [x] T021 [P] [US1] Add canonical schedule deduplication tests to `__tests__/lib/data/schedule-items.test.ts`
+- [x] T022 [P] [US1] Add venue request decision-control component tests to `__tests__/components/features/venue-admin/IceTimeRequestQueue.test.tsx`
 
 ### Implementation
 
-- [ ] T023 [US1] Make `decideIceTimeRequest` atomically create one confirmed full or partial venue reservation and enqueue typed notification intent in `lib/actions/venue-requests.ts`
-- [ ] T024 [US1] Propagate accepted-request cancellation and expiration into reservation lifecycle in `lib/actions/venue-requests.ts`
-- [ ] T025 [US1] Add assign, unassign, release, cancel, complete, unused, reschedule, and availability Server Actions to `lib/actions/venue-reservations.ts`
-- [ ] T026 [US1] Add venue manager approve/partial/decline/cancel/expire/annotate controls and approved-space display to `components/features/venue-admin/IceTimeRequestQueue.tsx`
-- [ ] T027 [US1] Add remaining-slice and offering-versus-occupancy display to `components/features/venue-admin/AvailableIceBrowser.tsx`
-- [ ] T028 [US1] Revalidate venue request, venue schedule, association operations, and affected team paths from `lib/actions/venue-requests.ts`
-- [ ] T029 [US1] Add association ice-reservation inventory and filters to `components/features/association-operations/VenueReservationInventory.tsx`
-- [ ] T030 [US1] Add venue-reservation-to-practice assignment workflow to `components/features/association-operations/VenueReservationAssignmentDialog.tsx`
-- [ ] T031 [US1] Create Venue Reservations inventory route and server data loading in `app/(dashboard)/league/[leagueId]/venue-reservations/page.tsx`
-- [ ] T032 [US1] Update practice creation/editing to select confirmed venue-reservation inventory, atomically link/create its Event/RSVPs, and enqueue typed notification intent in `lib/actions/practice-sessions.ts`
-- [ ] T033 [US1] Update practice editor reservation selection, venue-local time, and reasoned override UI in `components/features/practice-planner/PracticeSessionEditor.tsx`
-- [ ] T034 [US1] Make signed-in calendar and venue schedule readers deduplicate linked practice/Event aliases via `lib/data/calendar.ts` and `lib/data/schedule-items.ts`
+- [x] T023 [US1] Make `decideIceTimeRequest` atomically create one confirmed full or partial venue reservation and enqueue typed notification intent in `lib/actions/venue-requests.ts`
+- [x] T024 [US1] Propagate accepted-request cancellation and expiration into reservation lifecycle in `lib/actions/venue-requests.ts`
+- [x] T025 [US1] Add assign, unassign, release, cancel, complete, unused, reschedule, and availability Server Actions to `lib/actions/venue-reservations.ts`
+- [x] T026 [US1] Add venue manager approve/partial/decline/cancel/expire/annotate controls and approved-space display to `components/features/venue-admin/IceTimeRequestQueue.tsx`
+- [x] T027 [US1] Add remaining-slice and offering-versus-occupancy display to `components/features/venue-admin/AvailableIceBrowser.tsx`
+- [x] T028 [US1] Revalidate venue request, venue schedule, association operations, and affected team paths from `lib/actions/venue-requests.ts`
+- [x] T029 [US1] Add association ice-reservation inventory and filters to `components/features/association-operations/VenueReservationInventory.tsx`
+- [x] T030 [US1] Add venue-reservation-to-practice assignment workflow to `components/features/association-operations/VenueReservationAssignmentDialog.tsx`
+- [x] T031 [US1] Create Venue Reservations inventory route and server data loading in `app/(dashboard)/league/[leagueId]/venue-reservations/page.tsx`
+- [x] T032 [US1] Update practice creation/editing to select confirmed venue-reservation inventory, atomically link/create its Event/RSVPs, and enqueue typed notification intent in `lib/actions/practice-sessions.ts`
+- [x] T033 [US1] Update practice editor reservation selection, venue-local time, and reasoned override UI in `components/features/practice-planner/PracticeSessionEditor.tsx`
+- [x] T034 [US1] Make signed-in calendar and venue schedule readers deduplicate linked practice/Event aliases via `lib/data/calendar.ts` and `lib/data/schedule-items.ts`
 
 **Checkpoint**: User Story 1 is deployable as the first useful association MVP.
 

--- a/types/association-operations.ts
+++ b/types/association-operations.ts
@@ -52,6 +52,11 @@ export interface VenueReservationView {
 }
 
 export interface PublicVenueReservationOccupancyView {
+  startsAt: Date;
+  endsAt: Date;
+}
+
+export interface VenueReservationConflictView {
   id: string;
   startsAt: Date;
   endsAt: Date;
@@ -60,10 +65,6 @@ export interface PublicVenueReservationOccupancyView {
   surfaceId: string | null;
   segmentId: string | null;
   status: "HELD" | "CONFIRMED" | "COMPLETED";
-}
-
-export interface VenueReservationConflictView
-  extends PublicVenueReservationOccupancyView {
   owner?: VenueReservationOwnerView;
   sourceRequestId?: string | null;
 }
@@ -89,6 +90,8 @@ export interface AssociationScheduleItemView {
   venueId: string | null;
   surfaceId: string | null;
   segmentId: string | null;
+  /** Participant-facing Event/RSVP destination when one exists. */
+  href?: string | null;
 }
 
 export interface AssociationOperationsSummaryView {

--- a/types/events.ts
+++ b/types/events.ts
@@ -134,6 +134,8 @@ export interface CalendarItem {
   href: string;
   /** Source-specific subtype: EventType, SignupEventCategory, or venue activity type. */
   eventType?: string;
+  /** Canonical identity shared by linked practice/Event aliases. */
+  venueReservationId?: string | null;
 }
 
 export type CalendarScopeKind = "team" | "league" | "venue";


### PR DESCRIPTION
## Summary
- convert full and partial ice-request approvals into canonical venue reservations
- add association reservation inventory, assignment, and lifecycle management
- atomically connect approved ice to practice sessions, participant Events, RSVPs, and deduplicated calendars

## Stack
3 of 4. Depends on `mbeacom-canonical-venue-reservations`.