### PR TITLE
fix(ci): unblock releases and badge publishing under the main ruleset

### DIFF
--- a/.github/AUTOMATION.md
+++ b/.github/AUTOMATION.md
@@ -184,7 +184,8 @@ These are automatically provided by GitHub Actions.
 
 ### Don'ts ❌
 
-- Don't manually edit version in package.json on `main`
+- Don't expect `package.json`'s version to track releases — it is deliberately
+  not bumped, and trails the newest tag (see "Check Version" below)
 - Don't create duplicate tags
 - Don't skip CI checks
 - Don't force push to `main`
@@ -220,15 +221,20 @@ gh run watch
 
 ### Check Version
 
-```bash
-# Current package.json version
-cat package.json | grep '"version"'
+The released version is the newest **git tag**, not `package.json`. The release
+workflow derives the version from `git describe` and no longer writes the field
+back, because pushing that bump to `main` is rejected by the branch ruleset and
+the failure used to abort the tag and release steps entirely.
 
-# Latest Git tag
+```bash
+# Latest Git tag — the source of truth
 git describe --tags --abbrev=0
 
 # Latest GitHub release
 gh release view --json tagName
+
+# package.json — a stale mirror; nothing reads it at build or runtime
+grep '"version"' package.json
 ```
 
 ## Troubleshooting
@@ -272,8 +278,7 @@ gh run view <failed-run-id>
 git tag -d v1.2.3
 git push origin :refs/tags/v1.2.3
 
-# Fix version in package.json
-# Recommit and re-release
+# Re-run the release workflow; it recomputes the version from the tags
 ```
 
 ## Examples

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -100,8 +100,10 @@ git push origin v1.2.3
   adrkit binary (never a registry fetch — see ADR-0005)
 - Validates both reports with `bun run adr:check-reports` before publishing, so a
   truncated write fails the run instead of rendering `no result` on the badge
-- Commits with `[skip ci]` so a report refresh does not start a release
-- Rebases and retries the push, since `release.yml` also writes to `main`
+- Publishes to the dedicated `badges` branch as a single force-pushed orphan
+  commit — never to `main`, whose ruleset rejects workflow pushes (GH013), and
+  which the rebase-and-retry loop this replaced could not work around
+- Holds no write access to the default branch as a result
 
 ## Release Configuration
 

--- a/.github/workflows/adr-badges.yml
+++ b/.github/workflows/adr-badges.yml
@@ -45,10 +45,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
-          # Full history: the push step rebases onto main when another workflow
-          # (release.yml also pushes there) landed a commit mid-run, and a
-          # shallow clone makes that rebase unreliable.
-          fetch-depth: 0
+          # `adrkit queue` reads the corpus, not history, and the publish step
+          # below builds an orphan commit, so neither needs ancestry. The
+          # default shallow clone is enough.
+          fetch-depth: 1
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2.0.2
@@ -92,39 +92,42 @@ jobs:
           mv .adrkit-staging/lint.json .adrkit-staging/queue.json .adrkit/
           rmdir .adrkit-staging
 
-      - name: Commit when the reports changed
+      # Published to a dedicated `badges` branch, NOT to main.
+      #
+      # The `main` ruleset requires four status checks, and a push straight from
+      # a workflow produces none of them, so pushing here was rejected outright
+      # with GH013. The previous rebase-and-retry loop could not help: the
+      # rejection is a rule violation, not a lost race, so all three attempts
+      # failed identically and the job errored. The ruleset is scoped to
+      # `~DEFAULT_BRANCH`, so any other branch is unrestricted.
+      #
+      # This also removes the reason this job was uneasy about itself: it no
+      # longer writes to the default branch at all.
+      #
+      # The branch holds nothing but these two generated files and has no
+      # history worth keeping, so each run rebuilds it as a single orphan commit
+      # and force-pushes. That is race-free by construction, which rebasing onto
+      # a shared branch never was. `[skip ci]` is gone with it -- no workflow
+      # watches this branch, so there is nothing to suppress.
+      - name: Publish the reports to the badges branch
         run: |
-          # `git diff` alone cannot see an untracked file, so on the first run it
-          # would report "no change" and never publish anything. Compare against
-          # the index, and stage the paths explicitly -- `commit -am` does not
-          # stage a new file and would sweep in unrelated tracked edits.
-          git add .adrkit/lint.json .adrkit/queue.json
-          if git diff --cached --quiet -- .adrkit; then
-            echo "Reports unchanged; nothing to commit."
-            exit 0
-          fi
-
           git config user.name  'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          # `[skip ci]` matches the convention release.yml already uses for its
-          # version-bump commit. Without it this push starts a release run and a
-          # full quality-gates run for a two-file JSON refresh; `.adrkit/**` is
-          # not covered by release.yml's `paths-ignore`, so the marker is what
-          # stops it.
-          git commit -m 'chore(adr): refresh corpus badge reports [skip ci]'
 
-          # release.yml pushes to main too, so a commit can land between the
-          # checkout and this push. The reports touch only .adrkit/*.json, which
-          # no other workflow writes, so the rebase applies cleanly and a plain
-          # retry is enough. No --force: this is a shared branch.
-          for attempt in 1 2 3; do
-            if git push; then
-              echo "Published on attempt $attempt."
-              exit 0
-            fi
-            echo "Push rejected on attempt $attempt; rebasing onto main."
-            git pull --rebase origin main
-          done
+          # --orphan keeps the working tree (the freshly generated reports) but
+          # starts with no parent, and stages every tracked path. `git reset`
+          # empties that index so the commit below can contain only these two
+          # files -- without it the branch would carry the whole repository.
+          #
+          # `git reset`, not `git rm -r --cached .`: the reports differ from
+          # HEAD at this point (they were just regenerated), and `git rm`
+          # refuses to drop a path whose staged content differs from both the
+          # file and HEAD. It fails, the index survives, and the branch
+          # silently gets everything.
+          git checkout --quiet --orphan badge-reports
+          git reset --quiet
+          git add .adrkit/lint.json .adrkit/queue.json
+          git commit --quiet -m 'chore(adr): refresh corpus badge reports'
 
-          echo "::error::Could not publish the ADR badge reports after 3 attempts."
-          exit 1
+          git push --force origin HEAD:badges
+          echo "Published to the badges branch."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,24 +115,23 @@ jobs:
             echo "🆕 Tag v$VERSION does not exist — will create tag and release"
           fi
 
-      - name: Update package.json version
-        if: steps.tag_check.outputs.exists == 'false'
-        run: |
-          VERSION=${{ steps.version.outputs.version }}
-          # Update version in package.json
-          cat package.json | jq ".version = \"$VERSION\"" > package.json.tmp
-          mv package.json.tmp package.json
-          echo "Updated package.json to version $VERSION"
-
-      - name: Commit version bump
-        if: steps.tag_check.outputs.exists == 'false'
-        run: |
-          VERSION=${{ steps.version.outputs.version }}
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
-          git add package.json
-          git commit -m "chore: bump version to $VERSION [skip ci]" || echo "No changes to commit"
-          git push
+      # There is deliberately no "bump package.json and push to main" step here.
+      #
+      # The `main` ruleset requires four status checks, and a direct push from
+      # this job produces none of them, so the push was rejected with GH013 and
+      # the job died before ever reaching the tag and release steps below —
+      # which are the steps that actually matter and which the ruleset does not
+      # govern (it targets branches; there is no tag protection).
+      #
+      # The bump was safe to drop rather than work around: the version above is
+      # derived from `git describe --tags`, so tags are already the source of
+      # truth, and nothing reads `package.json`'s version at build or runtime.
+      # Restoring the bump means re-breaking releases unless the ruleset gains
+      # a bypass for the Actions app (id 15368) — which would let any workflow
+      # holding `contents: write` push to main past all four required checks.
+      #
+      # `package.json` therefore trails the latest tag by design. Read the
+      # version from the newest tag or the GitHub release, not from the file.
 
       - name: Create Git tag
         if: steps.tag_check.outputs.exists == 'false'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -567,10 +567,17 @@ The two ADR badges in `README.md` — corpus size and ARB queue depth — are a
 recipe over JSON adrkit already emits, not a hosted service. When the corpus
 changes on `main`, `.github/workflows/adr-badges.yml` regenerates
 `.adrkit/lint.json` (`$.checked`) and `.adrkit/queue.json` (`$.totalItems`),
-validates them with `bun run adr:check-reports`, and commits them for
-shields.io to read. A malformed report renders as `no result` rather than
+validates them with `bun run adr:check-reports`, and force-pushes them as a
+single orphan commit to the dedicated **`badges`** branch, which is what
+shields.io reads. It does not write to `main`: the `main` ruleset requires four
+status checks that a workflow push cannot produce, so publishing there was
+rejected with GH013. A malformed report renders as `no result` rather than
 failing, so it is validated before it is published; regenerate the pair locally
 with the same two commands the workflow runs if you need to inspect them.
+
+The `.adrkit/*.json` committed on `main` are a point-in-time snapshot, not the
+published artifact — the `badges` branch is. Do not trust main's copies to be
+current, and do not "fix" the workflow by pointing it back at `main`.
 
 ### CI/CD and Releases
 
@@ -589,9 +596,17 @@ smoke tests, deployment checks, and CodeQL.
 **Release process**:
 1. Merge to `main` branch triggers automated release workflow
 2. GitHub Actions runs type-checking, linting, and the build
-3. Semantic version determined from commit messages
+3. Semantic version determined from commit messages, derived from the latest
+   git tag (`git describe --tags`) — tags are the source of truth
 4. Changelog generated automatically
-5. GitHub release created with assets
+5. Git tag pushed and GitHub release created with assets
+
+`package.json`'s `version` is deliberately **not** bumped and therefore trails
+the latest tag. The workflow used to commit that bump to `main`, but the `main`
+ruleset rejects workflow pushes, and the failure aborted the job before it ever
+tagged or released. Nothing reads the field at build or runtime, so it was
+dropped rather than worked around. Read the version from the newest tag or the
+GitHub release — the README's version badge does.
 
 See `.github/AUTOMATION.md` for full CI/CD details.
 

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
   # OpenLeague
 
   [![Release](https://github.com/mbeacom/openleague/workflows/Release/badge.svg)](https://github.com/mbeacom/openleague/actions/workflows/release.yml)
-  [![ADRs](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fmbeacom%2Fopenleague%2Fmain%2F.adrkit%2Flint.json&query=%24.checked&label=ADRs&color=cb492d)](./docs/adr)
-  [![ARB queue](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fmbeacom%2Fopenleague%2Fmain%2F.adrkit%2Fqueue.json&query=%24.totalItems&label=ARB%20queue&suffix=%20pending&color=cb492d)](./docs/adr)
+  [![ADRs](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fmbeacom%2Fopenleague%2Fbadges%2F.adrkit%2Flint.json&query=%24.checked&label=ADRs&color=cb492d)](./docs/adr)
+  [![ARB queue](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fmbeacom%2Fopenleague%2Fbadges%2F.adrkit%2Fqueue.json&query=%24.totalItems&label=ARB%20queue&suffix=%20pending&color=cb492d)](./docs/adr)
   [![Code License](https://img.shields.io/badge/code-Apache--2.0-blue.svg)](./LICENSE)
   [![Docs License](https://img.shields.io/badge/docs-CC%20BY%204.0-blue.svg)](./LICENSE-DOCS)
-  [![Version](https://img.shields.io/github/package-json/v/mbeacom/openleague)](./package.json)
+  [![Version](https://img.shields.io/github/v/release/mbeacom/openleague)](https://github.com/mbeacom/openleague/releases/latest)
 </div>
 
 A free, open-source platform for managing sports teams. Simplify your season with tools for roster management, scheduling, and team communication.


### PR DESCRIPTION
## Problem

The `main` ruleset requires four status checks. A push made directly from a workflow produces none of them, so both workflows that wrote to `main` were rejected:

```
remote: error: GH013: Repository rule violations found for refs/heads/main
remote: - 4 of 4 required status checks are expected.
 ! [remote rejected] main -> main
```

- **`release.yml`** fails at *Commit version bump* — which aborts the job *before* it creates the tag or the GitHub release. No release has been cut since **v0.70.3 (Aug 11)**; four merged PRs are unreleased.
- **`adr-badges.yml`** fails the same way (last success Aug 15, failing since Aug 16), so the ADR badges have been reading stale JSON.

## Fix

**`release.yml` — drop the bump.** The version is already derived from `git describe --tags`, so tags are the source of truth, and nothing reads `package.json`'s `version` at build or runtime. The failing step was writing a field no one consumes, at the cost of the two steps that matter. Tagging and releasing were never blocked: the ruleset targets *branches*, and there is no tag protection.

**`adr-badges.yml` — publish to a `badges` branch.** Its push isn't optional; it *is* the artifact. The ruleset is scoped to `~DEFAULT_BRANCH`, so every other branch is unrestricted. Each run rebuilds the branch as a single orphan commit and force-pushes it — race-free by construction, unlike rebasing onto a shared branch. The old rebase-and-retry loop could never have helped, because the rejection was a rule violation rather than a lost race. The job no longer needs write access to the default branch at all.

**Badges follow the new sources.** The version badge reads the latest release instead of `package.json`; the two ADR badges read the `badges` branch.

## Alternative considered

Adding the GitHub Actions app to the ruleset's bypass list (it isn't offered in the UI picker, but the REST API accepts it). Rejected: it would let any workflow holding `contents: write` push to `main` past all four required checks — a standing exemption granted so a bot could keep writing files nothing reads.

## Verification

The orphan-branch publish sequence was exercised against a scratch repo before being committed. The first attempt used `git rm -r --cached .`, which **fails** when the reports differ from `HEAD` — as they always do, having just been regenerated — leaving the index intact so the branch would have carried the *entire repository*. It uses `git reset` instead; re-tested end to end:

- only `.adrkit/lint.json` and `.adrkit/queue.json` land on the branch
- exactly one commit, and still one after a second run
- `main` untouched

`bun run validate-deployment-config` passes. Neither workflow now contains any push to `main`.

## Follow-up

`package.json`'s version trails the newest tag by design; `CLAUDE.md` and `.github/AUTOMATION.md` record that, along with a note not to "fix" the badge workflow by repointing it at `main`. The `.adrkit/*.json` still committed on `main` are now a point-in-time snapshot rather than the published artifact — untracking them is a reasonable later cleanup.

After merge, the next release run computes **0.71.0**, covering the backlog.