### PR TITLE
fix(ci): set the tagger identity and serialize release runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,18 @@ permissions:
   issues: write
   discussions: write
 
+# Two merges landing close together start two runs that compute the SAME next
+# version from the same latest tag, then race to create it -- exactly what
+# happened when #341 and #342 merged nine seconds apart. Serialize instead.
+#
+# `cancel-in-progress: false`, matching adr-badges.yml: cancelling a run that
+# has already pushed a tag would leave the tag without its GitHub release, which
+# is worse than waiting. The duplicate is handled by the existing tag_check
+# step, which the second run reaches only after the first has finished.
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 jobs:
   release:
     name: Create Release
@@ -137,6 +149,12 @@ jobs:
         if: steps.tag_check.outputs.exists == 'false'
         run: |
           VERSION=${{ steps.version.outputs.version }}
+          # `git tag -a` is annotated, so it writes a tagger ident and fails with
+          # "empty ident name" without one. The identity used to be set by the
+          # version-bump step that stood here; it is configured locally now so
+          # that it lives in the step that actually needs it.
+          git config user.name  'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git tag -a "v$VERSION" -m "Release v$VERSION"
           git push origin "v$VERSION"
 


### PR DESCRIPTION
Follow-up to #342. The release run it unblocked got further and then failed for a different reason.

## 1. Missing tagger identity

#342 deleted the version-bump step — which was also where `git config user.name` / `user.email` were set. `git tag -a` creates an **annotated** tag, which writes a tagger ident, so the next step over died:

```
Committer identity unknown
fatal: empty ident name (for <runner@...>) not allowed
##[error]Process completed with exit code 128.
```

My oversight in #342: I removed the config lines along with the step that happened to contain them, without noticing a later step depended on them. The identity is now set inside the step that actually needs it, so it can't be orphaned again.

**The #342 fix itself is confirmed working.** That run got past version determination — resolving **v0.71.0** — and reached the tag step. The GH013 rejection is genuinely gone; this was a second failure standing behind it.

## 2. No concurrency group

`release.yml` was the only workflow in the repo without one. Merging #341 and #342 nine seconds apart started two Release runs that resolved the same latest tag, computed the same next version, and raced to create it — not hypothetical, it's in the run history.

`cancel-in-progress: false`, matching `adr-badges.yml`: cancelling a run that has already pushed its tag would strand the tag without its GitHub release. Serialized, the second run reaches the existing `tag_check` step and skips cleanly.

## Notes

- `adr-badges.yml` audited for the same identity gap — it sets one before its commit, so it's fine. No other workflow does `git commit`/`git tag` without an identity.
- `adr-badges.yml` still hasn't been exercised: it triggers only on `docs/adr/**` changes, and neither PR touched the corpus.
- `bun run validate-deployment-config` passes; the only remaining push in `release.yml` is the tag push.