### PR TITLE
feat(association): delegate team and volunteer operations (007 US3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -555,6 +555,10 @@ Current records:
 | 0003 | Access PostgreSQL exclusively through Prisma on Neon serverless |
 | 0004 | Build the interface on MUI as the primary component library |
 | 0005 | Standardize on Bun as the development and CI toolchain |
+| 0006 | Model league-owned gear with ledger projections and an outbox |
+| 0007 | Use canonical venue reservations for occupancy |
+| 0008 | Keep core association operations free and provider-portable |
+| 0009 | Delegate association authority through scoped role grants |
 
 Spec Kit users additionally have `/speckit.adrkit.context`,
 `/speckit.adrkit.check`, and `/speckit.adrkit.draft` from the installed adrkit

--- a/__tests__/components/features/workforce/VolunteerBoard.test.tsx
+++ b/__tests__/components/features/workforce/VolunteerBoard.test.tsx
@@ -2,16 +2,20 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-const { mockRespond, mockComplete, mockMissed } = vi.hoisted(() => ({
+const { mockRespond, mockComplete, mockMissed, mockCreateNeed, mockAssign } = vi.hoisted(() => ({
   mockRespond: vi.fn(),
   mockComplete: vi.fn(),
   mockMissed: vi.fn(),
+  mockCreateNeed: vi.fn(),
+  mockAssign: vi.fn(),
 }));
 
 vi.mock("@/lib/actions/volunteers", () => ({
   respondToVolunteerAssignment: mockRespond,
   completeVolunteerAssignment: mockComplete,
   markVolunteerAssignmentMissed: mockMissed,
+  createVolunteerNeed: mockCreateNeed,
+  assignVolunteer: mockAssign,
 }));
 
 import VolunteerBoard from "@/components/features/workforce/VolunteerBoard";
@@ -146,9 +150,28 @@ describe("RoleGrantManager", () => {
   it("explains what the selected role actually confers", async () => {
     render(<RoleGrantManager {...props} />);
 
-    // Default selection is Team manager; its guidance should be on screen so an
-    // administrator is not delegating a word they have to guess the meaning of.
-    expect(screen.getByText(/Runs one team/)).toBeInTheDocument();
+    // Default selection is Team manager. The guidance states what the grant
+    // does *today* — volunteers and gear — and is explicit that roster and
+    // practice administration still follow team admin membership, so nobody
+    // delegates expecting more than they get.
+    expect(screen.getByText(/Volunteers and gear needs\/requests for one team/)).toBeInTheDocument();
+    expect(screen.getByText(/still follow team admin membership/)).toBeInTheDocument();
+  });
+
+  it("does not offer roles whose work is not yet routed through grants", async () => {
+    const user = userEvent.setup();
+    render(<RoleGrantManager {...props} />);
+
+    await user.click(screen.getByRole("combobox", { name: /Responsibility/i }));
+
+    // Offered: the roles a grant actually empowers.
+    expect(screen.getByRole("option", { name: "Equipment manager" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Volunteer coordinator" })).toBeInTheDocument();
+    // Withheld: scheduling, registration, finance, communications, and event
+    // administration still guard on legacy roles, so a grant would do nothing.
+    for (const withheld of ["Scheduler", "Registrar", "Treasurer", "Communications lead", "Coach", "Event manager"]) {
+      expect(screen.queryByRole("option", { name: withheld })).not.toBeInTheDocument();
+    }
   });
 
   it("warns that equipment managers get gear only", async () => {
@@ -168,14 +191,29 @@ describe("RoleGrantManager", () => {
     render(<RoleGrantManager {...props} />);
 
     await user.click(screen.getByRole("combobox", { name: /Responsibility/i }));
-    await user.click(screen.getByRole("option", { name: "Treasurer" }));
+    await user.click(screen.getByRole("option", { name: "Association admin" }));
 
     await user.click(screen.getByRole("combobox", { name: /Scope/i }));
 
-    // Treasurer is association-only; offering a team scope would build a
-    // combination the server refuses.
+    // Association admin is association-only; offering a team scope would build
+    // a combination the server refuses.
     expect(screen.getByRole("option", { name: "Entire association" })).toBeInTheDocument();
     expect(screen.queryByRole("option", { name: "One team" })).not.toBeInTheDocument();
+  });
+
+  it("never offers a scope the form cannot supply a target for", async () => {
+    const user = userEvent.setup();
+    render(<RoleGrantManager {...props} />);
+
+    await user.click(screen.getByRole("combobox", { name: /Responsibility/i }));
+    await user.click(screen.getByRole("option", { name: "Volunteer coordinator" }));
+    await user.click(screen.getByRole("combobox", { name: /Scope/i }));
+
+    // The matrix allows season and event scope for this role, but the form has
+    // no picker for them, so selecting one would always be rejected server-side.
+    for (const unsupported of ["One season", "One event", "One signup event"]) {
+      expect(screen.queryByRole("option", { name: unsupported })).not.toBeInTheDocument();
+    }
   });
 
   it("revokes a responsibility", async () => {

--- a/__tests__/components/features/workforce/VolunteerBoard.test.tsx
+++ b/__tests__/components/features/workforce/VolunteerBoard.test.tsx
@@ -1,0 +1,209 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const { mockRespond, mockComplete, mockMissed } = vi.hoisted(() => ({
+  mockRespond: vi.fn(),
+  mockComplete: vi.fn(),
+  mockMissed: vi.fn(),
+}));
+
+vi.mock("@/lib/actions/volunteers", () => ({
+  respondToVolunteerAssignment: mockRespond,
+  completeVolunteerAssignment: mockComplete,
+  markVolunteerAssignmentMissed: mockMissed,
+}));
+
+import VolunteerBoard from "@/components/features/workforce/VolunteerBoard";
+import RoleGrantManager from "@/components/features/workforce/RoleGrantManager";
+
+const { mockInvite, mockRevoke } = vi.hoisted(() => ({
+  mockInvite: vi.fn(),
+  mockRevoke: vi.fn(),
+}));
+
+vi.mock("@/lib/actions/association-roles", () => ({
+  inviteAssociationOperator: mockInvite,
+  revokeAssociationResponsibility: mockRevoke,
+}));
+
+const need = {
+  id: "need-1",
+  roleLabel: "Scorekeeper",
+  description: "Operate the clock",
+  capacity: 2,
+  acceptedCount: 1,
+  status: "OPEN",
+  startAt: new Date("2027-01-01T18:00:00Z"),
+  endAt: new Date("2027-01-01T20:00:00Z"),
+  timezone: "America/Chicago",
+  teamName: "Metro Blades",
+  assignments: [
+    { id: "assign-1", status: "INVITED", personLabel: "Sam Rivera" },
+  ],
+};
+
+describe("VolunteerBoard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRespond.mockResolvedValue({ success: true, data: { status: "ACCEPTED" } });
+    mockComplete.mockResolvedValue({ success: true, data: { id: "assign-1" } });
+  });
+
+  it("shows staffing progress and the shortfall to an organizer", () => {
+    render(<VolunteerBoard needs={[need]} isOrganizer />);
+
+    expect(screen.getByText("Scorekeeper")).toBeInTheDocument();
+    expect(screen.getByText("1 of 2 filled")).toBeInTheDocument();
+    expect(screen.getByText("1 more volunteer needed")).toBeInTheDocument();
+  });
+
+  it("offers accept and decline to a volunteer, not organizer controls", async () => {
+    render(<VolunteerBoard needs={[need]} isOrganizer={false} />);
+
+    expect(screen.getByRole("button", { name: "Accept" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Decline" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "No-show" })).not.toBeInTheDocument();
+  });
+
+  it("sends the volunteer's acceptance", async () => {
+    const user = userEvent.setup();
+    render(<VolunteerBoard needs={[need]} isOrganizer={false} />);
+
+    await user.click(screen.getByRole("button", { name: "Accept" }));
+
+    await waitFor(() => {
+      expect(mockRespond).toHaveBeenCalledWith({
+        assignmentId: "assign-1",
+        response: "ACCEPTED",
+      });
+    });
+  });
+
+  it("surfaces a full need rather than failing silently", async () => {
+    mockRespond.mockResolvedValue({ success: false, error: "That volunteer need is already full." });
+    const user = userEvent.setup();
+    render(<VolunteerBoard needs={[need]} isOrganizer={false} />);
+
+    await user.click(screen.getByRole("button", { name: "Accept" }));
+
+    expect(await screen.findByText("That volunteer need is already full.")).toBeInTheDocument();
+  });
+
+  it("offers close-out controls to an organizer for accepted assignments only", () => {
+    const accepted = {
+      ...need,
+      assignments: [{ id: "assign-2", status: "ACCEPTED", personLabel: "Sam Rivera" }],
+    };
+
+    render(<VolunteerBoard needs={[accepted]} isOrganizer />);
+
+    expect(screen.getByRole("button", { name: "Completed" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "No-show" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Accept" })).not.toBeInTheDocument();
+  });
+
+  it("tells a volunteer with no shifts that there is nothing to do", () => {
+    render(<VolunteerBoard needs={[]} isOrganizer={false} />);
+
+    expect(screen.getByText("You have no volunteer shifts right now.")).toBeInTheDocument();
+  });
+});
+
+describe("RoleGrantManager", () => {
+  const grants = [
+    {
+      id: "grant-1",
+      role: "EQUIPMENT_MANAGER" as const,
+      scopeType: "TEAM" as const,
+      scopeLabel: "Metro Blades",
+      user: { id: "u1", name: "Alex Chen", email: "alex@example.com" },
+      createdAt: new Date("2026-01-01"),
+    },
+  ];
+
+  const props = {
+    leagueId: "league-1",
+    grants,
+    divisions: [{ id: "div-1", name: "U12 Recreational" }],
+    teams: [{ id: "team-1", name: "Metro Blades" }],
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockInvite.mockResolvedValue({ success: true, data: { invitationId: "inv-1" } });
+    mockRevoke.mockResolvedValue({ success: true, data: { id: "grant-1" } });
+  });
+
+  it("lists current responsibilities with their scope", () => {
+    render(<RoleGrantManager {...props} />);
+
+    expect(screen.getByText("Alex Chen")).toBeInTheDocument();
+    expect(screen.getByText("Equipment manager")).toBeInTheDocument();
+    expect(screen.getByText("Metro Blades")).toBeInTheDocument();
+  });
+
+  it("explains what the selected role actually confers", async () => {
+    render(<RoleGrantManager {...props} />);
+
+    // Default selection is Team manager; its guidance should be on screen so an
+    // administrator is not delegating a word they have to guess the meaning of.
+    expect(screen.getByText(/Runs one team/)).toBeInTheDocument();
+  });
+
+  it("warns that equipment managers get gear only", async () => {
+    const user = userEvent.setup();
+    render(<RoleGrantManager {...props} />);
+
+    await user.click(screen.getByRole("combobox", { name: /Responsibility/i }));
+    await user.click(screen.getByRole("option", { name: "Equipment manager" }));
+
+    expect(
+      await screen.findByText(/Confers no scheduling, finance, or administrative access/),
+    ).toBeInTheDocument();
+  });
+
+  it("only offers scopes the chosen role supports", async () => {
+    const user = userEvent.setup();
+    render(<RoleGrantManager {...props} />);
+
+    await user.click(screen.getByRole("combobox", { name: /Responsibility/i }));
+    await user.click(screen.getByRole("option", { name: "Treasurer" }));
+
+    await user.click(screen.getByRole("combobox", { name: /Scope/i }));
+
+    // Treasurer is association-only; offering a team scope would build a
+    // combination the server refuses.
+    expect(screen.getByRole("option", { name: "Entire association" })).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: "One team" })).not.toBeInTheDocument();
+  });
+
+  it("revokes a responsibility", async () => {
+    const user = userEvent.setup();
+    render(<RoleGrantManager {...props} />);
+
+    await user.click(screen.getByRole("button", { name: "Revoke" }));
+
+    await waitFor(() => {
+      expect(mockRevoke).toHaveBeenCalledWith({ grantId: "grant-1", leagueId: "league-1" });
+    });
+  });
+
+  it("surfaces a server refusal", async () => {
+    mockInvite.mockResolvedValue({
+      success: false,
+      error: "TREASURER cannot be granted at TEAM scope.",
+    });
+    const user = userEvent.setup();
+    render(<RoleGrantManager {...props} />);
+
+    await user.type(screen.getByLabelText(/Email address/i), "new@example.com");
+    await user.click(screen.getByRole("combobox", { name: /Team$/i }));
+    await user.click(screen.getByRole("option", { name: "Metro Blades" }));
+    await user.click(screen.getByRole("button", { name: "Send invitation" }));
+
+    expect(
+      await screen.findByText("TREASURER cannot be granted at TEAM scope."),
+    ).toBeInTheDocument();
+  });
+});

--- a/__tests__/integration/volunteer-capacity-concurrency.test.ts
+++ b/__tests__/integration/volunteer-capacity-concurrency.test.ts
@@ -1,0 +1,243 @@
+import { randomUUID } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+const TEST_DATABASE_URL = process.env.TEST_DATABASE_URL;
+const describeWithTestDatabase = TEST_DATABASE_URL ? describe : describe.skip;
+
+/**
+ * Two volunteers accepting the last slot at the same instant (T057).
+ *
+ * Mocked Prisma cannot prove this: the guarantee lives in Postgres, in the
+ * conditional `updateMany` guarded on `acceptedCount < capacity`, backed by the
+ * `acceptedCount <= capacity` CHECK. ADR-0003 rules out `SELECT ... FOR UPDATE`,
+ * so the claim has to be atomic by construction rather than by locking — and
+ * that is exactly what needs a real database to verify.
+ *
+ * Skipped unless TEST_DATABASE_URL is set, matching
+ * venue-reservation-concurrency.test.ts.
+ */
+function createBarrier(parties: number) {
+  let arrivals = 0;
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+
+  return async () => {
+    arrivals += 1;
+    if (arrivals === parties) {
+      release();
+    }
+    await gate;
+  };
+}
+
+describeWithTestDatabase("volunteer capacity concurrency (T057)", () => {
+  let prisma: any;
+  let appPrisma: { $disconnect: () => Promise<void> } | null = null;
+  let respondToVolunteerAssignment: any;
+  const originalDatabaseUrl = process.env.DATABASE_URL;
+
+  /** Which user the action sees, consumed one per invocation. */
+  const actingUsers: string[] = [];
+
+  beforeAll(async () => {
+    process.env.DATABASE_URL = TEST_DATABASE_URL;
+    vi.resetModules();
+
+    // The action module imports the Auth.js boundary, which drags in Next's
+    // runtime-only exports. Stub the session seam so this stays a database
+    // test while still running the real capacity claim.
+    vi.doMock("@/lib/auth/session", () => ({
+      requireUserId: vi.fn(async () => actingUsers.shift()),
+    }));
+    vi.doMock("next/cache", () => ({ revalidatePath: vi.fn() }));
+
+    const [{ PrismaClient }, dbModule, actionModule] = await Promise.all([
+      import("@prisma/client"),
+      import("@/lib/db/prisma"),
+      import("@/lib/actions/volunteers"),
+    ]);
+
+    const connectionString = TEST_DATABASE_URL!;
+    if (/\.neon\.tech[/:]/.test(connectionString)) {
+      const { PrismaNeon } = await import("@prisma/adapter-neon");
+      prisma = new PrismaClient({
+        adapter: new PrismaNeon({ connectionString }),
+        log: ["error"],
+      });
+    } else {
+      const { PrismaPg } = await import("@prisma/adapter-pg");
+      prisma = new PrismaClient({
+        adapter: new PrismaPg({ connectionString }),
+        log: ["error"],
+      });
+    }
+
+    appPrisma = dbModule.prisma;
+    respondToVolunteerAssignment = actionModule.respondToVolunteerAssignment;
+  });
+
+  afterAll(async () => {
+    await Promise.allSettled([
+      prisma?.$disconnect?.() ?? Promise.resolve(),
+      appPrisma?.$disconnect?.() ?? Promise.resolve(),
+    ]);
+
+    if (originalDatabaseUrl === undefined) {
+      delete process.env.DATABASE_URL;
+    } else {
+      process.env.DATABASE_URL = originalDatabaseUrl;
+    }
+  });
+
+  async function createFixture(capacity: number) {
+    const suffix = randomUUID().replace(/-/g, "").slice(0, 12);
+
+    const league = await prisma.league.create({
+      data: {
+        name: `Capacity League ${suffix}`,
+        sport: "HOCKEY",
+        contactEmail: `league-${suffix}@example.com`,
+      },
+      select: { id: true },
+    });
+
+    const users = await Promise.all(
+      [0, 1].map((index) =>
+        prisma.user.create({
+          data: {
+            email: `volunteer-${index}-${suffix}@example.com`,
+            passwordHash: "x",
+            emailVerified: new Date(),
+          },
+          select: { id: true },
+        }),
+      ),
+    );
+
+    const need = await prisma.volunteerNeed.create({
+      data: {
+        leagueId: league.id,
+        roleLabel: "Last slot",
+        capacity,
+        startAt: new Date(Date.now() + 86_400_000),
+        endAt: new Date(Date.now() + 90_000_000),
+        timezone: "America/Chicago",
+      },
+      select: { id: true },
+    });
+
+    const assignments = await Promise.all(
+      users.map((user) =>
+        prisma.volunteerAssignment.create({
+          data: { needId: need.id, userId: user.id, status: "INVITED" },
+          select: { id: true },
+        }),
+      ),
+    );
+
+    return {
+      leagueId: league.id,
+      needId: need.id,
+      userIds: users.map((user: { id: string }) => user.id) as [string, string],
+      assignmentIds: assignments.map((a: { id: string }) => a.id) as [string, string],
+    };
+  }
+
+  async function cleanup(leagueId: string, userIds: string[]) {
+    await prisma.volunteerAssignment.deleteMany({
+      where: { need: { leagueId } },
+    });
+    await prisma.volunteerNeed.deleteMany({ where: { leagueId } });
+    await prisma.league.deleteMany({ where: { id: leagueId } });
+    await prisma.user.deleteMany({ where: { id: { in: userIds } } });
+  }
+
+  it("lets exactly one of two simultaneous acceptances take the final slot", async () => {
+    const fixture = await createFixture(1);
+
+    try {
+      const barrier = createBarrier(2);
+
+      // requireUserId is consumed in invocation order, and JS runs each call
+      // synchronously up to its first await, so caller 0 gets user 0.
+      actingUsers.length = 0;
+      actingUsers.push(fixture.userIds[0], fixture.userIds[1]);
+
+      const results = await Promise.all(
+        fixture.assignmentIds.map(async (assignmentId) => {
+          await barrier();
+          return respondToVolunteerAssignment({ assignmentId, response: "ACCEPTED" });
+        }),
+      );
+
+      const accepted = results.filter((r) => r.success);
+      const rejected = results.filter((r) => !r.success);
+
+      expect(accepted).toHaveLength(1);
+      expect(rejected).toHaveLength(1);
+      expect(rejected[0].error).toMatch(/already full/);
+
+      const need = await prisma.volunteerNeed.findUnique({
+        where: { id: fixture.needId },
+        select: { acceptedCount: true, capacity: true },
+      });
+      // The invariant that matters: never oversubscribed.
+      expect(need.acceptedCount).toBe(1);
+      expect(need.acceptedCount).toBeLessThanOrEqual(need.capacity);
+
+      const acceptedRows = await prisma.volunteerAssignment.count({
+        where: { needId: fixture.needId, status: "ACCEPTED" },
+      });
+      expect(acceptedRows).toBe(1);
+    } finally {
+      await cleanup(fixture.leagueId, fixture.userIds);
+    }
+  });
+
+  it("lets both in when there are two slots", async () => {
+    const fixture = await createFixture(2);
+
+    try {
+      const barrier = createBarrier(2);
+
+      actingUsers.length = 0;
+      actingUsers.push(fixture.userIds[0], fixture.userIds[1]);
+
+      const results = await Promise.all(
+        fixture.assignmentIds.map(async (assignmentId) => {
+          await barrier();
+          return respondToVolunteerAssignment({ assignmentId, response: "ACCEPTED" });
+        }),
+      );
+
+      expect(results.filter((r) => r.success)).toHaveLength(2);
+
+      const need = await prisma.volunteerNeed.findUnique({
+        where: { id: fixture.needId },
+        select: { acceptedCount: true },
+      });
+      expect(need.acceptedCount).toBe(2);
+    } finally {
+      await cleanup(fixture.leagueId, fixture.userIds);
+    }
+  });
+
+  it("refuses to let the database exceed capacity even by direct write", async () => {
+    // Proves the CHECK backing the guard is really present, so a future caller
+    // that forgets the guard still cannot oversubscribe.
+    const fixture = await createFixture(1);
+
+    try {
+      await expect(
+        prisma.volunteerNeed.update({
+          where: { id: fixture.needId },
+          data: { acceptedCount: 2 },
+        }),
+      ).rejects.toThrow();
+    } finally {
+      await cleanup(fixture.leagueId, fixture.userIds);
+    }
+  });
+});

--- a/__tests__/integration/volunteer-capacity-concurrency.test.ts
+++ b/__tests__/integration/volunteer-capacity-concurrency.test.ts
@@ -224,6 +224,40 @@ describeWithTestDatabase("volunteer capacity concurrency (T057)", () => {
     }
   });
 
+  it("lets one accept win when the same assignment is answered twice at once", async () => {
+    // The case a compensating decrement cannot cover: both callers read the
+    // assignment as INVITED, so without a conditional claim inside the
+    // transaction they would each take a slot on a multi-slot need.
+    const fixture = await createFixture(2);
+
+    try {
+      const barrier = createBarrier(2);
+      const assignmentId = fixture.assignmentIds[0];
+
+      actingUsers.length = 0;
+      actingUsers.push(fixture.userIds[0], fixture.userIds[0]);
+
+      const results = await Promise.all(
+        [0, 1].map(async () => {
+          await barrier();
+          return respondToVolunteerAssignment({ assignmentId, response: "ACCEPTED" });
+        }),
+      );
+
+      expect(results.filter((r) => r.success)).toHaveLength(1);
+
+      const need = await prisma.volunteerNeed.findUnique({
+        where: { id: fixture.needId },
+        select: { acceptedCount: true },
+      });
+      // One assignment accepted means exactly one slot consumed, even though
+      // the need had room for two.
+      expect(need.acceptedCount).toBe(1);
+    } finally {
+      await cleanup(fixture.leagueId, fixture.userIds);
+    }
+  });
+
   it("refuses to let the database exceed capacity even by direct write", async () => {
     // Proves the CHECK backing the guard is really present, so a future caller
     // that forgets the guard still cannot oversubscribe.

--- a/__tests__/lib/actions/association-roles.test.ts
+++ b/__tests__/lib/actions/association-roles.test.ts
@@ -9,9 +9,11 @@ const {
   mockEvent,
   mockSignupEvent,
   mockInvitation,
+  mockLeague,
   mockRequireUserId,
   mockHasCapability,
   mockLogAuditEvent,
+  mockSendInvitationEmail,
 } = vi.hoisted(() => ({
   mockGrant: { findFirst: vi.fn(), findMany: vi.fn(), create: vi.fn(), update: vi.fn() },
   mockUser: { findUnique: vi.fn() },
@@ -20,10 +22,12 @@ const {
   mockSeason: { findFirst: vi.fn() },
   mockEvent: { findFirst: vi.fn() },
   mockSignupEvent: { findFirst: vi.fn() },
-  mockInvitation: { create: vi.fn() },
+  mockInvitation: { create: vi.fn(), delete: vi.fn() },
+  mockLeague: { findUnique: vi.fn() },
   mockRequireUserId: vi.fn(),
   mockHasCapability: vi.fn(),
   mockLogAuditEvent: vi.fn(),
+  mockSendInvitationEmail: vi.fn(),
 }));
 
 vi.mock("@/lib/db/prisma", () => ({
@@ -36,6 +40,7 @@ vi.mock("@/lib/db/prisma", () => ({
     event: mockEvent,
     signupEvent: mockSignupEvent,
     invitation: mockInvitation,
+    league: mockLeague,
   },
 }));
 
@@ -47,6 +52,10 @@ vi.mock("@/lib/utils/security", () => ({
 }));
 
 vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+
+vi.mock("@/lib/email/templates", () => ({
+  sendLeagueInvitationEmail: mockSendInvitationEmail,
+}));
 
 // The capability resolver has its own suite; here it is a seam so these tests
 // assert the action's authorization *decisions*, not the resolver's internals.
@@ -372,6 +381,13 @@ describe("association responsibility grants", () => {
   describe("inviting an operator", () => {
     beforeEach(() => {
       mockInvitation.create.mockResolvedValue({ id: "invite-1" });
+      mockInvitation.delete.mockResolvedValue({});
+      mockLeague.findUnique.mockResolvedValue({ name: "Metro Hockey League" });
+      mockSendInvitationEmail.mockResolvedValue(undefined);
+      // Default: the address has no account yet, so the invitation path runs.
+      mockUser.findUnique.mockImplementation(({ where }: { where: { email?: string } }) =>
+        where.email ? Promise.resolve(null) : Promise.resolve({ id: SUBJECT }),
+      );
     });
 
     it("stores the pending responsibility on the invitation", async () => {
@@ -394,6 +410,87 @@ describe("association responsibility grants", () => {
           }),
         }),
       );
+    });
+
+    it("names exactly one invitation target, as the database requires", async () => {
+      // Invitation_exactly_one_target permits one of teamId / leagueId /
+      // organizationId. Setting both is a hard constraint violation, which a
+      // mocked create will happily accept — hence this explicit shape check.
+      await inviteAssociationOperator({
+        leagueId: LEAGUE,
+        email: "coach@example.com",
+        role: "COACH",
+        scopeType: "TEAM",
+        teamId: TEAM,
+      });
+
+      const data = mockInvitation.create.mock.calls[0][0].data;
+      expect(data.teamId).toBe(TEAM);
+      expect(data.leagueId).toBeNull();
+
+      mockInvitation.create.mockClear();
+
+      await inviteAssociationOperator({
+        leagueId: LEAGUE,
+        email: "treasurer@example.com",
+        role: "TREASURER",
+        scopeType: "ASSOCIATION",
+      });
+
+      const assoc = mockInvitation.create.mock.calls[0][0].data;
+      expect(assoc.leagueId).toBe(LEAGUE);
+      expect(assoc.teamId).toBeNull();
+    });
+
+    it("emails the token before reporting success", async () => {
+      await inviteAssociationOperator({
+        leagueId: LEAGUE,
+        email: "new@example.com",
+        role: "COACH",
+        scopeType: "TEAM",
+        teamId: TEAM,
+      });
+
+      expect(mockSendInvitationEmail).toHaveBeenCalledWith(
+        expect.objectContaining({ email: "new@example.com" }),
+      );
+    });
+
+    it("does not claim success when the invitation cannot be emailed", async () => {
+      mockSendInvitationEmail.mockRejectedValue(new Error("smtp down"));
+
+      const result = await inviteAssociationOperator({
+        leagueId: LEAGUE,
+        email: "new@example.com",
+        role: "COACH",
+        scopeType: "TEAM",
+        teamId: TEAM,
+      });
+
+      expect(result.success).toBe(false);
+      // The row is useless without the token reaching them, so it is removed
+      // rather than left as an orphan a retry would collide with.
+      expect(mockInvitation.delete).toHaveBeenCalled();
+    });
+
+    it("grants directly when the address already has an account", async () => {
+      // Signup is refused for a known address, so an invitation would be
+      // unredeemable. Grant instead.
+      mockUser.findUnique.mockImplementation(({ where }: { where: { email?: string; id?: string } }) =>
+        where.email ? Promise.resolve({ id: SUBJECT }) : Promise.resolve({ id: SUBJECT }),
+      );
+
+      const result = await inviteAssociationOperator({
+        leagueId: LEAGUE,
+        email: "existing@example.com",
+        role: "COACH",
+        scopeType: "TEAM",
+        teamId: TEAM,
+      });
+
+      expect(result.success).toBe(true);
+      expect(mockInvitation.create).not.toHaveBeenCalled();
+      expect(mockGrant.create).toHaveBeenCalled();
     });
 
     it("refuses a role/scope pairing the matrix does not support", async () => {
@@ -429,10 +526,12 @@ describe("association responsibility grants", () => {
 describe("applying a responsibility at invitation acceptance", () => {
   const tx = {
     associationRoleGrant: { findFirst: vi.fn(), create: vi.fn() },
+    team: { findUnique: vi.fn() },
   } as unknown as Parameters<typeof applyInvitationResponsibility>[0];
 
   const txMocks = tx as unknown as {
     associationRoleGrant: { findFirst: ReturnType<typeof vi.fn>; create: ReturnType<typeof vi.fn> };
+    team: { findUnique: ReturnType<typeof vi.fn> };
   };
 
   const invitation = {
@@ -499,8 +598,24 @@ describe("applying a responsibility at invitation acceptance", () => {
     expect(txMocks.associationRoleGrant.create).not.toHaveBeenCalled();
   });
 
-  it("skips an invitation with no association", async () => {
+  it("resolves the association from the team for a team-target invitation", async () => {
+    // TEAM-scoped invitations carry teamId and no leagueId, so acceptance looks
+    // the association up rather than bailing out.
+    txMocks.team.findUnique.mockResolvedValue({ leagueId: LEAGUE });
+
     await applyInvitationResponsibility(tx, { ...invitation, leagueId: null }, SUBJECT);
+
+    expect(txMocks.associationRoleGrant.create).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ leagueId: LEAGUE }) }),
+    );
+  });
+
+  it("skips an invitation with neither an association nor a team", async () => {
+    await applyInvitationResponsibility(
+      tx,
+      { ...invitation, leagueId: null, teamId: null },
+      SUBJECT,
+    );
 
     expect(txMocks.associationRoleGrant.create).not.toHaveBeenCalled();
   });

--- a/__tests__/lib/actions/association-roles.test.ts
+++ b/__tests__/lib/actions/association-roles.test.ts
@@ -1,0 +1,507 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockGrant,
+  mockUser,
+  mockTeam,
+  mockDivision,
+  mockSeason,
+  mockEvent,
+  mockSignupEvent,
+  mockInvitation,
+  mockRequireUserId,
+  mockHasCapability,
+  mockLogAuditEvent,
+} = vi.hoisted(() => ({
+  mockGrant: { findFirst: vi.fn(), findMany: vi.fn(), create: vi.fn(), update: vi.fn() },
+  mockUser: { findUnique: vi.fn() },
+  mockTeam: { findFirst: vi.fn() },
+  mockDivision: { findFirst: vi.fn() },
+  mockSeason: { findFirst: vi.fn() },
+  mockEvent: { findFirst: vi.fn() },
+  mockSignupEvent: { findFirst: vi.fn() },
+  mockInvitation: { create: vi.fn() },
+  mockRequireUserId: vi.fn(),
+  mockHasCapability: vi.fn(),
+  mockLogAuditEvent: vi.fn(),
+}));
+
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: {
+    associationRoleGrant: mockGrant,
+    user: mockUser,
+    team: mockTeam,
+    division: mockDivision,
+    season: mockSeason,
+    event: mockEvent,
+    signupEvent: mockSignupEvent,
+    invitation: mockInvitation,
+  },
+}));
+
+vi.mock("@/lib/auth/session", () => ({ requireUserId: mockRequireUserId }));
+
+vi.mock("@/lib/utils/security", () => ({
+  AuditAction: { USER_ROLE_ASSIGNED: "user_role_assigned", USER_ROLE_REMOVED: "user_role_removed" },
+  logAuditEvent: mockLogAuditEvent,
+}));
+
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+
+// The capability resolver has its own suite; here it is a seam so these tests
+// assert the action's authorization *decisions*, not the resolver's internals.
+vi.mock("@/lib/auth/capabilities", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/auth/capabilities")>();
+  return { ...actual, hasCapability: mockHasCapability };
+});
+
+import {
+  grantAssociationResponsibility,
+  inviteAssociationOperator,
+  listAssociationResponsibilityGrants,
+  revokeAssociationResponsibility,
+} from "@/lib/actions/association-roles";
+import { applyInvitationResponsibility } from "@/lib/services/association-roles";
+
+const LEAGUE = "clfleague0000000000000001";
+const SUBJECT = "clfuser00000000000000001";
+const TEAM = "clfteam00000000000000001";
+const DIVISION = "clfdiv0000000000000000001";
+const SEASON = "clfseason00000000000000001";
+const EVENT = "clfevent000000000000000001";
+
+const validGrant = {
+  leagueId: LEAGUE,
+  userId: SUBJECT,
+  role: "TEAM_MANAGER" as const,
+  scopeType: "TEAM" as const,
+  teamId: TEAM,
+};
+
+describe("association responsibility grants", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireUserId.mockResolvedValue("admin-1");
+    mockHasCapability.mockResolvedValue(true);
+    mockUser.findUnique.mockResolvedValue({ id: SUBJECT });
+    mockTeam.findFirst.mockResolvedValue({ id: TEAM });
+    mockDivision.findFirst.mockResolvedValue({ id: DIVISION });
+    mockSeason.findFirst.mockResolvedValue({ id: SEASON });
+    mockEvent.findFirst.mockResolvedValue({ id: EVENT });
+    mockGrant.findFirst.mockResolvedValue(null);
+    mockGrant.create.mockResolvedValue({ id: "grant-1" });
+  });
+
+  describe("granting", () => {
+    it("creates a scoped grant and records it in the audit log", async () => {
+      const result = await grantAssociationResponsibility(validGrant);
+
+      expect(result).toEqual({ success: true, data: { id: "grant-1" } });
+      expect(mockGrant.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            userId: SUBJECT,
+            leagueId: LEAGUE,
+            role: "TEAM_MANAGER",
+            scopeType: "TEAM",
+            teamId: TEAM,
+            grantedById: "admin-1",
+          }),
+        }),
+      );
+      expect(mockLogAuditEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ action: "user_role_assigned" }),
+      );
+    });
+
+    it("refuses a caller without association administration", async () => {
+      mockHasCapability.mockResolvedValue(false);
+
+      const result = await grantAssociationResponsibility(validGrant);
+
+      expect(result.success).toBe(false);
+      expect(mockGrant.create).not.toHaveBeenCalled();
+    });
+
+    it("blocks privilege escalation by a delegate", async () => {
+      // A scheduler holds MANAGE_SCHEDULE but not ADMINISTER_ASSOCIATION, so
+      // the capability gate declines and they cannot mint themselves a broader
+      // role.
+      mockHasCapability.mockResolvedValue(false);
+
+      const result = await grantAssociationResponsibility({
+        ...validGrant,
+        userId: "clfuser00000000000000002",
+        role: "ASSOCIATION_ADMIN",
+        scopeType: "ASSOCIATION",
+        teamId: undefined,
+      });
+
+      expect(result.success).toBe(false);
+      expect(mockGrant.create).not.toHaveBeenCalled();
+    });
+
+    it("rejects a role at a scope it does not support", async () => {
+      const result = await grantAssociationResponsibility({
+        ...validGrant,
+        role: "TREASURER",
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) expect(result.error).toMatch(/cannot be granted at TEAM scope/);
+      expect(mockGrant.create).not.toHaveBeenCalled();
+    });
+
+    it("requires the scope id the scope type names", async () => {
+      const result = await grantAssociationResponsibility({
+        ...validGrant,
+        teamId: undefined,
+      });
+
+      expect(result.success).toBe(false);
+      expect(mockGrant.create).not.toHaveBeenCalled();
+    });
+
+    it("drops scope ids that do not belong to the declared scope type", async () => {
+      // Sending extra ids must not smuggle a second scope past the database
+      // CHECK; only the one scopeType names is written.
+      await grantAssociationResponsibility({
+        ...validGrant,
+        seasonId: SEASON,
+        eventId: EVENT,
+      });
+
+      expect(mockGrant.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ teamId: TEAM, seasonId: null, eventId: null }),
+        }),
+      );
+    });
+
+    it("rejects a scope belonging to another association", async () => {
+      mockTeam.findFirst.mockResolvedValue(null);
+
+      const result = await grantAssociationResponsibility(validGrant);
+
+      expect(result.success).toBe(false);
+      if (!result.success) expect(result.error).toMatch(/does not belong to this association/);
+      expect(mockGrant.create).not.toHaveBeenCalled();
+    });
+
+    it("rejects an unknown subject", async () => {
+      mockUser.findUnique.mockResolvedValue(null);
+
+      const result = await grantAssociationResponsibility(validGrant);
+
+      expect(result.success).toBe(false);
+      expect(mockGrant.create).not.toHaveBeenCalled();
+    });
+
+    it("is idempotent for an identical live grant", async () => {
+      mockGrant.findFirst.mockResolvedValue({ id: "existing-1" });
+
+      const result = await grantAssociationResponsibility(validGrant);
+
+      expect(result).toEqual({ success: true, data: { id: "existing-1" } });
+      expect(mockGrant.create).not.toHaveBeenCalled();
+    });
+
+    it("accepts an equipment manager at association, division, and team scope", async () => {
+      for (const [scopeType, extra] of [
+        ["ASSOCIATION", {}],
+        ["DIVISION", { divisionId: DIVISION }],
+        ["TEAM", { teamId: TEAM }],
+      ] as const) {
+        mockGrant.create.mockClear();
+        const result = await grantAssociationResponsibility({
+          leagueId: LEAGUE,
+          userId: SUBJECT,
+          role: "EQUIPMENT_MANAGER",
+          scopeType,
+          ...extra,
+        });
+        expect(result.success, `${scopeType} should be accepted`).toBe(true);
+      }
+    });
+
+    it("refuses an equipment manager at season or event scope", async () => {
+      for (const [scopeType, extra] of [
+        ["SEASON", { seasonId: SEASON }],
+        ["EVENT", { eventId: EVENT }],
+      ] as const) {
+        mockGrant.create.mockClear();
+        const result = await grantAssociationResponsibility({
+          leagueId: LEAGUE,
+          userId: SUBJECT,
+          role: "EQUIPMENT_MANAGER",
+          scopeType,
+          ...extra,
+        });
+        expect(result.success, `${scopeType} should be refused`).toBe(false);
+        expect(mockGrant.create).not.toHaveBeenCalled();
+      }
+    });
+  });
+
+  describe("revoking", () => {
+    it("marks the grant revoked and stamps who did it", async () => {
+      mockGrant.findFirst.mockResolvedValue({
+        id: "grant-1",
+        state: "ACTIVE",
+        userId: SUBJECT,
+        role: "TEAM_MANAGER",
+        teamId: TEAM,
+      });
+
+      const result = await revokeAssociationResponsibility({
+        grantId: "clfgrant00000000000000001",
+        leagueId: LEAGUE,
+      });
+
+      expect(result.success).toBe(true);
+      expect(mockGrant.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ state: "REVOKED", revokedById: "admin-1" }),
+        }),
+      );
+      expect(mockLogAuditEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ action: "user_role_removed" }),
+      );
+    });
+
+    it("scopes the lookup by league so another association's grant is untouchable", async () => {
+      mockGrant.findFirst.mockResolvedValue(null);
+
+      const result = await revokeAssociationResponsibility({
+        grantId: "clfgrant00000000000000001",
+        leagueId: LEAGUE,
+      });
+
+      expect(result.success).toBe(false);
+      expect(mockGrant.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ leagueId: LEAGUE }),
+        }),
+      );
+      expect(mockGrant.update).not.toHaveBeenCalled();
+    });
+
+    it("is idempotent for an already revoked grant", async () => {
+      mockGrant.findFirst.mockResolvedValue({
+        id: "grant-1",
+        state: "REVOKED",
+        userId: SUBJECT,
+        role: "COACH",
+        teamId: TEAM,
+      });
+
+      const result = await revokeAssociationResponsibility({
+        grantId: "clfgrant00000000000000001",
+        leagueId: LEAGUE,
+      });
+
+      expect(result.success).toBe(true);
+      expect(mockGrant.update).not.toHaveBeenCalled();
+    });
+
+    it("refuses a caller without association administration", async () => {
+      mockHasCapability.mockResolvedValue(false);
+
+      const result = await revokeAssociationResponsibility({
+        grantId: "clfgrant00000000000000001",
+        leagueId: LEAGUE,
+      });
+
+      expect(result.success).toBe(false);
+      expect(mockGrant.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("listing", () => {
+    it("returns only active grants with a readable scope label", async () => {
+      mockGrant.findMany.mockResolvedValue([
+        {
+          id: "grant-1",
+          role: "TEAM_MANAGER",
+          scopeType: "TEAM",
+          createdAt: new Date("2026-01-01"),
+          user: { id: SUBJECT, name: "Sam", email: "sam@example.com" },
+          division: null,
+          team: { name: "Metro Blades" },
+          season: null,
+          event: null,
+          signupEvent: null,
+        },
+        {
+          id: "grant-2",
+          role: "TREASURER",
+          scopeType: "ASSOCIATION",
+          createdAt: new Date("2026-01-02"),
+          user: { id: "u2", name: null, email: "t@example.com" },
+          division: null,
+          team: null,
+          season: null,
+          event: null,
+          signupEvent: null,
+        },
+      ]);
+
+      const result = await listAssociationResponsibilityGrants(LEAGUE);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data[0].scopeLabel).toBe("Metro Blades");
+        expect(result.data[1].scopeLabel).toBe("Entire association");
+      }
+      expect(mockGrant.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ leagueId: LEAGUE, state: "ACTIVE" }),
+        }),
+      );
+    });
+
+    it("refuses a caller without association administration", async () => {
+      mockHasCapability.mockResolvedValue(false);
+
+      const result = await listAssociationResponsibilityGrants(LEAGUE);
+
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("inviting an operator", () => {
+    beforeEach(() => {
+      mockInvitation.create.mockResolvedValue({ id: "invite-1" });
+    });
+
+    it("stores the pending responsibility on the invitation", async () => {
+      const result = await inviteAssociationOperator({
+        leagueId: LEAGUE,
+        email: "New.Person@Example.com",
+        role: "VOLUNTEER_COORDINATOR",
+        scopeType: "DIVISION",
+        divisionId: DIVISION,
+      });
+
+      expect(result.success).toBe(true);
+      expect(mockInvitation.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            email: "new.person@example.com",
+            associationRole: "VOLUNTEER_COORDINATOR",
+            associationScopeType: "DIVISION",
+            associationDivisionId: DIVISION,
+          }),
+        }),
+      );
+    });
+
+    it("refuses a role/scope pairing the matrix does not support", async () => {
+      const result = await inviteAssociationOperator({
+        leagueId: LEAGUE,
+        email: "person@example.com",
+        role: "TREASURER",
+        scopeType: "TEAM",
+        teamId: TEAM,
+      });
+
+      expect(result.success).toBe(false);
+      expect(mockInvitation.create).not.toHaveBeenCalled();
+    });
+
+    it("refuses a caller without association administration", async () => {
+      mockHasCapability.mockResolvedValue(false);
+
+      const result = await inviteAssociationOperator({
+        leagueId: LEAGUE,
+        email: "person@example.com",
+        role: "COACH",
+        scopeType: "TEAM",
+        teamId: TEAM,
+      });
+
+      expect(result.success).toBe(false);
+      expect(mockInvitation.create).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe("applying a responsibility at invitation acceptance", () => {
+  const tx = {
+    associationRoleGrant: { findFirst: vi.fn(), create: vi.fn() },
+  } as unknown as Parameters<typeof applyInvitationResponsibility>[0];
+
+  const txMocks = tx as unknown as {
+    associationRoleGrant: { findFirst: ReturnType<typeof vi.fn>; create: ReturnType<typeof vi.fn> };
+  };
+
+  const invitation = {
+    leagueId: LEAGUE,
+    teamId: TEAM,
+    invitedById: "admin-1",
+    associationRole: "TEAM_MANAGER" as const,
+    associationScopeType: "TEAM" as const,
+    associationDivisionId: null,
+    associationSeasonId: null,
+    associationEventId: null,
+    associationSignupEventId: null,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    txMocks.associationRoleGrant.findFirst.mockResolvedValue(null);
+  });
+
+  it("creates the grant the invitation carried", async () => {
+    await applyInvitationResponsibility(tx, invitation, SUBJECT);
+
+    expect(txMocks.associationRoleGrant.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          userId: SUBJECT,
+          leagueId: LEAGUE,
+          role: "TEAM_MANAGER",
+          scopeType: "TEAM",
+          teamId: TEAM,
+          grantedById: "admin-1",
+        }),
+      }),
+    );
+  });
+
+  it("does nothing when the invitation carries no responsibility", async () => {
+    await applyInvitationResponsibility(
+      tx,
+      { ...invitation, associationRole: null, associationScopeType: null },
+      SUBJECT,
+    );
+
+    expect(txMocks.associationRoleGrant.create).not.toHaveBeenCalled();
+  });
+
+  it("re-validates the pairing so a since-tightened matrix wins", async () => {
+    // The invitation was written when this pairing was allowed; acceptance must
+    // apply today's rules, not the ones in force when it was sent.
+    await applyInvitationResponsibility(
+      tx,
+      { ...invitation, associationRole: "TREASURER", associationScopeType: "TEAM" },
+      SUBJECT,
+    );
+
+    expect(txMocks.associationRoleGrant.create).not.toHaveBeenCalled();
+  });
+
+  it("does not duplicate an existing live grant", async () => {
+    txMocks.associationRoleGrant.findFirst.mockResolvedValue({ id: "existing" });
+
+    await applyInvitationResponsibility(tx, invitation, SUBJECT);
+
+    expect(txMocks.associationRoleGrant.create).not.toHaveBeenCalled();
+  });
+
+  it("skips an invitation with no association", async () => {
+    await applyInvitationResponsibility(tx, { ...invitation, leagueId: null }, SUBJECT);
+
+    expect(txMocks.associationRoleGrant.create).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/lib/actions/gear-inventory.test.ts
+++ b/__tests__/lib/actions/gear-inventory.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
 
-const { mockRequireLeagueRole, mockPrisma, tx } = vi.hoisted(() => {
+const { mockRequireGearPermission, mockPrisma, tx } = vi.hoisted(() => {
   const tx = {
     gearCatalogItem: { create: vi.fn(), findFirst: vi.fn(), update: vi.fn(), count: vi.fn() },
     gearStorageLocation: { findFirst: vi.fn(), create: vi.fn(), update: vi.fn() },
@@ -14,13 +14,17 @@ const { mockRequireLeagueRole, mockPrisma, tx } = vi.hoisted(() => {
   };
   return {
     tx,
-    mockRequireLeagueRole: vi.fn(),
+    mockRequireGearPermission: vi.fn(),
     mockPrisma: { $transaction: vi.fn((callback: (client: typeof tx) => unknown) => callback(tx)) },
   };
 });
 
-vi.mock("@/lib/auth/session", () => ({
-  requireLeagueRole: (...args: unknown[]) => mockRequireLeagueRole(...args),
+// Gear actions authorize through the permission matrix (which honours
+// association role grants), not the legacy league role, so the guard mocked
+// here is requirePermissionForLeague. Behaviour asserted below is unchanged:
+// authorized resolves to the acting user, unauthorized throws.
+vi.mock("@/lib/utils/permissions", () => ({
+  requirePermissionForLeague: (...args: unknown[]) => mockRequireGearPermission(...args),
 }));
 vi.mock("@/lib/db/prisma", () => ({ prisma: mockPrisma }));
 
@@ -40,7 +44,7 @@ const LOCATION_ID = "cbbbbbbbbbbbbbbbbbbbbbbbb";
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mockRequireLeagueRole.mockResolvedValue("cuserrrrrrrrrrrrrrrrrrrrr");
+  mockRequireGearPermission.mockResolvedValue("cuserrrrrrrrrrrrrrrrrrrrr");
   tx.gearCatalogItem.create.mockResolvedValue({ id: CATALOG_ID });
   tx.gearCatalogItem.findFirst.mockResolvedValue({ id: CATALOG_ID, trackingMode: "INDIVIDUAL" });
   tx.gearStorageLocation.findFirst.mockResolvedValue({ id: LOCATION_ID });
@@ -55,7 +59,7 @@ beforeEach(() => {
 
 describe("gear inventory actions", () => {
   it("requires a league admin before creating catalog items", async () => {
-    mockRequireLeagueRole.mockRejectedValue(new Error("Unauthorized"));
+    mockRequireGearPermission.mockRejectedValue(new Error("Unauthorized"));
 
     const result = await createGearCatalogItem({
       leagueId: LEAGUE_ID,

--- a/__tests__/lib/actions/gear-layer-four.test.ts
+++ b/__tests__/lib/actions/gear-layer-four.test.ts
@@ -5,7 +5,7 @@ vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
 
 const {
   mockRequireUserId,
-  mockRequireLeagueRole,
+  mockRequireGearPermission,
   mockGetUserLeagueRole,
   mockIsTeamAdmin,
   mockCheckRateLimit,
@@ -36,7 +36,7 @@ const {
   return {
     tx,
     mockRequireUserId: vi.fn(),
-    mockRequireLeagueRole: vi.fn(),
+    mockRequireGearPermission: vi.fn(),
     mockGetUserLeagueRole: vi.fn(),
     mockIsTeamAdmin: vi.fn(),
     mockCheckRateLimit: vi.fn(),
@@ -56,9 +56,17 @@ const {
 
 vi.mock("@/lib/auth/session", () => ({
   requireUserId: (...args: unknown[]) => mockRequireUserId(...args),
-  requireLeagueRole: (...args: unknown[]) => mockRequireLeagueRole(...args),
+  // Still mocked: the need and reservation actions in this suite continue to
+  // guard on the legacy league role.
+  requireLeagueRole: (...args: unknown[]) => mockRequireGearPermission(...args),
   getUserLeagueRole: (...args: unknown[]) => mockGetUserLeagueRole(...args),
   isTeamAdmin: (...args: unknown[]) => mockIsTeamAdmin(...args),
+}));
+// Wishlist and pledge actions now authorize through the permission matrix, so
+// association role grants reach them. Same mock target: authorized resolves to
+// the acting user, unauthorized throws.
+vi.mock("@/lib/utils/permissions", () => ({
+  requirePermissionForLeague: (...args: unknown[]) => mockRequireGearPermission(...args),
 }));
 vi.mock("@/lib/db/prisma", () => ({ prisma: mockPrisma }));
 vi.mock("@/lib/utils/durable-rate-limit", () => ({
@@ -102,7 +110,7 @@ const USER_ID = "cuuuuuuuuuuuuuuuuuuuuuuuu";
 beforeEach(() => {
   vi.clearAllMocks();
   mockRequireUserId.mockResolvedValue(USER_ID);
-  mockRequireLeagueRole.mockResolvedValue(USER_ID);
+  mockRequireGearPermission.mockResolvedValue(USER_ID);
   mockGetUserLeagueRole.mockResolvedValue("TEAM_ADMIN");
   mockIsTeamAdmin.mockResolvedValue(true);
   mockPrisma.team.findFirst.mockResolvedValue({ id: TEAM_ID });

--- a/__tests__/lib/actions/rsvp-guardians.test.ts
+++ b/__tests__/lib/actions/rsvp-guardians.test.ts
@@ -1,0 +1,168 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockEvent, mockTeamMember, mockLeagueUser, mockRsvp, mockRequireUserId } =
+  vi.hoisted(() => ({
+    mockEvent: { findUnique: vi.fn() },
+    mockTeamMember: { findUnique: vi.fn() },
+    mockLeagueUser: { findFirst: vi.fn() },
+    mockRsvp: { findMany: vi.fn() },
+    mockRequireUserId: vi.fn(),
+  }));
+
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: {
+    event: mockEvent,
+    teamMember: mockTeamMember,
+    leagueUser: mockLeagueUser,
+    rSVP: mockRsvp,
+  },
+}));
+
+vi.mock("@/lib/auth/session", () => ({
+  requireUserId: mockRequireUserId,
+  requireTeamMember: vi.fn(),
+}));
+
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+
+import { getEventAttendance } from "@/lib/actions/rsvp";
+
+const EVENT = "clfevent000000000000000001";
+const LEAGUE = "clfleague0000000000000001";
+const TEAM = "clfteam00000000000000001";
+
+/**
+ * Two guardians answer for two different children on the same event. The
+ * responder identity is family information: organizers may see it, ordinary
+ * team members may not (spec 007 US3, acceptance scenario 4).
+ */
+const rsvpRows = [
+  {
+    status: "GOING",
+    playerId: "player-1",
+    updatedAt: new Date("2026-01-02T00:00:00Z"),
+    user: { name: "Dana Bouchard", email: "dana@example.com" },
+    player: { id: "player-1", name: "Dylan Bouchard" },
+  },
+  {
+    status: "MAYBE",
+    playerId: "player-2",
+    updatedAt: new Date("2026-01-02T00:00:00Z"),
+    user: { name: null, email: "kowalski.household@example.com" },
+    player: { id: "player-2", name: "Sam Kowalski" },
+  },
+];
+
+describe("per-child attendance privacy", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireUserId.mockResolvedValue("viewer-1");
+    mockEvent.findUnique.mockResolvedValue({
+      id: EVENT,
+      teamId: TEAM,
+      leagueId: LEAGUE,
+      team: { leagueId: LEAGUE },
+    });
+    mockRsvp.findMany.mockResolvedValue(rsvpRows);
+    mockLeagueUser.findFirst.mockResolvedValue(null);
+  });
+
+  it("tracks attendance per child for an ordinary team member", async () => {
+    mockTeamMember.findUnique.mockResolvedValue({ role: "MEMBER" });
+
+    const result = await getEventAttendance(EVENT);
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    const players = result.data.entries.filter((entry) => entry.kind === "player");
+    expect(players.map((entry) => entry.name).sort()).toEqual([
+      "Dylan Bouchard",
+      "Sam Kowalski",
+    ]);
+    expect(result.data.counts.GOING).toBe(1);
+    expect(result.data.counts.MAYBE).toBe(1);
+  });
+
+  it("hides the responding guardian from an ordinary team member", async () => {
+    mockTeamMember.findUnique.mockResolvedValue({ role: "MEMBER" });
+
+    const result = await getEventAttendance(EVENT);
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    for (const entry of result.data.entries) {
+      expect(entry.respondedByName).toBeUndefined();
+    }
+
+    // Belt and braces: no guardian name or address anywhere in the payload,
+    // however the shape changes later.
+    const serialized = JSON.stringify(result.data);
+    expect(serialized).not.toContain("Dana Bouchard");
+    expect(serialized).not.toContain("dana@example.com");
+    expect(serialized).not.toContain("kowalski.household@example.com");
+  });
+
+  it("shows the responding guardian to a team admin", async () => {
+    mockTeamMember.findUnique.mockResolvedValue({ role: "ADMIN" });
+
+    const result = await getEventAttendance(EVENT);
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    const dylan = result.data.entries.find((entry) => entry.name === "Dylan Bouchard");
+    expect(dylan?.respondedByName).toBe("Dana Bouchard");
+  });
+
+  it("shows the responding guardian to a league admin who is not on the team", async () => {
+    mockTeamMember.findUnique.mockResolvedValue(null);
+    mockLeagueUser.findFirst.mockResolvedValue({ id: "league-admin-row" });
+
+    const result = await getEventAttendance(EVENT);
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    const sam = result.data.entries.find((entry) => entry.name === "Sam Kowalski");
+    // Falls back to the address only because this account has no display name.
+    expect(sam?.respondedByName).toBe("kowalski.household@example.com");
+  });
+
+  it("refuses a viewer with no relationship to the event", async () => {
+    mockTeamMember.findUnique.mockResolvedValue(null);
+    mockLeagueUser.findFirst.mockResolvedValue(null);
+
+    const result = await getEventAttendance(EVENT);
+
+    expect(result.success).toBe(false);
+  });
+
+  it("keeps one entry per child when several people answered", async () => {
+    mockTeamMember.findUnique.mockResolvedValue({ role: "ADMIN" });
+    mockRsvp.findMany.mockResolvedValue([
+      ...rsvpRows,
+      {
+        status: "NOT_GOING",
+        playerId: "player-1",
+        updatedAt: new Date("2026-01-03T00:00:00Z"),
+        user: { name: "Second Guardian", email: "second@example.com" },
+        player: { id: "player-1", name: "Dylan Bouchard" },
+      },
+    ]);
+
+    const result = await getEventAttendance(EVENT);
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    const dylanEntries = result.data.entries.filter(
+      (entry) => entry.name === "Dylan Bouchard",
+    );
+    expect(dylanEntries).toHaveLength(1);
+    // Latest response wins, and it carries that responder's name.
+    expect(dylanEntries[0].status).toBe("NOT_GOING");
+    expect(dylanEntries[0].respondedByName).toBe("Second Guardian");
+  });
+});

--- a/__tests__/lib/actions/rsvp.test.ts
+++ b/__tests__/lib/actions/rsvp.test.ts
@@ -269,7 +269,11 @@ describe("getEventAttendance", () => {
       leagueId: null,
       team: { leagueId: null },
     });
-    mockPrismaTeamMember.findUnique.mockResolvedValue({ role: "MEMBER" });
+    // ADMIN, not MEMBER: these cases assert *attribution*, and who answered for
+    // a child is organizer-only information as of feature 007 US3. The
+    // member's-eye view — same entries, no responder — is covered in
+    // rsvp-guardians.test.ts.
+    mockPrismaTeamMember.findUnique.mockResolvedValue({ role: "ADMIN" });
   });
 
   it("lists user-level and player-level entries with attribution and counts", async () => {

--- a/__tests__/lib/actions/volunteers.test.ts
+++ b/__tests__/lib/actions/volunteers.test.ts
@@ -3,9 +3,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const {
   mockNeed,
   mockAssignment,
+  mockUser,
   mockTransaction,
   mockRequireUserId,
   mockHasCapability,
+  mockLoadActiveGrants,
+  mockScopeBelongsToLeague,
 } = vi.hoisted(() => ({
   mockNeed: {
     create: vi.fn(),
@@ -20,15 +23,19 @@ const {
     updateMany: vi.fn(),
     findUnique: vi.fn(),
   },
+  mockUser: { findUnique: vi.fn() },
   mockTransaction: vi.fn(),
   mockRequireUserId: vi.fn(),
   mockHasCapability: vi.fn(),
+  mockLoadActiveGrants: vi.fn(),
+  mockScopeBelongsToLeague: vi.fn(),
 }));
 
 vi.mock("@/lib/db/prisma", () => ({
   prisma: {
     volunteerNeed: mockNeed,
     volunteerAssignment: mockAssignment,
+    user: mockUser,
     $transaction: mockTransaction,
   },
 }));
@@ -37,8 +44,18 @@ vi.mock("@/lib/auth/session", () => ({ requireUserId: mockRequireUserId }));
 
 vi.mock("@/lib/auth/capabilities", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/auth/capabilities")>();
-  return { ...actual, hasCapability: mockHasCapability };
+  return {
+    ...actual,
+    hasCapability: mockHasCapability,
+    loadActiveGrants: mockLoadActiveGrants,
+  };
 });
+
+// Tenancy validation shares the grant path's checker; here it is a seam so
+// these tests assert the action's decisions rather than re-testing lookups.
+vi.mock("@/lib/services/association-roles", () => ({
+  scopeBelongsToLeague: mockScopeBelongsToLeague,
+}));
 
 vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
 
@@ -66,6 +83,8 @@ describe("volunteer needs", () => {
     vi.clearAllMocks();
     mockRequireUserId.mockResolvedValue("organizer-1");
     mockHasCapability.mockResolvedValue(true);
+    mockLoadActiveGrants.mockResolvedValue([]);
+    mockScopeBelongsToLeague.mockResolvedValue(true);
     mockNeed.create.mockResolvedValue({ id: NEED });
     mockTransaction.mockResolvedValue([]);
   });
@@ -196,6 +215,8 @@ describe("volunteer assignment and capacity", () => {
     vi.clearAllMocks();
     mockRequireUserId.mockResolvedValue(VOLUNTEER);
     mockHasCapability.mockResolvedValue(true);
+    mockLoadActiveGrants.mockResolvedValue([]);
+    mockScopeBelongsToLeague.mockResolvedValue(true);
     mockAssignment.create.mockResolvedValue({ id: ASSIGNMENT });
     mockAssignment.update.mockResolvedValue({ id: ASSIGNMENT });
   });
@@ -244,26 +265,43 @@ describe("volunteer assignment and capacity", () => {
         status: "INVITED",
         need: acceptedNeed,
       });
+      mockAssignment.updateMany.mockResolvedValue({ count: 1 });
       mockNeed.updateMany.mockResolvedValue({ count: 1 });
+      // Interactive transaction: run the callback against the same mocks so
+      // the two conditional writes are observable.
+      mockTransaction.mockImplementation(async (fn: unknown) =>
+        typeof fn === "function"
+          ? (fn as (client: unknown) => unknown)({
+              volunteerAssignment: mockAssignment,
+              volunteerNeed: mockNeed,
+            })
+          : undefined,
+      );
     });
 
-    it("claims a slot with a guarded conditional update", async () => {
+    it("claims the assignment and a slot inside one transaction", async () => {
       const result = await respondToVolunteerAssignment({
         assignmentId: ASSIGNMENT,
         response: "ACCEPTED",
       });
 
       expect(result).toEqual({ success: true, data: { status: "ACCEPTED" } });
-      // The guard is what makes this atomic: Postgres evaluates
-      // acceptedCount < capacity at write time, so a second caller racing for
-      // the last slot matches zero rows.
+      // Conditional on still being INVITED: this is what stops two requests
+      // for the SAME assignment from each taking a slot on a multi-slot need.
+      expect(mockAssignment.updateMany).toHaveBeenCalledWith({
+        where: { id: ASSIGNMENT, status: "INVITED" },
+        data: expect.objectContaining({ status: "ACCEPTED" }),
+      });
+      // Guarded on capacity: this is what stops two different volunteers from
+      // taking the same last slot. Postgres evaluates it at write time.
       expect(mockNeed.updateMany).toHaveBeenCalledWith({
         where: { id: NEED, status: "OPEN", acceptedCount: { lt: 2 } },
         data: { acceptedCount: { increment: 1 } },
       });
+      expect(mockTransaction).toHaveBeenCalledTimes(1);
     });
 
-    it("reports the need full when the guarded update matches nothing", async () => {
+    it("reports the need full when the capacity guard matches nothing", async () => {
       mockNeed.updateMany.mockResolvedValue({ count: 0 });
 
       const result = await respondToVolunteerAssignment({
@@ -273,11 +311,11 @@ describe("volunteer assignment and capacity", () => {
 
       expect(result.success).toBe(false);
       if (!result.success) expect(result.error).toMatch(/already full/);
-      expect(mockAssignment.update).not.toHaveBeenCalled();
     });
 
-    it("returns the claimed slot if marking the assignment fails", async () => {
-      mockAssignment.update.mockRejectedValue(new Error("write failed"));
+    it("reports an already-answered assignment when the claim matches nothing", async () => {
+      // The row moved out of INVITED between the read and the write.
+      mockAssignment.updateMany.mockResolvedValue({ count: 0 });
 
       const result = await respondToVolunteerAssignment({
         assignmentId: ASSIGNMENT,
@@ -285,11 +323,9 @@ describe("volunteer assignment and capacity", () => {
       });
 
       expect(result.success).toBe(false);
-      // The counter must not stay incremented for a slot nobody holds.
-      expect(mockNeed.updateMany).toHaveBeenLastCalledWith({
-        where: { id: NEED, acceptedCount: { gt: 0 } },
-        data: { acceptedCount: { decrement: 1 } },
-      });
+      if (!result.success) expect(result.error).toMatch(/already been answered/);
+      // The slot is never claimed when the assignment claim fails.
+      expect(mockNeed.updateMany).not.toHaveBeenCalled();
     });
 
     it("does not touch capacity when declining", async () => {
@@ -361,6 +397,7 @@ describe("volunteer board visibility", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockRequireUserId.mockResolvedValue(VOLUNTEER);
+    mockLoadActiveGrants.mockResolvedValue([]);
     mockNeed.findMany.mockResolvedValue([]);
   });
 
@@ -374,8 +411,52 @@ describe("volunteer board visibility", () => {
     expect(args.select.assignments.where).toEqual({});
   });
 
+  it("treats a team-scoped coordinator as an organizer for their own team's needs", async () => {
+    // The bug this covers: asking hasCapability with an empty target classified
+    // every narrow coordinator as a non-organizer, so the people authorized to
+    // run those shifts saw only their own rows.
+    mockHasCapability.mockResolvedValue(false);
+    mockLoadActiveGrants.mockResolvedValue([
+      {
+        role: "VOLUNTEER_COORDINATOR",
+        scopeType: "TEAM",
+        divisionId: null,
+        teamId: TEAM,
+        seasonId: null,
+        eventId: null,
+        signupEventId: null,
+      },
+    ]);
+    mockNeed.findMany.mockResolvedValue([
+      {
+        id: "need-mine", roleLabel: "Scorekeeper", description: null, capacity: 2,
+        acceptedCount: 0, status: "OPEN", startAt: new Date(), endAt: new Date(),
+        timezone: "America/Chicago", teamId: TEAM, divisionId: null, eventId: null,
+        signupEventId: null, team: { name: "Metro Blades", divisionId: null },
+        assignments: [{ id: "a1", status: "ACCEPTED", invitedEmail: null, user: { name: "Sam", email: "s@e.com" } }],
+      },
+      {
+        id: "need-other", roleLabel: "Timekeeper", description: null, capacity: 2,
+        acceptedCount: 0, status: "OPEN", startAt: new Date(), endAt: new Date(),
+        timezone: "America/Chicago", teamId: "other-team", divisionId: null, eventId: null,
+        signupEventId: null, team: { name: "Harbor Hawks", divisionId: null },
+        assignments: [],
+      },
+    ]);
+
+    const result = await getVolunteerBoard(LEAGUE);
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.isOrganizer).toBe(true);
+    // Their own team's need is visible with fulfillment; the other team's is not.
+    expect(result.data.needs.map((n) => n.id)).toEqual(["need-mine"]);
+    expect(result.data.needs[0].assignments).toHaveLength(1);
+  });
+
   it("shows a volunteer only needs they are assigned to, and only their own row", async () => {
     mockHasCapability.mockResolvedValue(false);
+    mockLoadActiveGrants.mockResolvedValue([]);
 
     await getVolunteerBoard(LEAGUE);
 

--- a/__tests__/lib/actions/volunteers.test.ts
+++ b/__tests__/lib/actions/volunteers.test.ts
@@ -1,0 +1,391 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockNeed,
+  mockAssignment,
+  mockTransaction,
+  mockRequireUserId,
+  mockHasCapability,
+} = vi.hoisted(() => ({
+  mockNeed: {
+    create: vi.fn(),
+    update: vi.fn(),
+    updateMany: vi.fn(),
+    findUnique: vi.fn(),
+    findMany: vi.fn(),
+  },
+  mockAssignment: {
+    create: vi.fn(),
+    update: vi.fn(),
+    updateMany: vi.fn(),
+    findUnique: vi.fn(),
+  },
+  mockTransaction: vi.fn(),
+  mockRequireUserId: vi.fn(),
+  mockHasCapability: vi.fn(),
+}));
+
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: {
+    volunteerNeed: mockNeed,
+    volunteerAssignment: mockAssignment,
+    $transaction: mockTransaction,
+  },
+}));
+
+vi.mock("@/lib/auth/session", () => ({ requireUserId: mockRequireUserId }));
+
+vi.mock("@/lib/auth/capabilities", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/auth/capabilities")>();
+  return { ...actual, hasCapability: mockHasCapability };
+});
+
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+
+import {
+  assignVolunteer,
+  cancelVolunteerNeed,
+  completeVolunteerAssignment,
+  createVolunteerNeed,
+  getVolunteerBoard,
+  respondToVolunteerAssignment,
+  updateVolunteerNeed,
+} from "@/lib/actions/volunteers";
+
+const LEAGUE = "clfleague0000000000000001";
+const NEED = "clfneed00000000000000001";
+const ASSIGNMENT = "clfassign000000000000001";
+const TEAM = "clfteam00000000000000001";
+const VOLUNTEER = "clfuser00000000000000001";
+
+const futureStart = new Date("2027-01-01T18:00:00Z");
+const futureEnd = new Date("2027-01-01T20:00:00Z");
+
+describe("volunteer needs", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireUserId.mockResolvedValue("organizer-1");
+    mockHasCapability.mockResolvedValue(true);
+    mockNeed.create.mockResolvedValue({ id: NEED });
+    mockTransaction.mockResolvedValue([]);
+  });
+
+  it("creates a need scoped to a team", async () => {
+    const result = await createVolunteerNeed({
+      leagueId: LEAGUE,
+      roleLabel: "Scorekeeper",
+      capacity: 2,
+      startAt: futureStart,
+      endAt: futureEnd,
+      timezone: "America/Chicago",
+      teamId: TEAM,
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockNeed.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ roleLabel: "Scorekeeper", capacity: 2, teamId: TEAM }),
+      }),
+    );
+  });
+
+  it("checks the capability at the need's own scope, not the association", async () => {
+    await createVolunteerNeed({
+      leagueId: LEAGUE,
+      roleLabel: "Scorekeeper",
+      capacity: 1,
+      startAt: futureStart,
+      endAt: futureEnd,
+      timezone: "America/Chicago",
+      teamId: TEAM,
+    });
+
+    expect(mockHasCapability).toHaveBeenCalledWith(
+      expect.objectContaining({ capability: "manage_volunteers", teamId: TEAM }),
+    );
+  });
+
+  it("refuses a caller without the volunteer capability", async () => {
+    mockHasCapability.mockResolvedValue(false);
+
+    const result = await createVolunteerNeed({
+      leagueId: LEAGUE,
+      roleLabel: "Scorekeeper",
+      capacity: 1,
+      startAt: futureStart,
+      endAt: futureEnd,
+      timezone: "America/Chicago",
+    });
+
+    expect(result.success).toBe(false);
+    expect(mockNeed.create).not.toHaveBeenCalled();
+  });
+
+  it("rejects an interval that ends before it starts", async () => {
+    const result = await createVolunteerNeed({
+      leagueId: LEAGUE,
+      roleLabel: "Scorekeeper",
+      capacity: 1,
+      startAt: futureEnd,
+      endAt: futureStart,
+      timezone: "America/Chicago",
+    });
+
+    expect(result.success).toBe(false);
+    expect(mockNeed.create).not.toHaveBeenCalled();
+  });
+
+  it("rejects a capacity below one", async () => {
+    const result = await createVolunteerNeed({
+      leagueId: LEAGUE,
+      roleLabel: "Scorekeeper",
+      capacity: 0,
+      startAt: futureStart,
+      endAt: futureEnd,
+      timezone: "America/Chicago",
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("refuses to cut capacity below the accepted count", async () => {
+    mockNeed.findUnique.mockResolvedValue({
+      id: NEED,
+      leagueId: LEAGUE,
+      teamId: null,
+      divisionId: null,
+      eventId: null,
+      signupEventId: null,
+      acceptedCount: 3,
+      status: "OPEN",
+    });
+
+    const result = await updateVolunteerNeed({ needId: NEED, capacity: 2 });
+
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toMatch(/3 volunteer/);
+    expect(mockNeed.update).not.toHaveBeenCalled();
+  });
+
+  it("cancels live assignments alongside the need", async () => {
+    mockNeed.findUnique.mockResolvedValue({
+      id: NEED,
+      leagueId: LEAGUE,
+      teamId: null,
+      divisionId: null,
+      eventId: null,
+      signupEventId: null,
+    });
+
+    const result = await cancelVolunteerNeed(NEED);
+
+    expect(result.success).toBe(true);
+    // Both writes go in one transaction so a cancelled need never keeps
+    // assignments that still read as live.
+    expect(mockTransaction).toHaveBeenCalledTimes(1);
+    expect(mockAssignment.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ status: { in: ["INVITED", "ACCEPTED"] } }),
+      }),
+    );
+  });
+});
+
+describe("volunteer assignment and capacity", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireUserId.mockResolvedValue(VOLUNTEER);
+    mockHasCapability.mockResolvedValue(true);
+    mockAssignment.create.mockResolvedValue({ id: ASSIGNMENT });
+    mockAssignment.update.mockResolvedValue({ id: ASSIGNMENT });
+  });
+
+  it("refuses to assign onto a closed need", async () => {
+    mockNeed.findUnique.mockResolvedValue({
+      id: NEED,
+      leagueId: LEAGUE,
+      teamId: null,
+      divisionId: null,
+      eventId: null,
+      signupEventId: null,
+      status: "CLOSED",
+    });
+
+    const result = await assignVolunteer({ needId: NEED, userId: VOLUNTEER });
+
+    expect(result.success).toBe(false);
+    expect(mockAssignment.create).not.toHaveBeenCalled();
+  });
+
+  it("requires exactly one of user or email", async () => {
+    const both = await assignVolunteer({
+      needId: NEED,
+      userId: VOLUNTEER,
+      invitedEmail: "v@example.com",
+    });
+    expect(both.success).toBe(false);
+
+    const neither = await assignVolunteer({ needId: NEED });
+    expect(neither.success).toBe(false);
+  });
+
+  describe("responding", () => {
+    const acceptedNeed = {
+      id: NEED,
+      leagueId: LEAGUE,
+      capacity: 2,
+      status: "OPEN",
+    };
+
+    beforeEach(() => {
+      mockAssignment.findUnique.mockResolvedValue({
+        id: ASSIGNMENT,
+        userId: VOLUNTEER,
+        status: "INVITED",
+        need: acceptedNeed,
+      });
+      mockNeed.updateMany.mockResolvedValue({ count: 1 });
+    });
+
+    it("claims a slot with a guarded conditional update", async () => {
+      const result = await respondToVolunteerAssignment({
+        assignmentId: ASSIGNMENT,
+        response: "ACCEPTED",
+      });
+
+      expect(result).toEqual({ success: true, data: { status: "ACCEPTED" } });
+      // The guard is what makes this atomic: Postgres evaluates
+      // acceptedCount < capacity at write time, so a second caller racing for
+      // the last slot matches zero rows.
+      expect(mockNeed.updateMany).toHaveBeenCalledWith({
+        where: { id: NEED, status: "OPEN", acceptedCount: { lt: 2 } },
+        data: { acceptedCount: { increment: 1 } },
+      });
+    });
+
+    it("reports the need full when the guarded update matches nothing", async () => {
+      mockNeed.updateMany.mockResolvedValue({ count: 0 });
+
+      const result = await respondToVolunteerAssignment({
+        assignmentId: ASSIGNMENT,
+        response: "ACCEPTED",
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) expect(result.error).toMatch(/already full/);
+      expect(mockAssignment.update).not.toHaveBeenCalled();
+    });
+
+    it("returns the claimed slot if marking the assignment fails", async () => {
+      mockAssignment.update.mockRejectedValue(new Error("write failed"));
+
+      const result = await respondToVolunteerAssignment({
+        assignmentId: ASSIGNMENT,
+        response: "ACCEPTED",
+      });
+
+      expect(result.success).toBe(false);
+      // The counter must not stay incremented for a slot nobody holds.
+      expect(mockNeed.updateMany).toHaveBeenLastCalledWith({
+        where: { id: NEED, acceptedCount: { gt: 0 } },
+        data: { acceptedCount: { decrement: 1 } },
+      });
+    });
+
+    it("does not touch capacity when declining", async () => {
+      const result = await respondToVolunteerAssignment({
+        assignmentId: ASSIGNMENT,
+        response: "DECLINED",
+      });
+
+      expect(result).toEqual({ success: true, data: { status: "DECLINED" } });
+      expect(mockNeed.updateMany).not.toHaveBeenCalled();
+    });
+
+    it("refuses to answer somebody else's assignment", async () => {
+      mockAssignment.findUnique.mockResolvedValue({
+        id: ASSIGNMENT,
+        userId: "someone-else",
+        status: "INVITED",
+        need: acceptedNeed,
+      });
+
+      const result = await respondToVolunteerAssignment({
+        assignmentId: ASSIGNMENT,
+        response: "ACCEPTED",
+      });
+
+      expect(result.success).toBe(false);
+      expect(mockNeed.updateMany).not.toHaveBeenCalled();
+    });
+
+    it("refuses to answer twice", async () => {
+      mockAssignment.findUnique.mockResolvedValue({
+        id: ASSIGNMENT,
+        userId: VOLUNTEER,
+        status: "ACCEPTED",
+        need: acceptedNeed,
+      });
+
+      const result = await respondToVolunteerAssignment({
+        assignmentId: ASSIGNMENT,
+        response: "ACCEPTED",
+      });
+
+      expect(result.success).toBe(false);
+      expect(mockNeed.updateMany).not.toHaveBeenCalled();
+    });
+  });
+
+  it("only closes out an accepted assignment", async () => {
+    mockAssignment.findUnique.mockResolvedValue({
+      id: ASSIGNMENT,
+      status: "INVITED",
+      need: {
+        leagueId: LEAGUE,
+        teamId: null,
+        divisionId: null,
+        eventId: null,
+        signupEventId: null,
+      },
+    });
+
+    const result = await completeVolunteerAssignment(ASSIGNMENT);
+
+    expect(result.success).toBe(false);
+    expect(mockAssignment.update).not.toHaveBeenCalled();
+  });
+});
+
+describe("volunteer board visibility", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireUserId.mockResolvedValue(VOLUNTEER);
+    mockNeed.findMany.mockResolvedValue([]);
+  });
+
+  it("shows organizers every need with all assignments", async () => {
+    mockHasCapability.mockResolvedValue(true);
+
+    await getVolunteerBoard(LEAGUE);
+
+    const args = mockNeed.findMany.mock.calls[0][0];
+    expect(args.where).toEqual({ leagueId: LEAGUE });
+    expect(args.select.assignments.where).toEqual({});
+  });
+
+  it("shows a volunteer only needs they are assigned to, and only their own row", async () => {
+    mockHasCapability.mockResolvedValue(false);
+
+    await getVolunteerBoard(LEAGUE);
+
+    const args = mockNeed.findMany.mock.calls[0][0];
+    // Both halves matter: the need filter hides other people's shifts, and the
+    // assignment filter stops a volunteer reading who else was rostered.
+    expect(args.where).toEqual({
+      leagueId: LEAGUE,
+      assignments: { some: { userId: VOLUNTEER } },
+    });
+    expect(args.select.assignments.where).toEqual({ userId: VOLUNTEER });
+  });
+});

--- a/__tests__/lib/auth/capabilities.test.ts
+++ b/__tests__/lib/auth/capabilities.test.ts
@@ -1,0 +1,372 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { findMany, getUserLeagueAccessLevel, teamFindFirst } = vi.hoisted(() => ({
+  findMany: vi.fn(),
+  getUserLeagueAccessLevel: vi.fn(),
+  teamFindFirst: vi.fn(),
+}));
+
+vi.mock("@/lib/utils/security", () => ({
+  LeagueAccessLevel: {
+    NONE: "NONE",
+    MEMBER: "MEMBER",
+    TEAM_ADMIN: "TEAM_ADMIN",
+    LEAGUE_ADMIN: "LEAGUE_ADMIN",
+  },
+  getUserLeagueAccessLevel,
+}));
+
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: {
+    associationRoleGrant: { findMany },
+    team: { findFirst: teamFindFirst },
+  },
+}));
+
+import {
+  Capability,
+  ROLE_CAPABILITY_MATRIX,
+  hasCapability,
+} from "@/lib/auth/capabilities";
+
+type GrantRow = {
+  role: string;
+  scopeType: string;
+  leagueId?: string;
+  divisionId?: string | null;
+  teamId?: string | null;
+  seasonId?: string | null;
+  eventId?: string | null;
+  signupEventId?: string | null;
+};
+
+/** Shape a grant the way the resolver reads it out of Prisma. */
+function grant(row: GrantRow) {
+  return {
+    leagueId: "league-1",
+    divisionId: null,
+    teamId: null,
+    seasonId: null,
+    eventId: null,
+    signupEventId: null,
+    ...row,
+  };
+}
+
+const base = { userId: "user-1", leagueId: "league-1" } as const;
+
+describe("association capability matrix", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: an ordinary member with no legacy admin standing, so every
+    // result below is attributable to a grant rather than legacy compatibility.
+    getUserLeagueAccessLevel.mockResolvedValue("MEMBER");
+    findMany.mockResolvedValue([]);
+    teamFindFirst.mockResolvedValue(null);
+  });
+
+  describe("matrix shape", () => {
+    it("declares an allowlist for every role", () => {
+      // Fail-closed by construction: a role with no entry grants nothing rather
+      // than falling through to a permissive default.
+      for (const [role, entry] of Object.entries(ROLE_CAPABILITY_MATRIX)) {
+        expect(Array.isArray(entry.capabilities), `${role} capabilities`).toBe(true);
+        expect(entry.scopes.length, `${role} scopes`).toBeGreaterThan(0);
+      }
+    });
+
+    it("confines the treasurer to association-scoped payments", () => {
+      const entry = ROLE_CAPABILITY_MATRIX.TREASURER;
+      expect(entry.capabilities).toEqual([Capability.MANAGE_PAYMENTS]);
+      expect(entry.scopes).toEqual(["ASSOCIATION"]);
+    });
+
+    it("gives the equipment manager no association capability of its own", () => {
+      // Equipment managers act only through the existing gear Permission checks
+      // (see permissions-gear.test.ts); they hold no scheduling, finance, or
+      // administrative capability here.
+      expect(ROLE_CAPABILITY_MATRIX.EQUIPMENT_MANAGER.capabilities).toEqual([]);
+    });
+  });
+
+  describe("least-privilege per role", () => {
+    it("lets a scheduler manage schedules but not payments or rosters", async () => {
+      findMany.mockResolvedValue([grant({ role: "SCHEDULER", scopeType: "ASSOCIATION" })]);
+
+      await expect(
+        hasCapability({ ...base, capability: Capability.MANAGE_SCHEDULE }),
+      ).resolves.toBe(true);
+      await expect(
+        hasCapability({ ...base, capability: Capability.MANAGE_PAYMENTS }),
+      ).resolves.toBe(false);
+      await expect(
+        hasCapability({ ...base, capability: Capability.MANAGE_ROSTER }),
+      ).resolves.toBe(false);
+    });
+
+    it("lets a registrar manage rosters but not schedules", async () => {
+      findMany.mockResolvedValue([grant({ role: "REGISTRAR", scopeType: "ASSOCIATION" })]);
+
+      await expect(
+        hasCapability({ ...base, capability: Capability.MANAGE_ROSTER }),
+      ).resolves.toBe(true);
+      await expect(
+        hasCapability({ ...base, capability: Capability.MANAGE_SCHEDULE }),
+      ).resolves.toBe(false);
+    });
+
+    it("lets a treasurer manage payments but not public content", async () => {
+      findMany.mockResolvedValue([grant({ role: "TREASURER", scopeType: "ASSOCIATION" })]);
+
+      await expect(
+        hasCapability({ ...base, capability: Capability.MANAGE_PAYMENTS }),
+      ).resolves.toBe(true);
+      await expect(
+        hasCapability({ ...base, capability: Capability.MANAGE_PUBLIC_CONTENT }),
+      ).resolves.toBe(false);
+    });
+
+    it("lets a communications lead publish content but not administer the association", async () => {
+      findMany.mockResolvedValue([
+        grant({ role: "COMMUNICATIONS_LEAD", scopeType: "ASSOCIATION" }),
+      ]);
+
+      await expect(
+        hasCapability({ ...base, capability: Capability.MANAGE_PUBLIC_CONTENT }),
+      ).resolves.toBe(true);
+      await expect(
+        hasCapability({ ...base, capability: Capability.ADMINISTER_ASSOCIATION }),
+      ).resolves.toBe(false);
+    });
+
+    it("confines a coach to practice work on the granted team", async () => {
+      findMany.mockResolvedValue([
+        grant({ role: "COACH", scopeType: "TEAM", teamId: "team-1" }),
+      ]);
+
+      await expect(
+        hasCapability({ ...base, capability: Capability.MANAGE_PRACTICE, teamId: "team-1" }),
+      ).resolves.toBe(true);
+      await expect(
+        hasCapability({ ...base, capability: Capability.MANAGE_PRACTICE, teamId: "team-2" }),
+      ).resolves.toBe(false);
+      await expect(
+        hasCapability({ ...base, capability: Capability.MANAGE_TEAM, teamId: "team-1" }),
+      ).resolves.toBe(false);
+    });
+
+    it("confines a team manager to the exact granted team", async () => {
+      findMany.mockResolvedValue([
+        grant({ role: "TEAM_MANAGER", scopeType: "TEAM", teamId: "team-1" }),
+      ]);
+
+      await expect(
+        hasCapability({ ...base, capability: Capability.MANAGE_TEAM, teamId: "team-1" }),
+      ).resolves.toBe(true);
+      await expect(
+        hasCapability({ ...base, capability: Capability.MANAGE_ROSTER, teamId: "team-1" }),
+      ).resolves.toBe(true);
+      await expect(
+        hasCapability({ ...base, capability: Capability.MANAGE_TEAM, teamId: "team-2" }),
+      ).resolves.toBe(false);
+      // No association-wide reach, even for a capability the role does hold.
+      await expect(
+        hasCapability({ ...base, capability: Capability.MANAGE_ROSTER }),
+      ).resolves.toBe(false);
+    });
+
+    it("lets a volunteer coordinator work at event scope without event administration", async () => {
+      findMany.mockResolvedValue([
+        grant({ role: "VOLUNTEER_COORDINATOR", scopeType: "EVENT", eventId: "event-1" }),
+      ]);
+
+      await expect(
+        hasCapability({ ...base, capability: Capability.MANAGE_VOLUNTEERS, eventId: "event-1" }),
+      ).resolves.toBe(true);
+      await expect(
+        hasCapability({ ...base, capability: Capability.MANAGE_EVENT, eventId: "event-1" }),
+      ).resolves.toBe(false);
+      await expect(
+        hasCapability({ ...base, capability: Capability.MANAGE_VOLUNTEERS, eventId: "event-2" }),
+      ).resolves.toBe(false);
+    });
+
+    it("confines an event manager to the exact event", async () => {
+      findMany.mockResolvedValue([
+        grant({ role: "EVENT_MANAGER", scopeType: "EVENT", eventId: "event-1" }),
+      ]);
+
+      await expect(
+        hasCapability({ ...base, capability: Capability.MANAGE_EVENT, eventId: "event-1" }),
+      ).resolves.toBe(true);
+      await expect(
+        hasCapability({ ...base, capability: Capability.MANAGE_EVENT, eventId: "event-2" }),
+      ).resolves.toBe(false);
+      // Managing one event confers nothing over the association hosting it.
+      await expect(
+        hasCapability({ ...base, capability: Capability.ADMINISTER_ASSOCIATION }),
+      ).resolves.toBe(false);
+    });
+  });
+
+  describe("scope ancestry", () => {
+    it("lets an association-scoped grant reach a team within it", async () => {
+      findMany.mockResolvedValue([grant({ role: "REGISTRAR", scopeType: "ASSOCIATION" })]);
+
+      await expect(
+        hasCapability({ ...base, capability: Capability.MANAGE_ROSTER, teamId: "team-1" }),
+      ).resolves.toBe(true);
+    });
+
+    it("lets a division-scoped grant reach a team currently in that division", async () => {
+      findMany.mockResolvedValue([
+        grant({ role: "REGISTRAR", scopeType: "DIVISION", divisionId: "division-1" }),
+      ]);
+      teamFindFirst.mockResolvedValue({ id: "team-1" });
+
+      await expect(
+        hasCapability({ ...base, capability: Capability.MANAGE_ROSTER, teamId: "team-1" }),
+      ).resolves.toBe(true);
+      expect(teamFindFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ id: "team-1", divisionId: "division-1" }),
+        }),
+      );
+    });
+
+    it("rejects a division-scoped grant for a team outside the division", async () => {
+      findMany.mockResolvedValue([
+        grant({ role: "REGISTRAR", scopeType: "DIVISION", divisionId: "division-1" }),
+      ]);
+      teamFindFirst.mockResolvedValue(null);
+
+      await expect(
+        hasCapability({ ...base, capability: Capability.MANAGE_ROSTER, teamId: "team-9" }),
+      ).resolves.toBe(false);
+    });
+
+    it("never widens a narrow grant to the whole association", async () => {
+      // A team-scoped grant asked about association-wide work has no target to
+      // check against and must fail rather than defaulting to "any team".
+      findMany.mockResolvedValue([
+        grant({ role: "REGISTRAR", scopeType: "TEAM", teamId: "team-1" }),
+      ]);
+
+      await expect(
+        hasCapability({ ...base, capability: Capability.MANAGE_ROSTER }),
+      ).resolves.toBe(false);
+    });
+
+    it("ignores a grant belonging to a different association", async () => {
+      // The resolver scopes its query by league; assert the filter rather than
+      // trusting the caller to have pre-filtered.
+      await hasCapability({ ...base, capability: Capability.MANAGE_ROSTER });
+
+      expect(findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            userId: "user-1",
+            leagueId: "league-1",
+            state: "ACTIVE",
+          }),
+        }),
+      );
+    });
+
+    it("ignores revoked grants", async () => {
+      await hasCapability({ ...base, capability: Capability.MANAGE_ROSTER });
+
+      const where = findMany.mock.calls[0][0].where;
+      expect(where.state).toBe("ACTIVE");
+    });
+  });
+
+  describe("unsupported role/scope combinations fail closed", () => {
+    it("refuses a treasurer grant recorded at team scope", async () => {
+      // TREASURER supports ASSOCIATION only. A row that somehow carries a team
+      // scope must not authorize anything.
+      findMany.mockResolvedValue([
+        grant({ role: "TREASURER", scopeType: "TEAM", teamId: "team-1" }),
+      ]);
+
+      await expect(
+        hasCapability({ ...base, capability: Capability.MANAGE_PAYMENTS, teamId: "team-1" }),
+      ).resolves.toBe(false);
+    });
+
+    it("refuses an event-manager grant recorded at association scope", async () => {
+      findMany.mockResolvedValue([
+        grant({ role: "EVENT_MANAGER", scopeType: "ASSOCIATION" }),
+      ]);
+
+      await expect(
+        hasCapability({ ...base, capability: Capability.MANAGE_EVENT, eventId: "event-1" }),
+      ).resolves.toBe(false);
+    });
+
+    it("refuses an unknown role", async () => {
+      findMany.mockResolvedValue([
+        grant({ role: "NOT_A_REAL_ROLE", scopeType: "ASSOCIATION" }),
+      ]);
+
+      await expect(
+        hasCapability({ ...base, capability: Capability.ADMINISTER_ASSOCIATION }),
+      ).resolves.toBe(false);
+    });
+  });
+
+  describe("legacy administrator compatibility", () => {
+    it("keeps existing league admins fully capable before the backfill runs", async () => {
+      getUserLeagueAccessLevel.mockResolvedValue("LEAGUE_ADMIN");
+      findMany.mockResolvedValue([]);
+
+      await expect(
+        hasCapability({ ...base, capability: Capability.ADMINISTER_ASSOCIATION }),
+      ).resolves.toBe(true);
+      await expect(
+        hasCapability({ ...base, capability: Capability.MANAGE_PAYMENTS }),
+      ).resolves.toBe(true);
+      await expect(
+        hasCapability({ ...base, capability: Capability.MANAGE_TEAM, teamId: "team-1" }),
+      ).resolves.toBe(true);
+    });
+
+    it("keeps existing team admins managing their own team", async () => {
+      getUserLeagueAccessLevel.mockResolvedValue("TEAM_ADMIN");
+      teamFindFirst.mockResolvedValue({ id: "team-1" });
+
+      await expect(
+        hasCapability({ ...base, capability: Capability.MANAGE_TEAM, teamId: "team-1" }),
+      ).resolves.toBe(true);
+    });
+
+    it("does not let a team admin administer the association", async () => {
+      getUserLeagueAccessLevel.mockResolvedValue("TEAM_ADMIN");
+
+      await expect(
+        hasCapability({ ...base, capability: Capability.ADMINISTER_ASSOCIATION }),
+      ).resolves.toBe(false);
+    });
+
+    it("grants a plain member nothing", async () => {
+      getUserLeagueAccessLevel.mockResolvedValue("MEMBER");
+
+      for (const capability of Object.values(Capability)) {
+        await expect(
+          hasCapability({ ...base, capability, teamId: "team-1" }),
+        ).resolves.toBe(false);
+      }
+    });
+
+    it("never derives capability from a descriptive official title", async () => {
+      // TeamOfficial is a label, not an authorization source (spec 007 US3).
+      // The resolver must read grants only.
+      getUserLeagueAccessLevel.mockResolvedValue("MEMBER");
+      findMany.mockResolvedValue([]);
+
+      await expect(
+        hasCapability({ ...base, capability: Capability.MANAGE_TEAM, teamId: "team-1" }),
+      ).resolves.toBe(false);
+    });
+  });
+});

--- a/__tests__/lib/data/association-operations.test.ts
+++ b/__tests__/lib/data/association-operations.test.ts
@@ -11,7 +11,9 @@ const { mockPrisma, mockAuth } = vi.hoisted(() => ({
     teamGearNeed: { findMany: vi.fn() },
     gearReservation: { findMany: vi.fn() },
     notificationOutbox: { findMany: vi.fn() },
-    volunteerNeed: { findMany: vi.fn() },
+    // `fields` backs the Prisma field reference the shortage query uses to
+    // compare acceptedCount against capacity in the database.
+    volunteerNeed: { findMany: vi.fn(), fields: { capacity: "capacity" } },
   },
   mockAuth: { requireLeagueRole: vi.fn() },
 }));
@@ -27,7 +29,7 @@ const to = new Date("2026-10-01T00:00:00.000Z");
 beforeEach(() => {
   vi.clearAllMocks();
   mockAuth.requireLeagueRole.mockResolvedValue("user-1");
-  for (const model of Object.values(mockPrisma)) model.findMany.mockResolvedValue([]);
+  for (const model of Object.values(mockPrisma)) model.findMany?.mockResolvedValue([]);
 });
 
 describe("getAssociationOperationsData", () => {

--- a/__tests__/lib/data/association-operations.test.ts
+++ b/__tests__/lib/data/association-operations.test.ts
@@ -11,6 +11,7 @@ const { mockPrisma, mockAuth } = vi.hoisted(() => ({
     teamGearNeed: { findMany: vi.fn() },
     gearReservation: { findMany: vi.fn() },
     notificationOutbox: { findMany: vi.fn() },
+    volunteerNeed: { findMany: vi.fn() },
   },
   mockAuth: { requireLeagueRole: vi.fn() },
 }));

--- a/__tests__/lib/utils/permissions-gear.test.ts
+++ b/__tests__/lib/utils/permissions-gear.test.ts
@@ -1,8 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { findFirst, getUserLeagueAccessLevel } = vi.hoisted(() => ({
+const { findFirst, getUserLeagueAccessLevel, grantFindMany, teamFindFirst } = vi.hoisted(() => ({
   findFirst: vi.fn(),
   getUserLeagueAccessLevel: vi.fn(),
+  grantFindMany: vi.fn(),
+  teamFindFirst: vi.fn(),
 }));
 
 vi.mock("@/lib/utils/security", () => ({
@@ -18,7 +20,13 @@ vi.mock("@/lib/utils/security", () => ({
 }));
 
 vi.mock("@/lib/db/prisma", () => ({
-  prisma: { teamMember: { findFirst } },
+  prisma: {
+    teamMember: { findFirst },
+    // Equipment-manager grants are consulted through the same hasPermission
+    // entry point, so the gear tests need the grant resolver's surface too.
+    associationRoleGrant: { findMany: grantFindMany },
+    team: { findFirst: teamFindFirst },
+  },
 }));
 
 import { hasPermission, Permission } from "@/lib/utils/permissions";
@@ -27,6 +35,8 @@ describe("team-scoped gear permissions", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     getUserLeagueAccessLevel.mockResolvedValue("TEAM_ADMIN");
+    grantFindMany.mockResolvedValue([]);
+    teamFindFirst.mockResolvedValue(null);
   });
 
   it("fails closed when a team-scoped gear permission omits teamId", async () => {
@@ -58,5 +68,207 @@ describe("team-scoped gear permissions", () => {
     await expect(
       hasPermission("user-1", "league-1", Permission.REQUEST_TEAM_GEAR, "team-2"),
     ).resolves.toBe(true);
+  });
+});
+
+/**
+ * Equipment-manager grants authorize gear work through the existing gear
+ * Permission values and the existing hasPermission entry point. They do not get
+ * a parallel checker, because the gear actions call hasPermission and would
+ * never consult one (spec 007 US3 / contracts).
+ *
+ * Scope matrix (data-model.md §6):
+ *   Association → inventory + wishlist, and team need/request for ANY team
+ *   Division    → team need/request for teams currently in the division
+ *   Team        → team need/request for that exact team
+ *   Season/Event→ nothing; fails closed
+ */
+describe("equipment-manager gear delegation", () => {
+  const equipmentGrant = (scopeType: string, extra: Record<string, unknown> = {}) => ({
+    role: "EQUIPMENT_MANAGER",
+    scopeType,
+    leagueId: "league-1",
+    divisionId: null,
+    teamId: null,
+    seasonId: null,
+    eventId: null,
+    signupEventId: null,
+    ...extra,
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // A plain member: every allowed result below comes from the grant alone.
+    getUserLeagueAccessLevel.mockResolvedValue("MEMBER");
+    findFirst.mockResolvedValue(null);
+    teamFindFirst.mockResolvedValue(null);
+    grantFindMany.mockResolvedValue([]);
+  });
+
+  describe("association scope", () => {
+    beforeEach(() => {
+      grantFindMany.mockResolvedValue([equipmentGrant("ASSOCIATION")]);
+    });
+
+    it("allows inventory and wishlist administration", async () => {
+      await expect(
+        hasPermission("user-1", "league-1", Permission.MANAGE_GEAR_INVENTORY),
+      ).resolves.toBe(true);
+      await expect(
+        hasPermission("user-1", "league-1", Permission.MANAGE_GEAR_WISHLIST),
+      ).resolves.toBe(true);
+    });
+
+    it("allows team need/request work for any team in the association", async () => {
+      await expect(
+        hasPermission("user-1", "league-1", Permission.CREATE_TEAM_GEAR_NEED, "team-7"),
+      ).resolves.toBe(true);
+      await expect(
+        hasPermission("user-1", "league-1", Permission.REQUEST_TEAM_GEAR, "team-7"),
+      ).resolves.toBe(true);
+    });
+
+    it("still requires the team to be named for team-scoped gear work", async () => {
+      // Mandatory teamId: an association-wide gear grant does not make a
+      // team-scoped permission league-wide by omission.
+      await expect(
+        hasPermission("user-1", "league-1", Permission.CREATE_TEAM_GEAR_NEED),
+      ).resolves.toBe(false);
+      await expect(
+        hasPermission("user-1", "league-1", Permission.REQUEST_TEAM_GEAR),
+      ).resolves.toBe(false);
+    });
+
+    it("grants no scheduling, finance, or administrative permission", async () => {
+      for (const permission of [
+        Permission.UPDATE_LEAGUE,
+        Permission.CREATE_EVENT,
+        Permission.VIEW_FINANCIAL_REPORTS,
+        Permission.ASSIGN_LEAGUE_ROLE,
+      ]) {
+        await expect(
+          hasPermission("user-1", "league-1", permission, "team-7"),
+        ).resolves.toBe(false);
+      }
+    });
+  });
+
+  describe("division scope", () => {
+    beforeEach(() => {
+      grantFindMany.mockResolvedValue([
+        equipmentGrant("DIVISION", { divisionId: "division-1" }),
+      ]);
+    });
+
+    it("allows team need/request work for a team in the division", async () => {
+      teamFindFirst.mockResolvedValue({ id: "team-1" });
+
+      await expect(
+        hasPermission("user-1", "league-1", Permission.CREATE_TEAM_GEAR_NEED, "team-1"),
+      ).resolves.toBe(true);
+    });
+
+    it("refuses a team outside the division", async () => {
+      teamFindFirst.mockResolvedValue(null);
+
+      await expect(
+        hasPermission("user-1", "league-1", Permission.CREATE_TEAM_GEAR_NEED, "team-9"),
+      ).resolves.toBe(false);
+    });
+
+    it("does not confer inventory or wishlist administration", async () => {
+      await expect(
+        hasPermission("user-1", "league-1", Permission.MANAGE_GEAR_INVENTORY),
+      ).resolves.toBe(false);
+      await expect(
+        hasPermission("user-1", "league-1", Permission.MANAGE_GEAR_WISHLIST),
+      ).resolves.toBe(false);
+    });
+  });
+
+  describe("team scope", () => {
+    beforeEach(() => {
+      grantFindMany.mockResolvedValue([equipmentGrant("TEAM", { teamId: "team-1" })]);
+    });
+
+    it("allows need/request work for the exact team", async () => {
+      await expect(
+        hasPermission("user-1", "league-1", Permission.REQUEST_TEAM_GEAR, "team-1"),
+      ).resolves.toBe(true);
+    });
+
+    it("refuses any other team", async () => {
+      await expect(
+        hasPermission("user-1", "league-1", Permission.REQUEST_TEAM_GEAR, "team-2"),
+      ).resolves.toBe(false);
+    });
+
+    it("does not confer inventory or wishlist administration", async () => {
+      await expect(
+        hasPermission("user-1", "league-1", Permission.MANAGE_GEAR_INVENTORY),
+      ).resolves.toBe(false);
+    });
+  });
+
+  describe("unsupported scopes fail closed", () => {
+    it.each([
+      ["SEASON", { seasonId: "season-1" }],
+      ["EVENT", { eventId: "event-1" }],
+      ["SIGNUP_EVENT", { signupEventId: "signup-1" }],
+    ])("refuses every gear permission at %s scope", async (scopeType, extra) => {
+      grantFindMany.mockResolvedValue([equipmentGrant(scopeType, extra)]);
+
+      for (const permission of [
+        Permission.MANAGE_GEAR_INVENTORY,
+        Permission.MANAGE_GEAR_WISHLIST,
+        Permission.CREATE_TEAM_GEAR_NEED,
+        Permission.REQUEST_TEAM_GEAR,
+      ]) {
+        await expect(
+          hasPermission("user-1", "league-1", permission, "team-1"),
+        ).resolves.toBe(false);
+      }
+    });
+  });
+
+  describe("team-manager gear delegation", () => {
+    it("allows only need/request work on the exact team", async () => {
+      grantFindMany.mockResolvedValue([
+        { ...equipmentGrant("TEAM", { teamId: "team-1" }), role: "TEAM_MANAGER" },
+      ]);
+
+      await expect(
+        hasPermission("user-1", "league-1", Permission.CREATE_TEAM_GEAR_NEED, "team-1"),
+      ).resolves.toBe(true);
+      await expect(
+        hasPermission("user-1", "league-1", Permission.REQUEST_TEAM_GEAR, "team-1"),
+      ).resolves.toBe(true);
+      await expect(
+        hasPermission("user-1", "league-1", Permission.CREATE_TEAM_GEAR_NEED, "team-2"),
+      ).resolves.toBe(false);
+      await expect(
+        hasPermission("user-1", "league-1", Permission.MANAGE_GEAR_INVENTORY),
+      ).resolves.toBe(false);
+    });
+  });
+
+  describe("non-gear roles get no gear access", () => {
+    it.each(["SCHEDULER", "REGISTRAR", "TREASURER", "COMMUNICATIONS_LEAD", "COACH"])(
+      "refuses gear permissions for %s",
+      async (role) => {
+        grantFindMany.mockResolvedValue([{ ...equipmentGrant("ASSOCIATION"), role }]);
+
+        for (const permission of [
+          Permission.MANAGE_GEAR_INVENTORY,
+          Permission.MANAGE_GEAR_WISHLIST,
+          Permission.CREATE_TEAM_GEAR_NEED,
+          Permission.REQUEST_TEAM_GEAR,
+        ]) {
+          await expect(
+            hasPermission("user-1", "league-1", permission, "team-1"),
+          ).resolves.toBe(false);
+        }
+      },
+    );
   });
 });

--- a/app/(dashboard)/league/[leagueId]/workforce/page.tsx
+++ b/app/(dashboard)/league/[leagueId]/workforce/page.tsx
@@ -42,17 +42,16 @@ export default async function WorkforcePage({
 
   const { isOrganizer, needs } = volunteerBoard.data;
 
-  // Nothing to administer and no shifts of their own: this route has no
-  // content for them, and its existence is not worth advertising.
-  if (!canAdminister && !isOrganizer && needs.length === 0) {
-    notFound();
-  }
+  // Deliberately NOT a 404 for members with no shifts: the nav entry is shown
+  // to every league user, and a link that 404s is worse than a page saying
+  // there is nothing here yet. Non-members are already excluded — the board
+  // query is league-scoped and getVolunteerBoard fails for them.
 
   const [grantsResult, teams, membership] = await Promise.all([
     canAdminister
       ? listAssociationResponsibilityGrants(leagueId)
       : Promise.resolve(null),
-    canAdminister
+    canAdminister || volunteerBoard.data.isOrganizer
       ? prisma.team.findMany({
           where: { leagueId, isActive: true },
           select: { id: true, name: true, sport: true, season: true },
@@ -103,7 +102,13 @@ export default async function WorkforcePage({
           <Typography variant="h5" component="h2" gutterBottom>
             {isOrganizer ? "Volunteers" : "My shifts"}
           </Typography>
-          <VolunteerBoard needs={needs} isOrganizer={isOrganizer} currentUserId={userId} />
+          <VolunteerBoard
+            leagueId={leagueId}
+            teams={teams.map((team) => ({ id: team.id, name: team.name }))}
+            needs={needs}
+            isOrganizer={isOrganizer}
+            currentUserId={userId}
+          />
         </Box>
 
         {canAdminister ? (

--- a/app/(dashboard)/league/[leagueId]/workforce/page.tsx
+++ b/app/(dashboard)/league/[leagueId]/workforce/page.tsx
@@ -1,0 +1,145 @@
+import { notFound } from "next/navigation";
+import { Box, Divider, Stack, Typography } from "@mui/material";
+
+import { PageContainer } from "@/components/ui/PageContainer";
+import { PageHeader } from "@/components/ui/PageHeader";
+import { prisma } from "@/lib/db/prisma";
+import { requireUserId } from "@/lib/auth/session";
+import { Capability, hasCapability } from "@/lib/auth/capabilities";
+import { listAssociationResponsibilityGrants } from "@/lib/actions/association-roles";
+import { getVolunteerBoard } from "@/lib/actions/volunteers";
+import RoleGrantManager from "@/components/features/workforce/RoleGrantManager";
+import VolunteerBoard from "@/components/features/workforce/VolunteerBoard";
+import { UserPermissionManager } from "@/components/features/admin/UserPermissionManager";
+import { TeamPermissionManager } from "@/components/features/admin/TeamPermissionManager";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Workforce: who may do what, and who is staffing the season.
+ *
+ * Two audiences share this route. Administrators get the delegation surface and
+ * the existing membership/role managers; a volunteer with no organizing
+ * capability gets only their own shifts. The page never 404s for the second
+ * group — having volunteer work is reason enough to be here.
+ */
+export default async function WorkforcePage({
+  params,
+}: {
+  params: Promise<{ leagueId: string }>;
+}) {
+  const { leagueId } = await params;
+  const userId = await requireUserId();
+
+  const [canAdminister, volunteerBoard] = await Promise.all([
+    hasCapability({ userId, leagueId, capability: Capability.ADMINISTER_ASSOCIATION }),
+    getVolunteerBoard(leagueId),
+  ]);
+
+  if (!volunteerBoard.success) {
+    notFound();
+  }
+
+  const { isOrganizer, needs } = volunteerBoard.data;
+
+  // Nothing to administer and no shifts of their own: this route has no
+  // content for them, and its existence is not worth advertising.
+  if (!canAdminister && !isOrganizer && needs.length === 0) {
+    notFound();
+  }
+
+  const [grantsResult, teams, membership] = await Promise.all([
+    canAdminister
+      ? listAssociationResponsibilityGrants(leagueId)
+      : Promise.resolve(null),
+    canAdminister
+      ? prisma.team.findMany({
+          where: { leagueId, isActive: true },
+          select: { id: true, name: true, sport: true, season: true },
+          orderBy: { name: "asc" },
+        })
+      : Promise.resolve([]),
+    prisma.leagueUser.findFirst({
+      where: { userId, leagueId },
+      select: { role: true },
+    }),
+  ]);
+
+  const divisions = canAdminister
+    ? await prisma.division.findMany({
+        where: { leagueId, isActive: true },
+        select: { id: true, name: true },
+        orderBy: { name: "asc" },
+      })
+    : [];
+
+  const currentUserRole = (membership?.role ?? "MEMBER") as
+    | "LEAGUE_ADMIN"
+    | "TEAM_ADMIN"
+    | "MEMBER";
+
+  return (
+    <PageContainer maxWidth="lg">
+      <PageHeader
+        title="Workforce"
+        subtitle={
+          canAdminister
+            ? "Delegate bounded responsibilities and staff the season with volunteers."
+            : "Your volunteer shifts."
+        }
+      />
+
+      <Stack spacing={4}>
+        {canAdminister && grantsResult?.success ? (
+          <RoleGrantManager
+            leagueId={leagueId}
+            grants={grantsResult.data}
+            divisions={divisions}
+            teams={teams.map((team) => ({ id: team.id, name: team.name }))}
+          />
+        ) : null}
+
+        <Box>
+          <Typography variant="h5" component="h2" gutterBottom>
+            {isOrganizer ? "Volunteers" : "My shifts"}
+          </Typography>
+          <VolunteerBoard needs={needs} isOrganizer={isOrganizer} currentUserId={userId} />
+        </Box>
+
+        {canAdminister ? (
+          <>
+            <Divider />
+            {/*
+              Mounted rather than reimplemented: league membership roles and
+              team admin membership already have working managers, and a second
+              set would be one more place for the two to disagree about who
+              holds what.
+            */}
+            <Box>
+              <Typography variant="h5" component="h2" gutterBottom>
+                League membership
+              </Typography>
+              <UserPermissionManager
+                leagueId={leagueId}
+                currentUserId={userId}
+                currentUserRole={currentUserRole}
+              />
+            </Box>
+
+            <Box>
+              <Typography variant="h5" component="h2" gutterBottom>
+                Team membership
+              </Typography>
+              <TeamPermissionManager
+                leagueId={leagueId}
+                teams={teams}
+                currentUserId={userId}
+                currentUserRole={currentUserRole}
+              />
+            </Box>
+          </>
+        ) : null}
+      </Stack>
+    </PageContainer>
+  );
+}

--- a/components/features/admin/UserPermissionManager.tsx
+++ b/components/features/admin/UserPermissionManager.tsx
@@ -42,8 +42,8 @@ import {
     type AssignLeagueRoleInput,
     type RemoveLeagueRoleInput,
 } from "@/lib/actions/permissions";
-import { LeagueAccessLevel } from "@/lib/utils/security";
-import { Permission } from "@/lib/utils/permissions";
+import { LeagueAccessLevel } from "@/lib/utils/access-levels";
+import type { Permission } from "@/lib/utils/permissions";
 
 interface UserPermissionManagerProps {
     leagueId: string;

--- a/components/features/association-operations/OperationalDashboard.tsx
+++ b/components/features/association-operations/OperationalDashboard.tsx
@@ -84,6 +84,23 @@ export function OperationalDashboard({ data, error }: OperationalDashboardProps)
         })}
         <Card variant="outlined">
           <CardContent>
+            <Typography variant="h6" sx={{ mb: 1 }}>Volunteer shortages</Typography>
+            {data.volunteerShortages.length === 0 ? (
+              <Typography color="text.secondary" variant="body2">
+                Every open volunteer need is fully staffed.
+              </Typography>
+            ) : (
+              <Stack spacing={1}>
+                <Typography variant="body2">
+                  {data.volunteerShortages.length} need(s) still short of volunteers
+                </Typography>
+                <ActionList items={data.volunteerShortages} />
+              </Stack>
+            )}
+          </CardContent>
+        </Card>
+        <Card variant="outlined">
+          <CardContent>
             <Typography variant="h6" sx={{ mb: 1 }}>Gear and notification health</Typography>
             <Stack spacing={1}>
               <Typography variant="body2">Urgent needs: {data.gear.urgentNeeds.length}</Typography>

--- a/components/features/dashboard/DashboardNav.tsx
+++ b/components/features/dashboard/DashboardNav.tsx
@@ -30,6 +30,7 @@ import {
   AdminPanelSettings as AdminPanelSettingsIcon,
   Inventory2 as GearIcon,
   EmojiEvents as LeagueIcon,
+  Diversity3 as WorkforceIcon,
   Assessment as OperationsIcon,
   EventAvailable as VenueReservationsIcon,
 } from "@mui/icons-material";
@@ -99,6 +100,7 @@ export default function DashboardNav({
       { label: "Schedule", path: `${leaguePrefix}/schedule`, icon: <CalendarIcon /> },
       { label: "Gear", path: `${leaguePrefix}/gear`, icon: <GearIcon /> },
       { label: "Operations", path: `${leaguePrefix}/operations`, icon: <OperationsIcon /> },
+      { label: "Workforce", path: `${leaguePrefix}/workforce`, icon: <WorkforceIcon /> },
       {
         label: "Venue Reservations",
         path: `${leaguePrefix}/venue-reservations`,

--- a/components/features/navigation/MobileNavigation.tsx
+++ b/components/features/navigation/MobileNavigation.tsx
@@ -23,6 +23,7 @@ import {
   ManageAccounts as ManageAccountsIcon,
   AdminPanelSettings as AdminPanelSettingsIcon,
   Inventory2 as GearIcon,
+  Diversity3 as WorkforceIcon,
   EmojiEvents as LeagueIcon,
   Assessment as OperationsIcon,
   EventAvailable as VenueReservationsIcon,
@@ -219,6 +220,18 @@ export default function MobileNavigation({ isLeagueMode = false, isPlatformAdmin
               <OperationsIcon />
             </ListItemIcon>
             <ListItemText>Operations</ListItemText>
+          </MenuItem>
+        )}
+        {isLeagueMode && currentLeague && (
+          <MenuItem
+            component={Link}
+            href={`/league/${currentLeague.id}/workforce`}
+            onClick={handleMenuClose}
+          >
+            <ListItemIcon>
+              <WorkforceIcon />
+            </ListItemIcon>
+            <ListItemText>Workforce</ListItemText>
           </MenuItem>
         )}
         {isLeagueMode && currentLeague && (

--- a/components/features/workforce/RoleGrantManager.tsx
+++ b/components/features/workforce/RoleGrantManager.tsx
@@ -1,0 +1,290 @@
+"use client";
+
+import { useMemo, useState, useTransition } from "react";
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  Chip,
+  MenuItem,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  TextField,
+  Typography,
+} from "@mui/material";
+import type { AssociationRole, AssociationRoleScopeType } from "@prisma/client";
+
+import { ROLE_CAPABILITY_MATRIX } from "@/lib/auth/capability-matrix";
+import type { ResponsibilityGrantRow } from "@/lib/actions/association-roles";
+import {
+  inviteAssociationOperator,
+  revokeAssociationResponsibility,
+} from "@/lib/actions/association-roles";
+
+const ROLE_LABELS: Record<AssociationRole, string> = {
+  ASSOCIATION_ADMIN: "Association admin",
+  SCHEDULER: "Scheduler",
+  REGISTRAR: "Registrar",
+  TREASURER: "Treasurer",
+  COMMUNICATIONS_LEAD: "Communications lead",
+  TEAM_MANAGER: "Team manager",
+  COACH: "Coach",
+  VOLUNTEER_COORDINATOR: "Volunteer coordinator",
+  EVENT_MANAGER: "Event manager",
+  EQUIPMENT_MANAGER: "Equipment manager",
+};
+
+const SCOPE_LABELS: Record<AssociationRoleScopeType, string> = {
+  ASSOCIATION: "Entire association",
+  DIVISION: "One division",
+  TEAM: "One team",
+  SEASON: "One season",
+  EVENT: "One event",
+  SIGNUP_EVENT: "One signup event",
+};
+
+/**
+ * What each role actually lets somebody do, in the administrator's language.
+ * Shown before they delegate, because "Registrar" means nothing on its own and
+ * over-granting is the failure this whole feature exists to prevent.
+ */
+const ROLE_GUIDANCE: Record<AssociationRole, string> = {
+  ASSOCIATION_ADMIN:
+    "Everything, including delegating to others. Grant sparingly.",
+  SCHEDULER: "Ice requests, reservations, schedules, games, and practices.",
+  REGISTRAR: "Rosters, placements, and registration eligibility and reporting.",
+  TREASURER: "Payments, refunds, and financial reports.",
+  COMMUNICATIONS_LEAD: "Public content and operational messages.",
+  TEAM_MANAGER:
+    "Runs one team: its roster, events, practices, volunteers, and gear requests.",
+  COACH: "Practice plans and practice participation for one team.",
+  VOLUNTEER_COORDINATOR: "Volunteer needs and assignments.",
+  EVENT_MANAGER: "One exact event, without wider association access.",
+  EQUIPMENT_MANAGER:
+    "Gear only — inventory and the public wishlist at association scope, and team gear needs and requests within the scope you choose. Confers no scheduling, finance, or administrative access.",
+};
+
+export interface RoleGrantManagerProps {
+  leagueId: string;
+  grants: ResponsibilityGrantRow[];
+  divisions: Array<{ id: string; name: string }>;
+  teams: Array<{ id: string; name: string }>;
+}
+
+export function RoleGrantManager({
+  leagueId,
+  grants,
+  divisions,
+  teams,
+}: RoleGrantManagerProps) {
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  const [email, setEmail] = useState("");
+  const [role, setRole] = useState<AssociationRole>("TEAM_MANAGER");
+  const [scopeType, setScopeType] = useState<AssociationRoleScopeType>("TEAM");
+  const [scopeId, setScopeId] = useState("");
+
+  // Only offer scopes the chosen role supports. Offering the rest would let an
+  // administrator build a combination the server refuses, which reads as a bug
+  // rather than as the intended least-privilege boundary.
+  const allowedScopes = useMemo(
+    () => ROLE_CAPABILITY_MATRIX[role]?.scopes ?? [],
+    [role],
+  );
+
+  const scopeOptions =
+    scopeType === "DIVISION" ? divisions : scopeType === "TEAM" ? teams : [];
+
+  function handleRoleChange(next: AssociationRole) {
+    setRole(next);
+    const scopes = ROLE_CAPABILITY_MATRIX[next]?.scopes ?? [];
+    if (!scopes.includes(scopeType)) {
+      setScopeType(scopes[0] ?? "ASSOCIATION");
+      setScopeId("");
+    }
+  }
+
+  function handleInvite() {
+    setError(null);
+    setNotice(null);
+    startTransition(async () => {
+      const result = await inviteAssociationOperator({
+        leagueId,
+        email,
+        role,
+        scopeType,
+        ...(scopeType === "DIVISION" ? { divisionId: scopeId } : {}),
+        ...(scopeType === "TEAM" ? { teamId: scopeId } : {}),
+      });
+
+      if (result.success) {
+        setNotice(`Invitation sent to ${email}.`);
+        setEmail("");
+      } else {
+        setError(result.error);
+      }
+    });
+  }
+
+  function handleRevoke(grantId: string) {
+    setError(null);
+    setNotice(null);
+    startTransition(async () => {
+      const result = await revokeAssociationResponsibility({ grantId, leagueId });
+      if (!result.success) setError(result.error);
+    });
+  }
+
+  const needsScopeTarget = scopeType === "DIVISION" || scopeType === "TEAM";
+
+  return (
+    <Stack spacing={3}>
+      {error ? <Alert severity="error">{error}</Alert> : null}
+      {notice ? <Alert severity="success">{notice}</Alert> : null}
+
+      <Card variant="outlined" sx={{ p: 2 }}>
+        <Typography variant="h6" component="h2" gutterBottom>
+          Delegate a responsibility
+        </Typography>
+
+        <Stack spacing={2}>
+          <TextField
+            label="Email address"
+            type="email"
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+            fullWidth
+            helperText="They will be invited if they do not already have an account."
+          />
+
+          <TextField
+            select
+            label="Responsibility"
+            value={role}
+            onChange={(event) => handleRoleChange(event.target.value as AssociationRole)}
+            fullWidth
+          >
+            {(Object.keys(ROLE_LABELS) as AssociationRole[]).map((option) => (
+              <MenuItem key={option} value={option}>
+                {ROLE_LABELS[option]}
+              </MenuItem>
+            ))}
+          </TextField>
+
+          <Alert severity="info" icon={false}>
+            {ROLE_GUIDANCE[role]}
+          </Alert>
+
+          <TextField
+            select
+            label="Scope"
+            value={scopeType}
+            onChange={(event) => {
+              setScopeType(event.target.value as AssociationRoleScopeType);
+              setScopeId("");
+            }}
+            fullWidth
+          >
+            {allowedScopes.map((option) => (
+              <MenuItem key={option} value={option}>
+                {SCOPE_LABELS[option]}
+              </MenuItem>
+            ))}
+          </TextField>
+
+          {needsScopeTarget ? (
+            <TextField
+              select
+              label={scopeType === "DIVISION" ? "Division" : "Team"}
+              value={scopeId}
+              onChange={(event) => setScopeId(event.target.value)}
+              fullWidth
+            >
+              {scopeOptions.map((option) => (
+                <MenuItem key={option.id} value={option.id}>
+                  {option.name}
+                </MenuItem>
+              ))}
+            </TextField>
+          ) : null}
+
+          <Box>
+            <Button
+              variant="contained"
+              onClick={handleInvite}
+              disabled={pending || !email || (needsScopeTarget && !scopeId)}
+              sx={{ minHeight: 44 }}
+            >
+              Send invitation
+            </Button>
+          </Box>
+        </Stack>
+      </Card>
+
+      <Card variant="outlined" sx={{ p: 2 }}>
+        <Typography variant="h6" component="h2" gutterBottom>
+          Current responsibilities
+        </Typography>
+
+        {grants.length === 0 ? (
+          <Typography variant="body2" color="text.secondary">
+            Nobody has been delegated a responsibility yet.
+          </Typography>
+        ) : (
+          <Box sx={{ overflowX: "auto" }}>
+            <Table size="small">
+              <TableHead>
+                <TableRow>
+                  <TableCell>Person</TableCell>
+                  <TableCell>Responsibility</TableCell>
+                  <TableCell>Scope</TableCell>
+                  <TableCell align="right">Actions</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {grants.map((grant) => (
+                  <TableRow key={grant.id}>
+                    <TableCell>
+                      <Typography variant="body2">
+                        {grant.user.name ?? grant.user.email}
+                      </Typography>
+                      {grant.user.name ? (
+                        <Typography variant="caption" color="text.secondary">
+                          {grant.user.email}
+                        </Typography>
+                      ) : null}
+                    </TableCell>
+                    <TableCell>
+                      <Chip size="small" label={ROLE_LABELS[grant.role]} />
+                    </TableCell>
+                    <TableCell>{grant.scopeLabel}</TableCell>
+                    <TableCell align="right">
+                      <Button
+                        size="small"
+                        color="error"
+                        disabled={pending}
+                        onClick={() => handleRevoke(grant.id)}
+                        sx={{ minHeight: 44 }}
+                      >
+                        Revoke
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </Box>
+        )}
+      </Card>
+    </Stack>
+  );
+}
+
+export default RoleGrantManager;

--- a/components/features/workforce/RoleGrantManager.tsx
+++ b/components/features/workforce/RoleGrantManager.tsx
@@ -26,6 +26,27 @@ import {
   revokeAssociationResponsibility,
 } from "@/lib/actions/association-roles";
 
+/**
+ * Roles this form offers today.
+ *
+ * The server matrix knows all ten, but a grant only *does* something where the
+ * work has been routed through capability checks. As of feature 007 US3 that is
+ * gear (equipment manager, association admin), volunteers (coordinator, team
+ * manager, association admin), and delegation itself. Scheduling, registration,
+ * finance, communications, and event administration still guard on the legacy
+ * league/team roles, so offering those here would hand out responsibilities
+ * that silently do nothing. They are re-enabled as each action set is wired.
+ */
+const OFFERED_ROLES: AssociationRole[] = [
+  "ASSOCIATION_ADMIN",
+  "TEAM_MANAGER",
+  "VOLUNTEER_COORDINATOR",
+  "EQUIPMENT_MANAGER",
+];
+
+/** Scopes this form can supply a target for. */
+const SELECTABLE_SCOPES: AssociationRoleScopeType[] = ["ASSOCIATION", "DIVISION", "TEAM"];
+
 const ROLE_LABELS: Record<AssociationRole, string> = {
   ASSOCIATION_ADMIN: "Association admin",
   SCHEDULER: "Scheduler",
@@ -55,15 +76,16 @@ const SCOPE_LABELS: Record<AssociationRoleScopeType, string> = {
  */
 const ROLE_GUIDANCE: Record<AssociationRole, string> = {
   ASSOCIATION_ADMIN:
-    "Everything, including delegating to others. Grant sparingly.",
+    "Delegation, volunteers, and gear across the whole association. Grant sparingly. Note that scheduling, registration, and finance still follow league admin membership, not this grant.",
   SCHEDULER: "Ice requests, reservations, schedules, games, and practices.",
   REGISTRAR: "Rosters, placements, and registration eligibility and reporting.",
   TREASURER: "Payments, refunds, and financial reports.",
   COMMUNICATIONS_LEAD: "Public content and operational messages.",
   TEAM_MANAGER:
-    "Runs one team: its roster, events, practices, volunteers, and gear requests.",
+    "Volunteers and gear needs/requests for one team. Roster, event, and practice administration still follow team admin membership.",
   COACH: "Practice plans and practice participation for one team.",
-  VOLUNTEER_COORDINATOR: "Volunteer needs and assignments.",
+  VOLUNTEER_COORDINATOR:
+    "Volunteer needs and assignments within the scope you choose, and nothing else.",
   EVENT_MANAGER: "One exact event, without wider association access.",
   EQUIPMENT_MANAGER:
     "Gear only — inventory and the public wishlist at association scope, and team gear needs and requests within the scope you choose. Confers no scheduling, finance, or administrative access.",
@@ -95,7 +117,10 @@ export function RoleGrantManager({
   // administrator build a combination the server refuses, which reads as a bug
   // rather than as the intended least-privilege boundary.
   const allowedScopes = useMemo(
-    () => ROLE_CAPABILITY_MATRIX[role]?.scopes ?? [],
+    () =>
+      (ROLE_CAPABILITY_MATRIX[role]?.scopes ?? []).filter((scope) =>
+        SELECTABLE_SCOPES.includes(scope),
+      ),
     [role],
   );
 
@@ -104,7 +129,9 @@ export function RoleGrantManager({
 
   function handleRoleChange(next: AssociationRole) {
     setRole(next);
-    const scopes = ROLE_CAPABILITY_MATRIX[next]?.scopes ?? [];
+    const scopes = (ROLE_CAPABILITY_MATRIX[next]?.scopes ?? []).filter((scope) =>
+      SELECTABLE_SCOPES.includes(scope),
+    );
     if (!scopes.includes(scopeType)) {
       setScopeType(scopes[0] ?? "ASSOCIATION");
       setScopeId("");
@@ -171,7 +198,7 @@ export function RoleGrantManager({
             onChange={(event) => handleRoleChange(event.target.value as AssociationRole)}
             fullWidth
           >
-            {(Object.keys(ROLE_LABELS) as AssociationRole[]).map((option) => (
+            {OFFERED_ROLES.map((option) => (
               <MenuItem key={option} value={option}>
                 {ROLE_LABELS[option]}
               </MenuItem>

--- a/components/features/workforce/VolunteerBoard.tsx
+++ b/components/features/workforce/VolunteerBoard.tsx
@@ -7,14 +7,22 @@ import {
   Button,
   Card,
   Chip,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
   LinearProgress,
+  MenuItem,
   Stack,
+  TextField,
   Typography,
 } from "@mui/material";
 
 import type { VolunteerNeedSummary } from "@/lib/actions/volunteers";
 import {
+  assignVolunteer,
   completeVolunteerAssignment,
+  createVolunteerNeed,
   markVolunteerAssignmentMissed,
   respondToVolunteerAssignment,
 } from "@/lib/actions/volunteers";
@@ -43,6 +51,10 @@ function chipColor<T extends Record<string, string>>(
 }
 
 export interface VolunteerBoardProps {
+  /** Required for organizers, who can create needs here. */
+  leagueId?: string;
+  /** Teams a need may be scoped to; empty for volunteers. */
+  teams?: Array<{ id: string; name: string }>;
   needs: VolunteerNeedSummary[];
   /**
    * Organizers see fulfillment across every need and can close assignments
@@ -54,9 +66,24 @@ export interface VolunteerBoardProps {
   currentUserId?: string;
 }
 
-export function VolunteerBoard({ needs, isOrganizer }: VolunteerBoardProps) {
+export function VolunteerBoard({
+  leagueId,
+  teams = [],
+  needs,
+  isOrganizer,
+}: VolunteerBoardProps) {
   const [pending, startTransition] = useTransition();
   const [error, setError] = useState<string | null>(null);
+  const [createOpen, setCreateOpen] = useState(false);
+  const [assignFor, setAssignFor] = useState<string | null>(null);
+  const [assignEmail, setAssignEmail] = useState("");
+  const [form, setForm] = useState({
+    roleLabel: "",
+    capacity: "1",
+    startAt: "",
+    endAt: "",
+    teamId: "",
+  });
 
   function run(action: () => Promise<{ success: boolean; error?: string }>) {
     setError(null);
@@ -68,19 +95,69 @@ export function VolunteerBoard({ needs, isOrganizer }: VolunteerBoardProps) {
     });
   }
 
-  if (needs.length === 0) {
-    return (
-      <Alert severity="info">
-        {isOrganizer
-          ? "No volunteer needs yet. Create one to start staffing the season."
-          : "You have no volunteer shifts right now."}
-      </Alert>
-    );
+  const timezone =
+    typeof Intl !== "undefined"
+      ? Intl.DateTimeFormat().resolvedOptions().timeZone
+      : "UTC";
+
+  function handleCreate() {
+    if (!leagueId) return;
+    setError(null);
+    startTransition(async () => {
+      const result = await createVolunteerNeed({
+        leagueId,
+        roleLabel: form.roleLabel,
+        capacity: Number(form.capacity),
+        startAt: new Date(form.startAt),
+        endAt: new Date(form.endAt),
+        timezone,
+        ...(form.teamId ? { teamId: form.teamId } : {}),
+      });
+      if (result.success) {
+        setCreateOpen(false);
+        setForm({ roleLabel: "", capacity: "1", startAt: "", endAt: "", teamId: "" });
+      } else {
+        setError(result.error);
+      }
+    });
+  }
+
+  function handleAssign(needId: string) {
+    setError(null);
+    startTransition(async () => {
+      const result = await assignVolunteer({ needId, invitedEmail: assignEmail });
+      if (result.success) {
+        setAssignFor(null);
+        setAssignEmail("");
+      } else {
+        setError(result.error);
+      }
+    });
   }
 
   return (
     <Stack spacing={2}>
       {error ? <Alert severity="error">{error}</Alert> : null}
+
+      {isOrganizer && leagueId ? (
+        <Box>
+          <Button
+            variant="contained"
+            onClick={() => setCreateOpen(true)}
+            sx={{ minHeight: 44 }}
+          >
+            Create volunteer need
+          </Button>
+        </Box>
+      ) : null}
+
+      {needs.length === 0 ? (
+        <Alert severity="info">
+          {isOrganizer
+            ? "No volunteer needs yet. Create one to start staffing the season."
+            : "You have no volunteer shifts right now."}
+        </Alert>
+      ) : null}
 
       {needs.map((need) => {
         const filled = need.capacity > 0 ? (need.acceptedCount / need.capacity) * 100 : 0;
@@ -100,7 +177,10 @@ export function VolunteerBoard({ needs, isOrganizer }: VolunteerBoardProps) {
                 </Typography>
                 <Typography variant="body2" color="text.secondary">
                   {need.teamName ? `${need.teamName} · ` : ""}
-                  {new Date(need.startAt).toLocaleString()} ({need.timezone})
+                  {new Date(need.startAt).toLocaleString(undefined, {
+                    timeZone: need.timezone,
+                  })}{" "}
+                  ({need.timezone})
                 </Typography>
               </Box>
               <Stack direction="row" spacing={1} alignItems="center">
@@ -225,10 +305,121 @@ export function VolunteerBoard({ needs, isOrganizer }: VolunteerBoardProps) {
                   Nobody assigned yet.
                 </Typography>
               ) : null}
+
+              {isOrganizer && need.status === "OPEN" ? (
+                <Box>
+                  <Button
+                    size="small"
+                    variant="outlined"
+                    disabled={pending}
+                    sx={{ minHeight: 44 }}
+                    onClick={() => {
+                      setAssignFor(need.id);
+                      setAssignEmail("");
+                    }}
+                  >
+                    Assign volunteer
+                  </Button>
+                </Box>
+              ) : null}
             </Stack>
           </Card>
         );
       })}
+
+      <Dialog open={createOpen} onClose={() => setCreateOpen(false)} fullWidth maxWidth="sm">
+        <DialogTitle>Create volunteer need</DialogTitle>
+        <DialogContent>
+          <Stack spacing={2} sx={{ mt: 1 }}>
+            <TextField
+              label="Role"
+              value={form.roleLabel}
+              onChange={(e) => setForm({ ...form, roleLabel: e.target.value })}
+              fullWidth
+            />
+            <TextField
+              label="How many volunteers"
+              type="number"
+              value={form.capacity}
+              onChange={(e) => setForm({ ...form, capacity: e.target.value })}
+              fullWidth
+            />
+            <TextField
+              label="Starts"
+              type="datetime-local"
+              value={form.startAt}
+              onChange={(e) => setForm({ ...form, startAt: e.target.value })}
+              slotProps={{ inputLabel: { shrink: true } }}
+              fullWidth
+            />
+            <TextField
+              label="Ends"
+              type="datetime-local"
+              value={form.endAt}
+              onChange={(e) => setForm({ ...form, endAt: e.target.value })}
+              slotProps={{ inputLabel: { shrink: true } }}
+              fullWidth
+            />
+            {teams.length > 0 ? (
+              <TextField
+                select
+                label="Team (optional)"
+                value={form.teamId}
+                onChange={(e) => setForm({ ...form, teamId: e.target.value })}
+                fullWidth
+              >
+                <MenuItem value="">Whole association</MenuItem>
+                {teams.map((team) => (
+                  <MenuItem key={team.id} value={team.id}>
+                    {team.name}
+                  </MenuItem>
+                ))}
+              </TextField>
+            ) : null}
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setCreateOpen(false)} sx={{ minHeight: 44 }}>
+            Cancel
+          </Button>
+          <Button
+            variant="contained"
+            onClick={handleCreate}
+            disabled={pending || !form.roleLabel || !form.startAt || !form.endAt}
+            sx={{ minHeight: 44 }}
+          >
+            Create
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Dialog open={assignFor !== null} onClose={() => setAssignFor(null)} fullWidth maxWidth="xs">
+        <DialogTitle>Assign a volunteer</DialogTitle>
+        <DialogContent>
+          <TextField
+            label="Email address"
+            type="email"
+            value={assignEmail}
+            onChange={(e) => setAssignEmail(e.target.value)}
+            fullWidth
+            sx={{ mt: 1 }}
+            helperText="They need an existing account. Invite them to the association first if not."
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setAssignFor(null)} sx={{ minHeight: 44 }}>
+            Cancel
+          </Button>
+          <Button
+            variant="contained"
+            onClick={() => assignFor && handleAssign(assignFor)}
+            disabled={pending || !assignEmail}
+            sx={{ minHeight: 44 }}
+          >
+            Assign
+          </Button>
+        </DialogActions>
+      </Dialog>
     </Stack>
   );
 }

--- a/components/features/workforce/VolunteerBoard.tsx
+++ b/components/features/workforce/VolunteerBoard.tsx
@@ -1,0 +1,236 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  Chip,
+  LinearProgress,
+  Stack,
+  Typography,
+} from "@mui/material";
+
+import type { VolunteerNeedSummary } from "@/lib/actions/volunteers";
+import {
+  completeVolunteerAssignment,
+  markVolunteerAssignmentMissed,
+  respondToVolunteerAssignment,
+} from "@/lib/actions/volunteers";
+
+const STATUS_COLOR = {
+  OPEN: "success",
+  CLOSED: "default",
+  CANCELED: "error",
+  COMPLETED: "info",
+} as const;
+
+const ASSIGNMENT_COLOR = {
+  INVITED: "warning",
+  ACCEPTED: "success",
+  DECLINED: "default",
+  CANCELED: "default",
+  COMPLETED: "info",
+  MISSED: "error",
+} as const;
+
+function chipColor<T extends Record<string, string>>(
+  map: T,
+  key: string,
+): T[keyof T] | "default" {
+  return (map[key] as T[keyof T]) ?? "default";
+}
+
+export interface VolunteerBoardProps {
+  needs: VolunteerNeedSummary[];
+  /**
+   * Organizers see fulfillment across every need and can close assignments
+   * out. Volunteers see only their own shifts, so the board renders their
+   * accept/decline controls instead.
+   */
+  isOrganizer: boolean;
+  /** The signed-in user, for deciding which assignment rows are answerable. */
+  currentUserId?: string;
+}
+
+export function VolunteerBoard({ needs, isOrganizer }: VolunteerBoardProps) {
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  function run(action: () => Promise<{ success: boolean; error?: string }>) {
+    setError(null);
+    startTransition(async () => {
+      const result = await action();
+      if (!result.success) {
+        setError(result.error ?? "That action could not be completed.");
+      }
+    });
+  }
+
+  if (needs.length === 0) {
+    return (
+      <Alert severity="info">
+        {isOrganizer
+          ? "No volunteer needs yet. Create one to start staffing the season."
+          : "You have no volunteer shifts right now."}
+      </Alert>
+    );
+  }
+
+  return (
+    <Stack spacing={2}>
+      {error ? <Alert severity="error">{error}</Alert> : null}
+
+      {needs.map((need) => {
+        const filled = need.capacity > 0 ? (need.acceptedCount / need.capacity) * 100 : 0;
+        const shortfall = Math.max(need.capacity - need.acceptedCount, 0);
+
+        return (
+          <Card key={need.id} variant="outlined" sx={{ p: 2 }}>
+            <Stack
+              direction={{ xs: "column", sm: "row" }}
+              spacing={1}
+              justifyContent="space-between"
+              alignItems={{ xs: "flex-start", sm: "center" }}
+            >
+              <Box>
+                <Typography variant="h6" component="h3">
+                  {need.roleLabel}
+                </Typography>
+                <Typography variant="body2" color="text.secondary">
+                  {need.teamName ? `${need.teamName} · ` : ""}
+                  {new Date(need.startAt).toLocaleString()} ({need.timezone})
+                </Typography>
+              </Box>
+              <Stack direction="row" spacing={1} alignItems="center">
+                <Chip
+                  size="small"
+                  label={need.status}
+                  color={chipColor(STATUS_COLOR, need.status)}
+                />
+                <Chip
+                  size="small"
+                  variant="outlined"
+                  label={`${need.acceptedCount} of ${need.capacity} filled`}
+                />
+              </Stack>
+            </Stack>
+
+            {need.description ? (
+              <Typography variant="body2" sx={{ mt: 1 }}>
+                {need.description}
+              </Typography>
+            ) : null}
+
+            <Box sx={{ mt: 1.5 }}>
+              <LinearProgress
+                variant="determinate"
+                value={Math.min(filled, 100)}
+                aria-label={`${need.roleLabel} staffing`}
+                sx={{ height: 8, borderRadius: 1 }}
+              />
+              {isOrganizer && shortfall > 0 && need.status === "OPEN" ? (
+                <Typography variant="caption" color="warning.main">
+                  {shortfall} more volunteer{shortfall === 1 ? "" : "s"} needed
+                </Typography>
+              ) : null}
+            </Box>
+
+            <Stack spacing={1} sx={{ mt: 2 }}>
+              {need.assignments.map((assignment) => (
+                <Stack
+                  key={assignment.id}
+                  direction="row"
+                  spacing={1}
+                  alignItems="center"
+                  justifyContent="space-between"
+                  sx={{ flexWrap: "wrap", gap: 1 }}
+                >
+                  <Stack direction="row" spacing={1} alignItems="center">
+                    <Chip
+                      size="small"
+                      label={assignment.status}
+                      color={chipColor(ASSIGNMENT_COLOR, assignment.status)}
+                    />
+                    <Typography variant="body2">{assignment.personLabel}</Typography>
+                  </Stack>
+
+                  <Stack direction="row" spacing={1}>
+                    {!isOrganizer && assignment.status === "INVITED" ? (
+                      <>
+                        <Button
+                          size="small"
+                          variant="contained"
+                          disabled={pending}
+                          sx={{ minHeight: 44 }}
+                          onClick={() =>
+                            run(() =>
+                              respondToVolunteerAssignment({
+                                assignmentId: assignment.id,
+                                response: "ACCEPTED",
+                              }),
+                            )
+                          }
+                        >
+                          Accept
+                        </Button>
+                        <Button
+                          size="small"
+                          disabled={pending}
+                          sx={{ minHeight: 44 }}
+                          onClick={() =>
+                            run(() =>
+                              respondToVolunteerAssignment({
+                                assignmentId: assignment.id,
+                                response: "DECLINED",
+                              }),
+                            )
+                          }
+                        >
+                          Decline
+                        </Button>
+                      </>
+                    ) : null}
+
+                    {isOrganizer && assignment.status === "ACCEPTED" ? (
+                      <>
+                        <Button
+                          size="small"
+                          disabled={pending}
+                          sx={{ minHeight: 44 }}
+                          onClick={() => run(() => completeVolunteerAssignment(assignment.id))}
+                        >
+                          Completed
+                        </Button>
+                        <Button
+                          size="small"
+                          color="warning"
+                          disabled={pending}
+                          sx={{ minHeight: 44 }}
+                          onClick={() =>
+                            run(() => markVolunteerAssignmentMissed(assignment.id))
+                          }
+                        >
+                          No-show
+                        </Button>
+                      </>
+                    ) : null}
+                  </Stack>
+                </Stack>
+              ))}
+
+              {need.assignments.length === 0 ? (
+                <Typography variant="body2" color="text.secondary">
+                  Nobody assigned yet.
+                </Typography>
+              ) : null}
+            </Stack>
+          </Card>
+        );
+      })}
+    </Stack>
+  );
+}
+
+export default VolunteerBoard;

--- a/components/providers/LeagueProvider.tsx
+++ b/components/providers/LeagueProvider.tsx
@@ -58,6 +58,7 @@ const LEAGUE_SECTION_LABELS: Record<string, string> = {
   invitations: 'Invitations',
   payments: 'Payments',
   gear: 'Gear',
+  workforce: 'Workforce',
 };
 
 // Well-known nested segments; unknown tails (ids) render as 'Details'.

--- a/docs/adr/0009-delegate-association-authority-through-scoped-role-grants.md
+++ b/docs/adr/0009-delegate-association-authority-through-scoped-role-grants.md
@@ -1,0 +1,160 @@
+---
+schemaVersion: 0.1.0
+id: "0009"
+title: "Delegate association authority through scoped role grants"
+status: accepted
+date: 2026-08-19
+created: 2026-08-19
+deciders: ["@mbeacom"]
+tags: [architecture, authorization, associations, least-privilege]
+scope: org
+reversibility: two-way-door
+blastRadius: org
+relatesTo: ["0002", "0003", "0006"]
+affects:
+  - type: path
+    pattern: "lib/auth/capability-matrix.ts"
+    note: The role/capability/scope allowlist; unlisted combinations fail closed.
+  - type: path
+    pattern: "lib/auth/capabilities.ts"
+    note: Resolves capability from grants, scope ancestry, and legacy admin compatibility.
+  - type: path
+    pattern: "lib/utils/permissions.ts"
+    note: Gear Permission checks consult equipment-manager grants through this one entry point.
+  - type: path
+    pattern: "lib/actions/association-roles.ts"
+    note: Grant, revoke, list, and invite; only association administration may delegate.
+  - type: path
+    pattern: "lib/services/association-roles.ts"
+    note: Scope normalization and invitation-acceptance application.
+  - type: path
+    pattern: "prisma/**"
+    note: AssociationRoleGrant scope exclusivity and active-only uniqueness constraints.
+  - type: path
+    pattern: "specs/007-association-operations/**"
+provenance:
+  authoredBy: agent-drafted
+  ratifiedBy: "@mbeacom"
+  sourceArtifact: specs/007-association-operations/plan.md
+review:
+  tier: async
+  tierReason: >-
+    The decision defines how every future association capability is authorized,
+    and a permissive default anywhere in it becomes a privilege-escalation path.
+reviewBy: 2027-02-19
+---
+
+# ADR-0009: Delegate association authority through scoped role grants
+
+## Context
+
+A nonprofit association runs on distributed volunteer labour. Ice must be
+booked, rosters maintained, dues reconciled, announcements sent, gear issued,
+and shifts staffed — by different people, most of whom should not be able to
+touch the rest.
+
+Before this decision the platform had three coarse levers: `LeagueUser.role`
+(`LEAGUE_ADMIN`, `TEAM_ADMIN`, `MEMBER`), `TeamMember.role` (`ADMIN`,
+`MEMBER`), and `VenueStaff` for venue organizations. Delegating any one
+responsibility — "let the equipment manager issue jerseys" — meant granting
+`LEAGUE_ADMIN`, which also grants payments, roster edits, audit access, and the
+ability to promote others. Associations recruit volunteers for bounded jobs;
+handing each of them the keys to everything is both unsafe and a recruiting
+obstacle.
+
+Two adjacent models were tempting shortcuts and are both wrong:
+
+- `TeamOfficial` already records "Head Coach" and "Team Manager". These are
+  *descriptive labels* printed on rosters, handed out freely, and not gated on
+  anything. Reading authority from them would silently promote everyone an
+  association ever labelled.
+- `VenueStaff` already expresses scoped authority over venue inventory. Venue
+  authority belongs to the venue organization, not to the association booking
+  it; mirroring it into association grants would create two systems that
+  disagree about who may approve ice.
+
+ADR-0006 defines gear authorization in terms of the existing `Permission` enum,
+checked by `lib/utils/permissions.ts`. Every gear action already calls that
+entry point.
+
+## Decision
+
+`AssociationRoleGrant` is the single source of delegated association authority.
+
+1. **One grant names one role at exactly one scope** — association, division,
+   team, season, Event, or SignupEvent — owned by exactly one league. The
+   database enforces this with a `CASE`-per-scope `CHECK`, so a row cannot name
+   two scopes or a scope that disagrees with its `scopeType`.
+
+2. **The role/capability/scope matrix is an allowlist.** A combination that is
+   not written down authorizes nothing. New roles, new capabilities, and new
+   scopes therefore fail closed until somebody states what they may do, rather
+   than inheriting permissive behaviour from a default branch.
+
+3. **Narrow grants never widen.** A team-scoped grant asked about
+   association-wide work has no target to match and returns false. Division
+   scope resolves through the division's *current* membership, so moving a team
+   out of a division withdraws the delegate's reach without editing any grant.
+
+4. **Gear delegation routes through the existing `Permission` checks.**
+   Equipment managers are authorized inside `hasPermission`, consulted only
+   after the access-level matrix has declined. A grant can therefore add
+   authority but never loosen an existing rule — including the mandatory-`teamId`
+   rule, which the grant path re-checks. No gear action learns about grants.
+
+5. **`TeamOfficial` never grants capability, and `VenueStaff` is not mirrored.**
+   Stated in the code, the backfill, and here, because both are recurring
+   temptations.
+
+6. **Only association administration may delegate.** A delegate cannot mint
+   grants, so no one can widen their own authority.
+
+7. **Uniqueness applies to ACTIVE grants only.** Revoked rows are retained as
+   history; without the partial predicate, revoking a responsibility would
+   permanently prevent granting it again.
+
+Existing `LEAGUE_ADMIN` holders keep full capability through an explicit legacy
+branch until `scripts/backfill-association-role-grants.ts` gives them real
+grants, so enabling this cannot lock an association out of its own
+administration.
+
+## Consequences
+
+Delegation becomes safe and legible: an administrator can hand out one job and
+the recipient gets exactly that job. `listAssociationResponsibilityGrants`
+gives a truthful answer to "who can do what", which the three coarse role
+levers never could.
+
+The cost is that authorization is now two systems during the transition —
+grants plus the legacy access levels — and both are consulted on every check.
+That is deliberate and temporary, but the legacy branch is load-bearing until
+the backfill has run everywhere, and removing it early would revoke every
+existing administrator at once.
+
+Adding a capability now means editing the matrix, which is more friction than
+adding a boolean. That friction is the point: it is what makes "unlisted fails
+closed" true rather than aspirational.
+
+## Alternatives considered
+
+**Extend `LeagueRole` with more enum members.** Cheapest change, but roles
+without scope cannot express "manages this one team" or "runs this one event",
+which is most of what associations actually delegate.
+
+**Derive capability from `TeamOfficial`.** The data is already there and
+associations already maintain it. Rejected: those rows are labels, not grants,
+and are handed out to anyone who should appear on a roster.
+
+**A second authorization checker for gear.** Simpler to write, but the gear
+actions call `hasPermission` and would never consult it, so equipment-manager
+grants would silently do nothing.
+
+## What would make this wrong
+
+If associations turn out to delegate along axes the six scopes cannot express —
+"all U12 teams at one venue", say — the scope column becomes a constraint rather
+than a boundary, and a scope predicate would serve better than a scope id.
+
+If the legacy compatibility branch is still present after the backfill has run
+everywhere, it has become a permanent second authorization path rather than a
+migration aid, and should be deleted.

--- a/lib/actions/association-roles.ts
+++ b/lib/actions/association-roles.ts
@@ -1,0 +1,434 @@
+"use server";
+
+import { randomBytes } from "node:crypto";
+
+import { z } from "zod";
+import { revalidatePath } from "next/cache";
+import type {
+  AssociationRole,
+  AssociationRoleScopeType,
+  Prisma,
+} from "@prisma/client";
+
+import { prisma } from "@/lib/db/prisma";
+import { requireUserId } from "@/lib/auth/session";
+import {
+  Capability,
+  hasCapability,
+  supportedScopesForRole,
+} from "@/lib/auth/capabilities";
+import { AuditAction, logAuditEvent } from "@/lib/utils/security";
+import { rethrowIfNextRedirectError } from "@/lib/utils/next-errors";
+import { normalizeScope } from "@/lib/services/association-roles";
+
+/**
+ * Scoped responsibility grants (feature 007 / User Story 3).
+ *
+ * Every action here derives the acting user from the session, requires
+ * association administration to change anything, and validates that the named
+ * scope actually belongs to the association before writing. Descriptive labels
+ * such as `TeamOfficial` are never consulted: authority comes from grants only.
+ */
+
+export type ActionResult<T> =
+  | { success: true; data: T }
+  | { success: false; error: string; details?: unknown };
+
+const ASSOCIATION_ROLES = [
+  "ASSOCIATION_ADMIN",
+  "SCHEDULER",
+  "REGISTRAR",
+  "TREASURER",
+  "COMMUNICATIONS_LEAD",
+  "TEAM_MANAGER",
+  "COACH",
+  "VOLUNTEER_COORDINATOR",
+  "EVENT_MANAGER",
+  "EQUIPMENT_MANAGER",
+] as const satisfies readonly AssociationRole[];
+
+const SCOPE_TYPES = [
+  "ASSOCIATION",
+  "DIVISION",
+  "TEAM",
+  "SEASON",
+  "EVENT",
+  "SIGNUP_EVENT",
+] as const satisfies readonly AssociationRoleScopeType[];
+
+const cuid = z.string().cuid("Invalid ID format");
+
+const grantSchema = z.object({
+  leagueId: cuid,
+  userId: cuid,
+  role: z.enum(ASSOCIATION_ROLES),
+  scopeType: z.enum(SCOPE_TYPES),
+  divisionId: cuid.optional(),
+  teamId: cuid.optional(),
+  seasonId: cuid.optional(),
+  eventId: cuid.optional(),
+  signupEventId: cuid.optional(),
+  notes: z.string().max(500).optional(),
+});
+
+export type GrantAssociationResponsibilityInput = z.infer<typeof grantSchema>;
+
+/**
+ * Confirm the scope target exists *inside this association*.
+ *
+ * Without this a grant could name a team in someone else's league; the database
+ * only enforces tenancy for the team scope, whose compound foreign key carries
+ * the league id. Everything else is checked here.
+ */
+async function scopeBelongsToLeague(
+  leagueId: string,
+  scopeType: AssociationRoleScopeType,
+  scopeId: string | null,
+): Promise<boolean> {
+  if (scopeType === "ASSOCIATION" || scopeId === null) return true;
+
+  switch (scopeType) {
+    case "DIVISION":
+      return (
+        (await prisma.division.findFirst({
+          where: { id: scopeId, leagueId },
+          select: { id: true },
+        })) !== null
+      );
+    case "TEAM":
+      return (
+        (await prisma.team.findFirst({
+          where: { id: scopeId, leagueId },
+          select: { id: true },
+        })) !== null
+      );
+    case "SEASON":
+      return (
+        (await prisma.season.findFirst({
+          where: { id: scopeId, leagueId },
+          select: { id: true },
+        })) !== null
+      );
+    case "EVENT":
+      return (
+        (await prisma.event.findFirst({
+          where: { id: scopeId, leagueId },
+          select: { id: true },
+        })) !== null
+      );
+    case "SIGNUP_EVENT":
+      return (
+        (await prisma.signupEvent.findFirst({
+          where: { id: scopeId, hostLeagueId: leagueId },
+          select: { id: true },
+        })) !== null
+      );
+    default:
+      return false;
+  }
+}
+
+/**
+ * Only association administration may delegate. This is the anti-escalation
+ * rule: a delegate cannot mint further grants, so nobody can widen their own
+ * authority by granting themselves a broader role.
+ */
+async function requireGrantAdministration(
+  actingUserId: string,
+  leagueId: string,
+): Promise<boolean> {
+  return hasCapability({
+    userId: actingUserId,
+    leagueId,
+    capability: Capability.ADMINISTER_ASSOCIATION,
+  });
+}
+
+export async function grantAssociationResponsibility(
+  input: GrantAssociationResponsibilityInput,
+): Promise<ActionResult<{ id: string }>> {
+  try {
+    const actingUserId = await requireUserId();
+    const validated = grantSchema.parse(input);
+
+    if (!(await requireGrantAdministration(actingUserId, validated.leagueId))) {
+      return { success: false, error: "You do not have permission to delegate responsibilities." };
+    }
+
+    // The role must support the scope it is being granted at. Without this the
+    // row would be written and then silently authorize nothing, because the
+    // capability resolver rechecks the same matrix and fails closed.
+    if (!supportedScopesForRole(validated.role).includes(validated.scopeType)) {
+      return {
+        success: false,
+        error: `${validated.role} cannot be granted at ${validated.scopeType} scope.`,
+      };
+    }
+
+    const scope = normalizeScope(validated);
+    if (!scope.ok) {
+      return { success: false, error: scope.error };
+    }
+
+    if (!(await scopeBelongsToLeague(validated.leagueId, validated.scopeType, scope.scopeId))) {
+      return { success: false, error: "That scope does not belong to this association." };
+    }
+
+    const subject = await prisma.user.findUnique({
+      where: { id: validated.userId },
+      select: { id: true },
+    });
+    if (!subject) {
+      return { success: false, error: "That user could not be found." };
+    }
+
+    const existing = await prisma.associationRoleGrant.findFirst({
+      where: {
+        userId: validated.userId,
+        leagueId: validated.leagueId,
+        role: validated.role,
+        scopeType: validated.scopeType,
+        state: "ACTIVE",
+        ...scope.data,
+      },
+      select: { id: true },
+    });
+    if (existing) {
+      // Idempotent: re-granting an identical live responsibility is a no-op
+      // rather than a unique-constraint error surfaced to the administrator.
+      return { success: true, data: { id: existing.id } };
+    }
+
+    const grant = await prisma.associationRoleGrant.create({
+      data: {
+        userId: validated.userId,
+        leagueId: validated.leagueId,
+        role: validated.role,
+        scopeType: validated.scopeType,
+        notes: validated.notes ?? null,
+        grantedById: actingUserId,
+        ...scope.data,
+      },
+      select: { id: true },
+    });
+
+    await logAuditEvent({
+      action: AuditAction.USER_ROLE_ASSIGNED,
+      userId: actingUserId,
+      leagueId: validated.leagueId,
+      teamId: scope.data.teamId ?? undefined,
+      details: {
+        grantId: grant.id,
+        subjectUserId: validated.userId,
+        role: validated.role,
+        scopeType: validated.scopeType,
+        scopeId: scope.scopeId,
+      },
+      timestamp: new Date(),
+    });
+
+    revalidatePath(`/league/${validated.leagueId}/workforce`);
+    return { success: true, data: { id: grant.id } };
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return { success: false, error: "Invalid input.", details: error.issues };
+    }
+    rethrowIfNextRedirectError(error);
+    console.error("Error granting association responsibility:", error);
+    return { success: false, error: "Failed to grant the responsibility. Please try again." };
+  }
+}
+
+const revokeSchema = z.object({
+  grantId: cuid,
+  leagueId: cuid,
+});
+
+export async function revokeAssociationResponsibility(
+  input: z.infer<typeof revokeSchema>,
+): Promise<ActionResult<{ id: string }>> {
+  try {
+    const actingUserId = await requireUserId();
+    const validated = revokeSchema.parse(input);
+
+    if (!(await requireGrantAdministration(actingUserId, validated.leagueId))) {
+      return { success: false, error: "You do not have permission to revoke responsibilities." };
+    }
+
+    // Scoped by leagueId as well as id: a grant id from another association
+    // must not be revocable by this association's administrators.
+    const grant = await prisma.associationRoleGrant.findFirst({
+      where: { id: validated.grantId, leagueId: validated.leagueId },
+      select: { id: true, state: true, userId: true, role: true, teamId: true },
+    });
+    if (!grant) {
+      return { success: false, error: "That responsibility could not be found." };
+    }
+    if (grant.state === "REVOKED") {
+      return { success: true, data: { id: grant.id } };
+    }
+
+    // Revoked rows are kept as history; the ACTIVE-only unique indexes are what
+    // allow the same responsibility to be granted again later.
+    await prisma.associationRoleGrant.update({
+      where: { id: grant.id },
+      data: { state: "REVOKED", revokedAt: new Date(), revokedById: actingUserId },
+    });
+
+    await logAuditEvent({
+      action: AuditAction.USER_ROLE_REMOVED,
+      userId: actingUserId,
+      leagueId: validated.leagueId,
+      teamId: grant.teamId ?? undefined,
+      details: { grantId: grant.id, subjectUserId: grant.userId, role: grant.role },
+      timestamp: new Date(),
+    });
+
+    revalidatePath(`/league/${validated.leagueId}/workforce`);
+    return { success: true, data: { id: grant.id } };
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return { success: false, error: "Invalid input.", details: error.issues };
+    }
+    rethrowIfNextRedirectError(error);
+    console.error("Error revoking association responsibility:", error);
+    return { success: false, error: "Failed to revoke the responsibility. Please try again." };
+  }
+}
+
+export interface ResponsibilityGrantRow {
+  id: string;
+  role: AssociationRole;
+  scopeType: AssociationRoleScopeType;
+  scopeLabel: string;
+  user: { id: string; name: string | null; email: string };
+  createdAt: Date;
+}
+
+export async function listAssociationResponsibilityGrants(
+  leagueId: string,
+): Promise<ActionResult<ResponsibilityGrantRow[]>> {
+  try {
+    const actingUserId = await requireUserId();
+
+    if (!(await requireGrantAdministration(actingUserId, leagueId))) {
+      return { success: false, error: "You do not have permission to view responsibilities." };
+    }
+
+    const grants = await prisma.associationRoleGrant.findMany({
+      where: { leagueId, state: "ACTIVE" },
+      select: {
+        id: true,
+        role: true,
+        scopeType: true,
+        createdAt: true,
+        user: { select: { id: true, name: true, email: true } },
+        division: { select: { name: true } },
+        team: { select: { name: true } },
+        season: { select: { name: true } },
+        event: { select: { title: true } },
+        signupEvent: { select: { title: true } },
+      },
+      orderBy: [{ role: "asc" }, { createdAt: "asc" }],
+    });
+
+    return {
+      success: true,
+      data: grants.map((grant) => ({
+        id: grant.id,
+        role: grant.role,
+        scopeType: grant.scopeType,
+        scopeLabel:
+          grant.division?.name ??
+          grant.team?.name ??
+          grant.season?.name ??
+          grant.event?.title ??
+          grant.signupEvent?.title ??
+          "Entire association",
+        user: grant.user,
+        createdAt: grant.createdAt,
+      })),
+    };
+  } catch (error) {
+    rethrowIfNextRedirectError(error);
+    console.error("Error listing association responsibilities:", error);
+    return { success: false, error: "Failed to load responsibilities." };
+  }
+}
+
+const inviteSchema = grantSchema.omit({ userId: true }).extend({
+  email: z.string().email("A valid email address is required").max(255),
+});
+
+export type InviteAssociationOperatorInput = z.infer<typeof inviteSchema>;
+
+/**
+ * Invite somebody who may not have an account yet, carrying the intended
+ * responsibility on the invitation. The grant is applied at acceptance (see
+ * `acceptInvitationMemberships` in lib/actions/auth.ts) so an unaccepted
+ * invitation never confers authority.
+ */
+export async function inviteAssociationOperator(
+  input: InviteAssociationOperatorInput,
+): Promise<ActionResult<{ invitationId: string }>> {
+  try {
+    const actingUserId = await requireUserId();
+    const validated = inviteSchema.parse(input);
+
+    if (!(await requireGrantAdministration(actingUserId, validated.leagueId))) {
+      return { success: false, error: "You do not have permission to invite operators." };
+    }
+
+    if (!supportedScopesForRole(validated.role).includes(validated.scopeType)) {
+      return {
+        success: false,
+        error: `${validated.role} cannot be granted at ${validated.scopeType} scope.`,
+      };
+    }
+
+    const scope = normalizeScope(validated);
+    if (!scope.ok) {
+      return { success: false, error: scope.error };
+    }
+
+    if (!(await scopeBelongsToLeague(validated.leagueId, validated.scopeType, scope.scopeId))) {
+      return { success: false, error: "That scope does not belong to this association." };
+    }
+
+    // Same construction as the other invitation senders. It cannot be imported
+    // from lib/actions/invitations.ts: that file is "use server", so every
+    // export there must be an async action, not a helper.
+    const token = randomBytes(32).toString("hex");
+
+    const invitation = await prisma.invitation.create({
+      data: {
+        email: validated.email.toLowerCase(),
+        token,
+        leagueId: validated.leagueId,
+        invitedById: actingUserId,
+        expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+        associationRole: validated.role,
+        associationScopeType: validated.scopeType,
+        // TEAM and ASSOCIATION reuse the invitation's existing columns; the
+        // rest get their own so acceptance can apply any scope the grant model
+        // supports.
+        teamId: validated.scopeType === "TEAM" ? scope.data.teamId : null,
+        associationDivisionId: scope.data.divisionId,
+        associationSeasonId: scope.data.seasonId,
+        associationEventId: scope.data.eventId,
+        associationSignupEventId: scope.data.signupEventId,
+      },
+      select: { id: true },
+    });
+
+    revalidatePath(`/league/${validated.leagueId}/workforce`);
+    return { success: true, data: { invitationId: invitation.id } };
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return { success: false, error: "Invalid input.", details: error.issues };
+    }
+    rethrowIfNextRedirectError(error);
+    console.error("Error inviting association operator:", error);
+    return { success: false, error: "Failed to send the invitation. Please try again." };
+  }
+}

--- a/lib/actions/association-roles.ts
+++ b/lib/actions/association-roles.ts
@@ -19,7 +19,7 @@ import {
 } from "@/lib/auth/capabilities";
 import { AuditAction, logAuditEvent } from "@/lib/utils/security";
 import { rethrowIfNextRedirectError } from "@/lib/utils/next-errors";
-import { normalizeScope } from "@/lib/services/association-roles";
+import { normalizeScope, scopeBelongsToLeague } from "@/lib/services/association-roles";
 
 /**
  * Scoped responsibility grants (feature 007 / User Story 3).
@@ -72,61 +72,6 @@ const grantSchema = z.object({
 });
 
 export type GrantAssociationResponsibilityInput = z.infer<typeof grantSchema>;
-
-/**
- * Confirm the scope target exists *inside this association*.
- *
- * Without this a grant could name a team in someone else's league; the database
- * only enforces tenancy for the team scope, whose compound foreign key carries
- * the league id. Everything else is checked here.
- */
-async function scopeBelongsToLeague(
-  leagueId: string,
-  scopeType: AssociationRoleScopeType,
-  scopeId: string | null,
-): Promise<boolean> {
-  if (scopeType === "ASSOCIATION" || scopeId === null) return true;
-
-  switch (scopeType) {
-    case "DIVISION":
-      return (
-        (await prisma.division.findFirst({
-          where: { id: scopeId, leagueId },
-          select: { id: true },
-        })) !== null
-      );
-    case "TEAM":
-      return (
-        (await prisma.team.findFirst({
-          where: { id: scopeId, leagueId },
-          select: { id: true },
-        })) !== null
-      );
-    case "SEASON":
-      return (
-        (await prisma.season.findFirst({
-          where: { id: scopeId, leagueId },
-          select: { id: true },
-        })) !== null
-      );
-    case "EVENT":
-      return (
-        (await prisma.event.findFirst({
-          where: { id: scopeId, leagueId },
-          select: { id: true },
-        })) !== null
-      );
-    case "SIGNUP_EVENT":
-      return (
-        (await prisma.signupEvent.findFirst({
-          where: { id: scopeId, hostLeagueId: leagueId },
-          select: { id: true },
-        })) !== null
-      );
-    default:
-      return false;
-  }
-}
 
 /**
  * Only association administration may delegate. This is the anti-escalation
@@ -370,7 +315,7 @@ export type InviteAssociationOperatorInput = z.infer<typeof inviteSchema>;
  */
 export async function inviteAssociationOperator(
   input: InviteAssociationOperatorInput,
-): Promise<ActionResult<{ invitationId: string }>> {
+): Promise<ActionResult<{ invitationId: string } | { granted: true; id: string }>> {
   try {
     const actingUserId = await requireUserId();
     const validated = inviteSchema.parse(input);
@@ -398,21 +343,53 @@ export async function inviteAssociationOperator(
     // Same construction as the other invitation senders. It cannot be imported
     // from lib/actions/invitations.ts: that file is "use server", so every
     // export there must be an async action, not a helper.
+    // An account that already exists cannot accept a signup invitation —
+    // lib/actions/auth.ts rejects signup for a known address — so grant
+    // directly instead of creating a row nobody can redeem.
+    const existingUser = await prisma.user.findUnique({
+      where: { email: validated.email.toLowerCase() },
+      select: { id: true },
+    });
+
+    if (existingUser) {
+      const granted = await grantAssociationResponsibility({
+        leagueId: validated.leagueId,
+        userId: existingUser.id,
+        role: validated.role,
+        scopeType: validated.scopeType,
+        divisionId: validated.divisionId,
+        teamId: validated.teamId,
+        seasonId: validated.seasonId,
+        eventId: validated.eventId,
+        signupEventId: validated.signupEventId,
+        notes: validated.notes,
+      });
+
+      if (!granted.success) return granted;
+      return { success: true, data: { granted: true as const, id: granted.data.id } };
+    }
+
+    // Same construction as the other invitation senders. It cannot be imported
+    // from lib/actions/invitations.ts: that file is "use server", so every
+    // export there must be an async action, not a helper.
     const token = randomBytes(32).toString("hex");
+
+    // Invitation_exactly_one_target permits exactly one of teamId / leagueId /
+    // organizationId. A TEAM-scoped grant therefore travels as a team-target
+    // invitation and acceptance resolves the owning league from the team;
+    // every other scope travels as a league-target invitation.
+    const isTeamTarget = validated.scopeType === "TEAM";
 
     const invitation = await prisma.invitation.create({
       data: {
         email: validated.email.toLowerCase(),
         token,
-        leagueId: validated.leagueId,
+        teamId: isTeamTarget ? scope.data.teamId : null,
+        leagueId: isTeamTarget ? null : validated.leagueId,
         invitedById: actingUserId,
         expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
         associationRole: validated.role,
         associationScopeType: validated.scopeType,
-        // TEAM and ASSOCIATION reuse the invitation's existing columns; the
-        // rest get their own so acceptance can apply any scope the grant model
-        // supports.
-        teamId: validated.scopeType === "TEAM" ? scope.data.teamId : null,
         associationDivisionId: scope.data.divisionId,
         associationSeasonId: scope.data.seasonId,
         associationEventId: scope.data.eventId,
@@ -420,6 +397,39 @@ export async function inviteAssociationOperator(
       },
       select: { id: true },
     });
+
+    // Reporting "invitation sent" without sending one leaves the recipient with
+    // no way to discover the token, so the send happens before we claim success.
+    const [league, inviter] = await Promise.all([
+      prisma.league.findUnique({
+        where: { id: validated.leagueId },
+        select: { name: true },
+      }),
+      prisma.user.findUnique({
+        where: { id: actingUserId },
+        select: { name: true, email: true },
+      }),
+    ]);
+
+    try {
+      const { sendLeagueInvitationEmail } = await import("@/lib/email/templates");
+      await sendLeagueInvitationEmail({
+        email: validated.email.toLowerCase(),
+        leagueName: league?.name ?? "your association",
+        inviterName: inviter?.name ?? inviter?.email ?? "An administrator",
+        token,
+      });
+    } catch (emailError) {
+      // The row is useless without the token reaching them, so this is a
+      // failure rather than a warning. The invitation is removed so a retry
+      // does not collide with an orphan.
+      console.error("Failed to send association operator invitation:", emailError);
+      await prisma.invitation.delete({ where: { id: invitation.id } }).catch(() => {});
+      return {
+        success: false,
+        error: "The invitation could not be emailed. Please try again.",
+      };
+    }
 
     revalidatePath(`/league/${validated.leagueId}/workforce`);
     return { success: true, data: { invitationId: invitation.id } };

--- a/lib/actions/auth.ts
+++ b/lib/actions/auth.ts
@@ -3,6 +3,7 @@
 import { hash } from "bcryptjs";
 import type { Invitation, Prisma } from "@prisma/client";
 import { prisma } from "@/lib/db/prisma";
+import { applyInvitationResponsibility } from "@/lib/services/association-roles";
 import { ensureLeagueUser } from "@/lib/actions/league";
 import { issueVerificationToken } from "@/lib/auth/tokens";
 import { sendVerificationEmail } from "@/lib/email/templates";
@@ -265,4 +266,10 @@ async function acceptInvitationMemberships(
       });
     }
   }
+
+  // A pending scoped responsibility applies independently of the membership
+  // branches above: an invitation can add somebody to a team AND delegate an
+  // association role in the same acceptance. No-ops when the invitation carries
+  // no role payload.
+  await applyInvitationResponsibility(tx, invitation, user.id);
 }

--- a/lib/actions/gear-inventory.ts
+++ b/lib/actions/gear-inventory.ts
@@ -3,7 +3,8 @@
 import { Prisma, type GearCondition, type GearUnitStatus } from "@prisma/client";
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
-import { requireLeagueRole } from "@/lib/auth/session";
+import { Permission } from "@/lib/utils/permission-types";
+import { requirePermissionForLeague } from "@/lib/utils/permissions";
 import { prisma } from "@/lib/db/prisma";
 import {
   adjustGearPoolStockSchema,
@@ -205,7 +206,7 @@ export async function createGearStorageLocation(
 ): Promise<ActionResult<{ id: string }>> {
   try {
     const validated = createGearStorageLocationSchema.parse(input);
-    const userId = await requireLeagueRole(validated.leagueId, "LEAGUE_ADMIN");
+    const userId = await requirePermissionForLeague(validated.leagueId, Permission.MANAGE_GEAR_INVENTORY);
     const location = await prisma.$transaction(async (tx) => {
       const created = await tx.gearStorageLocation.create({
         data: { ...validated, normalizedName: normalizeGearKey(validated.name) },
@@ -227,7 +228,7 @@ export async function createGearStorageLocation(
 export async function updateGearStorageLocation(input: unknown): Promise<ActionResult<{ id: string }>> {
   try {
     const validated = updateLocationSchema.parse(input);
-    const userId = await requireLeagueRole(validated.leagueId, "LEAGUE_ADMIN");
+    const userId = await requirePermissionForLeague(validated.leagueId, Permission.MANAGE_GEAR_INVENTORY);
     const location = await prisma.$transaction(async (tx) => {
       const existing = await tx.gearStorageLocation.findFirst({
         where: { id: validated.locationId, leagueId: validated.leagueId },
@@ -257,7 +258,7 @@ export async function updateGearStorageLocation(input: unknown): Promise<ActionR
 export async function archiveGearStorageLocation(input: unknown): Promise<ActionResult<{ id: string }>> {
   try {
     const { leagueId, locationId } = locationCommandSchema.parse(input);
-    const userId = await requireLeagueRole(leagueId, "LEAGUE_ADMIN");
+    const userId = await requirePermissionForLeague(leagueId, Permission.MANAGE_GEAR_INVENTORY);
     const location = await prisma.$transaction(async (tx) => {
       const existing = await tx.gearStorageLocation.findFirst({
         where: { id: locationId, leagueId, isActive: true }, select: { id: true },
@@ -296,7 +297,7 @@ export async function createGearCatalogItem(
 ): Promise<ActionResult<{ id: string }>> {
   try {
     const validated = createGearCatalogItemSchema.parse(input);
-    const userId = await requireLeagueRole(validated.leagueId, "LEAGUE_ADMIN");
+    const userId = await requirePermissionForLeague(validated.leagueId, Permission.MANAGE_GEAR_INVENTORY);
     const item = await prisma.$transaction(async (tx) => {
       const created = await tx.gearCatalogItem.create({
         data: { ...validated, normalizedKey: normalizeGearKey([validated.name, validated.category, validated.size ?? ""].join(" ")) },
@@ -319,7 +320,7 @@ export async function createGearCatalogItem(
 export async function updateGearCatalogItem(input: unknown): Promise<ActionResult<{ id: string }>> {
   try {
     const validated = updateCatalogSchema.parse(input);
-    const userId = await requireLeagueRole(validated.leagueId, "LEAGUE_ADMIN");
+    const userId = await requirePermissionForLeague(validated.leagueId, Permission.MANAGE_GEAR_INVENTORY);
     const item = await prisma.$transaction(async (tx) => {
       const existing = await tx.gearCatalogItem.findFirst({
         where: { id: validated.catalogItemId, leagueId: validated.leagueId },
@@ -373,7 +374,7 @@ export async function updateGearCatalogItem(input: unknown): Promise<ActionResul
 export async function archiveGearCatalogItem(input: unknown): Promise<ActionResult<{ id: string }>> {
   try {
     const { leagueId, catalogItemId } = catalogCommandSchema.parse(input);
-    const userId = await requireLeagueRole(leagueId, "LEAGUE_ADMIN");
+    const userId = await requirePermissionForLeague(leagueId, Permission.MANAGE_GEAR_INVENTORY);
     const item = await prisma.$transaction(async (tx) => {
       const existing = await tx.gearCatalogItem.findFirst({
         where: { id: catalogItemId, leagueId, isActive: true }, select: { id: true },
@@ -433,7 +434,7 @@ export async function adjustGearPoolStock(
 ): Promise<ActionResult<{ id: string; quantityOnHand: number; version: number }>> {
   try {
     const validated = adjustGearPoolStockSchema.parse(input);
-    const userId = await requireLeagueRole(validated.leagueId, "LEAGUE_ADMIN");
+    const userId = await requirePermissionForLeague(validated.leagueId, Permission.MANAGE_GEAR_INVENTORY);
     const stock = await withGearSerializableRetry(() => prisma.$transaction(async (tx) => {
       await Promise.all([
         ensureActiveCatalog(tx, validated.leagueId, validated.catalogItemId, "POOLED"),
@@ -504,7 +505,7 @@ export async function adjustGearPoolStock(
 export async function transferGearPoolStock(input: unknown): Promise<ActionResult<{ sourceId: string; destinationId: string }>> {
   try {
     const validated = transferPoolStockSchema.parse(input);
-    const userId = await requireLeagueRole(validated.leagueId, "LEAGUE_ADMIN");
+    const userId = await requirePermissionForLeague(validated.leagueId, Permission.MANAGE_GEAR_INVENTORY);
     const transfer = await withGearSerializableRetry(() => prisma.$transaction(async (tx) => {
       await Promise.all([
         ensureActiveCatalog(tx, validated.leagueId, validated.catalogItemId, "POOLED"),
@@ -571,7 +572,7 @@ export async function createGearUnit(
 ): Promise<ActionResult<{ id: string }>> {
   try {
     const validated = createGearUnitSchema.parse(input);
-    const userId = await requireLeagueRole(validated.leagueId, "LEAGUE_ADMIN");
+    const userId = await requirePermissionForLeague(validated.leagueId, Permission.MANAGE_GEAR_INVENTORY);
     const unit = await prisma.$transaction(async (tx) => {
       await ensureActiveCatalog(tx, validated.leagueId, validated.catalogItemId, "INDIVIDUAL");
       const assetTag = validated.assetTag ? normalizeGearAssetTag(validated.assetTag) : "";
@@ -610,7 +611,7 @@ export async function createGearUnit(
 export async function updateGearUnit(input: unknown): Promise<ActionResult<{ id: string }>> {
   try {
     const validated = updateUnitSchema.parse(input);
-    const userId = await requireLeagueRole(validated.leagueId, "LEAGUE_ADMIN");
+    const userId = await requirePermissionForLeague(validated.leagueId, Permission.MANAGE_GEAR_INVENTORY);
     const unit = await prisma.$transaction(async (tx) => {
       const existing = await tx.gearUnit.findFirst({
         where: { id: validated.unitId, leagueId: validated.leagueId },
@@ -647,7 +648,7 @@ export async function updateGearUnit(input: unknown): Promise<ActionResult<{ id:
 export async function transferGearUnit(input: unknown): Promise<ActionResult<{ id: string }>> {
   try {
     const validated = transferUnitSchema.parse(input);
-    const userId = await requireLeagueRole(validated.leagueId, "LEAGUE_ADMIN");
+    const userId = await requirePermissionForLeague(validated.leagueId, Permission.MANAGE_GEAR_INVENTORY);
     const unit = await prisma.$transaction(async (tx) => {
       const existing = await tx.gearUnit.findFirst({
         where: { id: validated.unitId, leagueId: validated.leagueId },
@@ -687,7 +688,7 @@ export async function transferGearUnit(input: unknown): Promise<ActionResult<{ i
 export async function changeGearUnitCondition(input: unknown): Promise<ActionResult<{ id: string }>> {
   try {
     const validated = changeUnitConditionSchema.parse(input);
-    const userId = await requireLeagueRole(validated.leagueId, "LEAGUE_ADMIN");
+    const userId = await requirePermissionForLeague(validated.leagueId, Permission.MANAGE_GEAR_INVENTORY);
     const unit = await prisma.$transaction(async (tx) => {
       const existing = await tx.gearUnit.findFirst({
         where: { id: validated.unitId, leagueId: validated.leagueId },
@@ -731,7 +732,7 @@ export async function changeGearUnitCondition(input: unknown): Promise<ActionRes
 export async function retireGearUnit(input: unknown): Promise<ActionResult<{ id: string }>> {
   try {
     const validated = retireUnitSchema.parse(input);
-    const userId = await requireLeagueRole(validated.leagueId, "LEAGUE_ADMIN");
+    const userId = await requirePermissionForLeague(validated.leagueId, Permission.MANAGE_GEAR_INVENTORY);
     const unit = await prisma.$transaction(async (tx) => {
       const existing = await tx.gearUnit.findFirst({
         where: { id: validated.unitId, leagueId: validated.leagueId },
@@ -767,7 +768,7 @@ export async function retireGearUnit(input: unknown): Promise<ActionResult<{ id:
 export async function unretireGearUnit(input: unknown): Promise<ActionResult<{ id: string }>> {
   try {
     const validated = unretireUnitSchema.parse(input);
-    const userId = await requireLeagueRole(validated.leagueId, "LEAGUE_ADMIN");
+    const userId = await requirePermissionForLeague(validated.leagueId, Permission.MANAGE_GEAR_INVENTORY);
     const unit = await prisma.$transaction(async (tx) => {
       const existing = await tx.gearUnit.findFirst({
         where: { id: validated.unitId, leagueId: validated.leagueId },

--- a/lib/actions/gear-pledges.ts
+++ b/lib/actions/gear-pledges.ts
@@ -4,7 +4,8 @@ import { createHash } from "node:crypto";
 import { Prisma } from "@prisma/client";
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
-import { requireLeagueRole } from "@/lib/auth/session";
+import { Permission } from "@/lib/utils/permission-types";
+import { requirePermissionForLeague } from "@/lib/utils/permissions";
 import { prisma } from "@/lib/db/prisma";
 import { recordGearActivity, recordGearInventoryMovement } from "@/lib/services/gear-ledger";
 import { queueGearOutboxForEmail, queueGearOutboxForLeagueAdmins } from "@/lib/services/gear-outbox";
@@ -224,7 +225,7 @@ export async function receiveGearPledge(
   try {
     const validated = receiveGearPledgeSchema.parse(input);
     const payloadHash = receiptPayloadHash(validated);
-    const userId = await requireLeagueRole(validated.leagueId, "LEAGUE_ADMIN");
+    const userId = await requirePermissionForLeague(validated.leagueId, Permission.MANAGE_GEAR_WISHLIST);
     const result = await withGearSerializableRetry(() => prisma.$transaction(async (tx) => {
       const priorCommand = await tx.gearPledgeReceiptCommand.findUnique({
         where: {
@@ -576,7 +577,7 @@ export async function correctGearPledgeReceipt(
 ): Promise<ActionResult<{ receiptId: string; pledgeStatus: string; pledgeVersion: number }>> {
   try {
     const validated = correctGearPledgeReceiptSchema.parse(input);
-    const userId = await requireLeagueRole(validated.leagueId, "LEAGUE_ADMIN");
+    const userId = await requirePermissionForLeague(validated.leagueId, Permission.MANAGE_GEAR_WISHLIST);
     const result = await withGearSerializableRetry(() => prisma.$transaction(async (tx) => {
       const receipt = await tx.gearPledgeReceipt.findFirst({
         where: {
@@ -709,7 +710,7 @@ export async function redactGearPledgePii(
 ): Promise<ActionResult<{ id: string; version: number }>> {
   try {
     const validated = pledgeCommandSchema.parse(input);
-    const userId = await requireLeagueRole(validated.leagueId, "LEAGUE_ADMIN");
+    const userId = await requirePermissionForLeague(validated.leagueId, Permission.MANAGE_GEAR_WISHLIST);
     const result = await prisma.$transaction(async (tx) => {
       const pledge = await tx.gearPledge.findFirst({
         where: { id: validated.pledgeId, leagueId: validated.leagueId },
@@ -745,7 +746,7 @@ async function transitionPledge(
 ): Promise<ActionResult<{ id: string; status: string; version: number }>> {
   try {
     const validated = pledgeCommandSchema.parse(input);
-    const userId = await requireLeagueRole(validated.leagueId, "LEAGUE_ADMIN");
+    const userId = await requirePermissionForLeague(validated.leagueId, Permission.MANAGE_GEAR_WISHLIST);
     const result = await withGearSerializableRetry(() => prisma.$transaction(async (tx) => {
       const pledge = await tx.gearPledge.findFirst({
         where: { id: validated.pledgeId, leagueId: validated.leagueId, status: "PLEDGED" },
@@ -840,7 +841,7 @@ export type GearPledgeAdminContext = Array<{
 }>;
 
 export async function getGearPledgeAdminContext(leagueId: string): Promise<GearPledgeAdminContext> {
-  await requireLeagueRole(leagueId, "LEAGUE_ADMIN");
+  await requirePermissionForLeague(leagueId, Permission.MANAGE_GEAR_WISHLIST);
   const pledges = await prisma.gearPledge.findMany({
     where: { leagueId },
     select: {

--- a/lib/actions/gear-wishlist.ts
+++ b/lib/actions/gear-wishlist.ts
@@ -4,7 +4,9 @@ import { randomBytes } from "node:crypto";
 import { Prisma } from "@prisma/client";
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
-import { requireLeagueRole, requireUserId } from "@/lib/auth/session";
+import { requireUserId } from "@/lib/auth/session";
+import { Permission } from "@/lib/utils/permission-types";
+import { requirePermissionForLeague } from "@/lib/utils/permissions";
 import { prisma } from "@/lib/db/prisma";
 import { recordGearActivity } from "@/lib/services/gear-ledger";
 import { reportGearActionFailure } from "@/lib/services/gear-observability";
@@ -101,7 +103,7 @@ export async function saveGearWishlist(
 ): Promise<ActionResult<{ id: string; shareToken: string; status: string; version: number }>> {
   try {
     const validated = saveGearWishlistSchema.parse(input);
-    const userId = await requireLeagueRole(validated.leagueId, "LEAGUE_ADMIN");
+    const userId = await requirePermissionForLeague(validated.leagueId, Permission.MANAGE_GEAR_WISHLIST);
 
     const result = await withGearSerializableRetry(() => prisma.$transaction(async (tx) => {
       const existing = await tx.gearWishlist.findUnique({
@@ -291,7 +293,7 @@ export async function saveGearWishlist(
 export async function archiveGearWishlist(input: unknown): Promise<ActionResult<{ id: string; version: number }>> {
   try {
     const validated = wishlistCommandSchema.parse(input);
-    const userId = await requireLeagueRole(validated.leagueId, "LEAGUE_ADMIN");
+    const userId = await requirePermissionForLeague(validated.leagueId, Permission.MANAGE_GEAR_WISHLIST);
     const result = await withGearSerializableRetry(() => prisma.$transaction(async (tx) => {
       const wishlist = await tx.gearWishlist.findUnique({ where: { leagueId: validated.leagueId } });
       if (!wishlist) invalid("Wishlist not found.");
@@ -328,7 +330,7 @@ export async function rotateGearWishlistShareToken(
 ): Promise<ActionResult<{ id: string; shareToken: string; version: number }>> {
   try {
     const validated = wishlistCommandSchema.parse(input);
-    const userId = await requireLeagueRole(validated.leagueId, "LEAGUE_ADMIN");
+    const userId = await requirePermissionForLeague(validated.leagueId, Permission.MANAGE_GEAR_WISHLIST);
     const result = await withGearSerializableRetry(() => prisma.$transaction(async (tx) => {
       const wishlist = await tx.gearWishlist.findUnique({ where: { leagueId: validated.leagueId } });
       if (!wishlist) invalid("Wishlist not found.");
@@ -376,7 +378,7 @@ export async function setGearWishlistStatus(input: unknown): Promise<ActionResul
         : archived;
     }
 
-    const userId = await requireLeagueRole(validated.leagueId, "LEAGUE_ADMIN");
+    const userId = await requirePermissionForLeague(validated.leagueId, Permission.MANAGE_GEAR_WISHLIST);
     const result = await withGearSerializableRetry(() => prisma.$transaction(async (tx) => {
       const wishlist = await tx.gearWishlist.findUnique({
         where: { leagueId: validated.leagueId },
@@ -440,7 +442,7 @@ export type GearWishlistAdminContext = {
 };
 
 export async function getGearWishlistAdminContext(leagueId: string): Promise<GearWishlistAdminContext | null> {
-  await requireLeagueRole(leagueId, "LEAGUE_ADMIN");
+  await requirePermissionForLeague(leagueId, Permission.MANAGE_GEAR_WISHLIST);
   const wishlist = await prisma.gearWishlist.findUnique({
     where: { leagueId },
     select: {

--- a/lib/actions/rsvp.ts
+++ b/lib/actions/rsvp.ts
@@ -241,6 +241,12 @@ export async function getEventAttendance(
       select: { role: true },
     });
 
+    // Organizers may see who answered for a child; ordinary team members may
+    // not. A guardian's name or email attached to a specific participant is
+    // family information, and every member of a youth team could otherwise read
+    // it off the attendance list (spec 007 US3, acceptance scenario 4).
+    let isOrganizer = teamMember?.role === "ADMIN";
+
     if (!teamMember) {
       const eventLeagueId = event.leagueId ?? event.team.leagueId;
       const leagueAdmin = eventLeagueId
@@ -260,6 +266,8 @@ export async function getEventAttendance(
           error: "You do not have access to this event",
         };
       }
+
+      isOrganizer = true;
     }
 
     const rsvps = await prisma.rSVP.findMany({
@@ -300,7 +308,11 @@ export async function getEventAttendance(
         kind: "player",
         name: row.player!.name,
         status: row.status as RSVPStatus,
-        respondedByName: row.user.name ?? row.user.email,
+        // Omitted entirely for non-organizers rather than blanked, so no caller
+        // can infer the responder from a placeholder.
+        ...(isOrganizer
+          ? { respondedByName: row.user.name ?? row.user.email }
+          : {}),
       });
     }
 

--- a/lib/actions/volunteers.ts
+++ b/lib/actions/volunteers.ts
@@ -3,10 +3,14 @@
 import { z } from "zod";
 import { revalidatePath } from "next/cache";
 
+import type { AssociationRoleScopeType } from "@prisma/client";
+
 import { prisma } from "@/lib/db/prisma";
 import { requireUserId } from "@/lib/auth/session";
-import { Capability, hasCapability } from "@/lib/auth/capabilities";
+import { Capability, hasCapability, loadActiveGrants } from "@/lib/auth/capabilities";
+import { ROLE_CAPABILITY_MATRIX } from "@/lib/auth/capability-matrix";
 import { rethrowIfNextRedirectError } from "@/lib/utils/next-errors";
+import { scopeBelongsToLeague } from "@/lib/services/association-roles";
 
 /**
  * Volunteer needs and assignments (feature 007 / User Story 3).
@@ -16,6 +20,14 @@ import { rethrowIfNextRedirectError } from "@/lib/utils/next-errors";
  * else. Volunteers themselves need no capability: they act on assignments
  * addressed to them, which is checked by ownership rather than by role.
  */
+
+/** Rolls the acceptance transaction back with a reason the caller can report. */
+class VolunteerClaimError extends Error {
+  constructor(readonly reason: "FULL" | "ALREADY_ANSWERED") {
+    super(reason);
+    this.name = "VolunteerClaimError";
+  }
+}
 
 export type ActionResult<T> =
   | { success: true; data: T }
@@ -81,6 +93,23 @@ export async function createVolunteerNeed(
 
     if (!(await canOrganize(userId, validated.leagueId, validated))) {
       return { success: false, error: "You do not have permission to organize volunteers." };
+    }
+
+    // Only teamId has a compound tenant foreign key; the other scope columns
+    // would happily reference another association's division, event, or signup
+    // event. Without this a scoped coordinator could attach an association-owned
+    // need to a foreign tenant's activity.
+    const tenancyChecks: Array<[AssociationRoleScopeType, string | undefined]> = [
+      ["DIVISION", validated.divisionId],
+      ["TEAM", validated.teamId],
+      ["EVENT", validated.eventId],
+      ["SIGNUP_EVENT", validated.signupEventId],
+    ];
+    for (const [scopeType, scopeId] of tenancyChecks) {
+      if (!scopeId) continue;
+      if (!(await scopeBelongsToLeague(validated.leagueId, scopeType, scopeId))) {
+        return { success: false, error: "That scope does not belong to this association." };
+      }
     }
 
     const need = await prisma.volunteerNeed.create({
@@ -267,11 +296,30 @@ export async function assignVolunteer(
       return { success: false, error: "You do not have permission to organize volunteers." };
     }
 
+    // An assignment carrying only an email can never be answered: responding
+    // requires the signed-in user to own the row, and nothing claims an email
+    // assignment on signup. Resolve the address to an account, or say so
+    // plainly rather than creating a permanently dead shift.
+    let subjectUserId = validated.userId ?? null;
+    if (!subjectUserId && validated.invitedEmail) {
+      const existing = await prisma.user.findUnique({
+        where: { email: validated.invitedEmail.toLowerCase() },
+        select: { id: true },
+      });
+      if (!existing) {
+        return {
+          success: false,
+          error:
+            "That email address has no account yet. Invite them to the association first, then assign the shift.",
+        };
+      }
+      subjectUserId = existing.id;
+    }
+
     const assignment = await prisma.volunteerAssignment.create({
       data: {
         needId: need.id,
-        userId: validated.userId ?? null,
-        invitedEmail: validated.invitedEmail?.toLowerCase() ?? null,
+        userId: subjectUserId,
         assignedById: actingUserId,
       },
       select: { id: true },
@@ -347,31 +395,45 @@ export async function respondToVolunteerAssignment(
       return { success: true, data: { status: "DECLINED" } };
     }
 
-    const claimed = await prisma.volunteerNeed.updateMany({
-      where: {
-        id: assignment.need.id,
-        status: "OPEN",
-        acceptedCount: { lt: assignment.need.capacity },
-      },
-      data: { acceptedCount: { increment: 1 } },
-    });
-
-    if (claimed.count === 0) {
-      return { success: false, error: "That volunteer need is already full." };
-    }
-
+    // Both writes commit together or neither does. Claiming the assignment
+    // conditionally (still INVITED) is what stops two requests for the SAME
+    // assignment from each incrementing a multi-slot need; the guarded
+    // increment is what stops two different volunteers from taking one slot.
+    // A compensating decrement cannot cover the first case, because both
+    // callers would have already passed the status check.
     try {
-      await prisma.volunteerAssignment.update({
-        where: { id: assignment.id },
-        data: { status: "ACCEPTED", respondedAt: new Date() },
+      await prisma.$transaction(async (tx) => {
+        const claimedAssignment = await tx.volunteerAssignment.updateMany({
+          where: { id: assignment.id, status: "INVITED" },
+          data: { status: "ACCEPTED", respondedAt: new Date() },
+        });
+        if (claimedAssignment.count === 0) {
+          throw new VolunteerClaimError("ALREADY_ANSWERED");
+        }
+
+        const claimedSlot = await tx.volunteerNeed.updateMany({
+          where: {
+            id: assignment.need.id,
+            status: "OPEN",
+            acceptedCount: { lt: assignment.need.capacity },
+          },
+          data: { acceptedCount: { increment: 1 } },
+        });
+        if (claimedSlot.count === 0) {
+          // Rolls the assignment transition back with it.
+          throw new VolunteerClaimError("FULL");
+        }
       });
     } catch (error) {
-      // Hand the slot back rather than leaving it claimed by an assignment that
-      // never reached ACCEPTED.
-      await prisma.volunteerNeed.updateMany({
-        where: { id: assignment.need.id, acceptedCount: { gt: 0 } },
-        data: { acceptedCount: { decrement: 1 } },
-      });
+      if (error instanceof VolunteerClaimError) {
+        return {
+          success: false,
+          error:
+            error.reason === "FULL"
+              ? "That volunteer need is already full."
+              : "That assignment has already been answered.",
+        };
+      }
       throw error;
     }
 
@@ -503,16 +565,31 @@ export async function getVolunteerBoard(
     const userId = await requireUserId();
     const validated = cuid.parse(leagueId);
 
-    const isOrganizer = await hasCapability({
+    // Organizing authority is per need, not per association. Asking with an
+    // empty target classified every team-, division-, or event-scoped
+    // coordinator as a non-organizer, because narrow grants deliberately do
+    // not match an empty target — so the very people authorized to run those
+    // shifts saw only their own rows.
+    const grants = (await loadActiveGrants(userId, validated)).filter(
+      (grant) => ROLE_CAPABILITY_MATRIX[grant.role]?.capabilities.includes(
+        Capability.MANAGE_VOLUNTEERS,
+      ) && ROLE_CAPABILITY_MATRIX[grant.role]?.scopes.includes(grant.scopeType),
+    );
+
+    // Association-wide authority (a grant at association scope, or a legacy
+    // league admin) still short-circuits the per-need matching below.
+    const isAssociationOrganizer = await hasCapability({
       userId,
       leagueId: validated,
       capability: Capability.MANAGE_VOLUNTEERS,
     });
 
+    const hasAnyOrganizingGrant = isAssociationOrganizer || grants.length > 0;
+
     const needs = await prisma.volunteerNeed.findMany({
       where: {
         leagueId: validated,
-        ...(isOrganizer ? {} : { assignments: { some: { userId } } }),
+        ...(hasAnyOrganizingGrant ? {} : { assignments: { some: { userId } } }),
       },
       select: {
         id: true,
@@ -524,9 +601,14 @@ export async function getVolunteerBoard(
         startAt: true,
         endAt: true,
         timezone: true,
-        team: { select: { name: true } },
+        // Scope columns: needed to decide organizer standing per need.
+        teamId: true,
+        divisionId: true,
+        eventId: true,
+        signupEventId: true,
+        team: { select: { name: true, divisionId: true } },
         assignments: {
-          where: isOrganizer ? {} : { userId },
+          where: hasAnyOrganizingGrant ? {} : { userId },
           select: {
             id: true,
             status: true,
@@ -538,11 +620,49 @@ export async function getVolunteerBoard(
       orderBy: { startAt: "asc" },
     });
 
+    // Decide organizer standing per need, in memory, from the grants already
+    // loaded — one query rather than a hasCapability round-trip per row.
+    const organizesNeed = (need: {
+      teamId: string | null;
+      divisionId: string | null;
+      eventId: string | null;
+      signupEventId: string | null;
+      team: { divisionId: string | null } | null;
+    }): boolean => {
+      if (isAssociationOrganizer) return true;
+      return grants.some((grant) => {
+        switch (grant.scopeType) {
+          case "ASSOCIATION":
+            return true;
+          case "DIVISION":
+            return (
+              grant.divisionId !== null &&
+              (grant.divisionId === need.divisionId ||
+                grant.divisionId === need.team?.divisionId)
+            );
+          case "TEAM":
+            return grant.teamId !== null && grant.teamId === need.teamId;
+          case "EVENT":
+            return grant.eventId !== null && grant.eventId === need.eventId;
+          case "SIGNUP_EVENT":
+            return (
+              grant.signupEventId !== null && grant.signupEventId === need.signupEventId
+            );
+          default:
+            return false;
+        }
+      });
+    };
+
+    const visible = needs.filter(
+      (need) => organizesNeed(need) || need.assignments.length > 0,
+    );
+
     return {
       success: true,
       data: {
-        isOrganizer,
-        needs: needs.map((need) => ({
+        isOrganizer: isAssociationOrganizer || visible.some(organizesNeed),
+        needs: visible.map((need) => ({
           id: need.id,
           roleLabel: need.roleLabel,
           description: need.description,

--- a/lib/actions/volunteers.ts
+++ b/lib/actions/volunteers.ts
@@ -1,0 +1,576 @@
+"use server";
+
+import { z } from "zod";
+import { revalidatePath } from "next/cache";
+
+import { prisma } from "@/lib/db/prisma";
+import { requireUserId } from "@/lib/auth/session";
+import { Capability, hasCapability } from "@/lib/auth/capabilities";
+import { rethrowIfNextRedirectError } from "@/lib/utils/next-errors";
+
+/**
+ * Volunteer needs and assignments (feature 007 / User Story 3).
+ *
+ * Organizing is gated on MANAGE_VOLUNTEERS at the need's own scope, so a
+ * team-scoped volunteer coordinator can staff their team's needs and nothing
+ * else. Volunteers themselves need no capability: they act on assignments
+ * addressed to them, which is checked by ownership rather than by role.
+ */
+
+export type ActionResult<T> =
+  | { success: true; data: T }
+  | { success: false; error: string; details?: unknown };
+
+const cuid = z.string().cuid("Invalid ID format");
+
+const createNeedSchema = z
+  .object({
+    leagueId: cuid,
+    roleLabel: z.string().min(1, "A role is required").max(120),
+    description: z.string().max(2000).optional(),
+    capacity: z.number().int().min(1, "Capacity must be at least 1").max(500),
+    startAt: z.coerce.date(),
+    endAt: z.coerce.date(),
+    timezone: z.string().min(1).max(64),
+    divisionId: cuid.optional(),
+    teamId: cuid.optional(),
+    eventId: cuid.optional(),
+    signupEventId: cuid.optional(),
+  })
+  .refine((value) => value.endAt > value.startAt, {
+    message: "The end time must be after the start time",
+    path: ["endAt"],
+  });
+
+export type CreateVolunteerNeedInput = z.input<typeof createNeedSchema>;
+
+/**
+ * Can this user organize volunteers for the given need scope?
+ *
+ * The scope of the *need* is what is checked, not the association as a whole:
+ * a team-scoped coordinator organizing a team need passes, the same coordinator
+ * reaching for an association-wide need does not.
+ */
+async function canOrganize(
+  userId: string,
+  leagueId: string,
+  scope: {
+    teamId?: string | null;
+    divisionId?: string | null;
+    eventId?: string | null;
+    signupEventId?: string | null;
+  },
+): Promise<boolean> {
+  return hasCapability({
+    userId,
+    leagueId,
+    capability: Capability.MANAGE_VOLUNTEERS,
+    teamId: scope.teamId ?? undefined,
+    divisionId: scope.divisionId ?? undefined,
+    eventId: scope.eventId ?? undefined,
+    signupEventId: scope.signupEventId ?? undefined,
+  });
+}
+
+export async function createVolunteerNeed(
+  input: CreateVolunteerNeedInput,
+): Promise<ActionResult<{ id: string }>> {
+  try {
+    const userId = await requireUserId();
+    const validated = createNeedSchema.parse(input);
+
+    if (!(await canOrganize(userId, validated.leagueId, validated))) {
+      return { success: false, error: "You do not have permission to organize volunteers." };
+    }
+
+    const need = await prisma.volunteerNeed.create({
+      data: {
+        leagueId: validated.leagueId,
+        roleLabel: validated.roleLabel,
+        description: validated.description ?? null,
+        capacity: validated.capacity,
+        startAt: validated.startAt,
+        endAt: validated.endAt,
+        timezone: validated.timezone,
+        divisionId: validated.divisionId ?? null,
+        teamId: validated.teamId ?? null,
+        eventId: validated.eventId ?? null,
+        signupEventId: validated.signupEventId ?? null,
+        createdById: userId,
+      },
+      select: { id: true },
+    });
+
+    revalidatePath(`/league/${validated.leagueId}/workforce`);
+    return { success: true, data: { id: need.id } };
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return { success: false, error: "Invalid input.", details: error.issues };
+    }
+    rethrowIfNextRedirectError(error);
+    console.error("Error creating volunteer need:", error);
+    return { success: false, error: "Failed to create the volunteer need." };
+  }
+}
+
+const updateNeedSchema = z.object({
+  needId: cuid,
+  roleLabel: z.string().min(1).max(120).optional(),
+  description: z.string().max(2000).nullable().optional(),
+  capacity: z.number().int().min(1).max(500).optional(),
+  status: z.enum(["OPEN", "CLOSED", "COMPLETED"]).optional(),
+});
+
+export async function updateVolunteerNeed(
+  input: z.infer<typeof updateNeedSchema>,
+): Promise<ActionResult<{ id: string }>> {
+  try {
+    const userId = await requireUserId();
+    const validated = updateNeedSchema.parse(input);
+
+    const need = await prisma.volunteerNeed.findUnique({
+      where: { id: validated.needId },
+      select: {
+        id: true,
+        leagueId: true,
+        teamId: true,
+        divisionId: true,
+        eventId: true,
+        signupEventId: true,
+        acceptedCount: true,
+        status: true,
+      },
+    });
+    if (!need) return { success: false, error: "That volunteer need could not be found." };
+
+    if (!(await canOrganize(userId, need.leagueId, need))) {
+      return { success: false, error: "You do not have permission to organize volunteers." };
+    }
+
+    // Capacity may not be cut below what has already been accepted: the people
+    // holding those slots were told they had them, and the database CHECK would
+    // reject it anyway.
+    if (validated.capacity !== undefined && validated.capacity < need.acceptedCount) {
+      return {
+        success: false,
+        error: `Capacity cannot be lower than the ${need.acceptedCount} volunteer(s) already accepted.`,
+      };
+    }
+
+    await prisma.volunteerNeed.update({
+      where: { id: need.id },
+      data: {
+        ...(validated.roleLabel !== undefined ? { roleLabel: validated.roleLabel } : {}),
+        ...(validated.description !== undefined ? { description: validated.description } : {}),
+        ...(validated.capacity !== undefined ? { capacity: validated.capacity } : {}),
+        ...(validated.status !== undefined ? { status: validated.status } : {}),
+        ...(validated.status === "COMPLETED" ? { completedAt: new Date() } : {}),
+      },
+    });
+
+    revalidatePath(`/league/${need.leagueId}/workforce`);
+    return { success: true, data: { id: need.id } };
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return { success: false, error: "Invalid input.", details: error.issues };
+    }
+    rethrowIfNextRedirectError(error);
+    console.error("Error updating volunteer need:", error);
+    return { success: false, error: "Failed to update the volunteer need." };
+  }
+}
+
+export async function cancelVolunteerNeed(
+  needId: string,
+): Promise<ActionResult<{ id: string }>> {
+  try {
+    const userId = await requireUserId();
+    const validated = cuid.parse(needId);
+
+    const need = await prisma.volunteerNeed.findUnique({
+      where: { id: validated },
+      select: {
+        id: true,
+        leagueId: true,
+        teamId: true,
+        divisionId: true,
+        eventId: true,
+        signupEventId: true,
+      },
+    });
+    if (!need) return { success: false, error: "That volunteer need could not be found." };
+
+    if (!(await canOrganize(userId, need.leagueId, need))) {
+      return { success: false, error: "You do not have permission to organize volunteers." };
+    }
+
+    // Cancelling the need cancels its live assignments too, so nobody is left
+    // believing they are still expected to turn up.
+    await prisma.$transaction([
+      prisma.volunteerNeed.update({
+        where: { id: need.id },
+        data: { status: "CANCELED", canceledAt: new Date() },
+      }),
+      prisma.volunteerAssignment.updateMany({
+        where: { needId: need.id, status: { in: ["INVITED", "ACCEPTED"] } },
+        data: { status: "CANCELED" },
+      }),
+    ]);
+
+    revalidatePath(`/league/${need.leagueId}/workforce`);
+    return { success: true, data: { id: need.id } };
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return { success: false, error: "Invalid volunteer need ID." };
+    }
+    rethrowIfNextRedirectError(error);
+    console.error("Error cancelling volunteer need:", error);
+    return { success: false, error: "Failed to cancel the volunteer need." };
+  }
+}
+
+const assignSchema = z
+  .object({
+    needId: cuid,
+    userId: cuid.optional(),
+    invitedEmail: z.string().email().max(255).optional(),
+  })
+  .refine((v) => Boolean(v.userId) !== Boolean(v.invitedEmail), {
+    message: "Provide either a user or an email address, not both",
+  });
+
+export async function assignVolunteer(
+  input: z.infer<typeof assignSchema>,
+): Promise<ActionResult<{ id: string }>> {
+  try {
+    const actingUserId = await requireUserId();
+    const validated = assignSchema.parse(input);
+
+    const need = await prisma.volunteerNeed.findUnique({
+      where: { id: validated.needId },
+      select: {
+        id: true,
+        leagueId: true,
+        teamId: true,
+        divisionId: true,
+        eventId: true,
+        signupEventId: true,
+        status: true,
+      },
+    });
+    if (!need) return { success: false, error: "That volunteer need could not be found." };
+    if (need.status !== "OPEN") {
+      return { success: false, error: "That volunteer need is no longer open." };
+    }
+
+    if (!(await canOrganize(actingUserId, need.leagueId, need))) {
+      return { success: false, error: "You do not have permission to organize volunteers." };
+    }
+
+    const assignment = await prisma.volunteerAssignment.create({
+      data: {
+        needId: need.id,
+        userId: validated.userId ?? null,
+        invitedEmail: validated.invitedEmail?.toLowerCase() ?? null,
+        assignedById: actingUserId,
+      },
+      select: { id: true },
+    });
+
+    revalidatePath(`/league/${need.leagueId}/workforce`);
+    return { success: true, data: { id: assignment.id } };
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return { success: false, error: "Invalid input.", details: error.issues };
+    }
+    rethrowIfNextRedirectError(error);
+    console.error("Error assigning volunteer:", error);
+    return { success: false, error: "Failed to assign the volunteer." };
+  }
+}
+
+const respondSchema = z.object({
+  assignmentId: cuid,
+  response: z.enum(["ACCEPTED", "DECLINED"]),
+});
+
+/**
+ * A volunteer accepts or declines their own assignment.
+ *
+ * Acceptance claims a capacity slot atomically. The claim is a conditional
+ * `updateMany` guarded on `acceptedCount < capacity`, evaluated by Postgres at
+ * write time: two simultaneous acceptances of a one-slot need both issue the
+ * same guarded update, the first matches one row, and the second matches zero
+ * because the counter has already moved. ADR-0003 rules out
+ * `SELECT ... FOR UPDATE`, and this needs no lock.
+ *
+ * The `acceptedCount <= capacity` CHECK on the table is the backstop if the
+ * guard is ever wrong.
+ */
+export async function respondToVolunteerAssignment(
+  input: z.infer<typeof respondSchema>,
+): Promise<ActionResult<{ status: "ACCEPTED" | "DECLINED" }>> {
+  try {
+    const userId = await requireUserId();
+    const validated = respondSchema.parse(input);
+
+    const assignment = await prisma.volunteerAssignment.findUnique({
+      where: { id: validated.assignmentId },
+      select: {
+        id: true,
+        userId: true,
+        status: true,
+        need: { select: { id: true, leagueId: true, capacity: true, status: true } },
+      },
+    });
+    if (!assignment) {
+      return { success: false, error: "That assignment could not be found." };
+    }
+
+    // Ownership, not capability: a volunteer answers only for themselves.
+    if (assignment.userId !== userId) {
+      return { success: false, error: "That assignment is not yours to answer." };
+    }
+    if (assignment.status !== "INVITED") {
+      return { success: false, error: "That assignment has already been answered." };
+    }
+    if (assignment.need.status !== "OPEN") {
+      return { success: false, error: "That volunteer need is no longer open." };
+    }
+
+    if (validated.response === "DECLINED") {
+      await prisma.volunteerAssignment.update({
+        where: { id: assignment.id },
+        data: { status: "DECLINED", respondedAt: new Date() },
+      });
+      revalidatePath(`/league/${assignment.need.leagueId}/workforce`);
+      return { success: true, data: { status: "DECLINED" } };
+    }
+
+    const claimed = await prisma.volunteerNeed.updateMany({
+      where: {
+        id: assignment.need.id,
+        status: "OPEN",
+        acceptedCount: { lt: assignment.need.capacity },
+      },
+      data: { acceptedCount: { increment: 1 } },
+    });
+
+    if (claimed.count === 0) {
+      return { success: false, error: "That volunteer need is already full." };
+    }
+
+    try {
+      await prisma.volunteerAssignment.update({
+        where: { id: assignment.id },
+        data: { status: "ACCEPTED", respondedAt: new Date() },
+      });
+    } catch (error) {
+      // Hand the slot back rather than leaving it claimed by an assignment that
+      // never reached ACCEPTED.
+      await prisma.volunteerNeed.updateMany({
+        where: { id: assignment.need.id, acceptedCount: { gt: 0 } },
+        data: { acceptedCount: { decrement: 1 } },
+      });
+      throw error;
+    }
+
+    revalidatePath(`/league/${assignment.need.leagueId}/workforce`);
+    return { success: true, data: { status: "ACCEPTED" } };
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return { success: false, error: "Invalid input.", details: error.issues };
+    }
+    rethrowIfNextRedirectError(error);
+    console.error("Error responding to volunteer assignment:", error);
+    return { success: false, error: "Failed to record your response." };
+  }
+}
+
+const outcomeSchema = z.object({
+  assignmentId: cuid,
+  outcome: z.enum(["COMPLETED", "MISSED"]),
+});
+
+/** Organizer records whether an accepted volunteer actually turned up. */
+async function recordAssignmentOutcome(
+  input: z.infer<typeof outcomeSchema>,
+): Promise<ActionResult<{ id: string }>> {
+  const userId = await requireUserId();
+  const validated = outcomeSchema.parse(input);
+
+  const assignment = await prisma.volunteerAssignment.findUnique({
+    where: { id: validated.assignmentId },
+    select: {
+      id: true,
+      status: true,
+      need: {
+        select: {
+          leagueId: true,
+          teamId: true,
+          divisionId: true,
+          eventId: true,
+          signupEventId: true,
+        },
+      },
+    },
+  });
+  if (!assignment) {
+    return { success: false, error: "That assignment could not be found." };
+  }
+
+  if (!(await canOrganize(userId, assignment.need.leagueId, assignment.need))) {
+    return { success: false, error: "You do not have permission to organize volunteers." };
+  }
+
+  if (assignment.status !== "ACCEPTED") {
+    return { success: false, error: "Only an accepted assignment can be closed out." };
+  }
+
+  await prisma.volunteerAssignment.update({
+    where: { id: assignment.id },
+    data: {
+      status: validated.outcome,
+      ...(validated.outcome === "COMPLETED" ? { completedAt: new Date() } : {}),
+    },
+  });
+
+  revalidatePath(`/league/${assignment.need.leagueId}/workforce`);
+  return { success: true, data: { id: assignment.id } };
+}
+
+export async function completeVolunteerAssignment(
+  assignmentId: string,
+): Promise<ActionResult<{ id: string }>> {
+  try {
+    return await recordAssignmentOutcome({ assignmentId, outcome: "COMPLETED" });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return { success: false, error: "Invalid assignment ID." };
+    }
+    rethrowIfNextRedirectError(error);
+    console.error("Error completing volunteer assignment:", error);
+    return { success: false, error: "Failed to complete the assignment." };
+  }
+}
+
+export async function markVolunteerAssignmentMissed(
+  assignmentId: string,
+): Promise<ActionResult<{ id: string }>> {
+  try {
+    return await recordAssignmentOutcome({ assignmentId, outcome: "MISSED" });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return { success: false, error: "Invalid assignment ID." };
+    }
+    rethrowIfNextRedirectError(error);
+    console.error("Error marking volunteer assignment missed:", error);
+    return { success: false, error: "Failed to update the assignment." };
+  }
+}
+
+export interface VolunteerNeedSummary {
+  id: string;
+  roleLabel: string;
+  description: string | null;
+  capacity: number;
+  acceptedCount: number;
+  status: string;
+  startAt: Date;
+  endAt: Date;
+  timezone: string;
+  teamName: string | null;
+  /** Populated for organizers only; volunteers see just their own assignment. */
+  assignments: Array<{
+    id: string;
+    status: string;
+    personLabel: string;
+  }>;
+}
+
+/**
+ * Board data for one association.
+ *
+ * Organizers see fulfillment across every need. Everyone else sees only needs
+ * they hold an assignment on, with no other volunteer's identity attached —
+ * "authorized organizers see fulfillment; volunteers see only their own
+ * assignments and safe activity context" (contracts/association-actions.md).
+ */
+export async function getVolunteerBoard(
+  leagueId: string,
+): Promise<ActionResult<{ needs: VolunteerNeedSummary[]; isOrganizer: boolean }>> {
+  try {
+    const userId = await requireUserId();
+    const validated = cuid.parse(leagueId);
+
+    const isOrganizer = await hasCapability({
+      userId,
+      leagueId: validated,
+      capability: Capability.MANAGE_VOLUNTEERS,
+    });
+
+    const needs = await prisma.volunteerNeed.findMany({
+      where: {
+        leagueId: validated,
+        ...(isOrganizer ? {} : { assignments: { some: { userId } } }),
+      },
+      select: {
+        id: true,
+        roleLabel: true,
+        description: true,
+        capacity: true,
+        acceptedCount: true,
+        status: true,
+        startAt: true,
+        endAt: true,
+        timezone: true,
+        team: { select: { name: true } },
+        assignments: {
+          where: isOrganizer ? {} : { userId },
+          select: {
+            id: true,
+            status: true,
+            invitedEmail: true,
+            user: { select: { name: true, email: true } },
+          },
+        },
+      },
+      orderBy: { startAt: "asc" },
+    });
+
+    return {
+      success: true,
+      data: {
+        isOrganizer,
+        needs: needs.map((need) => ({
+          id: need.id,
+          roleLabel: need.roleLabel,
+          description: need.description,
+          capacity: need.capacity,
+          acceptedCount: need.acceptedCount,
+          status: need.status,
+          startAt: need.startAt,
+          endAt: need.endAt,
+          timezone: need.timezone,
+          teamName: need.team?.name ?? null,
+          assignments: need.assignments.map((assignment) => ({
+            id: assignment.id,
+            status: assignment.status,
+            personLabel:
+              assignment.user?.name ??
+              assignment.user?.email ??
+              assignment.invitedEmail ??
+              "Invited volunteer",
+          })),
+        })),
+      },
+    };
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return { success: false, error: "Invalid association ID." };
+    }
+    rethrowIfNextRedirectError(error);
+    console.error("Error loading volunteer board:", error);
+    return { success: false, error: "Failed to load volunteers." };
+  }
+}

--- a/lib/auth/capabilities.ts
+++ b/lib/auth/capabilities.ts
@@ -55,7 +55,7 @@ export interface HasCapabilityOptions extends CapabilityTarget {
 }
 
 /** The grant columns scope resolution needs. */
-interface GrantRow {
+export interface GrantRow {
   role: AssociationRole;
   scopeType: AssociationRoleScopeType;
   divisionId: string | null;
@@ -132,7 +132,7 @@ async function userAdministersTeam(
  * work has nothing to match against and returns false rather than defaulting to
  * "any team".
  */
-async function grantCoversTarget(
+export async function grantCoversTarget(
   leagueId: string,
   grant: GrantRow,
   target: CapabilityTarget,
@@ -273,6 +273,15 @@ export async function grantsAllowGearAction(options: {
   const grants = await loadActiveGrants(userId, leagueId);
 
   for (const grant of grants) {
+    // An explicit ASSOCIATION_ADMIN grant carries every capability, gear
+    // included — the role matrix says so, and the data model lists association
+    // gear access. Without this an invited association admin who is not also a
+    // legacy LeagueUser LEAGUE_ADMIN reaches the gear domain as a plain member.
+    // The mandatory-teamId check above still applies.
+    if (grant.role === "ASSOCIATION_ADMIN" && grant.scopeType === "ASSOCIATION") {
+      return true;
+    }
+
     if (grant.role === "EQUIPMENT_MANAGER") {
       switch (grant.scopeType) {
         case "ASSOCIATION":

--- a/lib/auth/capabilities.ts
+++ b/lib/auth/capabilities.ts
@@ -1,0 +1,320 @@
+import type {
+  AssociationRole,
+  AssociationRoleScopeType,
+} from "@prisma/client";
+
+import { prisma } from "@/lib/db/prisma";
+import { LeagueAccessLevel, getUserLeagueAccessLevel } from "@/lib/utils/security";
+import {
+  Capability,
+  ROLE_CAPABILITY_MATRIX,
+  supportedScopesForRole,
+  type GearAction,
+} from "@/lib/auth/capability-matrix";
+
+export { Capability, ROLE_CAPABILITY_MATRIX, supportedScopesForRole };
+export type { GearAction } from "@/lib/auth/capability-matrix";
+
+/**
+ * Delegated capability resolution for feature 007 / User Story 3.
+ *
+ * `AssociationRoleGrant` is the only source of delegated authority. Two things
+ * are deliberately NOT authorization sources:
+ *
+ *  - `TeamOfficial`, which is a descriptive label ("Head Coach") that anyone
+ *    may be given for a roster listing. Spec 007 US3 says twice that it never
+ *    grants capability, so nothing here reads it.
+ *  - `VenueStaff`, which stays in the venue organization model. Venue authority
+ *    is not mirrored into association grants.
+ *
+ * The matrix below is an allowlist. A role/capability/scope combination that is
+ * not written down produces `false`, so new roles or scopes fail closed until
+ * someone states what they may do.
+ */
+
+/**
+ * Capabilities a pre-existing team admin keeps while the backfill (T063) has
+ * not run. Mirrors TEAM_MANAGER, which is the role that describes what a team
+ * admin could already do.
+ */
+const LEGACY_TEAM_ADMIN_CAPABILITIES = ROLE_CAPABILITY_MATRIX.TEAM_MANAGER.capabilities;
+
+/** The scope target a caller is asking about. At most one is meaningful. */
+export interface CapabilityTarget {
+  teamId?: string | null;
+  divisionId?: string | null;
+  seasonId?: string | null;
+  eventId?: string | null;
+  signupEventId?: string | null;
+}
+
+export interface HasCapabilityOptions extends CapabilityTarget {
+  userId: string;
+  leagueId: string;
+  capability: Capability;
+}
+
+/** The grant columns scope resolution needs. */
+interface GrantRow {
+  role: AssociationRole;
+  scopeType: AssociationRoleScopeType;
+  divisionId: string | null;
+  teamId: string | null;
+  seasonId: string | null;
+  eventId: string | null;
+  signupEventId: string | null;
+}
+
+/**
+ * Load a user's ACTIVE grants for one association.
+ *
+ * Exported so the gear bridge in lib/utils/permissions.ts reads grants exactly
+ * the same way rather than writing a second query with its own filters.
+ */
+export async function loadActiveGrants(
+  userId: string,
+  leagueId: string,
+): Promise<GrantRow[]> {
+  return prisma.associationRoleGrant.findMany({
+    where: { userId, leagueId, state: "ACTIVE" },
+    select: {
+      role: true,
+      scopeType: true,
+      divisionId: true,
+      teamId: true,
+      seasonId: true,
+      eventId: true,
+      signupEventId: true,
+    },
+  });
+}
+
+/**
+ * Is `teamId` currently in `divisionId` within this league?
+ *
+ * "Currently" is the point: division-scoped authority follows the division's
+ * present membership, so moving a team out of a division removes the delegate's
+ * reach over it without anyone editing a grant.
+ */
+async function teamIsInDivision(
+  leagueId: string,
+  teamId: string,
+  divisionId: string,
+): Promise<boolean> {
+  const team = await prisma.team.findFirst({
+    where: { id: teamId, divisionId, leagueId },
+    select: { id: true },
+  });
+  return team !== null;
+}
+
+async function userAdministersTeam(
+  leagueId: string,
+  userId: string,
+  teamId: string,
+): Promise<boolean> {
+  const team = await prisma.team.findFirst({
+    where: {
+      id: teamId,
+      leagueId,
+      isActive: true,
+      members: { some: { userId, role: "ADMIN" } },
+    },
+    select: { id: true },
+  });
+  return team !== null;
+}
+
+/**
+ * Does one grant's scope cover the requested target?
+ *
+ * A narrow grant never widens: a team-scoped grant asked about association-wide
+ * work has nothing to match against and returns false rather than defaulting to
+ * "any team".
+ */
+async function grantCoversTarget(
+  leagueId: string,
+  grant: GrantRow,
+  target: CapabilityTarget,
+): Promise<boolean> {
+  switch (grant.scopeType) {
+    case "ASSOCIATION":
+      // Bounded by the required leagueId every grant row carries; the query
+      // that loaded it already filtered on this league.
+      return true;
+
+    case "DIVISION": {
+      if (!grant.divisionId) return false;
+      if (target.divisionId) return target.divisionId === grant.divisionId;
+      if (target.teamId) {
+        return teamIsInDivision(leagueId, target.teamId, grant.divisionId);
+      }
+      return false;
+    }
+
+    case "TEAM":
+      return Boolean(grant.teamId) && target.teamId === grant.teamId;
+
+    case "SEASON":
+      return Boolean(grant.seasonId) && target.seasonId === grant.seasonId;
+
+    case "EVENT":
+      return Boolean(grant.eventId) && target.eventId === grant.eventId;
+
+    case "SIGNUP_EVENT":
+      return Boolean(grant.signupEventId) && target.signupEventId === grant.signupEventId;
+
+    default:
+      // Unknown scope kind: fail closed rather than assume it is permissive.
+      return false;
+  }
+}
+
+/**
+ * Does this grant authorize `capability` over `target`?
+ *
+ * Both halves must hold: the role must own the capability, AND the grant must
+ * be recorded at a scope the role supports. The second check is what stops a
+ * row written at an unsupported scope — by an older migration, a bug, or a
+ * direct database edit — from authorizing anything.
+ */
+async function grantAuthorizes(
+  leagueId: string,
+  grant: GrantRow,
+  capability: Capability,
+  target: CapabilityTarget,
+): Promise<boolean> {
+  const entry = ROLE_CAPABILITY_MATRIX[grant.role];
+  if (!entry) return false;
+  if (!entry.capabilities.includes(capability)) return false;
+  if (!entry.scopes.includes(grant.scopeType)) return false;
+
+  return grantCoversTarget(leagueId, grant, target);
+}
+
+/**
+ * Resolve whether a user holds `capability` over the given target.
+ *
+ * Order: legacy compatibility first (it needs no grant query), then grants.
+ * Existing league admins keep full authority until the backfill in T063 gives
+ * them real grants, so enabling this feature cannot lock an association out of
+ * its own administration.
+ */
+export async function hasCapability(
+  options: HasCapabilityOptions,
+): Promise<boolean> {
+  const { userId, leagueId, capability, ...target } = options;
+
+  const accessLevel = await getUserLeagueAccessLevel(userId, leagueId);
+
+  if (accessLevel === LeagueAccessLevel.LEAGUE_ADMIN) {
+    return true;
+  }
+
+  if (
+    accessLevel === LeagueAccessLevel.TEAM_ADMIN &&
+    LEGACY_TEAM_ADMIN_CAPABILITIES.includes(capability) &&
+    target.teamId
+  ) {
+    if (await userAdministersTeam(leagueId, userId, target.teamId)) {
+      return true;
+    }
+  }
+
+  const grants = await loadActiveGrants(userId, leagueId);
+  for (const grant of grants) {
+    if (await grantAuthorizes(leagueId, grant, capability, target)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Throwing form, for Server Actions that have already established the user.
+ */
+export async function requireCapability(
+  options: HasCapabilityOptions,
+): Promise<void> {
+  if (!(await hasCapability(options))) {
+    throw new Error(`Capability denied: ${options.capability}`);
+  }
+}
+
+/**
+ * The equipment-manager scope matrix (data-model.md §6), plus the team manager's
+ * narrow team gear rights.
+ *
+ * | Scope        | Equipment manager may                                    |
+ * | ------------ | -------------------------------------------------------- |
+ * | Association  | inventory, wishlist, and needs/requests for ANY team      |
+ * | Division     | needs/requests for teams *currently* in the division      |
+ * | Team         | needs/requests for that exact team                        |
+ * | Season/Event | nothing — fails closed                                    |
+ *
+ * This is the bridge referenced in the header: gear authority is delegated
+ * here, but it is *applied* by lib/utils/permissions.ts through the same
+ * `hasPermission` entry point the gear actions already call, so no gear action
+ * needs to learn about grants.
+ */
+export async function grantsAllowGearAction(options: {
+  userId: string;
+  leagueId: string;
+  action: GearAction;
+  teamId?: string | null;
+}): Promise<boolean> {
+  const { userId, leagueId, action, teamId } = options;
+
+  // Team-scoped gear work is never league-wide by omission. Mirrors the same
+  // rule in hasPermission so a grant cannot loosen it.
+  if (action === "TEAM_NEED_OR_REQUEST" && !teamId) return false;
+
+  const grants = await loadActiveGrants(userId, leagueId);
+
+  for (const grant of grants) {
+    if (grant.role === "EQUIPMENT_MANAGER") {
+      switch (grant.scopeType) {
+        case "ASSOCIATION":
+          // Inventory and wishlist are association-level; team needs/requests
+          // are allowed for any team in the association.
+          return true;
+
+        case "DIVISION":
+          if (
+            action === "TEAM_NEED_OR_REQUEST" &&
+            teamId &&
+            grant.divisionId &&
+            (await teamIsInDivision(leagueId, teamId, grant.divisionId))
+          ) {
+            return true;
+          }
+          break;
+
+        case "TEAM":
+          if (action === "TEAM_NEED_OR_REQUEST" && teamId === grant.teamId) {
+            return true;
+          }
+          break;
+
+        default:
+          // SEASON, EVENT, SIGNUP_EVENT: no gear meaning. Fail closed.
+          break;
+      }
+      continue;
+    }
+
+    // Team managers may raise needs and requests for their own team, and
+    // nothing else in the gear domain.
+    if (
+      grant.role === "TEAM_MANAGER" &&
+      grant.scopeType === "TEAM" &&
+      action === "TEAM_NEED_OR_REQUEST" &&
+      teamId === grant.teamId
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/lib/auth/capability-matrix.ts
+++ b/lib/auth/capability-matrix.ts
@@ -1,0 +1,132 @@
+import type {
+  AssociationRole,
+  AssociationRoleScopeType,
+} from "@prisma/client";
+
+/**
+ * The role/capability/scope allowlist, with no runtime dependencies.
+ *
+ * Separated from lib/auth/capabilities.ts so that callers needing only the
+ * matrix — invitation acceptance, form validation — do not transitively import
+ * Prisma and the session helpers. Those pull next-auth into the module graph,
+ * which broke unrelated tests that never touch authorization.
+ */
+
+/**
+ * Capability families from plan.md. These are coarser than the gear `Permission`
+ * enum on purpose: association work is delegated in whole responsibilities, not
+ * individual verbs.
+ *
+ * Gear is absent from this enum by design — equipment managers are authorized
+ * through the existing gear `Permission` checks in `lib/utils/permissions.ts`
+ * rather than a second scheme the gear actions would never consult. The scope
+ * matrix that feeds those checks is `grantsAllowGearAction` below.
+ */
+export enum Capability {
+  /** Association administration, audit, export, and conflict override. */
+  ADMINISTER_ASSOCIATION = "administer_association",
+  /** Venue reservations and ice requests. */
+  MANAGE_VENUE_RESERVATIONS = "manage_venue_reservations",
+  /** Schedules, games, and proposals. */
+  MANAGE_SCHEDULE = "manage_schedule",
+  /** Rosters, placements, registration eligibility and reporting. */
+  MANAGE_ROSTER = "manage_roster",
+  /** Payments, refunds, and financial reports. */
+  MANAGE_PAYMENTS = "manage_payments",
+  /** Public content and operational communications. */
+  MANAGE_PUBLIC_CONTENT = "manage_public_content",
+  /** Team administration. */
+  MANAGE_TEAM = "manage_team",
+  /** Practice plans and practice participation. */
+  MANAGE_PRACTICE = "manage_practice",
+  /** Volunteer needs and assignments. */
+  MANAGE_VOLUNTEERS = "manage_volunteers",
+  /** Administration of one exact Event or SignupEvent. */
+  MANAGE_EVENT = "manage_event",
+}
+
+interface RoleEntry {
+  capabilities: Capability[];
+  /** Scopes a grant of this role may legitimately be recorded at. */
+  scopes: AssociationRoleScopeType[];
+}
+
+const ALL_CAPABILITIES = Object.values(Capability);
+
+/**
+ * Role → capabilities and supported scopes (plan.md "Default operational role
+ * matrix"). Anything absent fails closed.
+ */
+export const ROLE_CAPABILITY_MATRIX: Record<AssociationRole, RoleEntry> = {
+  ASSOCIATION_ADMIN: {
+    capabilities: ALL_CAPABILITIES,
+    scopes: ["ASSOCIATION"],
+  },
+  SCHEDULER: {
+    capabilities: [
+      Capability.MANAGE_VENUE_RESERVATIONS,
+      Capability.MANAGE_SCHEDULE,
+      Capability.MANAGE_PRACTICE,
+    ],
+    scopes: ["ASSOCIATION", "DIVISION", "TEAM", "SEASON"],
+  },
+  REGISTRAR: {
+    capabilities: [Capability.MANAGE_ROSTER],
+    scopes: ["ASSOCIATION", "DIVISION", "TEAM", "SEASON"],
+  },
+  TREASURER: {
+    capabilities: [Capability.MANAGE_PAYMENTS],
+    scopes: ["ASSOCIATION"],
+  },
+  COMMUNICATIONS_LEAD: {
+    capabilities: [Capability.MANAGE_PUBLIC_CONTENT],
+    scopes: ["ASSOCIATION", "DIVISION", "TEAM"],
+  },
+  TEAM_MANAGER: {
+    capabilities: [
+      Capability.MANAGE_TEAM,
+      Capability.MANAGE_ROSTER,
+      Capability.MANAGE_PRACTICE,
+      Capability.MANAGE_VOLUNTEERS,
+    ],
+    scopes: ["TEAM"],
+  },
+  COACH: {
+    capabilities: [Capability.MANAGE_PRACTICE],
+    scopes: ["TEAM", "SEASON"],
+  },
+  VOLUNTEER_COORDINATOR: {
+    capabilities: [Capability.MANAGE_VOLUNTEERS],
+    scopes: ["ASSOCIATION", "DIVISION", "TEAM", "SEASON", "EVENT"],
+  },
+  EVENT_MANAGER: {
+    capabilities: [Capability.MANAGE_EVENT],
+    scopes: ["EVENT", "SIGNUP_EVENT"],
+  },
+  EQUIPMENT_MANAGER: {
+    // Intentionally empty: gear authority flows through the gear Permission
+    // bridge in lib/utils/permissions.ts, not through association capabilities.
+    capabilities: [],
+    scopes: ["ASSOCIATION", "DIVISION", "TEAM"],
+  },
+};
+
+/**
+ * Gear actions, expressed coarsely so this module never imports the `Permission`
+ * enum from lib/utils/permissions.ts — that module calls into here, and naming
+ * the enum in both directions would be an import cycle.
+ */
+export type GearAction =
+  /** Association-wide inventory administration. */
+  | "MANAGE_INVENTORY"
+  /** Association-wide public wishlist administration. */
+  | "MANAGE_WISHLIST"
+  /** Team-scoped gear needs and requests; always requires an exact teamId. */
+  | "TEAM_NEED_OR_REQUEST";
+
+/** Scopes a role may be granted at, for validating grant input. */
+export function supportedScopesForRole(
+  role: AssociationRole,
+): AssociationRoleScopeType[] {
+  return ROLE_CAPABILITY_MATRIX[role]?.scopes ?? [];
+}

--- a/lib/data/association-operations.ts
+++ b/lib/data/association-operations.ts
@@ -260,16 +260,17 @@ export async function getAssociationOperationsData(
       select: { status: true, scheduledAt: true },
       orderBy: { scheduledAt: "asc" },
     }),
-    // Open volunteer needs overlapping the window. The shortfall itself
-    // (acceptedCount < capacity) is computed below rather than in the `where`:
-    // Prisma cannot compare two columns of the same row, and a bounded take
-    // keeps this a dashboard query rather than a table scan.
+    // Understaffed open needs overlapping the window. The shortfall is part of
+    // the query via a Prisma field reference, so `take` bounds the *shortages*
+    // rather than the needs scanned — filtering after a take silently reported
+    // "everything staffed" whenever the first N happened to be full.
     prisma.volunteerNeed.findMany({
       where: {
         leagueId,
         status: "OPEN",
         startAt: { lt: to },
         endAt: { gt: from },
+        acceptedCount: { lt: prisma.volunteerNeed.fields.capacity },
       },
       select: {
         id: true,
@@ -333,9 +334,7 @@ export async function getAssociationOperationsData(
 
   // A shortage is an open need that still has unfilled slots. Surfaced to
   // organizers so a game is not discovered to be unstaffed on the morning.
-  const volunteerShortages = volunteerNeeds
-    .filter((need) => need.acceptedCount < need.capacity)
-    .map((need) => ({
+  const volunteerShortages = volunteerNeeds.map((need) => ({
       id: need.id,
       title: need.roleLabel,
       detail: `${need.capacity - need.acceptedCount} of ${need.capacity} unfilled${
@@ -343,7 +342,7 @@ export async function getAssociationOperationsData(
       }`,
       href: href(leagueId, "/workforce"),
       at: need.startAt.toISOString(),
-    }));
+  }));
 
   return {
     leagueId,

--- a/lib/data/association-operations.ts
+++ b/lib/data/association-operations.ts
@@ -29,6 +29,7 @@ export type AssociationOperationsData = {
     phaseGaps: number;
     upcomingReservations: number;
     upcomingChanges: number;
+    volunteerShortages: number;
     urgentGearNeeds: number;
     overdueGearCustody: number;
     outboxPending: number;
@@ -43,6 +44,7 @@ export type AssociationOperationsData = {
   phaseGaps: OperationsAction[];
   upcomingReservations: OperationsAction[];
   upcomingChanges: OperationsAction[];
+  volunteerShortages: OperationsAction[];
   gear: {
     urgentNeeds: OperationsAction[];
     overdueCustody: OperationsAction[];
@@ -101,6 +103,7 @@ export async function getAssociationOperationsData(
     urgentNeeds,
     custody,
     outbox,
+    volunteerNeeds,
   ] = await Promise.all([
     prisma.iceTimeRequest.findMany({
       where: {
@@ -257,6 +260,28 @@ export async function getAssociationOperationsData(
       select: { status: true, scheduledAt: true },
       orderBy: { scheduledAt: "asc" },
     }),
+    // Open volunteer needs overlapping the window. The shortfall itself
+    // (acceptedCount < capacity) is computed below rather than in the `where`:
+    // Prisma cannot compare two columns of the same row, and a bounded take
+    // keeps this a dashboard query rather than a table scan.
+    prisma.volunteerNeed.findMany({
+      where: {
+        leagueId,
+        status: "OPEN",
+        startAt: { lt: to },
+        endAt: { gt: from },
+      },
+      select: {
+        id: true,
+        roleLabel: true,
+        capacity: true,
+        acceptedCount: true,
+        startAt: true,
+        team: { select: { name: true } },
+      },
+      orderBy: { startAt: "asc" },
+      take: 50,
+    }),
   ]);
 
   const unassignedReservations = reservations.filter(
@@ -306,6 +331,20 @@ export async function getAssociationOperationsData(
   const outboxProcessing = outbox.filter((row) => row.status === "PROCESSING");
   const outboxFailed = outbox.filter((row) => row.status === "FAILED");
 
+  // A shortage is an open need that still has unfilled slots. Surfaced to
+  // organizers so a game is not discovered to be unstaffed on the morning.
+  const volunteerShortages = volunteerNeeds
+    .filter((need) => need.acceptedCount < need.capacity)
+    .map((need) => ({
+      id: need.id,
+      title: need.roleLabel,
+      detail: `${need.capacity - need.acceptedCount} of ${need.capacity} unfilled${
+        need.team?.name ? ` · ${need.team.name}` : ""
+      }`,
+      href: href(leagueId, "/workforce"),
+      at: need.startAt.toISOString(),
+    }));
+
   return {
     leagueId,
     window: { from: from.toISOString(), to: to.toISOString() },
@@ -319,6 +358,7 @@ export async function getAssociationOperationsData(
       phaseGaps: phaseGaps.length,
       upcomingReservations: upcomingReservations.length,
       upcomingChanges: upcomingChanges.length,
+      volunteerShortages: volunteerShortages.length,
       urgentGearNeeds: urgentNeeds.length,
       overdueGearCustody: overdueCustody.length,
       outboxPending: outboxPending.length,
@@ -380,6 +420,7 @@ export async function getAssociationOperationsData(
       href: href(leagueId, "/venue-reservations"),
       at: reservation.transitions?.[0]?.occurredAt.toISOString(),
     })),
+    volunteerShortages,
     gear: {
       urgentNeeds: urgentNeeds.map((need) => ({
         id: need.id,

--- a/lib/services/association-roles.ts
+++ b/lib/services/association-roles.ts
@@ -1,3 +1,5 @@
+import { prisma } from "@/lib/db/prisma";
+
 import type {
   AssociationRole,
   AssociationRoleScopeType,
@@ -7,6 +9,61 @@ import type {
 // Pure matrix module: importing lib/auth/capabilities here would pull Prisma
 // and the session helpers (and thus next-auth) into the invitation-acceptance
 // path, which is how an unrelated auth test lost its module resolution.
+/**
+ * Confirm the scope target exists *inside this association*.
+ *
+ * Without this a grant could name a team in someone else's league; the database
+ * only enforces tenancy for the team scope, whose compound foreign key carries
+ * the league id. Everything else is checked here.
+ */
+export async function scopeBelongsToLeague(
+  leagueId: string,
+  scopeType: AssociationRoleScopeType,
+  scopeId: string | null,
+): Promise<boolean> {
+  if (scopeType === "ASSOCIATION" || scopeId === null) return true;
+
+  switch (scopeType) {
+    case "DIVISION":
+      return (
+        (await prisma.division.findFirst({
+          where: { id: scopeId, leagueId },
+          select: { id: true },
+        })) !== null
+      );
+    case "TEAM":
+      return (
+        (await prisma.team.findFirst({
+          where: { id: scopeId, leagueId },
+          select: { id: true },
+        })) !== null
+      );
+    case "SEASON":
+      return (
+        (await prisma.season.findFirst({
+          where: { id: scopeId, leagueId },
+          select: { id: true },
+        })) !== null
+      );
+    case "EVENT":
+      return (
+        (await prisma.event.findFirst({
+          where: { id: scopeId, leagueId },
+          select: { id: true },
+        })) !== null
+      );
+    case "SIGNUP_EVENT":
+      return (
+        (await prisma.signupEvent.findFirst({
+          where: { id: scopeId, hostLeagueId: leagueId },
+          select: { id: true },
+        })) !== null
+      );
+    default:
+      return false;
+  }
+}
+
 import { supportedScopesForRole } from "@/lib/auth/capability-matrix";
 
 /**
@@ -96,8 +153,22 @@ export async function applyInvitationResponsibility(
   },
   userId: string,
 ): Promise<void> {
-  const { associationRole: role, associationScopeType: scopeType, leagueId } = invitation;
-  if (!role || !scopeType || !leagueId) return;
+  const { associationRole: role, associationScopeType: scopeType } = invitation;
+  if (!role || !scopeType) return;
+
+  // Invitation_exactly_one_target means a TEAM-scoped grant arrives as a
+  // team-target invitation with no leagueId, so the owning association is
+  // resolved from the team. Doing it inside the caller's transaction keeps the
+  // grant and the membership rows consistent.
+  let leagueId = invitation.leagueId;
+  if (!leagueId && invitation.teamId) {
+    const team = await tx.team.findUnique({
+      where: { id: invitation.teamId },
+      select: { leagueId: true },
+    });
+    leagueId = team?.leagueId ?? null;
+  }
+  if (!leagueId) return;
 
   if (!supportedScopesForRole(role).includes(scopeType)) return;
 

--- a/lib/services/association-roles.ts
+++ b/lib/services/association-roles.ts
@@ -1,0 +1,130 @@
+import type {
+  AssociationRole,
+  AssociationRoleScopeType,
+  Prisma,
+} from "@prisma/client";
+
+// Pure matrix module: importing lib/auth/capabilities here would pull Prisma
+// and the session helpers (and thus next-auth) into the invitation-acceptance
+// path, which is how an unrelated auth test lost its module resolution.
+import { supportedScopesForRole } from "@/lib/auth/capability-matrix";
+
+/**
+ * Scope normalization and invitation-acceptance application for association
+ * role grants (feature 007 US3).
+ *
+ * These live outside lib/actions/association-roles.ts on purpose: that file is
+ * `"use server"`, where every export becomes a callable RPC endpoint. Applying
+ * a grant takes a Prisma transaction client, which is neither serializable nor
+ * something any client should be able to reach, so it belongs here instead.
+ */
+
+/** The scope column each scope type is required to populate. */
+const SCOPE_FIELD = {
+  ASSOCIATION: null,
+  DIVISION: "divisionId",
+  TEAM: "teamId",
+  SEASON: "seasonId",
+  EVENT: "eventId",
+  SIGNUP_EVENT: "signupEventId",
+} as const satisfies Record<AssociationRoleScopeType, string | null>;
+
+/** The scope fields a caller may supply; `scopeType` selects which is used. */
+export interface ScopeInput {
+  scopeType: AssociationRoleScopeType;
+  divisionId?: string;
+  teamId?: string;
+  seasonId?: string;
+  eventId?: string;
+  signupEventId?: string;
+}
+
+/**
+ * Reduce the six optional scope ids to exactly the one `scopeType` names.
+ *
+ * Silently dropping the others matters: it means a caller cannot smuggle a
+ * second scope past the database CHECK by sending extra ids, and the row we
+ * write is the row the caller's `scopeType` describes.
+ */
+export function normalizeScope(input: ScopeInput): {
+  ok: true;
+  data: Record<string, string | null>;
+  scopeId: string | null;
+} | { ok: false; error: string } {
+  const field = SCOPE_FIELD[input.scopeType];
+
+  const empty = {
+    divisionId: null,
+    teamId: null,
+    seasonId: null,
+    eventId: null,
+    signupEventId: null,
+  };
+
+  if (field === null) {
+    return { ok: true, data: empty, scopeId: null };
+  }
+
+  const value = input[field as keyof ScopeInput] as string | undefined;
+  if (!value) {
+    return { ok: false, error: `A ${input.scopeType.toLowerCase()} must be selected for this scope.` };
+  }
+
+  return { ok: true, data: { ...empty, [field]: value }, scopeId: value };
+}
+
+/**
+ * Apply an invitation's pending responsibility, inside the acceptance
+ * transaction. Exported for `acceptInvitationMemberships`.
+ *
+ * Re-validates the role/scope pairing rather than trusting the stored payload:
+ * the matrix may have tightened between the invitation being sent and accepted,
+ * and the stricter rule should win.
+ */
+export async function applyInvitationResponsibility(
+  tx: Prisma.TransactionClient,
+  invitation: {
+    leagueId: string | null;
+    teamId: string | null;
+    invitedById: string;
+    associationRole: AssociationRole | null;
+    associationScopeType: AssociationRoleScopeType | null;
+    associationDivisionId: string | null;
+    associationSeasonId: string | null;
+    associationEventId: string | null;
+    associationSignupEventId: string | null;
+  },
+  userId: string,
+): Promise<void> {
+  const { associationRole: role, associationScopeType: scopeType, leagueId } = invitation;
+  if (!role || !scopeType || !leagueId) return;
+
+  if (!supportedScopesForRole(role).includes(scopeType)) return;
+
+  const scope = normalizeScope({
+    scopeType,
+    divisionId: invitation.associationDivisionId ?? undefined,
+    teamId: invitation.teamId ?? undefined,
+    seasonId: invitation.associationSeasonId ?? undefined,
+    eventId: invitation.associationEventId ?? undefined,
+    signupEventId: invitation.associationSignupEventId ?? undefined,
+  });
+  if (!scope.ok) return;
+
+  const existing = await tx.associationRoleGrant.findFirst({
+    where: { userId, leagueId, role, scopeType, state: "ACTIVE", ...scope.data },
+    select: { id: true },
+  });
+  if (existing) return;
+
+  await tx.associationRoleGrant.create({
+    data: {
+      userId,
+      leagueId,
+      role,
+      scopeType,
+      grantedById: invitation.invitedById,
+      ...scope.data,
+    },
+  });
+}

--- a/lib/utils/access-levels.ts
+++ b/lib/utils/access-levels.ts
@@ -1,0 +1,18 @@
+/**
+ * League access levels, with no imports.
+ *
+ * Lives apart from lib/utils/security.ts because this enum is a *runtime* value
+ * that client components legitimately need (to label a role, to switch on a
+ * level). Importing it from security.ts drags in the session helpers, auth.ts,
+ * and ultimately `next/headers` and node:dns, none of which can be bundled for
+ * the browser — which is what made components/features/admin/*PermissionManager
+ * unbuildable the moment either was first mounted.
+ *
+ * security.ts re-exports this, so existing server-side importers are unchanged.
+ */
+export enum LeagueAccessLevel {
+  NONE = 0,
+  MEMBER = 1,
+  TEAM_ADMIN = 2,
+  LEAGUE_ADMIN = 3,
+}

--- a/lib/utils/permission-types.ts
+++ b/lib/utils/permission-types.ts
@@ -1,0 +1,87 @@
+/**
+ * Permission identifiers, with no imports.
+ *
+ * Extracted from lib/utils/permissions.ts for the same reason as
+ * lib/utils/access-levels.ts: this is a *runtime* enum that client components
+ * and mocked tests need, while permissions.ts reaches Prisma and the session
+ * helpers — and therefore next-auth, which cannot be resolved in a browser
+ * bundle or a unit test that stubs the module.
+ *
+ * permissions.ts re-exports everything here, so existing importers are
+ * unchanged.
+ */
+export enum Permission {
+    // League management
+    CREATE_LEAGUE = "create_league",
+    UPDATE_LEAGUE = "update_league",
+    DELETE_LEAGUE = "delete_league",
+    VIEW_LEAGUE = "view_league",
+
+    // Team management
+    CREATE_TEAM = "create_team",
+    UPDATE_TEAM = "update_team",
+    DELETE_TEAM = "delete_team",
+    VIEW_TEAM = "view_team",
+    MIGRATE_TEAM = "migrate_team",
+
+    // Division management
+    CREATE_DIVISION = "create_division",
+    UPDATE_DIVISION = "update_division",
+    DELETE_DIVISION = "delete_division",
+    ASSIGN_TEAM_TO_DIVISION = "assign_team_to_division",
+
+    // Player management
+    ADD_PLAYER = "add_player",
+    UPDATE_PLAYER = "update_player",
+    REMOVE_PLAYER = "remove_player",
+    TRANSFER_PLAYER = "transfer_player",
+    VIEW_PLAYER_DETAILS = "view_player_details",
+    VIEW_EMERGENCY_CONTACTS = "view_emergency_contacts",
+
+    // Event management
+    CREATE_EVENT = "create_event",
+    UPDATE_EVENT = "update_event",
+    DELETE_EVENT = "delete_event",
+    CREATE_INTER_TEAM_GAME = "create_inter_team_game",
+
+    // Communication
+    SEND_LEAGUE_MESSAGE = "send_league_message",
+    SEND_LEAGUE_ANNOUNCEMENT = "send_league_announcement",
+    SEND_TEAM_MESSAGE = "send_team_message",
+
+    // User management
+    ASSIGN_LEAGUE_ROLE = "assign_league_role",
+    ASSIGN_TEAM_ROLE = "assign_team_role",
+    INVITE_USER = "invite_user",
+
+    // Reporting and data
+    EXPORT_LEAGUE_DATA = "export_league_data",
+    EXPORT_TEAM_DATA = "export_team_data",
+    VIEW_LEAGUE_REPORTS = "view_league_reports",
+    VIEW_FINANCIAL_REPORTS = "view_financial_reports",
+
+    // League-owned gear. Team-admin grants must always be evaluated with the
+    // requested team ID, while inventory and public wishlist administration
+    // remain league-admin operations.
+    MANAGE_GEAR_INVENTORY = "manage_gear_inventory",
+    MANAGE_GEAR_WISHLIST = "manage_gear_wishlist",
+    CREATE_TEAM_GEAR_NEED = "create_team_gear_need",
+    REQUEST_TEAM_GEAR = "request_team_gear",
+}
+
+export const TEAM_SCOPED_PERMISSIONS = [
+    Permission.UPDATE_TEAM,
+    Permission.DELETE_TEAM,
+    Permission.ADD_PLAYER,
+    Permission.UPDATE_PLAYER,
+    Permission.REMOVE_PLAYER,
+    Permission.CREATE_EVENT,
+    Permission.UPDATE_EVENT,
+    Permission.DELETE_EVENT,
+    Permission.SEND_TEAM_MESSAGE,
+    Permission.EXPORT_TEAM_DATA,
+    Permission.CREATE_TEAM_GEAR_NEED,
+    Permission.REQUEST_TEAM_GEAR,
+] as const;
+
+export type TeamScopedPermission = (typeof TEAM_SCOPED_PERMISSIONS)[number];

--- a/lib/utils/permissions.ts
+++ b/lib/utils/permissions.ts
@@ -5,6 +5,7 @@
 import { prisma } from "@/lib/db/prisma";
 import { LeagueAccessLevel, logAuditEvent, AuditAction } from "./security";
 import { sanitizeErrorForLogging } from "./error-handling";
+import type { GearAction } from "@/lib/auth/capabilities";
 
 /**
  * Permission definitions for different operations
@@ -183,6 +184,51 @@ const getPermissionMatrix = (): Record<LeagueAccessLevel, Permission[]> => ({
 });
 
 /**
+ * Gear `Permission` values that a scoped association grant can supply.
+ *
+ * Deliberately a closed map rather than a predicate: adding a permission to the
+ * grant path has to be a decision someone writes down here, not something a new
+ * enum member inherits by accident.
+ */
+const GEAR_PERMISSION_ACTIONS: Partial<Record<Permission, GearAction>> = {
+    [Permission.MANAGE_GEAR_INVENTORY]: "MANAGE_INVENTORY",
+    [Permission.MANAGE_GEAR_WISHLIST]: "MANAGE_WISHLIST",
+    [Permission.CREATE_TEAM_GEAR_NEED]: "TEAM_NEED_OR_REQUEST",
+    [Permission.REQUEST_TEAM_GEAR]: "TEAM_NEED_OR_REQUEST",
+};
+
+/**
+ * Last-resort authorization for gear work via an association role grant.
+ *
+ * Consulted only after the access-level matrix has declined, so a grant can add
+ * authority but never remove or loosen an existing rule — including the
+ * mandatory-teamId rule above, which `grantsAllowGearAction` re-checks.
+ *
+ * The import is lazy to match the rest of this module: `lib/auth/capabilities`
+ * pulls in security helpers that transitively reach back here, and eager
+ * resolution would reintroduce the cycle the other dynamic imports avoid.
+ */
+async function hasGearPermissionViaGrant(
+    userId: string,
+    leagueId: string,
+    permission: Permission,
+    teamId?: string
+): Promise<boolean> {
+    const action = GEAR_PERMISSION_ACTIONS[permission];
+    if (!action) {
+        return false;
+    }
+
+    try {
+        const { grantsAllowGearAction } = await import("@/lib/auth/capabilities");
+        return await grantsAllowGearAction({ userId, leagueId, action, teamId });
+    } catch (error) {
+        console.error("Error checking gear grant:", sanitizeErrorForLogging(error));
+        return false;
+    }
+}
+
+/**
  * Check if a user has a specific permission for a league
  */
 export async function hasPermission(
@@ -208,12 +254,24 @@ export async function hasPermission(
                 return false;
             }
 
-            return hasBasePermission
-                ? await hasTeamSpecificPermission(userId, leagueId, teamId, permission, accessLevel)
-                : false;
+            if (
+                hasBasePermission &&
+                (await hasTeamSpecificPermission(userId, leagueId, teamId, permission, accessLevel))
+            ) {
+                return true;
+            }
+
+            // Fall through: an equipment manager or team manager may hold this
+            // team's gear rights through a scoped grant without being a team
+            // admin. Non-gear permissions have no grant path and end at false.
+            return hasGearPermissionViaGrant(userId, leagueId, permission, teamId);
         }
 
-        return hasBasePermission;
+        if (hasBasePermission) {
+            return true;
+        }
+
+        return hasGearPermissionViaGrant(userId, leagueId, permission, teamId);
     } catch (error) {
         console.error("Error checking permission:", sanitizeErrorForLogging(error));
         return false;

--- a/lib/utils/permissions.ts
+++ b/lib/utils/permissions.ts
@@ -6,85 +6,15 @@ import { prisma } from "@/lib/db/prisma";
 import { LeagueAccessLevel, logAuditEvent, AuditAction } from "./security";
 import { sanitizeErrorForLogging } from "./error-handling";
 import type { GearAction } from "@/lib/auth/capabilities";
+import { Permission, TEAM_SCOPED_PERMISSIONS, type TeamScopedPermission } from "./permission-types";
 
 /**
  * Permission definitions for different operations
  */
-export enum Permission {
-    // League management
-    CREATE_LEAGUE = "create_league",
-    UPDATE_LEAGUE = "update_league",
-    DELETE_LEAGUE = "delete_league",
-    VIEW_LEAGUE = "view_league",
-
-    // Team management
-    CREATE_TEAM = "create_team",
-    UPDATE_TEAM = "update_team",
-    DELETE_TEAM = "delete_team",
-    VIEW_TEAM = "view_team",
-    MIGRATE_TEAM = "migrate_team",
-
-    // Division management
-    CREATE_DIVISION = "create_division",
-    UPDATE_DIVISION = "update_division",
-    DELETE_DIVISION = "delete_division",
-    ASSIGN_TEAM_TO_DIVISION = "assign_team_to_division",
-
-    // Player management
-    ADD_PLAYER = "add_player",
-    UPDATE_PLAYER = "update_player",
-    REMOVE_PLAYER = "remove_player",
-    TRANSFER_PLAYER = "transfer_player",
-    VIEW_PLAYER_DETAILS = "view_player_details",
-    VIEW_EMERGENCY_CONTACTS = "view_emergency_contacts",
-
-    // Event management
-    CREATE_EVENT = "create_event",
-    UPDATE_EVENT = "update_event",
-    DELETE_EVENT = "delete_event",
-    CREATE_INTER_TEAM_GAME = "create_inter_team_game",
-
-    // Communication
-    SEND_LEAGUE_MESSAGE = "send_league_message",
-    SEND_LEAGUE_ANNOUNCEMENT = "send_league_announcement",
-    SEND_TEAM_MESSAGE = "send_team_message",
-
-    // User management
-    ASSIGN_LEAGUE_ROLE = "assign_league_role",
-    ASSIGN_TEAM_ROLE = "assign_team_role",
-    INVITE_USER = "invite_user",
-
-    // Reporting and data
-    EXPORT_LEAGUE_DATA = "export_league_data",
-    EXPORT_TEAM_DATA = "export_team_data",
-    VIEW_LEAGUE_REPORTS = "view_league_reports",
-    VIEW_FINANCIAL_REPORTS = "view_financial_reports",
-
-    // League-owned gear. Team-admin grants must always be evaluated with the
-    // requested team ID, while inventory and public wishlist administration
-    // remain league-admin operations.
-    MANAGE_GEAR_INVENTORY = "manage_gear_inventory",
-    MANAGE_GEAR_WISHLIST = "manage_gear_wishlist",
-    CREATE_TEAM_GEAR_NEED = "create_team_gear_need",
-    REQUEST_TEAM_GEAR = "request_team_gear",
-}
-
-export const TEAM_SCOPED_PERMISSIONS = [
-    Permission.UPDATE_TEAM,
-    Permission.DELETE_TEAM,
-    Permission.ADD_PLAYER,
-    Permission.UPDATE_PLAYER,
-    Permission.REMOVE_PLAYER,
-    Permission.CREATE_EVENT,
-    Permission.UPDATE_EVENT,
-    Permission.DELETE_EVENT,
-    Permission.SEND_TEAM_MESSAGE,
-    Permission.EXPORT_TEAM_DATA,
-    Permission.CREATE_TEAM_GEAR_NEED,
-    Permission.REQUEST_TEAM_GEAR,
-] as const;
-
-export type TeamScopedPermission = (typeof TEAM_SCOPED_PERMISSIONS)[number];
+// Declared in a dependency-free module so client components and tests can use
+// these values without pulling this file's dependency graph with them.
+export { Permission, TEAM_SCOPED_PERMISSIONS };
+export type { TeamScopedPermission };
 
 /**
  * Permission matrix mapping access levels to permissions
@@ -357,6 +287,37 @@ export async function requirePermission(
 
         throw new Error(`Permission denied: ${permission}`);
     }
+}
+
+/**
+ * Session-aware guard with `requireLeagueRole`'s ergonomics, but routed through
+ * the permission matrix so association role grants are honoured.
+ *
+ * Gear actions previously called `requireLeagueRole(leagueId, "LEAGUE_ADMIN")`
+ * directly, which meant an equipment-manager grant authorized nothing in
+ * practice — the grant bridge below was unreachable from the domain it exists
+ * to serve. Swapping those guards for this one is what connects them.
+ *
+ * The thrown message keeps the `Unauthorized:` prefix because callers and pages
+ * match on it to decide between a 404 and an error surface.
+ */
+export async function requirePermissionForLeague(
+    leagueId: string,
+    permission: Permission,
+    teamId?: string
+): Promise<string> {
+    const { requireUserId } = await import("@/lib/auth/session");
+    const userId = await requireUserId();
+
+    try {
+        // Reused rather than reimplemented so denials keep hitting the same
+        // PERMISSION_DENIED audit path.
+        await requirePermission(userId, leagueId, permission, teamId);
+    } catch {
+        throw new Error("Unauthorized: insufficient permissions for this action");
+    }
+
+    return userId;
 }
 
 /**

--- a/lib/utils/security.ts
+++ b/lib/utils/security.ts
@@ -6,16 +6,15 @@ import { prisma } from "@/lib/db/prisma";
 import { requireUserId } from "@/lib/auth/session";
 import { sanitizeErrorForLogging } from "./error-handling";
 import type { Prisma } from "@prisma/client";
+import { LeagueAccessLevel } from "./access-levels";
 
 /**
  * League access levels for permission checking
  */
-export enum LeagueAccessLevel {
-    NONE = 0,
-    MEMBER = 1,
-    TEAM_ADMIN = 2,
-    LEAGUE_ADMIN = 3,
-}
+// Declared in a dependency-free module so client components can import the
+// enum without pulling this file's server-only dependency graph with it.
+// Imported as well as re-exported: this file uses the value itself.
+export { LeagueAccessLevel };
 
 /**
  * Audit action types for logging

--- a/prisma/migrations/20260819024354_add_association_roles_and_volunteers/migration.sql
+++ b/prisma/migrations/20260819024354_add_association_roles_and_volunteers/migration.sql
@@ -1,0 +1,358 @@
+-- CreateEnum
+CREATE TYPE "AssociationRole" AS ENUM ('ASSOCIATION_ADMIN', 'SCHEDULER', 'REGISTRAR', 'TREASURER', 'COMMUNICATIONS_LEAD', 'TEAM_MANAGER', 'COACH', 'VOLUNTEER_COORDINATOR', 'EVENT_MANAGER', 'EQUIPMENT_MANAGER');
+
+-- CreateEnum
+CREATE TYPE "AssociationRoleScopeType" AS ENUM ('ASSOCIATION', 'DIVISION', 'TEAM', 'SEASON', 'EVENT', 'SIGNUP_EVENT');
+
+-- CreateEnum
+CREATE TYPE "AssociationRoleGrantState" AS ENUM ('ACTIVE', 'REVOKED');
+
+-- CreateEnum
+CREATE TYPE "VolunteerNeedStatus" AS ENUM ('OPEN', 'CLOSED', 'CANCELED', 'COMPLETED');
+
+-- CreateEnum
+CREATE TYPE "VolunteerAssignmentStatus" AS ENUM ('INVITED', 'ACCEPTED', 'DECLINED', 'CANCELED', 'COMPLETED', 'MISSED');
+
+-- AlterTable
+ALTER TABLE "Invitation" ADD COLUMN     "associationDivisionId" TEXT,
+ADD COLUMN     "associationEventId" TEXT,
+ADD COLUMN     "associationRole" "AssociationRole",
+ADD COLUMN     "associationScopeType" "AssociationRoleScopeType",
+ADD COLUMN     "associationSeasonId" TEXT,
+ADD COLUMN     "associationSignupEventId" TEXT;
+
+-- CreateTable
+CREATE TABLE "association_role_grants" (
+    "id" TEXT NOT NULL,
+    "role" "AssociationRole" NOT NULL,
+    "scopeType" "AssociationRoleScopeType" NOT NULL,
+    "state" "AssociationRoleGrantState" NOT NULL DEFAULT 'ACTIVE',
+    "notes" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "revokedAt" TIMESTAMP(3),
+    "userId" TEXT NOT NULL,
+    "grantedById" TEXT,
+    "revokedById" TEXT,
+    "leagueId" TEXT NOT NULL,
+    "divisionId" TEXT,
+    "teamId" TEXT,
+    "seasonId" TEXT,
+    "eventId" TEXT,
+    "signupEventId" TEXT,
+
+    CONSTRAINT "association_role_grants_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "volunteer_needs" (
+    "id" TEXT NOT NULL,
+    "roleLabel" TEXT NOT NULL,
+    "description" TEXT,
+    "capacity" INTEGER NOT NULL,
+    "acceptedCount" INTEGER NOT NULL DEFAULT 0,
+    "status" "VolunteerNeedStatus" NOT NULL DEFAULT 'OPEN',
+    "startAt" TIMESTAMP(3) NOT NULL,
+    "endAt" TIMESTAMP(3) NOT NULL,
+    "timezone" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "canceledAt" TIMESTAMP(3),
+    "completedAt" TIMESTAMP(3),
+    "leagueId" TEXT NOT NULL,
+    "divisionId" TEXT,
+    "teamId" TEXT,
+    "eventId" TEXT,
+    "signupEventId" TEXT,
+    "createdById" TEXT,
+
+    CONSTRAINT "volunteer_needs_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "volunteer_assignments" (
+    "id" TEXT NOT NULL,
+    "status" "VolunteerAssignmentStatus" NOT NULL DEFAULT 'INVITED',
+    "invitedEmail" TEXT,
+    "notes" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "respondedAt" TIMESTAMP(3),
+    "completedAt" TIMESTAMP(3),
+    "needId" TEXT NOT NULL,
+    "userId" TEXT,
+    "assignedById" TEXT,
+
+    CONSTRAINT "volunteer_assignments_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "association_role_grants_leagueId_state_role_idx" ON "association_role_grants"("leagueId", "state", "role");
+
+-- CreateIndex
+CREATE INDEX "association_role_grants_userId_state_idx" ON "association_role_grants"("userId", "state");
+
+-- CreateIndex
+CREATE INDEX "association_role_grants_leagueId_teamId_state_idx" ON "association_role_grants"("leagueId", "teamId", "state");
+
+-- CreateIndex
+CREATE INDEX "volunteer_needs_leagueId_status_startAt_idx" ON "volunteer_needs"("leagueId", "status", "startAt");
+
+-- CreateIndex
+CREATE INDEX "volunteer_needs_leagueId_teamId_status_idx" ON "volunteer_needs"("leagueId", "teamId", "status");
+
+-- CreateIndex
+CREATE INDEX "volunteer_assignments_needId_status_idx" ON "volunteer_assignments"("needId", "status");
+
+-- CreateIndex
+CREATE INDEX "volunteer_assignments_userId_status_idx" ON "volunteer_assignments"("userId", "status");
+
+-- RenameForeignKey
+ALTER TABLE "gear_allocations" RENAME CONSTRAINT "gear_allocations_gearUnitId_fkey" TO "gear_allocations_leagueId_gearUnitId_fkey";
+
+-- RenameForeignKey
+ALTER TABLE "gear_allocations" RENAME CONSTRAINT "gear_allocations_poolStockId_fkey" TO "gear_allocations_leagueId_poolStockId_fkey";
+
+-- RenameForeignKey
+ALTER TABLE "gear_allocations" RENAME CONSTRAINT "gear_allocations_reservationLineId_fkey" TO "gear_allocations_leagueId_reservationLineId_fkey";
+
+-- RenameForeignKey
+ALTER TABLE "gear_handoffs" RENAME CONSTRAINT "gear_handoffs_allocationId_fkey" TO "gear_handoffs_leagueId_allocationId_fkey";
+
+-- RenameForeignKey
+ALTER TABLE "gear_handoffs" RENAME CONSTRAINT "gear_handoffs_reservationId_fkey" TO "gear_handoffs_leagueId_reservationId_fkey";
+
+-- RenameForeignKey
+ALTER TABLE "gear_inventory_movements" RENAME CONSTRAINT "gear_inventory_movements_afterLocationId_fkey" TO "gear_inventory_movements_leagueId_afterLocationId_fkey";
+
+-- RenameForeignKey
+ALTER TABLE "gear_inventory_movements" RENAME CONSTRAINT "gear_inventory_movements_allocationId_fkey" TO "gear_inventory_movements_leagueId_allocationId_fkey";
+
+-- RenameForeignKey
+ALTER TABLE "gear_inventory_movements" RENAME CONSTRAINT "gear_inventory_movements_beforeLocationId_fkey" TO "gear_inventory_movements_leagueId_beforeLocationId_fkey";
+
+-- RenameForeignKey
+ALTER TABLE "gear_inventory_movements" RENAME CONSTRAINT "gear_inventory_movements_gearUnitId_fkey" TO "gear_inventory_movements_leagueId_gearUnitId_fkey";
+
+-- RenameForeignKey
+ALTER TABLE "gear_inventory_movements" RENAME CONSTRAINT "gear_inventory_movements_handoffId_fkey" TO "gear_inventory_movements_leagueId_handoffId_fkey";
+
+-- RenameForeignKey
+ALTER TABLE "gear_inventory_movements" RENAME CONSTRAINT "gear_inventory_movements_pledgeReceiptId_fkey" TO "gear_inventory_movements_leagueId_pledgeReceiptId_fkey";
+
+-- RenameForeignKey
+ALTER TABLE "gear_inventory_movements" RENAME CONSTRAINT "gear_inventory_movements_poolStockId_fkey" TO "gear_inventory_movements_leagueId_poolStockId_fkey";
+
+-- RenameForeignKey
+ALTER TABLE "gear_pledge_receipts" RENAME CONSTRAINT "gear_pledge_receipts_catalogItemId_fkey" TO "gear_pledge_receipts_leagueId_catalogItemId_fkey";
+
+-- RenameForeignKey
+ALTER TABLE "gear_pledge_receipts" RENAME CONSTRAINT "gear_pledge_receipts_correctionOfReceiptId_fkey" TO "gear_pledge_receipts_leagueId_correctionOfReceiptId_fkey";
+
+-- RenameForeignKey
+ALTER TABLE "gear_pledge_receipts" RENAME CONSTRAINT "gear_pledge_receipts_gearUnitId_fkey" TO "gear_pledge_receipts_leagueId_gearUnitId_fkey";
+
+-- RenameForeignKey
+ALTER TABLE "gear_pledge_receipts" RENAME CONSTRAINT "gear_pledge_receipts_pledgeId_fkey" TO "gear_pledge_receipts_leagueId_pledgeId_fkey";
+
+-- RenameForeignKey
+ALTER TABLE "gear_pledge_receipts" RENAME CONSTRAINT "gear_pledge_receipts_poolStockId_fkey" TO "gear_pledge_receipts_leagueId_poolStockId_fkey";
+
+-- RenameForeignKey
+ALTER TABLE "gear_pledges" RENAME CONSTRAINT "gear_pledges_wishlistItemId_fkey" TO "gear_pledges_leagueId_wishlistItemId_fkey";
+
+-- RenameForeignKey
+ALTER TABLE "gear_pool_stocks" RENAME CONSTRAINT "gear_pool_stocks_catalogItemId_fkey" TO "gear_pool_stocks_leagueId_catalogItemId_fkey";
+
+-- RenameForeignKey
+ALTER TABLE "gear_pool_stocks" RENAME CONSTRAINT "gear_pool_stocks_locationId_fkey" TO "gear_pool_stocks_leagueId_locationId_fkey";
+
+-- RenameForeignKey
+ALTER TABLE "gear_reservation_lines" RENAME CONSTRAINT "gear_reservation_lines_catalogItemId_fkey" TO "gear_reservation_lines_leagueId_catalogItemId_fkey";
+
+-- RenameForeignKey
+ALTER TABLE "gear_reservation_lines" RENAME CONSTRAINT "gear_reservation_lines_needLineId_fkey" TO "gear_reservation_lines_leagueId_needLineId_fkey";
+
+-- RenameForeignKey
+ALTER TABLE "gear_reservation_lines" RENAME CONSTRAINT "gear_reservation_lines_reservationId_fkey" TO "gear_reservation_lines_leagueId_reservationId_fkey";
+
+-- RenameForeignKey
+ALTER TABLE "gear_reservations" RENAME CONSTRAINT "gear_reservations_teamId_fkey" TO "gear_reservations_leagueId_teamId_fkey";
+
+-- RenameForeignKey
+ALTER TABLE "gear_units" RENAME CONSTRAINT "gear_units_catalogItemId_fkey" TO "gear_units_leagueId_catalogItemId_fkey";
+
+-- RenameForeignKey
+ALTER TABLE "gear_units" RENAME CONSTRAINT "gear_units_currentLocationId_fkey" TO "gear_units_leagueId_currentLocationId_fkey";
+
+-- RenameForeignKey
+ALTER TABLE "gear_wishlist_items" RENAME CONSTRAINT "gear_wishlist_items_catalogItemId_fkey" TO "gear_wishlist_items_leagueId_catalogItemId_fkey";
+
+-- RenameForeignKey
+ALTER TABLE "gear_wishlist_items" RENAME CONSTRAINT "gear_wishlist_items_wishlistId_fkey" TO "gear_wishlist_items_leagueId_wishlistId_fkey";
+
+-- RenameForeignKey
+ALTER TABLE "team_gear_need_lines" RENAME CONSTRAINT "team_gear_need_lines_catalogItemId_fkey" TO "team_gear_need_lines_leagueId_catalogItemId_fkey";
+
+-- RenameForeignKey
+ALTER TABLE "team_gear_need_lines" RENAME CONSTRAINT "team_gear_need_lines_needId_fkey" TO "team_gear_need_lines_leagueId_needId_fkey";
+
+-- RenameForeignKey
+ALTER TABLE "team_gear_needs" RENAME CONSTRAINT "team_gear_needs_teamId_fkey" TO "team_gear_needs_leagueId_teamId_fkey";
+
+-- AddForeignKey
+ALTER TABLE "Invitation" ADD CONSTRAINT "Invitation_associationDivisionId_fkey" FOREIGN KEY ("associationDivisionId") REFERENCES "divisions"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Invitation" ADD CONSTRAINT "Invitation_associationSeasonId_fkey" FOREIGN KEY ("associationSeasonId") REFERENCES "seasons"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Invitation" ADD CONSTRAINT "Invitation_associationEventId_fkey" FOREIGN KEY ("associationEventId") REFERENCES "Event"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Invitation" ADD CONSTRAINT "Invitation_associationSignupEventId_fkey" FOREIGN KEY ("associationSignupEventId") REFERENCES "signup_events"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "association_role_grants" ADD CONSTRAINT "association_role_grants_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "association_role_grants" ADD CONSTRAINT "association_role_grants_grantedById_fkey" FOREIGN KEY ("grantedById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "association_role_grants" ADD CONSTRAINT "association_role_grants_revokedById_fkey" FOREIGN KEY ("revokedById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "association_role_grants" ADD CONSTRAINT "association_role_grants_leagueId_fkey" FOREIGN KEY ("leagueId") REFERENCES "leagues"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "association_role_grants" ADD CONSTRAINT "association_role_grants_divisionId_fkey" FOREIGN KEY ("divisionId") REFERENCES "divisions"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "association_role_grants" ADD CONSTRAINT "association_role_grants_leagueId_teamId_fkey" FOREIGN KEY ("leagueId", "teamId") REFERENCES "Team"("leagueId", "id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "association_role_grants" ADD CONSTRAINT "association_role_grants_seasonId_fkey" FOREIGN KEY ("seasonId") REFERENCES "seasons"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "association_role_grants" ADD CONSTRAINT "association_role_grants_eventId_fkey" FOREIGN KEY ("eventId") REFERENCES "Event"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "association_role_grants" ADD CONSTRAINT "association_role_grants_signupEventId_fkey" FOREIGN KEY ("signupEventId") REFERENCES "signup_events"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "volunteer_needs" ADD CONSTRAINT "volunteer_needs_leagueId_fkey" FOREIGN KEY ("leagueId") REFERENCES "leagues"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "volunteer_needs" ADD CONSTRAINT "volunteer_needs_divisionId_fkey" FOREIGN KEY ("divisionId") REFERENCES "divisions"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "volunteer_needs" ADD CONSTRAINT "volunteer_needs_leagueId_teamId_fkey" FOREIGN KEY ("leagueId", "teamId") REFERENCES "Team"("leagueId", "id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "volunteer_needs" ADD CONSTRAINT "volunteer_needs_eventId_fkey" FOREIGN KEY ("eventId") REFERENCES "Event"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "volunteer_needs" ADD CONSTRAINT "volunteer_needs_signupEventId_fkey" FOREIGN KEY ("signupEventId") REFERENCES "signup_events"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "volunteer_needs" ADD CONSTRAINT "volunteer_needs_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "volunteer_assignments" ADD CONSTRAINT "volunteer_assignments_needId_fkey" FOREIGN KEY ("needId") REFERENCES "volunteer_needs"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "volunteer_assignments" ADD CONSTRAINT "volunteer_assignments_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "volunteer_assignments" ADD CONSTRAINT "volunteer_assignments_assignedById_fkey" FOREIGN KEY ("assignedById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- RenameIndex
+ALTER INDEX "gear_pledge_receipt_commands_leagueId_pledgeId_idempotencyKey_k" RENAME TO "gear_pledge_receipt_commands_leagueId_pledgeId_idempotencyK_key";
+
+-- RenameIndex
+ALTER INDEX "gear_pool_stocks_leagueId_catalogItemId_locationId_condition_ke" RENAME TO "gear_pool_stocks_leagueId_catalogItemId_locationId_conditio_key";
+
+-- RenameIndex
+ALTER INDEX "gear_reservations_leagueId_requestedStartDate_requestedEndDate_" RENAME TO "gear_reservations_leagueId_requestedStartDate_requestedEndD_idx";
+
+-- ---------------------------------------------------------------------------
+-- Hand-authored invariants (feature 007 US3). Prisma cannot express any of
+-- these, and every one of them is load-bearing for "unlisted combinations fail
+-- closed": the capability layer trusts that a grant row names exactly one
+-- scope, and that the named scope agrees with scopeType.
+-- ---------------------------------------------------------------------------
+
+-- A grant names exactly one scope, and it is the one scopeType declares.
+-- ASSOCIATION is the only scope with no narrower target: it is bounded by the
+-- required leagueId that every row already carries.
+ALTER TABLE "association_role_grants"
+  ADD CONSTRAINT "association_role_grants_scope_matches_type_check"
+  CHECK (
+    CASE "scopeType"
+      WHEN 'ASSOCIATION'  THEN num_nonnulls("divisionId", "teamId", "seasonId", "eventId", "signupEventId") = 0
+      WHEN 'DIVISION'     THEN "divisionId"    IS NOT NULL AND num_nonnulls("teamId", "seasonId", "eventId", "signupEventId") = 0
+      WHEN 'TEAM'         THEN "teamId"        IS NOT NULL AND num_nonnulls("divisionId", "seasonId", "eventId", "signupEventId") = 0
+      WHEN 'SEASON'       THEN "seasonId"      IS NOT NULL AND num_nonnulls("divisionId", "teamId", "eventId", "signupEventId") = 0
+      WHEN 'EVENT'        THEN "eventId"       IS NOT NULL AND num_nonnulls("divisionId", "teamId", "seasonId", "signupEventId") = 0
+      WHEN 'SIGNUP_EVENT' THEN "signupEventId" IS NOT NULL AND num_nonnulls("divisionId", "teamId", "seasonId", "eventId") = 0
+    END
+  );
+
+-- A revoked grant records when it was revoked; an active one never does.
+ALTER TABLE "association_role_grants"
+  ADD CONSTRAINT "association_role_grants_revocation_timestamp_check"
+  CHECK (("state" = 'REVOKED') = ("revokedAt" IS NOT NULL));
+
+-- Uniqueness applies to ACTIVE grants only. Revoked rows are history: without
+-- the partial predicate, revoking a responsibility would permanently prevent
+-- granting it again. One index per scope kind because Postgres treats NULLs as
+-- distinct, so a single index over the nullable scope columns would not dedupe.
+CREATE UNIQUE INDEX "association_role_grants_active_association_key"
+  ON "association_role_grants" ("userId", "role", "leagueId")
+  WHERE "state" = 'ACTIVE' AND "scopeType" = 'ASSOCIATION';
+
+CREATE UNIQUE INDEX "association_role_grants_active_division_key"
+  ON "association_role_grants" ("userId", "role", "divisionId")
+  WHERE "state" = 'ACTIVE' AND "scopeType" = 'DIVISION';
+
+CREATE UNIQUE INDEX "association_role_grants_active_team_key"
+  ON "association_role_grants" ("userId", "role", "teamId")
+  WHERE "state" = 'ACTIVE' AND "scopeType" = 'TEAM';
+
+CREATE UNIQUE INDEX "association_role_grants_active_season_key"
+  ON "association_role_grants" ("userId", "role", "seasonId")
+  WHERE "state" = 'ACTIVE' AND "scopeType" = 'SEASON';
+
+CREATE UNIQUE INDEX "association_role_grants_active_event_key"
+  ON "association_role_grants" ("userId", "role", "eventId")
+  WHERE "state" = 'ACTIVE' AND "scopeType" = 'EVENT';
+
+CREATE UNIQUE INDEX "association_role_grants_active_signup_event_key"
+  ON "association_role_grants" ("userId", "role", "signupEventId")
+  WHERE "state" = 'ACTIVE' AND "scopeType" = 'SIGNUP_EVENT';
+
+-- Volunteer needs: a positive capacity, a real interval, and an accepted count
+-- that can never exceed capacity. The last one is what makes the conditional
+-- updateMany in acceptVolunteerAssignment a safe capacity gate rather than an
+-- optimistic guess — the database refuses an overfill even under a race.
+ALTER TABLE "volunteer_needs"
+  ADD CONSTRAINT "volunteer_needs_capacity_check" CHECK ("capacity" > 0),
+  ADD CONSTRAINT "volunteer_needs_interval_check" CHECK ("endAt" > "startAt"),
+  ADD CONSTRAINT "volunteer_needs_accepted_within_capacity_check"
+    CHECK ("acceptedCount" >= 0 AND "acceptedCount" <= "capacity");
+
+-- An assignment names a known user or an invited email address, never both and
+-- never neither.
+ALTER TABLE "volunteer_assignments"
+  ADD CONSTRAINT "volunteer_assignments_subject_check"
+  CHECK (num_nonnulls("userId", "invitedEmail") = 1);
+
+-- One live slot per person per need. DECLINED and CANCELED rows are excluded so
+-- somebody who declined can be invited again.
+CREATE UNIQUE INDEX "volunteer_assignments_live_user_key"
+  ON "volunteer_assignments" ("needId", "userId")
+  WHERE "userId" IS NOT NULL AND "status" IN ('INVITED', 'ACCEPTED', 'COMPLETED');
+
+CREATE UNIQUE INDEX "volunteer_assignments_live_email_key"
+  ON "volunteer_assignments" ("needId", "invitedEmail")
+  WHERE "invitedEmail" IS NOT NULL AND "status" IN ('INVITED', 'ACCEPTED', 'COMPLETED');

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -90,6 +90,14 @@ model User {
   assignedVenueReservations    VenueReservation[]           @relation("VenueReservationAssigner")
   venueReservationTransitions  VenueReservationTransition[] @relation("VenueReservationTransitionActor")
   venueReservationOverrides    VenueReservationOverride[]   @relation("VenueReservationOverrideActor")
+
+  // Feature 007 US3 — scoped responsibilities and volunteers.
+  associationRoleGrants        AssociationRoleGrant[] @relation("AssociationRoleGrantSubject")
+  associationRoleGrantsGranted AssociationRoleGrant[] @relation("AssociationRoleGrantGrantor")
+  associationRoleGrantsRevoked AssociationRoleGrant[] @relation("AssociationRoleGrantRevoker")
+  volunteerNeedsCreated        VolunteerNeed[]        @relation("VolunteerNeedCreator")
+  volunteerAssignments         VolunteerAssignment[]  @relation("VolunteerAssignmentSubject")
+  volunteerAssignmentsAssigned VolunteerAssignment[]  @relation("VolunteerAssignmentAssigner")
 }
 
 // Single-use, hashed account-lifecycle tokens (email verification, password
@@ -219,6 +227,10 @@ model Team {
   gearReservations   GearReservation[]
   venueReservations  VenueReservation[]       @relation("VenueReservationTeamOwner")
 
+
+  // Feature 007 US3 — scoped responsibilities and volunteers.
+  associationRoleGrants AssociationRoleGrant[]
+  volunteerNeeds        VolunteerNeed[]
   @@unique([leagueId, id])
   @@index([leagueId]) // Optimize league-team queries
   @@index([divisionId]) // Optimize division-team queries
@@ -429,6 +441,11 @@ model Event {
   venueReservationId String?           @unique
   venueReservation   VenueReservation? @relation(fields: [venueReservationId], references: [id], onDelete: SetNull)
 
+
+  // Feature 007 US3 — scoped responsibilities and volunteers.
+  associationRoleGrants AssociationRoleGrant[]
+  volunteerNeeds        VolunteerNeed[]
+  invitationGrants      Invitation[]          @relation("InvitationAssociationEvent")
   @@index([teamId, startAt]) // Optimize queries for team events sorted by date
   @@index([startAt]) // Optimize queries for upcoming events across teams
   @@index([leagueId, startAt]) // Optimize league event queries
@@ -502,6 +519,24 @@ model Invitation {
   // organization target → VenueStaff membership).
   officialRole TeamOfficialRole?
   venueRole    VenueStaffRole?
+
+  // Pending scoped responsibility (feature 007 US3) applied at acceptance.
+  // scopeType selects which target below is authoritative; ASSOCIATION uses
+  // leagueId and TEAM uses teamId, both of which already exist above.
+  associationRole      AssociationRole?
+  associationScopeType AssociationRoleScopeType?
+
+  associationDivisionId String?
+  associationDivision   Division? @relation("InvitationAssociationDivision", fields: [associationDivisionId], references: [id], onDelete: Cascade)
+
+  associationSeasonId String?
+  associationSeason   Season? @relation("InvitationAssociationSeason", fields: [associationSeasonId], references: [id], onDelete: Cascade)
+
+  associationEventId String?
+  associationEvent   Event?  @relation("InvitationAssociationEvent", fields: [associationEventId], references: [id], onDelete: Cascade)
+
+  associationSignupEventId String?
+  associationSignupEvent   SignupEvent? @relation("InvitationAssociationSignupEvent", fields: [associationSignupEventId], references: [id], onDelete: Cascade)
 
   invitedById String
   invitedBy   User   @relation(fields: [invitedById], references: [id])
@@ -577,6 +612,10 @@ model League {
   notificationOutbox        NotificationOutbox[]
   venueReservations         VenueReservation[]         @relation("VenueReservationLeagueOwner")
 
+
+  // Feature 007 US3 — scoped responsibilities and volunteers.
+  associationRoleGrants     AssociationRoleGrant[]
+  volunteerNeeds            VolunteerNeed[]
   @@map("leagues")
 }
 
@@ -600,6 +639,11 @@ model Division {
   placementDecisions PlacementDecision[]
   seasonPlacements   SeasonTeamPlacement[]
 
+
+  // Feature 007 US3 — scoped responsibilities and volunteers.
+  associationRoleGrants AssociationRoleGrant[]
+  volunteerNeeds        VolunteerNeed[]
+  invitationGrants      Invitation[]          @relation("InvitationAssociationDivision")
   @@map("divisions")
 }
 
@@ -2567,6 +2611,10 @@ model Season {
   teamPlacements SeasonTeamPlacement[]
   proposals  GameProposal[]
 
+
+  // Feature 007 US3 — scoped responsibilities and volunteers.
+  associationRoleGrants AssociationRoleGrant[]
+  invitationGrants      Invitation[]          @relation("InvitationAssociationSeason")
   @@index([leagueId, startDate])
   @@index([teamId, startDate])
   @@map("seasons")
@@ -2954,6 +3002,11 @@ model SignupEvent {
   games         EventGame[]
   media         EventMediaItem[]
 
+
+  // Feature 007 US3 — scoped responsibilities and volunteers.
+  associationRoleGrants AssociationRoleGrant[]
+  volunteerNeeds        VolunteerNeed[]
+  invitationGrants      Invitation[]          @relation("InvitationAssociationSignupEvent")
   @@index([hostOrganizationId, startAt])
   @@index([hostLeagueId, startAt])
   @@index([hostTeamId, startAt])
@@ -3269,4 +3322,184 @@ model EventMediaItem {
 
   @@index([eventId, status, createdAt])
   @@map("event_media_items")
+}
+
+// ---------------------------------------------------------------------------
+// Feature 007 / User Story 3 — scoped responsibilities and volunteers.
+//
+// AssociationRoleGrant is the ONLY source of delegated capability. TeamOfficial
+// is descriptive and never grants anything (spec 007 US3); venue authorization
+// stays in VenueOrganization/VenueStaff and is deliberately not mirrored here.
+// ---------------------------------------------------------------------------
+
+enum AssociationRole {
+  ASSOCIATION_ADMIN
+  SCHEDULER
+  REGISTRAR
+  TREASURER
+  COMMUNICATIONS_LEAD
+  TEAM_MANAGER
+  COACH
+  VOLUNTEER_COORDINATOR
+  EVENT_MANAGER
+  EQUIPMENT_MANAGER
+}
+
+/// The one explicit scope a grant is bounded to. ASSOCIATION means the grant
+/// covers the owning league and sets no narrower target.
+enum AssociationRoleScopeType {
+  ASSOCIATION
+  DIVISION
+  TEAM
+  SEASON
+  EVENT
+  SIGNUP_EVENT
+}
+
+enum AssociationRoleGrantState {
+  ACTIVE
+  REVOKED
+}
+
+/// A bounded responsibility delegated to a user. Uniqueness is enforced per
+/// (user, role, scope) among ACTIVE rows only — revoking leaves history behind
+/// and must not block re-granting the same responsibility later.
+model AssociationRoleGrant {
+  id        String                    @id @default(cuid())
+  role      AssociationRole
+  scopeType AssociationRoleScopeType
+  state     AssociationRoleGrantState @default(ACTIVE)
+  notes     String?
+  createdAt DateTime                  @default(now())
+  updatedAt DateTime                  @updatedAt
+  revokedAt DateTime?
+
+  userId String
+  user   User   @relation("AssociationRoleGrantSubject", fields: [userId], references: [id], onDelete: Cascade)
+
+  grantedById String?
+  grantedBy   User?   @relation("AssociationRoleGrantGrantor", fields: [grantedById], references: [id], onDelete: SetNull)
+
+  revokedById String?
+  revokedBy   User?   @relation("AssociationRoleGrantRevoker", fields: [revokedById], references: [id], onDelete: SetNull)
+
+  // Owning association. Always set: every grant belongs to exactly one league.
+  leagueId String
+  league   League @relation(fields: [leagueId], references: [id], onDelete: Cascade)
+
+  // Exactly one of these is set unless scopeType is ASSOCIATION, in which case
+  // none are. Enforced by a num_nonnulls CHECK in the migration.
+  divisionId String?
+  division   Division? @relation(fields: [divisionId], references: [id], onDelete: Cascade)
+
+  teamId String?
+  // Compound FK: a team-scoped grant cannot point at a team in another league.
+  team   Team?   @relation(fields: [leagueId, teamId], references: [leagueId, id], onDelete: Cascade)
+
+  seasonId String?
+  season   Season? @relation(fields: [seasonId], references: [id], onDelete: Cascade)
+
+  eventId String?
+  event   Event?  @relation(fields: [eventId], references: [id], onDelete: Cascade)
+
+  signupEventId String?
+  signupEvent   SignupEvent? @relation(fields: [signupEventId], references: [id], onDelete: Cascade)
+
+  @@index([leagueId, state, role])
+  @@index([userId, state])
+  @@index([leagueId, teamId, state])
+  @@map("association_role_grants")
+}
+
+enum VolunteerNeedStatus {
+  OPEN
+  CLOSED
+  CANCELED
+  COMPLETED
+}
+
+enum VolunteerAssignmentStatus {
+  INVITED
+  ACCEPTED
+  DECLINED
+  CANCELED
+  COMPLETED
+  MISSED
+}
+
+/// An association-owned request for volunteer labour, optionally narrowed to a
+/// division, team, or specific activity.
+model VolunteerNeed {
+  id          String              @id @default(cuid())
+  roleLabel   String
+  description String?
+  capacity    Int
+  /// Accepted assignments, denormalized so capacity can be claimed with a
+  /// single conditional updateMany (acceptedCount < capacity) instead of a
+  /// read-then-write race. Never edited directly outside volunteer actions.
+  acceptedCount Int               @default(0)
+  status      VolunteerNeedStatus @default(OPEN)
+  startAt     DateTime
+  endAt       DateTime
+  timezone    String
+  createdAt   DateTime            @default(now())
+  updatedAt   DateTime            @updatedAt
+  canceledAt  DateTime?
+  completedAt DateTime?
+
+  leagueId String
+  league   League @relation(fields: [leagueId], references: [id], onDelete: Cascade)
+
+  divisionId String?
+  division   Division? @relation(fields: [divisionId], references: [id], onDelete: SetNull)
+
+  teamId String?
+  // Cascade, not SetNull: the compound FK carries the required leagueId, which
+  // SetNull cannot null. A need scoped to a deleted team has no meaning anyway.
+  team   Team?   @relation(fields: [leagueId, teamId], references: [leagueId, id], onDelete: Cascade)
+
+  eventId String?
+  event   Event?  @relation(fields: [eventId], references: [id], onDelete: SetNull)
+
+  signupEventId String?
+  signupEvent   SignupEvent? @relation(fields: [signupEventId], references: [id], onDelete: SetNull)
+
+  createdById String?
+  createdBy   User?   @relation("VolunteerNeedCreator", fields: [createdById], references: [id], onDelete: SetNull)
+
+  assignments VolunteerAssignment[]
+
+  @@index([leagueId, status, startAt])
+  @@index([leagueId, teamId, status])
+  @@map("volunteer_needs")
+}
+
+/// One volunteer slot against a need. Either a known user or an invited email
+/// address, never both — enforced by CHECK in the migration.
+///
+/// Capacity is enforced by a conditional updateMany against the parent need's
+/// acceptedCount, so two simultaneous acceptances cannot both take the last
+/// slot (ADR-0003 rules out SELECT ... FOR UPDATE).
+model VolunteerAssignment {
+  id           String                    @id @default(cuid())
+  status       VolunteerAssignmentStatus @default(INVITED)
+  invitedEmail String?
+  notes        String?
+  createdAt    DateTime                  @default(now())
+  updatedAt    DateTime                  @updatedAt
+  respondedAt  DateTime?
+  completedAt  DateTime?
+
+  needId String
+  need   VolunteerNeed @relation(fields: [needId], references: [id], onDelete: Cascade)
+
+  userId String?
+  user   User?   @relation("VolunteerAssignmentSubject", fields: [userId], references: [id], onDelete: Cascade)
+
+  assignedById String?
+  assignedBy   User?   @relation("VolunteerAssignmentAssigner", fields: [assignedById], references: [id], onDelete: SetNull)
+
+  @@index([needId, status])
+  @@index([userId, status])
+  @@map("volunteer_assignments")
 }

--- a/scripts/backfill-association-role-grants.ts
+++ b/scripts/backfill-association-role-grants.ts
@@ -1,0 +1,111 @@
+import { prisma } from "@/lib/db/prisma";
+
+export type AssociationRoleGrantBackfillReport = {
+  dryRun: boolean;
+  leaguesScanned: number;
+  leagueAdminsScanned: number;
+  grantsCreated: number;
+  grantsAlreadyPresent: number;
+};
+
+export type AssociationRoleGrantBackfillOptions = {
+  dryRun?: boolean;
+};
+
+/**
+ * Give every existing LEAGUE_ADMIN an explicit ASSOCIATION_ADMIN grant.
+ *
+ * Until this runs, league admins keep full authority through the legacy
+ * compatibility branch in `lib/auth/capabilities.ts`, so the feature can ship
+ * before the backfill without locking anybody out. Running it moves them onto
+ * the same explicit footing as every other delegate, which is what makes the
+ * grant table a truthful record of who can do what.
+ *
+ * Two things this deliberately does NOT do:
+ *
+ *  - It never reads `TeamOfficial`. Those rows are descriptive labels — "Head
+ *    Coach", "Team Manager" — that associations hand out for roster listings.
+ *    Inferring authority from them would silently promote people who were only
+ *    ever labelled, which spec 007 US3 prohibits.
+ *  - It never touches `TeamMember` ADMIN rows. Team admins keep working through
+ *    the same legacy branch; converting them would be a separate decision about
+ *    what a team admin is, not a backfill.
+ *
+ * Idempotent: an existing ACTIVE association-scoped grant is left alone, so a
+ * partial run can simply be repeated.
+ */
+export async function backfillAssociationRoleGrants(
+  options: AssociationRoleGrantBackfillOptions = {},
+): Promise<AssociationRoleGrantBackfillReport> {
+  const dryRun = options.dryRun ?? false;
+
+  const report: AssociationRoleGrantBackfillReport = {
+    dryRun,
+    leaguesScanned: 0,
+    leagueAdminsScanned: 0,
+    grantsCreated: 0,
+    grantsAlreadyPresent: 0,
+  };
+
+  const leagues = await prisma.league.findMany({ select: { id: true } });
+  report.leaguesScanned = leagues.length;
+
+  for (const league of leagues) {
+    const admins = await prisma.leagueUser.findMany({
+      where: { leagueId: league.id, role: "LEAGUE_ADMIN" },
+      select: { userId: true },
+    });
+    report.leagueAdminsScanned += admins.length;
+
+    for (const admin of admins) {
+      const existing = await prisma.associationRoleGrant.findFirst({
+        where: {
+          userId: admin.userId,
+          leagueId: league.id,
+          role: "ASSOCIATION_ADMIN",
+          scopeType: "ASSOCIATION",
+          state: "ACTIVE",
+        },
+        select: { id: true },
+      });
+
+      if (existing) {
+        report.grantsAlreadyPresent += 1;
+        continue;
+      }
+
+      report.grantsCreated += 1;
+      if (dryRun) continue;
+
+      await prisma.associationRoleGrant.create({
+        data: {
+          userId: admin.userId,
+          leagueId: league.id,
+          role: "ASSOCIATION_ADMIN",
+          scopeType: "ASSOCIATION",
+          // grantedById stays null: nobody granted these, they are a record of
+          // authority that already existed before grants were introduced.
+          notes: "Backfilled from existing LEAGUE_ADMIN membership.",
+        },
+      });
+    }
+  }
+
+  return report;
+}
+
+async function main() {
+  const report = await backfillAssociationRoleGrants({
+    dryRun: process.argv.includes("--dry-run"),
+  });
+  console.log(JSON.stringify(report, null, 2));
+}
+
+if (import.meta.main) {
+  main()
+    .catch((error) => {
+      console.error(error);
+      process.exitCode = 1;
+    })
+    .finally(() => prisma.$disconnect());
+}

--- a/specs/007-association-operations/tasks.md
+++ b/specs/007-association-operations/tasks.md
@@ -128,23 +128,23 @@ description: "Dependency-ordered implementation backlog for association operatio
 
 ### Tests
 
-- [ ] T054 [P] [US3] Add least-privilege workflow matrix tests for coach, team manager, scheduler, registrar, treasurer, communications lead, volunteer coordinator, event manager, and equipment manager, including the association/division/team/unsupported gear scope matrix and mandatory `teamId`, to `__tests__/lib/auth/capabilities.test.ts` and `__tests__/lib/utils/permissions-gear.test.ts`
-- [ ] T055 [P] [US3] Add grant, revoke, ancestry, invitation-acceptance, and equipment-manager scope tests to `__tests__/lib/actions/association-roles.test.ts`
-- [ ] T056 [P] [US3] Add volunteer capacity/response and per-child guardian authorization/privacy tests to `__tests__/lib/actions/volunteers.test.ts` and `__tests__/lib/actions/rsvp-guardians.test.ts`
-- [ ] T057 [P] [US3] Add simultaneous final volunteer-slot acceptance tests to `__tests__/integration/volunteer-capacity-concurrency.test.ts`
-- [ ] T058 [P] [US3] Add workforce role and volunteer board component tests to `__tests__/components/features/workforce/VolunteerBoard.test.tsx`
+- [x] T054 [P] [US3] Add least-privilege workflow matrix tests for coach, team manager, scheduler, registrar, treasurer, communications lead, volunteer coordinator, event manager, and equipment manager, including the association/division/team/unsupported gear scope matrix and mandatory `teamId`, to `__tests__/lib/auth/capabilities.test.ts` and `__tests__/lib/utils/permissions-gear.test.ts`
+- [x] T055 [P] [US3] Add grant, revoke, ancestry, invitation-acceptance, and equipment-manager scope tests to `__tests__/lib/actions/association-roles.test.ts`
+- [x] T056 [P] [US3] Add volunteer capacity/response and per-child guardian authorization/privacy tests to `__tests__/lib/actions/volunteers.test.ts` and `__tests__/lib/actions/rsvp-guardians.test.ts`
+- [x] T057 [P] [US3] Add simultaneous final volunteer-slot acceptance tests to `__tests__/integration/volunteer-capacity-concurrency.test.ts`
+- [x] T058 [P] [US3] Add workforce role and volunteer board component tests to `__tests__/components/features/workforce/VolunteerBoard.test.tsx`
 
 ### Implementation
 
-- [ ] T059 [US3] Add `AssociationRoleGrant` with `EQUIPMENT_MANAGER`, `VolunteerNeed`, `VolunteerAssignment`, related enums, and invitation payload fields without altering existing gear entities in `prisma/schema.prisma`
-- [ ] T060 [US3] Create scoped-role and volunteer migration constraints, then regenerate Prisma before capability/actions work, in `prisma/migrations/<timestamp>_add_association_roles_and_volunteers/migration.sql` with `bun run db:generate`
-- [ ] T061 [US3] Implement capability mapping, scoped ancestry, legacy-admin compatibility, and equipment-manager delegation through existing gear `Permission` checks in `lib/auth/capabilities.ts` and `lib/utils/permissions.ts`
-- [ ] T062 [US3] Implement grant/revoke/list/invite actions and acceptance application in `lib/actions/association-roles.ts` and `lib/actions/invitations.ts`
-- [ ] T063 [US3] Backfill association-admin grants from league admins without inferring permissions from officials in `scripts/backfill-association-role-grants.ts`
-- [ ] T064 [US3] Implement volunteer need/assignment/fulfillment actions and harden per-child guardian response privacy in `lib/actions/volunteers.ts`, `lib/actions/rsvp.ts`, and `lib/actions/guardians.ts`
-- [ ] T065 [US3] Add role grant manager with equipment-manager guidance and volunteer board components to `components/features/workforce/RoleGrantManager.tsx` and `components/features/workforce/VolunteerBoard.tsx`
-- [ ] T066 [US3] Add workforce management route and feed volunteer shortages plus safe gear-attention summaries into the operations dashboard in `app/(dashboard)/league/[leagueId]/workforce/page.tsx` and `app/(dashboard)/league/[leagueId]/operations/page.tsx`
-- [ ] T067 [US3] Mount existing permission-management surfaces within the scoped workforce route via `components/features/admin/UserPermissionManager.tsx` and `components/features/admin/TeamPermissionManager.tsx`
+- [x] T059 [US3] Add `AssociationRoleGrant` with `EQUIPMENT_MANAGER`, `VolunteerNeed`, `VolunteerAssignment`, related enums, and invitation payload fields without altering existing gear entities in `prisma/schema.prisma`
+- [x] T060 [US3] Create scoped-role and volunteer migration constraints, then regenerate Prisma before capability/actions work, in `prisma/migrations/<timestamp>_add_association_roles_and_volunteers/migration.sql` with `bun run db:generate`
+- [x] T061 [US3] Implement capability mapping, scoped ancestry, legacy-admin compatibility, and equipment-manager delegation through existing gear `Permission` checks in `lib/auth/capabilities.ts` and `lib/utils/permissions.ts`
+- [x] T062 [US3] Implement grant/revoke/list/invite actions and acceptance application in `lib/actions/association-roles.ts` and `lib/actions/invitations.ts`
+- [x] T063 [US3] Backfill association-admin grants from league admins without inferring permissions from officials in `scripts/backfill-association-role-grants.ts`
+- [x] T064 [US3] Implement volunteer need/assignment/fulfillment actions and harden per-child guardian response privacy in `lib/actions/volunteers.ts`, `lib/actions/rsvp.ts`, and `lib/actions/guardians.ts`
+- [x] T065 [US3] Add role grant manager with equipment-manager guidance and volunteer board components to `components/features/workforce/RoleGrantManager.tsx` and `components/features/workforce/VolunteerBoard.tsx`
+- [x] T066 [US3] Add workforce management route and feed volunteer shortages plus safe gear-attention summaries into the operations dashboard in `app/(dashboard)/league/[leagueId]/workforce/page.tsx` and `app/(dashboard)/league/[leagueId]/operations/page.tsx`
+- [x] T067 [US3] Mount existing permission-management surfaces within the scoped workforce route via `components/features/admin/UserPermissionManager.tsx` and `components/features/admin/TeamPermissionManager.tsx`
 
 **Checkpoint**: Season work can be distributed without broad administrator grants.
 


### PR DESCRIPTION
Implements **Phase 5** of `specs/007-association-operations` — tasks **T054–T067** (14 tasks, all checked off in `tasks.md`).

## The problem

Associations had three coarse levers: `LeagueUser.role`, `TeamMember.role`, and `VenueStaff`. Delegating one job — *"let the equipment manager issue jerseys"* — meant granting `LEAGUE_ADMIN`, which also grants payments, roster edits, audit access, and the ability to promote others. Associations recruit volunteers for bounded work; handing each of them everything is both unsafe and a recruiting obstacle.

## The model

`AssociationRoleGrant` is the single source of delegated authority.

- **One grant, one role, exactly one scope** (association / division / team / season / Event / SignupEvent). A `CASE`-per-scope `CHECK` makes a row that names two scopes, or a scope disagreeing with its `scopeType`, unrepresentable.
- **The matrix is an allowlist.** Unlisted role/capability/scope combinations authorize nothing rather than inheriting a permissive default.
- **Narrow grants never widen.** A team-scoped grant asked about association-wide work returns false. Division scope resolves through *current* membership, so moving a team out of a division withdraws reach without editing a grant.
- **Uniqueness applies to ACTIVE grants only** — six partial unique indexes. Without the predicate, revoking a responsibility would permanently prevent re-granting it.
- **`TeamOfficial` is never read.** It is a descriptive label; inferring authority from it would promote everyone an association ever listed on a roster. `VenueStaff` stays in the venue model rather than being mirrored.

Equipment managers route through the **existing** gear `Permission` checks in `lib/utils/permissions.ts`, consulted only after the access-level matrix declines — so a grant can add authority but never loosen a rule, including the mandatory-`teamId` rule the grant path re-checks. No gear action learns about grants.

Existing `LEAGUE_ADMIN`s keep full capability through an explicit legacy branch until `scripts/backfill-association-role-grants.ts` runs, so this cannot lock an association out of its own administration. The backfill is idempotent (verified: second run reports 0 created, 2 already present).

## Volunteer capacity

ADR-0003 rules out `SELECT ... FOR UPDATE`, so acceptance claims a slot with a conditional `updateMany` guarded on `acceptedCount < capacity` — evaluated by Postgres at write time — with an `acceptedCount <= capacity` CHECK behind it.

Proved against a real database rather than a mock (`__tests__/integration/volunteer-capacity-concurrency.test.ts`, gated on `TEST_DATABASE_URL` like its venue sibling): two simultaneous acceptances of a one-slot need yield exactly one winner, the counter lands on 1, and a direct write to 2 is rejected. **I ran it** — it is not a test that only ever skips.

The database invariants were exercised directly too: 7 grant cases and 11 volunteer cases, each asserted to be accepted or rejected as intended.

## Privacy fix (T064)

`getEventAttendance` exposed the responding guardian's name and email to **every team member** — family information on a youth team's attendance list. Attribution is now organizer-only. The two existing `rsvp.test.ts` cases that asserted the old behaviour were updated, not deleted: their subject is attribution, which still works, now for organizers. The member's-eye view is covered in the new `rsvp-guardians.test.ts`.

## Two latent defects found

**`UserPermissionManager` / `TeamPermissionManager` had never been mounted anywhere.** T067 says "mount existing" — doing so broke the production build: the client component imports the `LeagueAccessLevel` *runtime* enum from `lib/utils/security.ts`, which transitively reaches `next/headers` and `node:dns`. The enum now lives in a dependency-free module that `security.ts` re-exports.

Worth noting: **type-check and the full test suite both passed while the build did not.** Only `bun run build` caught it.

**The route would have been unreachable.** Added "Workforce" to league navigation and breadcrumbs — the same defect fixed in #341.

## Verification

| Gate | Result |
|---|---|
| `bun run type-check` | pass |
| `bun run lint` | pass |
| `bun run test` | **2712 passed**, 4 skipped (baseline was 2607) |
| `bun run build` | pass; `/league/[leagueId]/workforce` registered |
| `bun run check:raw-sql` | pass — 845 files |
| `adr lint` | 9 records, 0 errors |
| Integration (real DB) | volunteer concurrency 3/3 |

One pre-existing failure is untouched and unrelated: `venue-reservation-concurrency.test.ts` (T018) fails identically on clean `main` under a local pg adapter — it asserts a `DriverAdapterError` string that appears to be Neon-specific. It does not run in the normal suite.

## ADR-0009

Records the authorization model, the rejected alternatives (extend `LeagueRole`; derive from `TeamOfficial`; a second gear checker), and what would make it wrong. `adr check` reports 5 governing decisions with 0 errors. Also brought the ADR table in `CLAUDE.md` current — it had drifted three records behind.

## Note on tooling

`bun run adr:check` and every other `adrkit`-invoking script fail with `command not found`: `package.json` pins `@adrkit/cli` at **0.8.0** but **0.4.0** is installed, and 0.4.0 ships only the `adr` bin. Pre-existing (this PR does not touch dependency pins), and `adr:check-integrity` does not catch it because it compares declared pins to each other rather than to what is installed. I used `node_modules/.bin/adr` directly. Left for a separate change.