### PR TITLE
feat(association): publish association and team public pages (007 US4)

### DIFF
--- a/__tests__/api/public-association-ics.test.ts
+++ b/__tests__/api/public-association-ics.test.ts
@@ -1,8 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
 
-const { mockGetCurrentUserId, mockPrisma } = vi.hoisted(() => ({
+const { mockGetCurrentUserId, mockPrisma, mockResolvePublicAssociation } = vi.hoisted(() => ({
   mockGetCurrentUserId: vi.fn(),
+  mockResolvePublicAssociation: vi.fn(),
   mockPrisma: {
     league: { findFirst: vi.fn(), findUnique: vi.fn() },
     event: { findMany: vi.fn() },
@@ -21,19 +22,27 @@ vi.mock("@/lib/auth/session", () => ({
 }));
 
 vi.mock("@/lib/db/prisma", () => ({ prisma: mockPrisma }));
+vi.mock("@/lib/actions/association-profile", () => ({
+  resolvePublicAssociation: mockResolvePublicAssociation,
+}));
 
 import { GET } from "@/app/api/associations/[slug]/schedule.ics/route";
 
 const SLUG = "north-stars";
 const LEAGUE_NAME = "North Stars";
 
-function request() {
-  return new NextRequest(`http://localhost/api/associations/${SLUG}/schedule.ics`);
+function request(slug = SLUG) {
+  return new NextRequest(`http://localhost/api/associations/${slug}/schedule.ics`);
 }
 
 beforeEach(() => {
   vi.clearAllMocks();
   mockGetCurrentUserId.mockResolvedValue(null);
+  mockResolvePublicAssociation.mockResolvedValue({
+    id: "clleague0000000000000001",
+    canonicalSlug: SLUG,
+    redirected: false,
+  });
   mockPrisma.league.findFirst.mockResolvedValue({
     id: "clleague0000000000000001",
     name: LEAGUE_NAME,
@@ -118,10 +127,11 @@ describe("public association ICS", () => {
     expect(mockPrisma.league.findFirst).toHaveBeenCalledWith(
       expect.objectContaining({
         where: expect.objectContaining({
-          slug: SLUG,
+          id: "clleague0000000000000001",
           isActive: true,
+          profileStatus: "PUBLISHED",
         }),
-        select: { id: true, name: true, slug: true },
+        select: { id: true, name: true },
       }),
     );
     expect(response.status).toBe(200);
@@ -144,10 +154,29 @@ describe("public association ICS", () => {
   });
 
   it("returns not found for an unpublished association slug", async () => {
-    mockPrisma.league.findFirst.mockResolvedValue(null);
+    mockResolvePublicAssociation.mockResolvedValue(null);
 
     const response = await GET(request(), { params: Promise.resolve({ slug: SLUG }) });
 
     expect(response.status).toBe(404);
+    expect(mockPrisma.league.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("redirects a retired slug to the canonical ICS address", async () => {
+    mockResolvePublicAssociation.mockResolvedValue({
+      id: "clleague0000000000000001",
+      canonicalSlug: SLUG,
+      redirected: true,
+    });
+
+    const response = await GET(request("old-north-stars"), {
+      params: Promise.resolve({ slug: "old-north-stars" }),
+    });
+
+    expect(response.status).toBe(308);
+    expect(response.headers.get("location")).toBe(
+      `http://localhost/api/associations/${SLUG}/schedule.ics`,
+    );
+    expect(mockPrisma.league.findFirst).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/app/public-association-navigation.test.tsx
+++ b/__tests__/app/public-association-navigation.test.tsx
@@ -21,6 +21,8 @@ const association = {
   sport: "HOCKEY",
   publicDescription: "Youth hockey.",
   logoUrl: null,
+  brandPrimaryColor: "#123456",
+  brandSecondaryColor: "#654321",
   publicEmail: "hello@metro.example.com",
   publicPhone: null,
   divisions: [{ id: "d1", name: "U12 Recreational", ageGroup: "U12" }],
@@ -63,6 +65,7 @@ describe("association landing page reachability (SC-007)", () => {
   it("reaches every public announcement in one activation", () => {
     render(<PublicAssociationProfile association={association} />);
     expect(hrefs()).toContain("/associations/metro-hockey/news/season-opens");
+    expect(hrefs()).toContain("/associations/metro-hockey/news");
   });
 
   it("reaches an active published wishlist in one activation", () => {

--- a/__tests__/app/public-association-navigation.test.tsx
+++ b/__tests__/app/public-association-navigation.test.tsx
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import PublicAssociationProfile from "@/components/features/association-profile/PublicAssociationProfile";
+
+/**
+ * SC-007: every published team, the public schedule, public signup events,
+ * public announcements, and an active public wishlist must be reachable from
+ * the association landing page in no more than three link or button
+ * activations.
+ *
+ * Everything below is reachable in ONE, which leaves two to spare. Counting
+ * links on the landing page is the whole test: if a surface has no link here,
+ * no number of further activations reaches it.
+ */
+
+const association = {
+  id: "league-1",
+  name: "Metro Hockey",
+  slug: "metro-hockey",
+  sport: "HOCKEY",
+  publicDescription: "Youth hockey.",
+  logoUrl: null,
+  publicEmail: "hello@metro.example.com",
+  publicPhone: null,
+  divisions: [{ id: "d1", name: "U12 Recreational", ageGroup: "U12" }],
+  teams: [
+    { id: "t1", name: "Metro Blades", slug: "metro-blades", season: "Winter", division: { name: "U12 Recreational", ageGroup: "U12" } },
+    { id: "t2", name: "Harbor Hawks", slug: "harbor-hawks", season: "Winter", division: null },
+  ],
+  publicContentItems: [
+    { id: "c1", slug: "season-opens", title: "Season opens", summary: "Monday.", publishAt: new Date("2026-05-01"), team: null },
+  ],
+  gearWishlist: { shareToken: "tok-abc", title: "Equipment wishlist" },
+};
+
+function hrefs() {
+  return screen.getAllByRole("link").map((a) => a.getAttribute("href"));
+}
+
+describe("association landing page reachability (SC-007)", () => {
+  it("reaches every published team in one activation", () => {
+    render(<PublicAssociationProfile association={association} />);
+
+    expect(hrefs()).toEqual(
+      expect.arrayContaining([
+        "/associations/metro-hockey/teams/metro-blades",
+        "/associations/metro-hockey/teams/harbor-hawks",
+      ]),
+    );
+  });
+
+  it("reaches the public schedule in one activation", () => {
+    render(<PublicAssociationProfile association={association} />);
+    expect(hrefs()).toContain("/associations/metro-hockey/schedule");
+  });
+
+  it("reaches signup events in one activation", () => {
+    render(<PublicAssociationProfile association={association} />);
+    expect(hrefs()).toContain("/associations/metro-hockey/events");
+  });
+
+  it("reaches every public announcement in one activation", () => {
+    render(<PublicAssociationProfile association={association} />);
+    expect(hrefs()).toContain("/associations/metro-hockey/news/season-opens");
+  });
+
+  it("reaches an active published wishlist in one activation", () => {
+    render(<PublicAssociationProfile association={association} />);
+    expect(hrefs()).toContain("/gear-wishlist/tok-abc");
+  });
+
+  it("omits the wishlist link entirely when none is published", () => {
+    // The selector returns null unless status is PUBLISHED, so an unpublished
+    // wishlist leaves no token on the page at all.
+    render(<PublicAssociationProfile association={{ ...association, gearWishlist: null }} />);
+    expect(hrefs().some((href) => href?.startsWith("/gear-wishlist/"))).toBe(false);
+  });
+
+  it("shows the public contact details and the description", () => {
+    render(<PublicAssociationProfile association={association} />);
+    expect(screen.getByText("hello@metro.example.com")).toBeInTheDocument();
+    expect(screen.getByText("Youth hockey.")).toBeInTheDocument();
+  });
+
+  it("renders a team directory link for the full list", () => {
+    render(<PublicAssociationProfile association={association} />);
+    expect(hrefs()).toContain("/associations/metro-hockey/teams");
+  });
+});

--- a/__tests__/app/public-association-news.test.tsx
+++ b/__tests__/app/public-association-news.test.tsx
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+const { mockResolvePublicAssociation, mockListPublicAssociationContentPage } = vi.hoisted(
+  () => ({
+    mockResolvePublicAssociation: vi.fn(),
+    mockListPublicAssociationContentPage: vi.fn(),
+  }),
+);
+
+vi.mock("@/lib/actions/association-profile", () => ({
+  resolvePublicAssociation: mockResolvePublicAssociation,
+}));
+vi.mock("@/lib/actions/public-content", () => ({
+  listPublicAssociationContentPage: mockListPublicAssociationContentPage,
+}));
+
+import PublicAssociationNewsPage from "@/app/(marketing)/associations/[slug]/news/page";
+
+describe("PublicAssociationNewsPage", () => {
+  it("lists public announcements with bounded direct page navigation", async () => {
+    mockResolvePublicAssociation.mockResolvedValue({
+      id: "league-1",
+      canonicalSlug: "metro",
+      redirected: false,
+    });
+    mockListPublicAssociationContentPage.mockResolvedValue({
+      items: [
+        {
+          id: "item-1",
+          slug: "season-opens",
+          title: "Season opens",
+          summary: "Registration starts Monday.",
+        },
+      ],
+      page: 1,
+      totalItems: 21,
+      totalPages: 2,
+    });
+
+    const page = await PublicAssociationNewsPage({
+      params: Promise.resolve({ slug: "metro" }),
+      searchParams: Promise.resolve({ page: "1" }),
+    });
+    render(page);
+
+    expect(screen.getByRole("link", { name: /Season opens/ })).toHaveAttribute(
+      "href",
+      "/associations/metro/news/season-opens",
+    );
+    expect(screen.getByRole("link", { name: "Next" })).toHaveAttribute(
+      "href",
+      "/associations/metro/news?page=2",
+    );
+    expect(screen.getByLabelText("Page")).toHaveAttribute("max", "2");
+  });
+});

--- a/__tests__/app/public-association-privacy.test.tsx
+++ b/__tests__/app/public-association-privacy.test.tsx
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getPublicAssociationProfileSelect,
+  getPublicTeamProfileSelect,
+  publicAssociationSummarySelect,
+  publicContentSelect,
+  publicContentDetailSelect,
+  publicContentWhere,
+  publicPublishedAssociationWhere,
+  publicPublishedTeamWhere,
+  publicTeamSummarySelect,
+} from "@/lib/utils/public-associations";
+
+/**
+ * The public association surface is safe because of what its selectors do NOT
+ * contain. These assertions are deliberately negative: they fail when somebody
+ * adds a field, not when somebody removes one.
+ *
+ * Proven end to end as well — every route was fetched unauthenticated against a
+ * seeded database and checked for these exact values. This file is the
+ * repeatable form of that sweep.
+ */
+
+const NOW = new Date("2026-06-01T00:00:00Z");
+
+function keys(select: Record<string, unknown>): string[] {
+  return Object.keys(select);
+}
+
+describe("public association selectors exclude private data", () => {
+  const associationSelect = getPublicAssociationProfileSelect(NOW) as Record<string, unknown>;
+  const teamSelect = getPublicTeamProfileSelect(NOW) as Record<string, unknown>;
+
+  it("never selects the private administrative contact", () => {
+    // League.contactEmail / contactPhone are the admin contact. The public page
+    // uses publicEmail / publicPhone, which an administrator opts into.
+    expect(keys(associationSelect)).not.toContain("contactEmail");
+    expect(keys(associationSelect)).not.toContain("contactPhone");
+    expect(keys(associationSelect)).toContain("publicEmail");
+  });
+
+  it("never selects payment or merchant configuration", () => {
+    for (const field of [
+      "stripeAccountId",
+      "stripeChargesEnabled",
+      "stripePayoutsEnabled",
+      "stripeDetailsSubmitted",
+      "platformFeeBps",
+      "payments",
+    ]) {
+      expect(keys(associationSelect), field).not.toContain(field);
+    }
+  });
+
+  it("never selects rosters, members, or invitations", () => {
+    for (const field of ["players", "users", "invitations", "notificationPreferences"]) {
+      expect(keys(associationSelect), field).not.toContain(field);
+    }
+    expect(keys(teamSelect)).not.toContain("players");
+    expect(keys(teamSelect)).not.toContain("members");
+  });
+
+  it("never selects gear inventory, custody, donors, or pledges", () => {
+    for (const field of [
+      "gearCatalogItems",
+      "gearStorageLocations",
+      "gearPoolStocks",
+      "gearUnits",
+      "gearReservations",
+      "gearPledges",
+      "gearActivity",
+    ]) {
+      expect(keys(associationSelect), field).not.toContain(field);
+    }
+  });
+
+  it("exposes a published wishlist only as a token and a title", () => {
+    const wishlist = associationSelect.gearWishlist as {
+      where: { status: string };
+      select: Record<string, unknown>;
+    };
+    expect(wishlist.where).toEqual({ status: "PUBLISHED" });
+    // Nothing else: not items, not donors, not the league's inventory.
+    expect(keys(wishlist.select).sort()).toEqual(["shareToken", "title"]);
+  });
+
+  it("never selects the notification outbox or audit trail", () => {
+    for (const field of ["notificationOutbox", "auditLogs", "messages"]) {
+      expect(keys(associationSelect), field).not.toContain(field);
+    }
+  });
+
+  it("never selects the content author", () => {
+    // A volunteer posting a schedule change has not consented to a byline.
+    expect(keys(publicContentSelect)).not.toContain("author");
+    expect(keys(publicContentSelect)).not.toContain("authorId");
+    expect(keys(publicContentDetailSelect)).not.toContain("author");
+  });
+
+  it("only reads published, active associations and teams", () => {
+    expect(publicPublishedAssociationWhere).toEqual({
+      isActive: true,
+      profileStatus: "PUBLISHED",
+      slug: { not: null },
+    });
+    expect(publicPublishedTeamWhere).toEqual({
+      isActive: true,
+      profileStatus: "PUBLISHED",
+      slug: { not: null },
+    });
+  });
+
+  it("only reads public content whose time has come and which is not archived", () => {
+    expect(publicContentWhere(NOW)).toEqual({
+      visibility: "PUBLIC",
+      status: { in: ["PUBLISHED", "SCHEDULED"] },
+      publishAt: { lte: NOW },
+      archivedAt: null,
+    });
+  });
+
+  it("restricts nested teams on the association page to published ones", () => {
+    const teams = associationSelect.teams as { where: unknown };
+    expect(teams.where).toEqual(publicPublishedTeamWhere);
+  });
+
+  it("keeps the summary selectors minimal", () => {
+    expect(keys(publicAssociationSummarySelect)).not.toContain("contactEmail");
+    expect(keys(publicTeamSummarySelect)).not.toContain("players");
+  });
+});

--- a/__tests__/app/public-team-page.test.tsx
+++ b/__tests__/app/public-team-page.test.tsx
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+const {
+  mockGetPublicTeamProfile,
+  mockResolvePublicAssociation,
+  mockGetPublicTeamScheduleItems,
+} = vi.hoisted(() => ({
+  mockGetPublicTeamProfile: vi.fn(),
+  mockResolvePublicAssociation: vi.fn(),
+  mockGetPublicTeamScheduleItems: vi.fn(),
+}));
+
+vi.mock("@/lib/actions/association-profile", () => ({
+  getPublicTeamProfile: mockGetPublicTeamProfile,
+  resolvePublicAssociation: mockResolvePublicAssociation,
+}));
+vi.mock("@/lib/data/schedule-items", () => ({
+  getPublicTeamScheduleItems: mockGetPublicTeamScheduleItems,
+}));
+
+import PublicTeamPage from "@/app/(marketing)/associations/[slug]/teams/[teamSlug]/page";
+
+describe("PublicTeamPage", () => {
+  it("renders approved identity and only the team's public schedule", async () => {
+    mockResolvePublicAssociation.mockResolvedValue({
+      id: "league-1",
+      canonicalSlug: "metro",
+      redirected: false,
+    });
+    mockGetPublicTeamProfile.mockResolvedValue({
+      id: "team-1",
+      name: "Blades",
+      canonicalSlug: "blades",
+      season: "Winter",
+      logoUrl: "https://example.com/blades.png",
+      publicDescription: "Metro's U12 team.",
+      division: { name: "U12" },
+      league: { name: "Metro Hockey" },
+      publicContentItems: [],
+    });
+    mockGetPublicTeamScheduleItems.mockResolvedValue([
+      {
+        canonicalScheduleId: "season-game:1",
+        title: "Blades vs Hawks",
+        startsAt: new Date("2026-09-01T18:00:00Z"),
+        venueName: "North Rink",
+      },
+    ]);
+
+    const page = await PublicTeamPage({
+      params: Promise.resolve({ slug: "metro", teamSlug: "blades" }),
+    });
+    const { container } = render(page);
+
+    expect(screen.getByRole("heading", { level: 1, name: "Blades" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Team schedule" })).toBeInTheDocument();
+    expect(screen.getByText("Blades vs Hawks")).toBeInTheDocument();
+    expect(container.querySelector('img[src="https://example.com/blades.png"]')).not.toBeNull();
+    expect(mockGetPublicTeamScheduleItems).toHaveBeenCalledWith(
+      "league-1",
+      "team-1",
+      expect.objectContaining({
+        from: expect.any(Date),
+        to: expect.any(Date),
+      }),
+    );
+  });
+});

--- a/__tests__/app/public-team-privacy.test.tsx
+++ b/__tests__/app/public-team-privacy.test.tsx
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getPublicTeamProfileSelect,
+  publicTeamSummarySelect,
+  publicPublishedTeamWhere,
+} from "@/lib/utils/public-associations";
+
+/**
+ * The public team page shows identity and news. It must never show a roster:
+ * a youth team's page is exactly where participant and guardian data would do
+ * the most harm.
+ */
+const NOW = new Date("2026-06-01T00:00:00Z");
+
+describe("public team page excludes participant data", () => {
+  const select = getPublicTeamProfileSelect(NOW) as Record<string, unknown>;
+
+  it("never selects players, members, officials, or invitations", () => {
+    for (const field of ["players", "members", "teamOfficials", "invitations", "rsvps"]) {
+      expect(Object.keys(select), field).not.toContain(field);
+    }
+  });
+
+  it("never selects events, practices, or attendance", () => {
+    // The team page links to the association schedule, which applies its own
+    // public visibility filter, rather than reading events directly.
+    for (const field of ["events", "practiceSessions", "seasonGames"]) {
+      expect(Object.keys(select), field).not.toContain(field);
+    }
+  });
+
+  it("never selects gear needs or reservations", () => {
+    for (const field of ["gearNeeds", "gearReservations", "gearUnits"]) {
+      expect(Object.keys(select), field).not.toContain(field);
+    }
+  });
+
+  it("exposes only approved identity fields", () => {
+    expect(Object.keys(publicTeamSummarySelect).sort()).toEqual([
+      "division",
+      "id",
+      "logoUrl",
+      "name",
+      "publicDescription",
+      "season",
+      "slug",
+      "sport",
+    ]);
+  });
+
+  it("reads only published, active teams", () => {
+    expect(publicPublishedTeamWhere).toEqual({
+      isActive: true,
+      profileStatus: "PUBLISHED",
+      slug: { not: null },
+    });
+  });
+
+  it("carries the association only as its public summary", () => {
+    const league = select.league as { select: Record<string, unknown> };
+    expect(Object.keys(league.select)).not.toContain("contactEmail");
+    expect(Object.keys(league.select)).not.toContain("stripeAccountId");
+  });
+});

--- a/__tests__/app/public-team-privacy.test.tsx
+++ b/__tests__/app/public-team-privacy.test.tsx
@@ -23,8 +23,8 @@ describe("public team page excludes participant data", () => {
   });
 
   it("never selects events, practices, or attendance", () => {
-    // The team page links to the association schedule, which applies its own
-    // public visibility filter, rather than reading events directly.
+    // The team page reads the canonical public schedule separately, rather
+    // than widening this approved-identity selector with activity relations.
     for (const field of ["events", "practiceSessions", "seasonGames"]) {
       expect(Object.keys(select), field).not.toContain(field);
     }

--- a/__tests__/app/sitemap.test.ts
+++ b/__tests__/app/sitemap.test.ts
@@ -1,16 +1,24 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+
+const { mockLeague } = vi.hoisted(() => ({ mockLeague: { findMany: vi.fn() } }));
+
+// The sitemap now enumerates published association surfaces. Default to none so
+// the existing static-page assertions stay about the static pages.
+vi.mock('@/lib/db/prisma', () => ({ prisma: { league: mockLeague } }));
+mockLeague.findMany.mockResolvedValue([]);
+
 import sitemap from '@/app/sitemap';
 
 describe('Sitemap Generation', () => {
-    it('should generate a valid sitemap array', () => {
-        const sitemapData = sitemap();
+    it('should generate a valid sitemap array', async () => {
+        const sitemapData = await sitemap();
 
         expect(Array.isArray(sitemapData)).toBe(true);
         expect(sitemapData.length).toBeGreaterThan(0);
     });
 
-    it('should include homepage with highest priority', () => {
-        const sitemapData = sitemap();
+    it('should include homepage with highest priority', async () => {
+        const sitemapData = await sitemap();
         const homepage = sitemapData.find((entry) => entry.url === 'https://openl.app');
 
         expect(homepage).toBeDefined();
@@ -18,8 +26,8 @@ describe('Sitemap Generation', () => {
         expect(homepage?.changeFrequency).toBe('weekly');
     });
 
-    it('should include all marketing pages', () => {
-        const sitemapData = sitemap();
+    it('should include all marketing pages', async () => {
+        const sitemapData = await sitemap();
         const urls = sitemapData.map((entry) => entry.url);
 
         expect(urls).toContain('https://openl.app/features');
@@ -29,8 +37,8 @@ describe('Sitemap Generation', () => {
         expect(urls).toContain('https://openl.app/about');
     });
 
-    it('should include documentation pages', () => {
-        const sitemapData = sitemap();
+    it('should include documentation pages', async () => {
+        const sitemapData = await sitemap();
         const urls = sitemapData.map((entry) => entry.url);
 
         expect(urls).toContain('https://openl.app/docs');
@@ -40,8 +48,8 @@ describe('Sitemap Generation', () => {
         expect(urls).toContain('https://openl.app/docs/contributing');
     });
 
-    it('should include legal pages with lower priority', () => {
-        const sitemapData = sitemap();
+    it('should include legal pages with lower priority', async () => {
+        const sitemapData = await sitemap();
         const privacyPage = sitemapData.find((entry) => entry.url === 'https://openl.app/privacy');
         const termsPage = sitemapData.find((entry) => entry.url === 'https://openl.app/terms');
 
@@ -51,8 +59,8 @@ describe('Sitemap Generation', () => {
         expect(termsPage?.priority).toBe(0.3);
     });
 
-    it('should set appropriate priorities for different page types', () => {
-        const sitemapData = sitemap();
+    it('should set appropriate priorities for different page types', async () => {
+        const sitemapData = await sitemap();
         const homepage = sitemapData.find((entry) => entry.url === 'https://openl.app');
         const featuresPage = sitemapData.find((entry) => entry.url === 'https://openl.app/features');
         const legalPage = sitemapData.find((entry) => entry.url === 'https://openl.app/privacy');
@@ -61,8 +69,8 @@ describe('Sitemap Generation', () => {
         expect(featuresPage?.priority).toBeGreaterThan(legalPage?.priority || 0);
     });
 
-    it('should set appropriate change frequencies', () => {
-        const sitemapData = sitemap();
+    it('should set appropriate change frequencies', async () => {
+        const sitemapData = await sitemap();
         const homepage = sitemapData.find((entry) => entry.url === 'https://openl.app');
         const legalPage = sitemapData.find((entry) => entry.url === 'https://openl.app/privacy');
 
@@ -70,24 +78,24 @@ describe('Sitemap Generation', () => {
         expect(legalPage?.changeFrequency).toBe('yearly');
     });
 
-    it('should include lastModified dates for all entries', () => {
-        const sitemapData = sitemap();
+    it('should include lastModified dates for all entries', async () => {
+        const sitemapData = await sitemap();
 
         sitemapData.forEach((entry) => {
             expect(entry.lastModified).toBeInstanceOf(Date);
         });
     });
 
-    it('should use correct base URL', () => {
-        const sitemapData = sitemap();
+    it('should use correct base URL', async () => {
+        const sitemapData = await sitemap();
 
         sitemapData.forEach((entry) => {
             expect(entry.url).toMatch(/^https:\/\/openl\.app/);
         });
     });
 
-    it('should have valid priority values between 0 and 1', () => {
-        const sitemapData = sitemap();
+    it('should have valid priority values between 0 and 1', async () => {
+        const sitemapData = await sitemap();
 
         sitemapData.forEach((entry) => {
             expect(entry.priority).toBeGreaterThanOrEqual(0);
@@ -95,8 +103,8 @@ describe('Sitemap Generation', () => {
         });
     });
 
-    it('should have valid changeFrequency values', () => {
-        const sitemapData = sitemap();
+    it('should have valid changeFrequency values', async () => {
+        const sitemapData = await sitemap();
         const validFrequencies = ['always', 'hourly', 'daily', 'weekly', 'monthly', 'yearly', 'never'];
 
         sitemapData.forEach((entry) => {

--- a/__tests__/app/sitemap.test.ts
+++ b/__tests__/app/sitemap.test.ts
@@ -1,15 +1,31 @@
-import { describe, it, expect, vi } from 'vitest';
+import { beforeEach, describe, it, expect, vi } from 'vitest';
 
-const { mockLeague } = vi.hoisted(() => ({ mockLeague: { findMany: vi.fn() } }));
+const { mockLeague, mockTeam, mockContent } = vi.hoisted(() => ({
+    mockLeague: { findMany: vi.fn() },
+    mockTeam: { findMany: vi.fn() },
+    mockContent: { findMany: vi.fn() },
+}));
 
 // The sitemap now enumerates published association surfaces. Default to none so
 // the existing static-page assertions stay about the static pages.
-vi.mock('@/lib/db/prisma', () => ({ prisma: { league: mockLeague } }));
-mockLeague.findMany.mockResolvedValue([]);
+vi.mock('@/lib/db/prisma', () => ({
+    prisma: {
+        league: mockLeague,
+        team: mockTeam,
+        publicContentItem: mockContent,
+    },
+}));
 
 import sitemap from '@/app/sitemap';
 
 describe('Sitemap Generation', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockLeague.findMany.mockResolvedValue([]);
+        mockTeam.findMany.mockResolvedValue([]);
+        mockContent.findMany.mockResolvedValue([]);
+    });
+
     it('should generate a valid sitemap array', async () => {
         const sitemapData = await sitemap();
 
@@ -110,5 +126,42 @@ describe('Sitemap Generation', () => {
         sitemapData.forEach((entry) => {
             expect(validFrequencies).toContain(entry.changeFrequency);
         });
+    });
+
+    it('uses one global URL budget for association, team, and news pages', async () => {
+        const publishedAt = new Date('2026-08-01T00:00:00Z');
+        mockLeague.findMany.mockResolvedValue([
+            { slug: 'metro', publishedAt },
+        ]);
+        mockTeam.findMany.mockResolvedValue([
+            {
+                slug: 'blades',
+                publishedAt,
+                league: { slug: 'metro', publishedAt },
+            },
+        ]);
+        mockContent.findMany.mockResolvedValue([
+            {
+                slug: 'season-opens',
+                publishAt: publishedAt,
+                league: { slug: 'metro', publishedAt },
+            },
+        ]);
+
+        const sitemapData = await sitemap();
+        const urls = sitemapData.map((entry) => entry.url);
+
+        expect(urls).toEqual(expect.arrayContaining([
+            'https://openl.app/associations/metro/news',
+            'https://openl.app/associations/metro/teams/blades',
+            'https://openl.app/associations/metro/news/season-opens',
+        ]));
+        expect(sitemapData.length).toBeLessThanOrEqual(10_000);
+        expect(mockLeague.findMany.mock.calls[0][0].select.teams).toBeUndefined();
+        expect(mockLeague.findMany.mock.calls[0][0].select.publicContentItems).toBeUndefined();
+
+        const teamBudget = mockTeam.findMany.mock.calls[0][0].take;
+        const contentBudget = mockContent.findMany.mock.calls[0][0].take;
+        expect(teamBudget + contentBudget + 5).toBeLessThanOrEqual(9_984);
     });
 });

--- a/__tests__/components/features/association-profile/AssociationProfileEditor.test.tsx
+++ b/__tests__/components/features/association-profile/AssociationProfileEditor.test.tsx
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+vi.mock("@/lib/actions/association-profile", () => ({
+  setAssociationProfilePublished: vi.fn(),
+  updateAssociationProfile: vi.fn(),
+  updateAssociationSlug: vi.fn(),
+  updateTeamPublicProfile: vi.fn(),
+}));
+
+import AssociationProfileEditor from "@/components/features/association-profile/AssociationProfileEditor";
+
+describe("AssociationProfileEditor", () => {
+  it("exposes association branding and approved team identity controls", () => {
+    render(
+      <AssociationProfileEditor
+        leagueId="league-1"
+        profile={{
+          name: "Metro Hockey",
+          slug: "metro",
+          profileStatus: "PUBLISHED",
+          publicDescription: "Association description",
+          logoUrl: "https://example.com/association.png",
+          brandPrimaryColor: "#123456",
+          brandSecondaryColor: "#654321",
+          publicEmail: null,
+          publicPhone: null,
+        }}
+        teams={[
+          {
+            id: "team-1",
+            name: "Blades",
+            slug: "blades",
+            profileStatus: "DRAFT",
+            publicDescription: "Team description",
+            logoUrl: "https://example.com/team.png",
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByLabelText("Primary brand color")).toHaveValue("#123456");
+    expect(screen.getByLabelText("Secondary brand color")).toHaveValue("#654321");
+    expect(screen.getByRole("textbox", { name: "Blades public address" })).toHaveValue("blades");
+    expect(screen.getByRole("textbox", { name: "Blades public description" })).toHaveValue(
+      "Team description",
+    );
+    expect(screen.getByRole("textbox", { name: "Blades logo URL" })).toHaveValue(
+      "https://example.com/team.png",
+    );
+  });
+});

--- a/__tests__/components/features/association-profile/ContentEditor.test.tsx
+++ b/__tests__/components/features/association-profile/ContentEditor.test.tsx
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+const { mockCreatePublicContent } = vi.hoisted(() => ({
+  mockCreatePublicContent: vi.fn(),
+}));
+
+vi.mock("@/lib/actions/public-content", () => ({
+  archivePublicContent: vi.fn(),
+  createPublicContent: mockCreatePublicContent,
+  updatePublicContent: vi.fn(),
+}));
+
+import ContentEditor from "@/components/features/association-profile/ContentEditor";
+
+describe("ContentEditor", () => {
+  it("lets a team-scoped publisher save a draft for an authorized team", async () => {
+    mockCreatePublicContent.mockResolvedValue({ success: true, data: { id: "item-1" } });
+
+    render(
+      <ContentEditor
+        leagueId="league-1"
+        canPublishAssociationWide={false}
+        teams={[{ id: "team-1", name: "Blades" }]}
+        items={[]}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Title"), { target: { value: "Season opens" } });
+    fireEvent.change(screen.getByLabelText("Address"), { target: { value: "season-opens" } });
+    fireEvent.change(screen.getByLabelText("Body"), { target: { value: "Bring skates." } });
+    fireEvent.click(screen.getByRole("button", { name: "Save draft" }));
+
+    await waitFor(() => {
+      expect(mockCreatePublicContent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          leagueId: "league-1",
+          teamId: "team-1",
+          status: "DRAFT",
+        }),
+      );
+    });
+    expect(screen.queryByText("Whole association")).not.toBeInTheDocument();
+  });
+});

--- a/__tests__/components/features/association-profile/PublicAssociationProfile.test.tsx
+++ b/__tests__/components/features/association-profile/PublicAssociationProfile.test.tsx
@@ -10,6 +10,8 @@ const base = {
   sport: "HOCKEY",
   publicDescription: null,
   logoUrl: null,
+  brandPrimaryColor: null,
+  brandSecondaryColor: null,
   publicEmail: null,
   publicPhone: null,
   divisions: [],

--- a/__tests__/components/features/association-profile/PublicAssociationProfile.test.tsx
+++ b/__tests__/components/features/association-profile/PublicAssociationProfile.test.tsx
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import PublicAssociationProfile from "@/components/features/association-profile/PublicAssociationProfile";
+
+const base = {
+  id: "league-1",
+  name: "Metro Hockey",
+  slug: "metro-hockey",
+  sport: "HOCKEY",
+  publicDescription: null,
+  logoUrl: null,
+  publicEmail: null,
+  publicPhone: null,
+  divisions: [],
+  teams: [],
+  publicContentItems: [],
+  gearWishlist: null,
+};
+
+describe("PublicAssociationProfile", () => {
+  it("renders the association name as the page heading", () => {
+    render(<PublicAssociationProfile association={base} />);
+    expect(screen.getByRole("heading", { level: 1, name: "Metro Hockey" })).toBeInTheDocument();
+  });
+
+  it("omits empty sections rather than showing bare headings", () => {
+    render(<PublicAssociationProfile association={base} />);
+
+    expect(screen.queryByRole("heading", { name: "Teams" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "News" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Divisions" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Contact" })).not.toBeInTheDocument();
+  });
+
+  it("shows the contact section only when a public detail exists", () => {
+    render(
+      <PublicAssociationProfile
+        association={{ ...base, publicEmail: "hello@example.com" }}
+      />,
+    );
+    expect(screen.getByRole("heading", { name: "Contact" })).toBeInTheDocument();
+    expect(screen.getByText("hello@example.com")).toBeInTheDocument();
+  });
+
+  it("labels the wishlist with its own title", () => {
+    render(
+      <PublicAssociationProfile
+        association={{ ...base, gearWishlist: { shareToken: "tok", title: "Skate drive" } }}
+      />,
+    );
+    expect(screen.getByRole("link", { name: "Skate drive" })).toBeInTheDocument();
+  });
+
+  it("names a team's division and season", () => {
+    render(
+      <PublicAssociationProfile
+        association={{
+          ...base,
+          teams: [{ id: "t1", name: "Blades", slug: "blades", season: "Winter", division: { name: "U12", ageGroup: "U12" } }],
+        }}
+      />,
+    );
+    expect(screen.getByText("U12 · Winter")).toBeInTheDocument();
+  });
+});

--- a/__tests__/lib/actions/association-profile.test.ts
+++ b/__tests__/lib/actions/association-profile.test.ts
@@ -34,6 +34,7 @@ vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
 
 import {
   getPublicAssociationProfile,
+  resolveActiveAssociation,
   resolvePublicAssociation,
   setAssociationProfilePublished,
   updateAssociationProfile,
@@ -203,6 +204,26 @@ describe("association public profile", () => {
           create: expect.objectContaining({ slug: "blades", teamId: TEAM }),
         }),
       );
+      expect(mockRedirect.deleteMany).toHaveBeenCalledWith({
+        where: {
+          leagueId: LEAGUE,
+          slug: "metro-blades",
+          teamId: TEAM,
+        },
+      });
+    });
+
+    it("refuses a slug retired by another team in the association", async () => {
+      mockRedirect.findFirst.mockResolvedValue({ id: "other-team:metro-blades" });
+
+      const result = await updateTeamPublicProfile({
+        leagueId: LEAGUE,
+        teamId: TEAM,
+        slug: "metro-blades",
+      });
+
+      expect(result.success).toBe(false);
+      expect(mockTransaction).not.toHaveBeenCalled();
     });
 
     it("refuses to publish a team without an address", async () => {
@@ -272,6 +293,11 @@ describe("association public profile", () => {
       });
 
       await expect(resolvePublicAssociation("old-metro")).resolves.toBeNull();
+      await expect(resolveActiveAssociation("old-metro")).resolves.toEqual({
+        id: LEAGUE,
+        canonicalSlug: "metro",
+        redirected: true,
+      });
     });
 
     it("returns nothing for an unknown slug", async () => {

--- a/__tests__/lib/actions/association-profile.test.ts
+++ b/__tests__/lib/actions/association-profile.test.ts
@@ -1,0 +1,294 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockLeague,
+  mockTeam,
+  mockRedirect,
+  mockTransaction,
+  mockRequireUserId,
+  mockHasCapability,
+} = vi.hoisted(() => ({
+  mockLeague: { findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn() },
+  mockTeam: { findFirst: vi.fn(), findMany: vi.fn(), update: vi.fn() },
+  mockRedirect: { findFirst: vi.fn(), upsert: vi.fn(), deleteMany: vi.fn() },
+  mockTransaction: vi.fn(),
+  mockRequireUserId: vi.fn(),
+  mockHasCapability: vi.fn(),
+}));
+
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: {
+    league: mockLeague,
+    team: mockTeam,
+    publicSlugRedirect: mockRedirect,
+    $transaction: mockTransaction,
+  },
+}));
+
+vi.mock("@/lib/auth/session", () => ({ requireUserId: mockRequireUserId }));
+vi.mock("@/lib/auth/capabilities", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/auth/capabilities")>();
+  return { ...actual, hasCapability: mockHasCapability };
+});
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+
+import {
+  getPublicAssociationProfile,
+  resolvePublicAssociation,
+  setAssociationProfilePublished,
+  updateAssociationProfile,
+  updateAssociationSlug,
+  updateTeamPublicProfile,
+} from "@/lib/actions/association-profile";
+
+const LEAGUE = "clfleague0000000000000001";
+const TEAM = "clfteam00000000000000001";
+
+describe("association public profile", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireUserId.mockResolvedValue("admin-1");
+    mockHasCapability.mockResolvedValue(true);
+    mockLeague.findUnique.mockResolvedValue({ slug: "metro" });
+    mockLeague.findFirst.mockResolvedValue(null);
+    mockRedirect.findFirst.mockResolvedValue(null);
+    // The action reads the team, then checks whether the incoming slug is
+    // already taken — both via team.findFirst. Answer by query shape so the
+    // collision check does not match the team being renamed.
+    mockTeam.findFirst.mockImplementation(({ where }: { where: { id?: string; slug?: string } }) =>
+      Promise.resolve(where.slug ? null : { id: TEAM, slug: "blades" }),
+    );
+    mockTransaction.mockImplementation(async (fn: unknown) =>
+      typeof fn === "function"
+        ? (fn as (c: unknown) => unknown)({
+            league: mockLeague,
+            team: mockTeam,
+            publicSlugRedirect: mockRedirect,
+          })
+        : undefined,
+    );
+  });
+
+  describe("editing", () => {
+    it("saves only the fields the caller sent", async () => {
+      const result = await updateAssociationProfile({
+        leagueId: LEAGUE,
+        publicDescription: "A youth hockey association",
+      });
+
+      expect(result.success).toBe(true);
+      const data = mockLeague.update.mock.calls[0][0].data;
+      // A partial form submit must not null the fields it omitted.
+      expect(data).toEqual({ publicDescription: "A youth hockey association" });
+    });
+
+    it("refuses a caller without association administration", async () => {
+      mockHasCapability.mockResolvedValue(false);
+
+      const result = await updateAssociationProfile({ leagueId: LEAGUE, publicPhone: "555" });
+
+      expect(result.success).toBe(false);
+      expect(mockLeague.update).not.toHaveBeenCalled();
+    });
+
+    it("rejects a malformed brand colour", async () => {
+      const result = await updateAssociationProfile({
+        leagueId: LEAGUE,
+        brandPrimaryColor: "red",
+      });
+
+      expect(result.success).toBe(false);
+      expect(mockLeague.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("publishing", () => {
+    it("publishes and stamps the moment", async () => {
+      const result = await setAssociationProfilePublished({ leagueId: LEAGUE, publish: true });
+
+      expect(result.success).toBe(true);
+      expect(mockLeague.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ profileStatus: "PUBLISHED" }),
+        }),
+      );
+      expect(mockLeague.update.mock.calls[0][0].data.publishedAt).toBeInstanceOf(Date);
+    });
+
+    it("refuses to publish without a public address", async () => {
+      // The database enforces this too; the action turns it into an
+      // instruction rather than a constraint error.
+      mockLeague.findUnique.mockResolvedValue({ slug: null });
+
+      const result = await setAssociationProfilePublished({ leagueId: LEAGUE, publish: true });
+
+      expect(result.success).toBe(false);
+      if (!result.success) expect(result.error).toMatch(/public address/);
+      expect(mockLeague.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("renaming the slug", () => {
+    it("retires the old slug in the same transaction that frees it", async () => {
+      const result = await updateAssociationSlug({ leagueId: LEAGUE, slug: "metro-hockey" });
+
+      expect(result.success).toBe(true);
+      // One transaction: a shared link never points at nothing, because the
+      // window where neither the league nor a redirect answers does not exist.
+      expect(mockTransaction).toHaveBeenCalledTimes(1);
+      expect(mockRedirect.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          create: expect.objectContaining({ slug: "metro", leagueId: LEAGUE }),
+        }),
+      );
+      expect(mockLeague.update).toHaveBeenCalledWith(
+        expect.objectContaining({ data: { slug: "metro-hockey" } }),
+      );
+    });
+
+    it("clears any retirement of the incoming slug so it cannot self-redirect", async () => {
+      await updateAssociationSlug({ leagueId: LEAGUE, slug: "metro-hockey" });
+
+      expect(mockRedirect.deleteMany).toHaveBeenCalledWith({
+        where: { slug: "metro-hockey", teamId: null },
+      });
+    });
+
+    it("refuses a slug another association already uses", async () => {
+      mockLeague.findFirst.mockResolvedValue({ id: "other-league" });
+
+      const result = await updateAssociationSlug({ leagueId: LEAGUE, slug: "taken" });
+
+      expect(result.success).toBe(false);
+      expect(mockTransaction).not.toHaveBeenCalled();
+    });
+
+    it("refuses a slug retired by another association", async () => {
+      // A retired slug is as taken as a live one: reusing it would hijack
+      // somebody else's old links.
+      mockRedirect.findFirst.mockResolvedValue({ id: "redirect-1" });
+
+      const result = await updateAssociationSlug({ leagueId: LEAGUE, slug: "someone-elses-old" });
+
+      expect(result.success).toBe(false);
+      expect(mockTransaction).not.toHaveBeenCalled();
+    });
+
+    it("rejects a slug with unsafe characters", async () => {
+      for (const bad of ["Metro Hockey", "metro_hockey", "-metro", "metro--hockey", "ab"]) {
+        const result = await updateAssociationSlug({ leagueId: LEAGUE, slug: bad });
+        expect(result.success, `${bad} should be rejected`).toBe(false);
+      }
+    });
+
+    it("is a no-op when the slug has not changed", async () => {
+      const result = await updateAssociationSlug({ leagueId: LEAGUE, slug: "metro" });
+
+      expect(result.success).toBe(true);
+      expect(mockTransaction).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("team profiles", () => {
+    it("retires the old team slug on rename", async () => {
+      const result = await updateTeamPublicProfile({
+        leagueId: LEAGUE,
+        teamId: TEAM,
+        slug: "metro-blades",
+      });
+
+      expect(result.success).toBe(true);
+      expect(mockRedirect.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          create: expect.objectContaining({ slug: "blades", teamId: TEAM }),
+        }),
+      );
+    });
+
+    it("refuses to publish a team without an address", async () => {
+      mockTeam.findFirst.mockReset();
+      mockTeam.findFirst.mockResolvedValue({ id: TEAM, slug: null });
+
+      const result = await updateTeamPublicProfile({
+        leagueId: LEAGUE,
+        teamId: TEAM,
+        publish: true,
+      });
+
+      expect(result.success).toBe(false);
+    });
+
+    it("refuses a team from another association", async () => {
+      mockTeam.findFirst.mockReset();
+      mockTeam.findFirst.mockResolvedValue(null);
+
+      const result = await updateTeamPublicProfile({
+        leagueId: LEAGUE,
+        teamId: TEAM,
+        publicDescription: "x",
+      });
+
+      expect(result.success).toBe(false);
+      expect(mockTeam.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("resolving a public slug", () => {
+    it("returns the association directly when the slug is current", async () => {
+      mockLeague.findFirst.mockResolvedValue({ id: LEAGUE, slug: "metro" });
+
+      const resolved = await resolvePublicAssociation("metro");
+
+      expect(resolved).toEqual({ id: LEAGUE, canonicalSlug: "metro", redirected: false });
+      // Only published, active associations resolve.
+      expect(mockLeague.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ profileStatus: "PUBLISHED", isActive: true }),
+        }),
+      );
+    });
+
+    it("follows a retirement to whatever the association is called today", async () => {
+      mockLeague.findFirst.mockResolvedValue(null);
+      mockRedirect.findFirst.mockResolvedValue({
+        league: { id: LEAGUE, slug: "metro-hockey", profileStatus: "PUBLISHED", isActive: true },
+      });
+
+      const resolved = await resolvePublicAssociation("old-metro");
+
+      // The redirect stores the target id, not a slug, so a second rename does
+      // not strand the first old link and there are no chains to walk.
+      expect(resolved).toEqual({
+        id: LEAGUE,
+        canonicalSlug: "metro-hockey",
+        redirected: true,
+      });
+    });
+
+    it("does not resolve a retirement whose association was unpublished", async () => {
+      mockLeague.findFirst.mockResolvedValue(null);
+      mockRedirect.findFirst.mockResolvedValue({
+        league: { id: LEAGUE, slug: "metro", profileStatus: "UNPUBLISHED", isActive: true },
+      });
+
+      await expect(resolvePublicAssociation("old-metro")).resolves.toBeNull();
+    });
+
+    it("returns nothing for an unknown slug", async () => {
+      mockLeague.findFirst.mockResolvedValue(null);
+      mockRedirect.findFirst.mockResolvedValue(null);
+
+      await expect(resolvePublicAssociation("nope")).resolves.toBeNull();
+      await expect(getPublicAssociationProfile("nope")).resolves.toBeNull();
+    });
+
+    it("reads the public profile without a session", async () => {
+      mockLeague.findFirst.mockResolvedValue({ id: LEAGUE, slug: "metro" });
+
+      await getPublicAssociationProfile("metro");
+
+      // The public readers must never require authentication.
+      expect(mockRequireUserId).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/__tests__/lib/actions/public-content.test.ts
+++ b/__tests__/lib/actions/public-content.test.ts
@@ -1,0 +1,276 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockItem, mockTeam, mockLeague, mockRequireUserId, mockHasCapability } = vi.hoisted(
+  () => ({
+    mockItem: {
+      create: vi.fn(),
+      update: vi.fn(),
+      findFirst: vi.fn(),
+      findUnique: vi.fn(),
+      findMany: vi.fn(),
+    },
+    mockTeam: { findFirst: vi.fn() },
+    mockLeague: { findFirst: vi.fn() },
+    mockRequireUserId: vi.fn(),
+    mockHasCapability: vi.fn(),
+  }),
+);
+
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: { publicContentItem: mockItem, team: mockTeam, league: mockLeague },
+}));
+vi.mock("@/lib/auth/session", () => ({ requireUserId: mockRequireUserId }));
+vi.mock("@/lib/auth/capabilities", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/auth/capabilities")>();
+  return { ...actual, hasCapability: mockHasCapability };
+});
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+
+import {
+  archivePublicContent,
+  createPublicContent,
+  getPublicContentItem,
+  listPublicAssociationContent,
+  updatePublicContent,
+} from "@/lib/actions/public-content";
+
+const LEAGUE = "clfleague0000000000000001";
+const TEAM = "clfteam00000000000000001";
+const ITEM = "clfitem00000000000000001";
+const NOW = new Date("2026-06-01T12:00:00Z");
+
+describe("public content", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    mockRequireUserId.mockResolvedValue("editor-1");
+    mockHasCapability.mockResolvedValue(true);
+    mockItem.findFirst.mockResolvedValue(null);
+    mockItem.create.mockResolvedValue({ id: ITEM });
+    mockTeam.findFirst.mockResolvedValue({ id: TEAM });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const base = {
+    leagueId: LEAGUE,
+    slug: "season-opens",
+    title: "  Season opens  ",
+    body: "  Bring skates.  ",
+  };
+
+  describe("creating", () => {
+    it("publishes immediately when no date is given", async () => {
+      const result = await createPublicContent(base);
+
+      expect(result.success).toBe(true);
+      const data = mockItem.create.mock.calls[0][0].data;
+      expect(data.status).toBe("PUBLISHED");
+      expect(data.publishedAt).toEqual(NOW);
+      // Stored as written, trimmed: React escapes at render, so escaping here
+      // would show entities literally.
+      expect(data.title).toBe("Season opens");
+      expect(data.body).toBe("Bring skates.");
+    });
+
+    it("schedules a future date without publishing it", async () => {
+      const future = new Date("2026-07-01T00:00:00Z");
+
+      await createPublicContent({ ...base, publishAt: future });
+
+      const data = mockItem.create.mock.calls[0][0].data;
+      expect(data.status).toBe("SCHEDULED");
+      expect(data.publishAt).toEqual(future);
+      expect(data.publishedAt).toBeNull();
+    });
+
+    it("gates on the content capability, scoped to the team when given", async () => {
+      await createPublicContent({ ...base, teamId: TEAM });
+
+      expect(mockHasCapability).toHaveBeenCalledWith(
+        expect.objectContaining({ capability: "manage_public_content", teamId: TEAM }),
+      );
+    });
+
+    it("refuses a caller without the capability", async () => {
+      mockHasCapability.mockResolvedValue(false);
+
+      const result = await createPublicContent(base);
+
+      expect(result.success).toBe(false);
+      expect(mockItem.create).not.toHaveBeenCalled();
+    });
+
+    it("refuses a team from another association", async () => {
+      mockTeam.findFirst.mockResolvedValue(null);
+
+      const result = await createPublicContent({ ...base, teamId: TEAM });
+
+      expect(result.success).toBe(false);
+      expect(mockItem.create).not.toHaveBeenCalled();
+    });
+
+    it("refuses a slug already used in this association", async () => {
+      mockItem.findFirst.mockResolvedValue({ id: "other" });
+
+      const result = await createPublicContent(base);
+
+      expect(result.success).toBe(false);
+      expect(mockItem.create).not.toHaveBeenCalled();
+    });
+
+    it("rejects an unsafe slug", async () => {
+      for (const bad of ["Season Opens", "season_opens", "-season", "ab"]) {
+        const result = await createPublicContent({ ...base, slug: bad });
+        expect(result.success, `${bad} should be rejected`).toBe(false);
+      }
+    });
+  });
+
+  describe("updating", () => {
+    beforeEach(() => {
+      mockItem.findUnique.mockResolvedValue({
+        id: ITEM,
+        leagueId: LEAGUE,
+        teamId: null,
+        status: "PUBLISHED",
+        publishedAt: new Date("2026-05-01T00:00:00Z"),
+      });
+    });
+
+    it("keeps the original publication moment when rescheduling", async () => {
+      await updatePublicContent({ itemId: ITEM, publishAt: new Date("2026-05-15T00:00:00Z") });
+
+      const data = mockItem.update.mock.calls[0][0].data;
+      // Moving a published post's date should not rewrite when it first went out.
+      expect(data.publishedAt).toEqual(new Date("2026-05-01T00:00:00Z"));
+      expect(data.status).toBe("PUBLISHED");
+    });
+
+    it("moves a published post back to scheduled when dated forward", async () => {
+      await updatePublicContent({ itemId: ITEM, publishAt: new Date("2026-09-01T00:00:00Z") });
+
+      const data = mockItem.update.mock.calls[0][0].data;
+      expect(data.status).toBe("SCHEDULED");
+      expect(data.publishedAt).toBeNull();
+    });
+
+    it("refuses to edit an archived post", async () => {
+      mockItem.findUnique.mockResolvedValue({
+        id: ITEM,
+        leagueId: LEAGUE,
+        teamId: null,
+        status: "ARCHIVED",
+        publishedAt: null,
+      });
+
+      const result = await updatePublicContent({ itemId: ITEM, title: "New" });
+
+      expect(result.success).toBe(false);
+      expect(mockItem.update).not.toHaveBeenCalled();
+    });
+
+    it("checks the capability against the post's own team", async () => {
+      mockItem.findUnique.mockResolvedValue({
+        id: ITEM,
+        leagueId: LEAGUE,
+        teamId: TEAM,
+        status: "PUBLISHED",
+        publishedAt: NOW,
+      });
+
+      await updatePublicContent({ itemId: ITEM, title: "New" });
+
+      expect(mockHasCapability).toHaveBeenCalledWith(
+        expect.objectContaining({ teamId: TEAM }),
+      );
+    });
+  });
+
+  describe("archiving", () => {
+    it("stamps the archive moment", async () => {
+      mockItem.findUnique.mockResolvedValue({
+        id: ITEM, leagueId: LEAGUE, teamId: null, status: "PUBLISHED",
+      });
+
+      const result = await archivePublicContent(ITEM);
+
+      expect(result.success).toBe(true);
+      expect(mockItem.update.mock.calls[0][0].data).toEqual(
+        expect.objectContaining({ status: "ARCHIVED" }),
+      );
+    });
+
+    it("is idempotent", async () => {
+      mockItem.findUnique.mockResolvedValue({
+        id: ITEM, leagueId: LEAGUE, teamId: null, status: "ARCHIVED",
+      });
+
+      const result = await archivePublicContent(ITEM);
+
+      expect(result.success).toBe(true);
+      expect(mockItem.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("public reads", () => {
+    it("returns only public, unarchived items whose time has come", async () => {
+      mockItem.findMany.mockResolvedValue([]);
+
+      await listPublicAssociationContent(LEAGUE);
+
+      const where = mockItem.findMany.mock.calls[0][0].where;
+      expect(where).toEqual(
+        expect.objectContaining({
+          leagueId: LEAGUE,
+          visibility: "PUBLIC",
+          status: { in: ["PUBLISHED", "SCHEDULED"] },
+          publishAt: { lte: NOW },
+          archivedAt: null,
+        }),
+      );
+    });
+
+    it("never selects the author, so a volunteer's name stays off the page", async () => {
+      mockItem.findMany.mockResolvedValue([]);
+
+      await listPublicAssociationContent(LEAGUE);
+
+      const select = mockItem.findMany.mock.calls[0][0].select;
+      expect(select.author).toBeUndefined();
+      expect(select.authorId).toBeUndefined();
+      expect(select.visibility).toBeUndefined();
+    });
+
+    it("reads a single item without a session", async () => {
+      mockLeague.findFirst.mockResolvedValue({ id: LEAGUE, name: "Metro", slug: "metro" });
+      mockItem.findFirst.mockResolvedValue({ id: ITEM, slug: "season-opens" });
+
+      const result = await getPublicContentItem("metro", "season-opens");
+
+      expect(result?.item.id).toBe(ITEM);
+      expect(mockRequireUserId).not.toHaveBeenCalled();
+    });
+
+    it("returns nothing when the association is not published", async () => {
+      mockLeague.findFirst.mockResolvedValue(null);
+
+      await expect(getPublicContentItem("metro", "season-opens")).resolves.toBeNull();
+      expect(mockItem.findFirst).not.toHaveBeenCalled();
+    });
+
+    it("does not surface a members-only item to the public reader", async () => {
+      mockLeague.findFirst.mockResolvedValue({ id: LEAGUE, name: "Metro", slug: "metro" });
+      mockItem.findFirst.mockResolvedValue(null);
+
+      await getPublicContentItem("metro", "members-only-post");
+
+      expect(mockItem.findFirst.mock.calls[0][0].where).toEqual(
+        expect.objectContaining({ visibility: "PUBLIC" }),
+      );
+    });
+  });
+});

--- a/__tests__/lib/actions/public-content.test.ts
+++ b/__tests__/lib/actions/public-content.test.ts
@@ -1,18 +1,29 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockItem, mockTeam, mockLeague, mockRequireUserId, mockHasCapability } = vi.hoisted(
+const {
+  mockItem,
+  mockTeam,
+  mockLeague,
+  mockRequireUserId,
+  mockHasCapability,
+  mockLoadActiveGrants,
+  mockResolvePublicAssociation,
+} = vi.hoisted(
   () => ({
     mockItem: {
+      count: vi.fn(),
       create: vi.fn(),
       update: vi.fn(),
       findFirst: vi.fn(),
       findUnique: vi.fn(),
       findMany: vi.fn(),
     },
-    mockTeam: { findFirst: vi.fn() },
+    mockTeam: { findFirst: vi.fn(), findMany: vi.fn() },
     mockLeague: { findFirst: vi.fn() },
     mockRequireUserId: vi.fn(),
     mockHasCapability: vi.fn(),
+    mockLoadActiveGrants: vi.fn(),
+    mockResolvePublicAssociation: vi.fn(),
   }),
 );
 
@@ -22,15 +33,24 @@ vi.mock("@/lib/db/prisma", () => ({
 vi.mock("@/lib/auth/session", () => ({ requireUserId: mockRequireUserId }));
 vi.mock("@/lib/auth/capabilities", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/auth/capabilities")>();
-  return { ...actual, hasCapability: mockHasCapability };
+  return {
+    ...actual,
+    hasCapability: mockHasCapability,
+    loadActiveGrants: mockLoadActiveGrants,
+  };
 });
+vi.mock("@/lib/actions/association-profile", () => ({
+  resolvePublicAssociation: mockResolvePublicAssociation,
+}));
 vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
 
 import {
   archivePublicContent,
   createPublicContent,
   getPublicContentItem,
+  listAssociationContent,
   listPublicAssociationContent,
+  listPublicAssociationContentPage,
   updatePublicContent,
 } from "@/lib/actions/public-content";
 
@@ -46,9 +66,17 @@ describe("public content", () => {
     vi.setSystemTime(NOW);
     mockRequireUserId.mockResolvedValue("editor-1");
     mockHasCapability.mockResolvedValue(true);
+    mockLoadActiveGrants.mockResolvedValue([]);
+    mockResolvePublicAssociation.mockResolvedValue({
+      id: LEAGUE,
+      canonicalSlug: "metro",
+      redirected: false,
+    });
     mockItem.findFirst.mockResolvedValue(null);
+    mockItem.count.mockResolvedValue(0);
     mockItem.create.mockResolvedValue({ id: ITEM });
     mockTeam.findFirst.mockResolvedValue({ id: TEAM });
+    mockTeam.findMany.mockResolvedValue([]);
   });
 
   afterEach(() => {
@@ -84,6 +112,15 @@ describe("public content", () => {
       const data = mockItem.create.mock.calls[0][0].data;
       expect(data.status).toBe("SCHEDULED");
       expect(data.publishAt).toEqual(future);
+      expect(data.publishedAt).toBeNull();
+    });
+
+    it("saves a draft without making it publicly readable", async () => {
+      await createPublicContent({ ...base, status: "DRAFT" });
+
+      const data = mockItem.create.mock.calls[0][0].data;
+      expect(data.status).toBe("DRAFT");
+      expect(data.publishAt).toBeNull();
       expect(data.publishedAt).toBeNull();
     });
 
@@ -128,6 +165,15 @@ describe("public content", () => {
         expect(result.success, `${bad} should be rejected`).toBe(false);
       }
     });
+
+    it("rejects whitespace-only titles and bodies", async () => {
+      const blankTitle = await createPublicContent({ ...base, title: "   " });
+      const blankBody = await createPublicContent({ ...base, body: "\n\t" });
+
+      expect(blankTitle.success).toBe(false);
+      expect(blankBody.success).toBe(false);
+      expect(mockItem.create).not.toHaveBeenCalled();
+    });
   });
 
   describe("updating", () => {
@@ -137,6 +183,7 @@ describe("public content", () => {
         leagueId: LEAGUE,
         teamId: null,
         status: "PUBLISHED",
+        publishAt: new Date("2026-05-01T00:00:00Z"),
         publishedAt: new Date("2026-05-01T00:00:00Z"),
       });
     });
@@ -179,6 +226,7 @@ describe("public content", () => {
         leagueId: LEAGUE,
         teamId: TEAM,
         status: "PUBLISHED",
+        publishAt: NOW,
         publishedAt: NOW,
       });
 
@@ -187,6 +235,77 @@ describe("public content", () => {
       expect(mockHasCapability).toHaveBeenCalledWith(
         expect.objectContaining({ teamId: TEAM }),
       );
+    });
+
+    it("publishes a draft using its saved future schedule", async () => {
+      const future = new Date("2026-09-01T00:00:00Z");
+      mockItem.findUnique.mockResolvedValue({
+        id: ITEM,
+        leagueId: LEAGUE,
+        teamId: null,
+        status: "DRAFT",
+        publishAt: future,
+        publishedAt: null,
+      });
+
+      await updatePublicContent({ itemId: ITEM, status: "PUBLISHED" });
+
+      expect(mockItem.update.mock.calls[0][0].data).toEqual(
+        expect.objectContaining({
+          status: "SCHEDULED",
+          publishAt: future,
+          publishedAt: null,
+        }),
+      );
+    });
+
+    it("moves scheduled content back to draft", async () => {
+      mockItem.findUnique.mockResolvedValue({
+        id: ITEM,
+        leagueId: LEAGUE,
+        teamId: null,
+        status: "SCHEDULED",
+        publishAt: new Date("2026-09-01T00:00:00Z"),
+        publishedAt: null,
+      });
+
+      await updatePublicContent({ itemId: ITEM, status: "DRAFT" });
+
+      expect(mockItem.update.mock.calls[0][0].data).toEqual(
+        expect.objectContaining({ status: "DRAFT", publishedAt: null }),
+      );
+    });
+
+    it("does not move already-published content back to draft", async () => {
+      const result = await updatePublicContent({ itemId: ITEM, status: "DRAFT" });
+
+      expect(result.success).toBe(false);
+      expect(mockItem.update).not.toHaveBeenCalled();
+    });
+
+    it("does not move an elapsed scheduled post back to draft", async () => {
+      mockItem.findUnique.mockResolvedValue({
+        id: ITEM,
+        leagueId: LEAGUE,
+        teamId: null,
+        status: "SCHEDULED",
+        publishAt: new Date("2026-05-01T00:00:00Z"),
+        publishedAt: null,
+      });
+
+      const result = await updatePublicContent({ itemId: ITEM, status: "DRAFT" });
+
+      expect(result.success).toBe(false);
+      expect(mockItem.update).not.toHaveBeenCalled();
+    });
+
+    it("rejects whitespace-only update values", async () => {
+      const title = await updatePublicContent({ itemId: ITEM, title: "   " });
+      const body = await updatePublicContent({ itemId: ITEM, body: "\n\t" });
+
+      expect(title.success).toBe(false);
+      expect(body.success).toBe(false);
+      expect(mockItem.update).not.toHaveBeenCalled();
     });
   });
 
@@ -245,6 +364,19 @@ describe("public content", () => {
       expect(select.visibility).toBeUndefined();
     });
 
+    it("rejects an out-of-range page before constructing a Prisma skip", async () => {
+      mockItem.count.mockResolvedValue(20);
+
+      const result = await listPublicAssociationContentPage(
+        LEAGUE,
+        Number.MAX_SAFE_INTEGER,
+      );
+
+      expect(result.items).toEqual([]);
+      expect(result.totalPages).toBe(1);
+      expect(mockItem.findMany).not.toHaveBeenCalled();
+    });
+
     it("reads a single item without a session", async () => {
       mockLeague.findFirst.mockResolvedValue({ id: LEAGUE, name: "Metro", slug: "metro" });
       mockItem.findFirst.mockResolvedValue({ id: ITEM, slug: "season-opens" });
@@ -255,10 +387,30 @@ describe("public content", () => {
       expect(mockRequireUserId).not.toHaveBeenCalled();
     });
 
+    it("resolves retired association slugs to the canonical news URL", async () => {
+      mockResolvePublicAssociation.mockResolvedValue({
+        id: LEAGUE,
+        canonicalSlug: "metro-hockey",
+        redirected: true,
+      });
+      mockLeague.findFirst.mockResolvedValue({
+        id: LEAGUE,
+        name: "Metro",
+        slug: "metro-hockey",
+      });
+      mockItem.findFirst.mockResolvedValue({ id: ITEM, slug: "season-opens" });
+
+      const result = await getPublicContentItem("old-metro", "season-opens");
+
+      expect(mockResolvePublicAssociation).toHaveBeenCalledWith("old-metro");
+      expect(result?.association.slug).toBe("metro-hockey");
+    });
+
     it("returns nothing when the association is not published", async () => {
-      mockLeague.findFirst.mockResolvedValue(null);
+      mockResolvePublicAssociation.mockResolvedValue(null);
 
       await expect(getPublicContentItem("metro", "season-opens")).resolves.toBeNull();
+      expect(mockLeague.findFirst).not.toHaveBeenCalled();
       expect(mockItem.findFirst).not.toHaveBeenCalled();
     });
 
@@ -270,6 +422,41 @@ describe("public content", () => {
 
       expect(mockItem.findFirst.mock.calls[0][0].where).toEqual(
         expect.objectContaining({ visibility: "PUBLIC" }),
+      );
+    });
+  });
+
+  describe("management scope", () => {
+    it("returns only teams and content covered by a scoped communications grant", async () => {
+      mockHasCapability.mockResolvedValue(false);
+      mockLoadActiveGrants.mockResolvedValue([
+        {
+          role: "COMMUNICATIONS_LEAD",
+          scopeType: "TEAM",
+          divisionId: null,
+          teamId: TEAM,
+          seasonId: null,
+          eventId: null,
+          signupEventId: null,
+        },
+      ]);
+      mockTeam.findMany.mockResolvedValue([{ id: TEAM, name: "Blades" }]);
+      mockItem.findMany.mockResolvedValue([]);
+
+      const result = await listAssociationContent(LEAGUE);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.canPublishAssociationWide).toBe(false);
+        expect(result.data.teams).toEqual([{ id: TEAM, name: "Blades" }]);
+      }
+      expect(mockItem.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            leagueId: LEAGUE,
+            teamId: { in: [TEAM] },
+          },
+        }),
       );
     });
   });

--- a/app/(dashboard)/league/[leagueId]/content/page.tsx
+++ b/app/(dashboard)/league/[leagueId]/content/page.tsx
@@ -1,0 +1,52 @@
+import { notFound } from "next/navigation";
+
+import { PageContainer } from "@/components/ui/PageContainer";
+import { PageHeader } from "@/components/ui/PageHeader";
+import ContentEditor from "@/components/features/association-profile/ContentEditor";
+import { requireUserId } from "@/lib/auth/session";
+import { Capability, hasCapability } from "@/lib/auth/capabilities";
+import { listAssociationContent } from "@/lib/actions/public-content";
+import { prisma } from "@/lib/db/prisma";
+
+export const dynamic = "force-dynamic";
+
+/** News and announcements. Gated on the content capability, not league admin. */
+export default async function AssociationContentPage({
+  params,
+}: {
+  params: Promise<{ leagueId: string }>;
+}) {
+  const { leagueId } = await params;
+  const userId = await requireUserId();
+
+  if (
+    !(await hasCapability({
+      userId,
+      leagueId,
+      capability: Capability.MANAGE_PUBLIC_CONTENT,
+    }))
+  ) {
+    notFound();
+  }
+
+  const [content, teams] = await Promise.all([
+    listAssociationContent(leagueId),
+    prisma.team.findMany({
+      where: { leagueId, isActive: true },
+      select: { id: true, name: true },
+      orderBy: { name: "asc" },
+    }),
+  ]);
+
+  if (!content.success) notFound();
+
+  return (
+    <PageContainer maxWidth="lg">
+      <PageHeader
+        title="News"
+        subtitle="Announcements for your public page and team pages."
+      />
+      <ContentEditor leagueId={leagueId} teams={teams} items={content.data} />
+    </PageContainer>
+  );
+}

--- a/app/(dashboard)/league/[leagueId]/content/page.tsx
+++ b/app/(dashboard)/league/[leagueId]/content/page.tsx
@@ -3,10 +3,7 @@ import { notFound } from "next/navigation";
 import { PageContainer } from "@/components/ui/PageContainer";
 import { PageHeader } from "@/components/ui/PageHeader";
 import ContentEditor from "@/components/features/association-profile/ContentEditor";
-import { requireUserId } from "@/lib/auth/session";
-import { Capability, hasCapability } from "@/lib/auth/capabilities";
 import { listAssociationContent } from "@/lib/actions/public-content";
-import { prisma } from "@/lib/db/prisma";
 
 export const dynamic = "force-dynamic";
 
@@ -17,26 +14,7 @@ export default async function AssociationContentPage({
   params: Promise<{ leagueId: string }>;
 }) {
   const { leagueId } = await params;
-  const userId = await requireUserId();
-
-  if (
-    !(await hasCapability({
-      userId,
-      leagueId,
-      capability: Capability.MANAGE_PUBLIC_CONTENT,
-    }))
-  ) {
-    notFound();
-  }
-
-  const [content, teams] = await Promise.all([
-    listAssociationContent(leagueId),
-    prisma.team.findMany({
-      where: { leagueId, isActive: true },
-      select: { id: true, name: true },
-      orderBy: { name: "asc" },
-    }),
-  ]);
+  const content = await listAssociationContent(leagueId);
 
   if (!content.success) notFound();
 
@@ -46,7 +24,12 @@ export default async function AssociationContentPage({
         title="News"
         subtitle="Announcements for your public page and team pages."
       />
-      <ContentEditor leagueId={leagueId} teams={teams} items={content.data} />
+      <ContentEditor
+        leagueId={leagueId}
+        teams={content.data.teams}
+        items={content.data.items}
+        canPublishAssociationWide={content.data.canPublishAssociationWide}
+      />
     </PageContainer>
   );
 }

--- a/app/(dashboard)/league/[leagueId]/settings/public/page.tsx
+++ b/app/(dashboard)/league/[leagueId]/settings/public/page.tsx
@@ -45,7 +45,14 @@ export default async function PublicProfileSettingsPage({
     }),
     prisma.team.findMany({
       where: { leagueId, isActive: true },
-      select: { id: true, name: true, slug: true, profileStatus: true },
+      select: {
+        id: true,
+        name: true,
+        slug: true,
+        profileStatus: true,
+        publicDescription: true,
+        logoUrl: true,
+      },
       orderBy: { name: "asc" },
     }),
   ]);

--- a/app/(dashboard)/league/[leagueId]/settings/public/page.tsx
+++ b/app/(dashboard)/league/[leagueId]/settings/public/page.tsx
@@ -1,0 +1,64 @@
+import { notFound } from "next/navigation";
+
+import { PageContainer } from "@/components/ui/PageContainer";
+import { PageHeader } from "@/components/ui/PageHeader";
+import AssociationProfileEditor from "@/components/features/association-profile/AssociationProfileEditor";
+import { requireUserId } from "@/lib/auth/session";
+import { Capability, hasCapability } from "@/lib/auth/capabilities";
+import { prisma } from "@/lib/db/prisma";
+
+export const dynamic = "force-dynamic";
+
+/** Manage the public association and team pages. */
+export default async function PublicProfileSettingsPage({
+  params,
+}: {
+  params: Promise<{ leagueId: string }>;
+}) {
+  const { leagueId } = await params;
+  const userId = await requireUserId();
+
+  if (
+    !(await hasCapability({
+      userId,
+      leagueId,
+      capability: Capability.ADMINISTER_ASSOCIATION,
+    }))
+  ) {
+    notFound();
+  }
+
+  const [profile, teams] = await Promise.all([
+    prisma.league.findUnique({
+      where: { id: leagueId },
+      select: {
+        name: true,
+        slug: true,
+        profileStatus: true,
+        publicDescription: true,
+        logoUrl: true,
+        brandPrimaryColor: true,
+        brandSecondaryColor: true,
+        publicEmail: true,
+        publicPhone: true,
+      },
+    }),
+    prisma.team.findMany({
+      where: { leagueId, isActive: true },
+      select: { id: true, name: true, slug: true, profileStatus: true },
+      orderBy: { name: "asc" },
+    }),
+  ]);
+
+  if (!profile) notFound();
+
+  return (
+    <PageContainer maxWidth="lg">
+      <PageHeader
+        title="Public page"
+        subtitle="What families, opponents, and venue partners see when they look you up."
+      />
+      <AssociationProfileEditor leagueId={leagueId} profile={profile} teams={teams} />
+    </PageContainer>
+  );
+}

--- a/app/(marketing)/associations/[slug]/events/page.tsx
+++ b/app/(marketing)/associations/[slug]/events/page.tsx
@@ -1,4 +1,4 @@
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import {
   Card,
   CardContent,
@@ -10,6 +10,7 @@ import {
 import { LinkCardActionArea } from "@/components/ui/NextLinkComposites";
 import { prisma } from "@/lib/db/prisma";
 import { listPublicSignupEvents } from "@/lib/actions/signup-events";
+import { resolvePublicAssociation } from "@/lib/actions/association-profile";
 import { AGE_CLASSIFICATION_LABELS } from "@/lib/utils/age-level";
 import { formatDateTime } from "@/lib/utils/date";
 
@@ -26,12 +27,30 @@ export default async function AssociationEventsPage({
 }) {
   const { slug } = await params;
 
-  const league = await prisma.league.findUnique({
-    where: { slug },
-    select: { id: true, name: true, isActive: true },
-  });
+  // Resolves through the same path as the rest of the public association
+  // surface, so a renamed slug redirects here too rather than 404ing — this
+  // page predates the profile and used to resolve the slug on its own.
+  const resolved = await resolvePublicAssociation(slug);
+
+  const league = resolved
+    ? await prisma.league.findUnique({
+        where: { id: resolved.id },
+        select: { id: true, name: true, isActive: true },
+      })
+    : // Fall back to the original lookup: an association may publish signup
+      // events without ever publishing a public profile, and those event URLs
+      // must keep working.
+      await prisma.league.findUnique({
+        where: { slug },
+        select: { id: true, name: true, isActive: true },
+      });
+
   if (!league || !league.isActive) {
     notFound();
+  }
+
+  if (resolved && resolved.canonicalSlug !== slug) {
+    redirect(`/associations/${resolved.canonicalSlug}/events`);
   }
 
   const events = await listPublicSignupEvents({ hostLeagueId: league.id });

--- a/app/(marketing)/associations/[slug]/events/page.tsx
+++ b/app/(marketing)/associations/[slug]/events/page.tsx
@@ -10,7 +10,7 @@ import {
 import { LinkCardActionArea } from "@/components/ui/NextLinkComposites";
 import { prisma } from "@/lib/db/prisma";
 import { listPublicSignupEvents } from "@/lib/actions/signup-events";
-import { resolvePublicAssociation } from "@/lib/actions/association-profile";
+import { resolveActiveAssociation } from "@/lib/actions/association-profile";
 import { AGE_CLASSIFICATION_LABELS } from "@/lib/utils/age-level";
 import { formatDateTime } from "@/lib/utils/date";
 
@@ -27,29 +27,21 @@ export default async function AssociationEventsPage({
 }) {
   const { slug } = await params;
 
-  // Resolves through the same path as the rest of the public association
-  // surface, so a renamed slug redirects here too rather than 404ing — this
-  // page predates the profile and used to resolve the slug on its own.
-  const resolved = await resolvePublicAssociation(slug);
+  // Signup events predate public profiles. Resolve retired slugs for any active
+  // association without making its draft profile visible.
+  const resolved = await resolveActiveAssociation(slug);
+  if (!resolved) notFound();
 
-  const league = resolved
-    ? await prisma.league.findUnique({
-        where: { id: resolved.id },
-        select: { id: true, name: true, isActive: true },
-      })
-    : // Fall back to the original lookup: an association may publish signup
-      // events without ever publishing a public profile, and those event URLs
-      // must keep working.
-      await prisma.league.findUnique({
-        where: { slug },
-        select: { id: true, name: true, isActive: true },
-      });
+  const league = await prisma.league.findUnique({
+    where: { id: resolved.id },
+    select: { id: true, name: true, isActive: true },
+  });
 
   if (!league || !league.isActive) {
     notFound();
   }
 
-  if (resolved && resolved.canonicalSlug !== slug) {
+  if (resolved.canonicalSlug !== slug) {
     redirect(`/associations/${resolved.canonicalSlug}/events`);
   }
 

--- a/app/(marketing)/associations/[slug]/news/[contentSlug]/page.tsx
+++ b/app/(marketing)/associations/[slug]/news/[contentSlug]/page.tsx
@@ -1,0 +1,55 @@
+import { notFound } from "next/navigation";
+import { Chip, Container, Stack, Typography } from "@mui/material";
+
+import { LinkButton } from "@/components/ui/NextLinkComposites";
+import { getPublicContentItem } from "@/lib/actions/public-content";
+import { formatDateTime } from "@/lib/utils/date";
+
+export const dynamic = "force-dynamic";
+
+/** One public announcement or news item. */
+export default async function PublicNewsItemPage({
+  params,
+}: {
+  params: Promise<{ slug: string; contentSlug: string }>;
+}) {
+  const { slug, contentSlug } = await params;
+  const result = await getPublicContentItem(slug, contentSlug);
+  if (!result) notFound();
+
+  const { item, association } = result;
+
+  return (
+    <Container maxWidth="md" sx={{ py: { xs: 6, md: 8 } }}>
+      <Stack spacing={3}>
+        <LinkButton
+          href={`/associations/${association.slug}`}
+          variant="text"
+          sx={{ alignSelf: "flex-start", minHeight: 44 }}
+        >
+          ← {association.name}
+        </LinkButton>
+
+        <div>
+          <Typography variant="h3" component="h1">
+            {item.title}
+          </Typography>
+          <Stack direction="row" spacing={1} alignItems="center" sx={{ mt: 1 }}>
+            {item.publishAt ? (
+              <Typography variant="body2" color="text.secondary">
+                {formatDateTime(item.publishAt)}
+              </Typography>
+            ) : null}
+            {item.team ? <Chip size="small" label={item.team.name} /> : null}
+          </Stack>
+        </div>
+
+        {/* Rendered as text, not HTML: the body is stored exactly as authored
+            and React escapes it here, so a post can never inject markup. */}
+        <Typography variant="body1" sx={{ whiteSpace: "pre-wrap" }}>
+          {item.body}
+        </Typography>
+      </Stack>
+    </Container>
+  );
+}

--- a/app/(marketing)/associations/[slug]/news/[contentSlug]/page.tsx
+++ b/app/(marketing)/associations/[slug]/news/[contentSlug]/page.tsx
@@ -1,4 +1,4 @@
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import { Chip, Container, Stack, Typography } from "@mui/material";
 
 import { LinkButton } from "@/components/ui/NextLinkComposites";
@@ -18,6 +18,9 @@ export default async function PublicNewsItemPage({
   if (!result) notFound();
 
   const { item, association } = result;
+  if (association.slug !== slug) {
+    redirect(`/associations/${association.slug}/news/${contentSlug}`);
+  }
 
   return (
     <Container maxWidth="md" sx={{ py: { xs: 6, md: 8 } }}>

--- a/app/(marketing)/associations/[slug]/news/page.tsx
+++ b/app/(marketing)/associations/[slug]/news/page.tsx
@@ -1,0 +1,134 @@
+import { notFound, redirect } from "next/navigation";
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Container,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+
+import { LinkButton, LinkCardActionArea } from "@/components/ui/NextLinkComposites";
+import { resolvePublicAssociation } from "@/lib/actions/association-profile";
+import { listPublicAssociationContentPage } from "@/lib/actions/public-content";
+
+export const dynamic = "force-dynamic";
+
+const PAGE_SIZE = 20;
+
+export default async function PublicAssociationNewsPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ slug: string }>;
+  searchParams: Promise<{ page?: string | string[] }>;
+}) {
+  const { slug } = await params;
+  const rawPage = (await searchParams).page;
+  const parsedPage = Number(Array.isArray(rawPage) ? rawPage[0] : rawPage);
+  const page = Number.isSafeInteger(parsedPage) && parsedPage > 0 ? parsedPage : 1;
+
+  const association = await resolvePublicAssociation(slug);
+  if (!association) notFound();
+  if (association.canonicalSlug !== slug) {
+    redirect(
+      `/associations/${association.canonicalSlug}/news${page > 1 ? `?page=${page}` : ""}`,
+    );
+  }
+
+  const result = await listPublicAssociationContentPage(
+    association.id,
+    page,
+    PAGE_SIZE,
+  );
+  if (page > result.totalPages) notFound();
+
+  const base = `/associations/${association.canonicalSlug}`;
+
+  return (
+    <Container maxWidth="md" sx={{ py: { xs: 6, md: 8 } }}>
+      <Stack spacing={3}>
+        <div>
+          <Typography variant="h3" component="h1">
+            News
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            Public announcements from the association and its teams.
+          </Typography>
+        </div>
+
+        <LinkButton href={base} variant="outlined" sx={{ alignSelf: "flex-start" }}>
+          Back to association
+        </LinkButton>
+
+        {result.items.length === 0 ? (
+          <Typography color="text.secondary">No public announcements yet.</Typography>
+        ) : (
+          <Stack spacing={2}>
+            {result.items.map((item) => (
+              <Card key={item.id} variant="outlined">
+                <LinkCardActionArea href={`${base}/news/${item.slug}`}>
+                  <CardContent>
+                    <Typography variant="h6" component="h2">
+                      {item.title}
+                    </Typography>
+                    {item.summary ? (
+                      <Typography variant="body2" color="text.secondary">
+                        {item.summary}
+                      </Typography>
+                    ) : null}
+                  </CardContent>
+                </LinkCardActionArea>
+              </Card>
+            ))}
+          </Stack>
+        )}
+
+        {result.totalPages > 1 ? (
+          <Stack
+            direction={{ xs: "column", sm: "row" }}
+            spacing={2}
+            alignItems={{ sm: "center" }}
+          >
+            <Stack direction="row" spacing={1}>
+              {page > 1 ? (
+                <LinkButton href={`${base}/news?page=${page - 1}`} variant="outlined">
+                  Previous
+                </LinkButton>
+              ) : null}
+              {page < result.totalPages ? (
+                <LinkButton href={`${base}/news?page=${page + 1}`} variant="outlined">
+                  Next
+                </LinkButton>
+              ) : null}
+            </Stack>
+            <Box
+              component="form"
+              method="get"
+              action={`${base}/news`}
+              sx={{ display: "flex", gap: 1, alignItems: "center" }}
+            >
+              <TextField
+                name="page"
+                label="Page"
+                type="number"
+                defaultValue={page}
+                size="small"
+                slotProps={{ htmlInput: { min: 1, max: result.totalPages } }}
+                sx={{ width: 110 }}
+              />
+              <Button type="submit" variant="outlined">
+                Go
+              </Button>
+              <Typography variant="body2" color="text.secondary">
+                of {result.totalPages}
+              </Typography>
+            </Box>
+          </Stack>
+        ) : null}
+      </Stack>
+    </Container>
+  );
+}

--- a/app/(marketing)/associations/[slug]/page.tsx
+++ b/app/(marketing)/associations/[slug]/page.tsx
@@ -1,0 +1,38 @@
+import { notFound, redirect } from "next/navigation";
+import { Container } from "@mui/material";
+
+import PublicAssociationProfile from "@/components/features/association-profile/PublicAssociationProfile";
+import { getPublicAssociationProfile } from "@/lib/actions/association-profile";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Public association home (feature 007 / User Story 4).
+ *
+ * Reads only through the allowlist selectors in lib/utils/public-associations.ts,
+ * so no roster, contact, payment, gear-inventory, or outbox field can reach this
+ * page by accident.
+ */
+export default async function PublicAssociationPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const association = await getPublicAssociationProfile(slug);
+
+  if (!association) notFound();
+
+  // One canonical URL per association: a retired slug redirects rather than
+  // serving the page at a stale address, so shared links stay valid without
+  // splitting search-engine and analytics identity across two paths.
+  if (association.canonicalSlug !== slug) {
+    redirect(`/associations/${association.canonicalSlug}`);
+  }
+
+  return (
+    <Container maxWidth="lg" sx={{ py: { xs: 6, md: 8 } }}>
+      <PublicAssociationProfile association={association} />
+    </Container>
+  );
+}

--- a/app/(marketing)/associations/[slug]/schedule/page.tsx
+++ b/app/(marketing)/associations/[slug]/schedule/page.tsx
@@ -1,0 +1,110 @@
+import { notFound, redirect } from "next/navigation";
+import { Card, CardContent, Chip, Container, Stack, Typography } from "@mui/material";
+
+import { LinkButton } from "@/components/ui/NextLinkComposites";
+import { resolvePublicAssociation } from "@/lib/actions/association-profile";
+import { getPublicAssociationScheduleItems } from "@/lib/data/schedule-items";
+import { prisma } from "@/lib/db/prisma";
+import { formatDateTime } from "@/lib/utils/date";
+import { publicPublishedAssociationWhere } from "@/lib/utils/public-associations";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Canonical public association schedule (feature 007 / User Story 4).
+ *
+ * Reads through `getPublicAssociationScheduleItems`, which is the canonical
+ * reservation-backed reader required by ADR-0007 — this page does not re-derive
+ * occupancy from Events, SeasonGames, or schedule blocks, and so cannot show a
+ * game twice or disagree with the ICS feed at
+ * /api/associations/[slug]/schedule.ics, which reads the same function.
+ *
+ * `publicOnly` inside that reader is what applies the visibility filter; this
+ * page adds no filtering of its own and must not, or the two surfaces would
+ * drift apart.
+ */
+export default async function PublicAssociationSchedulePage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const resolved = await resolvePublicAssociation(slug);
+  if (!resolved) notFound();
+  if (resolved.canonicalSlug !== slug) {
+    redirect(`/associations/${resolved.canonicalSlug}/schedule`);
+  }
+
+  const now = new Date();
+  const [association, items] = await Promise.all([
+    prisma.league.findFirst({
+      where: { ...publicPublishedAssociationWhere, id: resolved.id },
+      select: { name: true },
+    }),
+    getPublicAssociationScheduleItems(resolved.id, {
+      from: now,
+      to: new Date(now.getTime() + 90 * 86_400_000),
+    }),
+  ]);
+  if (!association) notFound();
+
+  return (
+    <Container maxWidth="md" sx={{ py: { xs: 6, md: 8 } }}>
+      <Stack spacing={3}>
+        <div>
+          <Typography variant="h3" component="h1">
+            {association.name} schedule
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            The next 90 days of public activity.
+          </Typography>
+        </div>
+
+        <Stack direction="row" spacing={2}>
+          <LinkButton
+            href={`/associations/${resolved.canonicalSlug}`}
+            variant="outlined"
+            sx={{ minHeight: 44 }}
+          >
+            ← {association.name}
+          </LinkButton>
+          <LinkButton
+            href={`/api/associations/${resolved.canonicalSlug}/schedule.ics`}
+            variant="outlined"
+            sx={{ minHeight: 44 }}
+          >
+            Subscribe (.ics)
+          </LinkButton>
+        </Stack>
+
+        {items.length === 0 ? (
+          <Typography color="text.secondary">
+            Nothing public is scheduled in the next 90 days.
+          </Typography>
+        ) : (
+          <Stack spacing={2}>
+            {items.map((item) => (
+              <Card key={item.canonicalScheduleId} variant="outlined">
+                <CardContent>
+                  <Typography variant="h6" component="h2">
+                    {item.title}
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    {formatDateTime(item.startsAt)}
+                    {item.venueName ? ` · ${item.venueName}` : ""}
+                  </Typography>
+                  <Stack direction="row" spacing={1} sx={{ mt: 1 }} flexWrap="wrap" useFlexGap>
+                    {item.teamName ? <Chip size="small" label={item.teamName} /> : null}
+                    {item.divisionName ? (
+                      <Chip size="small" variant="outlined" label={item.divisionName} />
+                    ) : null}
+                  </Stack>
+                </CardContent>
+              </Card>
+            ))}
+          </Stack>
+        )}
+      </Stack>
+    </Container>
+  );
+}

--- a/app/(marketing)/associations/[slug]/teams/[teamSlug]/page.tsx
+++ b/app/(marketing)/associations/[slug]/teams/[teamSlug]/page.tsx
@@ -1,11 +1,21 @@
 import { notFound, redirect } from "next/navigation";
-import { Card, CardContent, Chip, Container, Stack, Typography } from "@mui/material";
+import {
+  Avatar,
+  Card,
+  CardContent,
+  Chip,
+  Container,
+  Stack,
+  Typography,
+} from "@mui/material";
 
 import { LinkButton, LinkCardActionArea } from "@/components/ui/NextLinkComposites";
 import {
   getPublicTeamProfile,
   resolvePublicAssociation,
 } from "@/lib/actions/association-profile";
+import { getPublicTeamScheduleItems } from "@/lib/data/schedule-items";
+import { formatDateTime } from "@/lib/utils/date";
 
 export const dynamic = "force-dynamic";
 
@@ -40,36 +50,73 @@ export default async function PublicTeamPage({
   // the relation is optional even though a published one always resolves here.
   const leagueName = team.league?.name ?? "Association";
   const base = `/associations/${association.canonicalSlug}`;
+  const now = new Date();
+  const scheduleItems = await getPublicTeamScheduleItems(association.id, team.id, {
+    from: now,
+    to: new Date(now.getTime() + 90 * 86_400_000),
+  });
 
   return (
     <Container maxWidth="md" sx={{ py: { xs: 6, md: 8 } }}>
       <Stack spacing={4}>
-        <div>
-          <Typography variant="overline" color="text.secondary">
-            {leagueName}
-          </Typography>
-          <Typography variant="h3" component="h1">
-            {team.name}
-          </Typography>
-          <Stack direction="row" spacing={1} sx={{ mt: 1 }}>
-            {team.division?.name ? <Chip size="small" label={team.division.name} /> : null}
-            <Chip size="small" label={team.season} />
-          </Stack>
-          {team.publicDescription ? (
-            <Typography variant="body1" sx={{ mt: 2 }}>
-              {team.publicDescription}
-            </Typography>
+        <Stack direction={{ xs: "column", sm: "row" }} spacing={3} alignItems="center">
+          {team.logoUrl ? (
+            <Avatar src={team.logoUrl} alt="" variant="rounded" sx={{ width: 96, height: 96 }} />
           ) : null}
-        </div>
+          <div>
+            <Typography variant="overline" color="text.secondary">
+              {leagueName}
+            </Typography>
+            <Typography variant="h3" component="h1">
+              {team.name}
+            </Typography>
+            <Stack direction="row" spacing={1} sx={{ mt: 1 }}>
+              {team.division?.name ? <Chip size="small" label={team.division.name} /> : null}
+              <Chip size="small" label={team.season} />
+            </Stack>
+            {team.publicDescription ? (
+              <Typography variant="body1" sx={{ mt: 2 }}>
+                {team.publicDescription}
+              </Typography>
+            ) : null}
+          </div>
+        </Stack>
 
         <Stack direction="row" spacing={2} flexWrap="wrap" useFlexGap>
           <LinkButton href={base} variant="outlined" sx={{ minHeight: 44 }}>
             {leagueName}
           </LinkButton>
-          <LinkButton href={`${base}/schedule`} variant="outlined" sx={{ minHeight: 44 }}>
+          <LinkButton href="#schedule" variant="outlined" sx={{ minHeight: 44 }}>
             Schedule
           </LinkButton>
         </Stack>
+
+        <div id="schedule">
+          <Typography variant="h5" component="h2" gutterBottom>
+            Team schedule
+          </Typography>
+          {scheduleItems.length === 0 ? (
+            <Typography color="text.secondary">
+              Nothing public is scheduled for this team in the next 90 days.
+            </Typography>
+          ) : (
+            <Stack spacing={2}>
+              {scheduleItems.map((item) => (
+                <Card key={item.canonicalScheduleId} variant="outlined">
+                  <CardContent>
+                    <Typography variant="h6" component="h3">
+                      {item.title}
+                    </Typography>
+                    <Typography variant="body2" color="text.secondary">
+                      {formatDateTime(item.startsAt)}
+                      {item.venueName ? ` · ${item.venueName}` : ""}
+                    </Typography>
+                  </CardContent>
+                </Card>
+              ))}
+            </Stack>
+          )}
+        </div>
 
         {team.publicContentItems.length > 0 ? (
           <div>

--- a/app/(marketing)/associations/[slug]/teams/[teamSlug]/page.tsx
+++ b/app/(marketing)/associations/[slug]/teams/[teamSlug]/page.tsx
@@ -1,0 +1,102 @@
+import { notFound, redirect } from "next/navigation";
+import { Card, CardContent, Chip, Container, Stack, Typography } from "@mui/material";
+
+import { LinkButton, LinkCardActionArea } from "@/components/ui/NextLinkComposites";
+import {
+  getPublicTeamProfile,
+  resolvePublicAssociation,
+} from "@/lib/actions/association-profile";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Public team page.
+ *
+ * Shows approved team identity and its public news. There is deliberately no
+ * roster here: players, guardians, emergency contacts, and jersey numbers are
+ * never selected by publicTeamSummarySelect, so this page cannot render them
+ * however it is edited later.
+ */
+export default async function PublicTeamPage({
+  params,
+}: {
+  params: Promise<{ slug: string; teamSlug: string }>;
+}) {
+  const { slug, teamSlug } = await params;
+
+  const association = await resolvePublicAssociation(slug);
+  if (!association) notFound();
+  if (association.canonicalSlug !== slug) {
+    redirect(`/associations/${association.canonicalSlug}/teams/${teamSlug}`);
+  }
+
+  const team = await getPublicTeamProfile(association.id, teamSlug);
+  if (!team) notFound();
+  if (team.canonicalSlug !== teamSlug) {
+    redirect(`/associations/${association.canonicalSlug}/teams/${team.canonicalSlug}`);
+  }
+
+  // Team.leagueId is nullable — teams can exist outside an association — so
+  // the relation is optional even though a published one always resolves here.
+  const leagueName = team.league?.name ?? "Association";
+  const base = `/associations/${association.canonicalSlug}`;
+
+  return (
+    <Container maxWidth="md" sx={{ py: { xs: 6, md: 8 } }}>
+      <Stack spacing={4}>
+        <div>
+          <Typography variant="overline" color="text.secondary">
+            {leagueName}
+          </Typography>
+          <Typography variant="h3" component="h1">
+            {team.name}
+          </Typography>
+          <Stack direction="row" spacing={1} sx={{ mt: 1 }}>
+            {team.division?.name ? <Chip size="small" label={team.division.name} /> : null}
+            <Chip size="small" label={team.season} />
+          </Stack>
+          {team.publicDescription ? (
+            <Typography variant="body1" sx={{ mt: 2 }}>
+              {team.publicDescription}
+            </Typography>
+          ) : null}
+        </div>
+
+        <Stack direction="row" spacing={2} flexWrap="wrap" useFlexGap>
+          <LinkButton href={base} variant="outlined" sx={{ minHeight: 44 }}>
+            {leagueName}
+          </LinkButton>
+          <LinkButton href={`${base}/schedule`} variant="outlined" sx={{ minHeight: 44 }}>
+            Schedule
+          </LinkButton>
+        </Stack>
+
+        {team.publicContentItems.length > 0 ? (
+          <div>
+            <Typography variant="h5" component="h2" gutterBottom>
+              Team news
+            </Typography>
+            <Stack spacing={2}>
+              {team.publicContentItems.map((item) => (
+                <Card key={item.id} variant="outlined">
+                  <LinkCardActionArea href={`${base}/news/${item.slug}`}>
+                    <CardContent>
+                      <Typography variant="h6" component="h3">
+                        {item.title}
+                      </Typography>
+                      {item.summary ? (
+                        <Typography variant="body2" color="text.secondary">
+                          {item.summary}
+                        </Typography>
+                      ) : null}
+                    </CardContent>
+                  </LinkCardActionArea>
+                </Card>
+              ))}
+            </Stack>
+          </div>
+        ) : null}
+      </Stack>
+    </Container>
+  );
+}

--- a/app/(marketing)/associations/[slug]/teams/page.tsx
+++ b/app/(marketing)/associations/[slug]/teams/page.tsx
@@ -1,0 +1,64 @@
+import { notFound, redirect } from "next/navigation";
+import { Card, CardContent, Container, Stack, Typography } from "@mui/material";
+
+import { LinkCardActionArea } from "@/components/ui/NextLinkComposites";
+import {
+  getPublicAssociationTeams,
+  resolvePublicAssociation,
+} from "@/lib/actions/association-profile";
+import { prisma } from "@/lib/db/prisma";
+import { publicPublishedAssociationWhere } from "@/lib/utils/public-associations";
+
+export const dynamic = "force-dynamic";
+
+/** Public team directory. One activation from the association home (SC-007). */
+export default async function PublicAssociationTeamsPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const resolved = await resolvePublicAssociation(slug);
+  if (!resolved) notFound();
+  if (resolved.canonicalSlug !== slug) {
+    redirect(`/associations/${resolved.canonicalSlug}/teams`);
+  }
+
+  const [association, teams] = await Promise.all([
+    prisma.league.findFirst({
+      where: { ...publicPublishedAssociationWhere, id: resolved.id },
+      select: { name: true },
+    }),
+    getPublicAssociationTeams(resolved.id),
+  ]);
+  if (!association) notFound();
+
+  return (
+    <Container maxWidth="lg" sx={{ py: { xs: 6, md: 8 } }}>
+      <Typography variant="h3" component="h1" gutterBottom>
+        {association.name} teams
+      </Typography>
+
+      {teams.length === 0 ? (
+        <Typography color="text.secondary">No teams have been published yet.</Typography>
+      ) : (
+        <Stack spacing={2} sx={{ mt: 3 }}>
+          {teams.map((team) => (
+            <Card key={team.id} variant="outlined">
+              <LinkCardActionArea href={`/associations/${resolved.canonicalSlug}/teams/${team.slug}`}>
+                <CardContent>
+                  <Typography variant="h6" component="h2">
+                    {team.name}
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    {team.division?.name ?? "No division"} · {team.season}
+                  </Typography>
+                </CardContent>
+              </LinkCardActionArea>
+            </Card>
+          ))}
+        </Stack>
+      )}
+    </Container>
+  );
+}

--- a/app/api/associations/[slug]/schedule.ics/route.ts
+++ b/app/api/associations/[slug]/schedule.ics/route.ts
@@ -4,7 +4,9 @@ import {
   buildScheduleIcs,
   getPublicAssociationScheduleItems,
 } from "@/lib/data/schedule-items";
+import { resolvePublicAssociation } from "@/lib/actions/association-profile";
 import { prisma } from "@/lib/db/prisma";
+import { publicPublishedAssociationWhere } from "@/lib/utils/public-associations";
 
 /**
  * GET /api/associations/[slug]/schedule.ics
@@ -14,18 +16,29 @@ import { prisma } from "@/lib/db/prisma";
  * allowlist and never selects participant, roster, payment, or audit data.
  */
 export async function GET(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: Promise<{ slug: string }> },
 ) {
   try {
     const { slug } = await params;
     if (!slug) return NextResponse.json({ error: "Not found" }, { status: 404 });
 
+    const resolved = await resolvePublicAssociation(slug);
+    if (!resolved) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+    if (resolved.redirected) {
+      const canonicalUrl = request.nextUrl.clone();
+      canonicalUrl.pathname =
+        `/api/associations/${resolved.canonicalSlug}/schedule.ics`;
+      return NextResponse.redirect(canonicalUrl, 308);
+    }
+
     const association = await prisma.league.findFirst({
-      where: { slug, isActive: true },
-      select: { id: true, name: true, slug: true },
+      where: { ...publicPublishedAssociationWhere, id: resolved.id },
+      select: { id: true, name: true },
     });
-    if (!association || association.slug !== slug) {
+    if (!association) {
       return NextResponse.json({ error: "Not found" }, { status: 404 });
     }
 

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -140,17 +140,25 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     // by the same published-only `where` the pages use, so an unpublished
     // association, team, or scheduled-but-not-yet-live post can never be
     // advertised here — the sitemap cannot leak what the pages would 404 on.
-    const associationPages = await getPublishedAssociationPages(baseUrl, currentDate);
+    const staticPageCount = marketingPages.length + docPages.length + legalPages.length;
+    const associationPages = await getPublishedAssociationPages(
+        baseUrl,
+        currentDate,
+        SITEMAP_URL_LIMIT - staticPageCount,
+    );
 
     return [...marketingPages, ...docPages, ...legalPages, ...associationPages];
 }
 
-/** Bounded so a large deployment cannot turn the sitemap into a table scan. */
-const SITEMAP_LIMIT = 500;
+/** One global cap keeps the generated document below the protocol's 50,000 URLs. */
+const SITEMAP_URL_LIMIT = 10_000;
+const ASSOCIATION_LIMIT = 500;
+const ASSOCIATION_SURFACE_COUNT = 5;
 
 async function getPublishedAssociationPages(
     baseUrl: string,
     currentDate: Date,
+    urlBudget: number,
 ): Promise<MetadataRoute.Sitemap> {
     try {
         const now = new Date();
@@ -159,22 +167,14 @@ async function getPublishedAssociationPages(
             select: {
                 slug: true,
                 publishedAt: true,
-                teams: {
-                    where: publicPublishedTeamWhere,
-                    select: { slug: true, publishedAt: true },
-                    take: SITEMAP_LIMIT,
-                },
-                publicContentItems: {
-                    where: publicContentWhere(now),
-                    select: { slug: true, publishAt: true },
-                    orderBy: { publishAt: 'desc' },
-                    take: SITEMAP_LIMIT,
-                },
             },
-            take: SITEMAP_LIMIT,
+            take: Math.min(
+                ASSOCIATION_LIMIT,
+                Math.floor(urlBudget / ASSOCIATION_SURFACE_COUNT),
+            ),
         });
 
-        return associations.flatMap((association) => {
+        const associationPages = associations.flatMap((association) => {
             if (!association.slug) return [];
             const base = `${baseUrl}/associations/${association.slug}`;
             const lastModified = association.publishedAt ?? currentDate;
@@ -184,24 +184,62 @@ async function getPublishedAssociationPages(
                 { url: `${base}/teams`, lastModified, changeFrequency: 'weekly' as const, priority: 0.6 },
                 { url: `${base}/schedule`, lastModified, changeFrequency: 'daily' as const, priority: 0.6 },
                 { url: `${base}/events`, lastModified, changeFrequency: 'daily' as const, priority: 0.6 },
-                ...association.teams.flatMap((team) =>
-                    team.slug
-                        ? [{
-                            url: `${base}/teams/${team.slug}`,
-                            lastModified: team.publishedAt ?? lastModified,
-                            changeFrequency: 'weekly' as const,
-                            priority: 0.5,
-                        }]
-                        : [],
-                ),
-                ...association.publicContentItems.map((item) => ({
-                    url: `${base}/news/${item.slug}`,
-                    lastModified: item.publishAt ?? lastModified,
-                    changeFrequency: 'monthly' as const,
-                    priority: 0.4,
-                })),
+                { url: `${base}/news`, lastModified, changeFrequency: 'weekly' as const, priority: 0.6 },
             ];
         });
+
+        const remainingBudget = Math.max(0, urlBudget - associationPages.length);
+        const teamBudget = Math.floor(remainingBudget / 2);
+        const contentBudget = remainingBudget - teamBudget;
+        const [teams, contentItems] = await Promise.all([
+            prisma.team.findMany({
+                where: {
+                    ...publicPublishedTeamWhere,
+                    league: { is: publicPublishedAssociationWhere },
+                },
+                select: {
+                    slug: true,
+                    publishedAt: true,
+                    league: { select: { slug: true, publishedAt: true } },
+                },
+                take: teamBudget,
+            }),
+            prisma.publicContentItem.findMany({
+                where: {
+                    ...publicContentWhere(now),
+                    league: { is: publicPublishedAssociationWhere },
+                },
+                select: {
+                    slug: true,
+                    publishAt: true,
+                    league: { select: { slug: true, publishedAt: true } },
+                },
+                orderBy: { publishAt: 'desc' },
+                take: contentBudget,
+            }),
+        ]);
+
+        const teamPages = teams.flatMap((team) => {
+            if (!team.slug || !team.league?.slug) return [];
+            return [{
+                    url: `${baseUrl}/associations/${team.league.slug}/teams/${team.slug}`,
+                    lastModified: team.publishedAt ?? team.league.publishedAt ?? currentDate,
+                    changeFrequency: 'weekly' as const,
+                    priority: 0.5,
+                }];
+        });
+        const contentPages = contentItems.flatMap((item) =>
+            item.league.slug
+                ? [{
+                    url: `${baseUrl}/associations/${item.league.slug}/news/${item.slug}`,
+                    lastModified: item.publishAt ?? item.league.publishedAt ?? currentDate,
+                    changeFrequency: 'monthly' as const,
+                    priority: 0.4,
+                }]
+                : [],
+        );
+
+        return [...associationPages, ...teamPages, ...contentPages].slice(0, urlBudget);
     } catch (error) {
         // A sitemap that throws takes the whole route down. The static pages
         // are still worth serving if the database is unreachable.

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,10 +1,30 @@
 import { MetadataRoute } from 'next';
 
+import { prisma } from '@/lib/db/prisma';
+import {
+    publicPublishedAssociationWhere,
+    publicPublishedTeamWhere,
+    publicContentWhere,
+} from '@/lib/utils/public-associations';
+
 /**
  * Dynamic sitemap generation for OpenLeague
  * https://nextjs.org/docs/app/api-reference/file-conventions/metadata/sitemap
  */
-export default function sitemap(): MetadataRoute.Sitemap {
+/**
+ * Revalidated hourly rather than baked at build time.
+ *
+ * Sitemaps are cached by default, but this one now enumerates published
+ * associations, teams, and news — all of which change between deploys. A
+ * build-time snapshot would omit everything published since, and would also
+ * freeze in whatever state the build-time database happened to be in (a
+ * database still awaiting the migration yields an empty association list,
+ * which the catch below turns into "no association pages" rather than a
+ * failed build).
+ */
+export const revalidate = 3600;
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     const baseUrl = 'https://openl.app';
     const currentDate = new Date();
 
@@ -116,5 +136,76 @@ export default function sitemap(): MetadataRoute.Sitemap {
         },
     ];
 
-    return [...marketingPages, ...docPages, ...legalPages];
+    // Published association surfaces (feature 007 US4). Every query is bounded
+    // by the same published-only `where` the pages use, so an unpublished
+    // association, team, or scheduled-but-not-yet-live post can never be
+    // advertised here — the sitemap cannot leak what the pages would 404 on.
+    const associationPages = await getPublishedAssociationPages(baseUrl, currentDate);
+
+    return [...marketingPages, ...docPages, ...legalPages, ...associationPages];
+}
+
+/** Bounded so a large deployment cannot turn the sitemap into a table scan. */
+const SITEMAP_LIMIT = 500;
+
+async function getPublishedAssociationPages(
+    baseUrl: string,
+    currentDate: Date,
+): Promise<MetadataRoute.Sitemap> {
+    try {
+        const now = new Date();
+        const associations = await prisma.league.findMany({
+            where: publicPublishedAssociationWhere,
+            select: {
+                slug: true,
+                publishedAt: true,
+                teams: {
+                    where: publicPublishedTeamWhere,
+                    select: { slug: true, publishedAt: true },
+                    take: SITEMAP_LIMIT,
+                },
+                publicContentItems: {
+                    where: publicContentWhere(now),
+                    select: { slug: true, publishAt: true },
+                    orderBy: { publishAt: 'desc' },
+                    take: SITEMAP_LIMIT,
+                },
+            },
+            take: SITEMAP_LIMIT,
+        });
+
+        return associations.flatMap((association) => {
+            if (!association.slug) return [];
+            const base = `${baseUrl}/associations/${association.slug}`;
+            const lastModified = association.publishedAt ?? currentDate;
+
+            return [
+                { url: base, lastModified, changeFrequency: 'weekly' as const, priority: 0.7 },
+                { url: `${base}/teams`, lastModified, changeFrequency: 'weekly' as const, priority: 0.6 },
+                { url: `${base}/schedule`, lastModified, changeFrequency: 'daily' as const, priority: 0.6 },
+                { url: `${base}/events`, lastModified, changeFrequency: 'daily' as const, priority: 0.6 },
+                ...association.teams.flatMap((team) =>
+                    team.slug
+                        ? [{
+                            url: `${base}/teams/${team.slug}`,
+                            lastModified: team.publishedAt ?? lastModified,
+                            changeFrequency: 'weekly' as const,
+                            priority: 0.5,
+                        }]
+                        : [],
+                ),
+                ...association.publicContentItems.map((item) => ({
+                    url: `${base}/news/${item.slug}`,
+                    lastModified: item.publishAt ?? lastModified,
+                    changeFrequency: 'monthly' as const,
+                    priority: 0.4,
+                })),
+            ];
+        });
+    } catch (error) {
+        // A sitemap that throws takes the whole route down. The static pages
+        // are still worth serving if the database is unreachable.
+        console.error('Sitemap: association pages unavailable', error);
+        return [];
+    }
 }

--- a/components/features/association-profile/AssociationProfileEditor.tsx
+++ b/components/features/association-profile/AssociationProfileEditor.tsx
@@ -24,6 +24,7 @@ import {
   updateAssociationSlug,
   updateTeamPublicProfile,
 } from "@/lib/actions/association-profile";
+import { VenueBrandingEditor } from "@/components/features/venue-admin/VenueBrandingEditor";
 
 export interface AssociationProfileEditorProps {
   leagueId: string;
@@ -43,6 +44,8 @@ export interface AssociationProfileEditorProps {
     name: string;
     slug: string | null;
     profileStatus: string;
+    publicDescription: string | null;
+    logoUrl: string | null;
   }>;
 }
 
@@ -64,8 +67,19 @@ export function AssociationProfileEditor({
     brandSecondaryColor: profile.brandSecondaryColor ?? "",
   });
   const [slug, setSlug] = useState(profile.slug ?? "");
-  const [teamSlugs, setTeamSlugs] = useState<Record<string, string>>(
-    Object.fromEntries(teams.map((team) => [team.id, team.slug ?? ""])),
+  const [teamFields, setTeamFields] = useState<
+    Record<string, { slug: string; publicDescription: string; logoUrl: string }>
+  >(
+    Object.fromEntries(
+      teams.map((team) => [
+        team.id,
+        {
+          slug: team.slug ?? "",
+          publicDescription: team.publicDescription ?? "",
+          logoUrl: team.logoUrl ?? "",
+        },
+      ]),
+    ),
   );
 
   const published = profile.profileStatus === "PUBLISHED";
@@ -165,11 +179,12 @@ export function AssociationProfileEditor({
             minRows={3}
             fullWidth
           />
-          <TextField
-            label="Logo URL"
-            value={fields.logoUrl}
-            onChange={(e) => setFields({ ...fields, logoUrl: e.target.value })}
-            fullWidth
+          <VenueBrandingEditor
+            logoUrl={fields.logoUrl}
+            brandPrimaryColor={fields.brandPrimaryColor}
+            brandSecondaryColor={fields.brandSecondaryColor}
+            disabled={pending}
+            onChange={(field, value) => setFields({ ...fields, [field]: value })}
           />
           <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
             <TextField
@@ -198,6 +213,8 @@ export function AssociationProfileEditor({
                       leagueId,
                       publicDescription: fields.publicDescription || null,
                       logoUrl: fields.logoUrl || null,
+                      brandPrimaryColor: fields.brandPrimaryColor || null,
+                      brandSecondaryColor: fields.brandSecondaryColor || null,
                       publicEmail: fields.publicEmail || null,
                       publicPhone: fields.publicPhone || null,
                     }),
@@ -222,6 +239,8 @@ export function AssociationProfileEditor({
               <TableRow>
                 <TableCell>Team</TableCell>
                 <TableCell>Address</TableCell>
+                <TableCell>Description</TableCell>
+                <TableCell>Logo URL</TableCell>
                 <TableCell>Status</TableCell>
                 <TableCell align="right">Actions</TableCell>
               </TableRow>
@@ -229,16 +248,61 @@ export function AssociationProfileEditor({
             <TableBody>
               {teams.map((team) => {
                 const teamPublished = team.profileStatus === "PUBLISHED";
-                const value = teamSlugs[team.id] ?? "";
+                const values = teamFields[team.id] ?? {
+                  slug: "",
+                  publicDescription: "",
+                  logoUrl: "",
+                };
                 return (
                   <TableRow key={team.id}>
                     <TableCell>{team.name}</TableCell>
                     <TableCell>
                       <TextField
                         size="small"
-                        value={value}
+                        value={values.slug}
+                        slotProps={{
+                          htmlInput: { "aria-label": `${team.name} public address` },
+                        }}
                         onChange={(e) =>
-                          setTeamSlugs({ ...teamSlugs, [team.id]: e.target.value })
+                          setTeamFields({
+                            ...teamFields,
+                            [team.id]: { ...values, slug: e.target.value },
+                          })
+                        }
+                      />
+                    </TableCell>
+                    <TableCell>
+                      <TextField
+                        size="small"
+                        value={values.publicDescription}
+                        multiline
+                        minRows={2}
+                        slotProps={{
+                          htmlInput: { "aria-label": `${team.name} public description` },
+                        }}
+                        onChange={(e) =>
+                          setTeamFields({
+                            ...teamFields,
+                            [team.id]: {
+                              ...values,
+                              publicDescription: e.target.value,
+                            },
+                          })
+                        }
+                      />
+                    </TableCell>
+                    <TableCell>
+                      <TextField
+                        size="small"
+                        value={values.logoUrl}
+                        slotProps={{
+                          htmlInput: { "aria-label": `${team.name} logo URL` },
+                        }}
+                        onChange={(e) =>
+                          setTeamFields({
+                            ...teamFields,
+                            [team.id]: { ...values, logoUrl: e.target.value },
+                          })
                         }
                       />
                     </TableCell>
@@ -253,7 +317,7 @@ export function AssociationProfileEditor({
                       <Stack direction="row" spacing={1} justifyContent="flex-end">
                         <Button
                           size="small"
-                          disabled={pending || !value || value === team.slug}
+                          disabled={pending}
                           sx={{ minHeight: 44 }}
                           onClick={() =>
                             run(
@@ -261,9 +325,11 @@ export function AssociationProfileEditor({
                                 updateTeamPublicProfile({
                                   leagueId,
                                   teamId: team.id,
-                                  slug: value,
+                                  ...(values.slug ? { slug: values.slug } : {}),
+                                  publicDescription: values.publicDescription || null,
+                                  logoUrl: values.logoUrl || null,
                                 }),
-                              "Team address saved.",
+                              "Team page saved.",
                             )
                           }
                         >
@@ -272,7 +338,7 @@ export function AssociationProfileEditor({
                         <Button
                           size="small"
                           variant={teamPublished ? "outlined" : "contained"}
-                          disabled={pending || !value}
+                          disabled={pending || !values.slug}
                           sx={{ minHeight: 44 }}
                           onClick={() =>
                             run(
@@ -280,7 +346,9 @@ export function AssociationProfileEditor({
                                 updateTeamPublicProfile({
                                   leagueId,
                                   teamId: team.id,
-                                  slug: value,
+                                  slug: values.slug,
+                                  publicDescription: values.publicDescription || null,
+                                  logoUrl: values.logoUrl || null,
                                   publish: !teamPublished,
                                 }),
                               teamPublished ? "Team unpublished." : "Team published.",

--- a/components/features/association-profile/AssociationProfileEditor.tsx
+++ b/components/features/association-profile/AssociationProfileEditor.tsx
@@ -1,0 +1,305 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  Chip,
+  Divider,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  TextField,
+  Typography,
+} from "@mui/material";
+
+import {
+  setAssociationProfilePublished,
+  updateAssociationProfile,
+  updateAssociationSlug,
+  updateTeamPublicProfile,
+} from "@/lib/actions/association-profile";
+
+export interface AssociationProfileEditorProps {
+  leagueId: string;
+  profile: {
+    name: string;
+    slug: string | null;
+    profileStatus: string;
+    publicDescription: string | null;
+    logoUrl: string | null;
+    brandPrimaryColor: string | null;
+    brandSecondaryColor: string | null;
+    publicEmail: string | null;
+    publicPhone: string | null;
+  };
+  teams: Array<{
+    id: string;
+    name: string;
+    slug: string | null;
+    profileStatus: string;
+  }>;
+}
+
+export function AssociationProfileEditor({
+  leagueId,
+  profile,
+  teams,
+}: AssociationProfileEditorProps) {
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  const [fields, setFields] = useState({
+    publicDescription: profile.publicDescription ?? "",
+    logoUrl: profile.logoUrl ?? "",
+    publicEmail: profile.publicEmail ?? "",
+    publicPhone: profile.publicPhone ?? "",
+    brandPrimaryColor: profile.brandPrimaryColor ?? "",
+    brandSecondaryColor: profile.brandSecondaryColor ?? "",
+  });
+  const [slug, setSlug] = useState(profile.slug ?? "");
+  const [teamSlugs, setTeamSlugs] = useState<Record<string, string>>(
+    Object.fromEntries(teams.map((team) => [team.id, team.slug ?? ""])),
+  );
+
+  const published = profile.profileStatus === "PUBLISHED";
+
+  function run(
+    action: () => Promise<{ success: boolean; error?: string }>,
+    successMessage: string,
+  ) {
+    setError(null);
+    setNotice(null);
+    startTransition(async () => {
+      const result = await action();
+      if (result.success) setNotice(successMessage);
+      else setError(result.error ?? "That change could not be saved.");
+    });
+  }
+
+  return (
+    <Stack spacing={3}>
+      {error ? <Alert severity="error">{error}</Alert> : null}
+      {notice ? <Alert severity="success">{notice}</Alert> : null}
+
+      <Card variant="outlined" sx={{ p: 2 }}>
+        <Stack direction="row" spacing={2} alignItems="center" justifyContent="space-between">
+          <Box>
+            <Typography variant="h6" component="h2">
+              Public page
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              {published && profile.slug
+                ? `Live at /associations/${profile.slug}`
+                : "Not published — only you can see this."}
+            </Typography>
+          </Box>
+          <Stack direction="row" spacing={1} alignItems="center">
+            <Chip
+              size="small"
+              label={profile.profileStatus}
+              color={published ? "success" : "default"}
+            />
+            <Button
+              variant={published ? "outlined" : "contained"}
+              disabled={pending}
+              sx={{ minHeight: 44 }}
+              onClick={() =>
+                run(
+                  () =>
+                    setAssociationProfilePublished({ leagueId, publish: !published }),
+                  published ? "Page unpublished." : "Page published.",
+                )
+              }
+            >
+              {published ? "Unpublish" : "Publish"}
+            </Button>
+          </Stack>
+        </Stack>
+      </Card>
+
+      <Card variant="outlined" sx={{ p: 2 }}>
+        <Typography variant="h6" component="h2" gutterBottom>
+          Public address
+        </Typography>
+        <Stack direction={{ xs: "column", sm: "row" }} spacing={2} alignItems="flex-start">
+          <TextField
+            label="Address"
+            value={slug}
+            onChange={(event) => setSlug(event.target.value)}
+            helperText="Lowercase letters, numbers, and hyphens. Old addresses keep working."
+            fullWidth
+          />
+          <Button
+            variant="outlined"
+            disabled={pending || !slug || slug === profile.slug}
+            sx={{ minHeight: 44 }}
+            onClick={() =>
+              run(
+                () => updateAssociationSlug({ leagueId, slug }),
+                "Address updated. The previous one now redirects here.",
+              )
+            }
+          >
+            Save address
+          </Button>
+        </Stack>
+      </Card>
+
+      <Card variant="outlined" sx={{ p: 2 }}>
+        <Typography variant="h6" component="h2" gutterBottom>
+          Details
+        </Typography>
+        <Stack spacing={2}>
+          <TextField
+            label="Description"
+            value={fields.publicDescription}
+            onChange={(e) => setFields({ ...fields, publicDescription: e.target.value })}
+            multiline
+            minRows={3}
+            fullWidth
+          />
+          <TextField
+            label="Logo URL"
+            value={fields.logoUrl}
+            onChange={(e) => setFields({ ...fields, logoUrl: e.target.value })}
+            fullWidth
+          />
+          <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
+            <TextField
+              label="Public email"
+              value={fields.publicEmail}
+              onChange={(e) => setFields({ ...fields, publicEmail: e.target.value })}
+              helperText="Shown publicly — not your admin contact address."
+              fullWidth
+            />
+            <TextField
+              label="Public phone"
+              value={fields.publicPhone}
+              onChange={(e) => setFields({ ...fields, publicPhone: e.target.value })}
+              fullWidth
+            />
+          </Stack>
+          <Box>
+            <Button
+              variant="contained"
+              disabled={pending}
+              sx={{ minHeight: 44 }}
+              onClick={() =>
+                run(
+                  () =>
+                    updateAssociationProfile({
+                      leagueId,
+                      publicDescription: fields.publicDescription || null,
+                      logoUrl: fields.logoUrl || null,
+                      publicEmail: fields.publicEmail || null,
+                      publicPhone: fields.publicPhone || null,
+                    }),
+                  "Details saved.",
+                )
+              }
+            >
+              Save details
+            </Button>
+          </Box>
+        </Stack>
+      </Card>
+
+      <Card variant="outlined" sx={{ p: 2 }}>
+        <Typography variant="h6" component="h2" gutterBottom>
+          Team pages
+        </Typography>
+        <Divider sx={{ mb: 1 }} />
+        <Box sx={{ overflowX: "auto" }}>
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>Team</TableCell>
+                <TableCell>Address</TableCell>
+                <TableCell>Status</TableCell>
+                <TableCell align="right">Actions</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {teams.map((team) => {
+                const teamPublished = team.profileStatus === "PUBLISHED";
+                const value = teamSlugs[team.id] ?? "";
+                return (
+                  <TableRow key={team.id}>
+                    <TableCell>{team.name}</TableCell>
+                    <TableCell>
+                      <TextField
+                        size="small"
+                        value={value}
+                        onChange={(e) =>
+                          setTeamSlugs({ ...teamSlugs, [team.id]: e.target.value })
+                        }
+                      />
+                    </TableCell>
+                    <TableCell>
+                      <Chip
+                        size="small"
+                        label={team.profileStatus}
+                        color={teamPublished ? "success" : "default"}
+                      />
+                    </TableCell>
+                    <TableCell align="right">
+                      <Stack direction="row" spacing={1} justifyContent="flex-end">
+                        <Button
+                          size="small"
+                          disabled={pending || !value || value === team.slug}
+                          sx={{ minHeight: 44 }}
+                          onClick={() =>
+                            run(
+                              () =>
+                                updateTeamPublicProfile({
+                                  leagueId,
+                                  teamId: team.id,
+                                  slug: value,
+                                }),
+                              "Team address saved.",
+                            )
+                          }
+                        >
+                          Save
+                        </Button>
+                        <Button
+                          size="small"
+                          variant={teamPublished ? "outlined" : "contained"}
+                          disabled={pending || !value}
+                          sx={{ minHeight: 44 }}
+                          onClick={() =>
+                            run(
+                              () =>
+                                updateTeamPublicProfile({
+                                  leagueId,
+                                  teamId: team.id,
+                                  slug: value,
+                                  publish: !teamPublished,
+                                }),
+                              teamPublished ? "Team unpublished." : "Team published.",
+                            )
+                          }
+                        >
+                          {teamPublished ? "Unpublish" : "Publish"}
+                        </Button>
+                      </Stack>
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+            </TableBody>
+          </Table>
+        </Box>
+      </Card>
+    </Stack>
+  );
+}
+
+export default AssociationProfileEditor;

--- a/components/features/association-profile/ContentEditor.tsx
+++ b/components/features/association-profile/ContentEditor.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import {
+  Alert, Box, Button, Card, Chip, MenuItem, Stack, Table, TableBody,
+  TableCell, TableHead, TableRow, TextField, Typography,
+} from "@mui/material";
+
+import {
+  archivePublicContent,
+  createPublicContent,
+} from "@/lib/actions/public-content";
+
+export interface ContentEditorProps {
+  leagueId: string;
+  teams: Array<{ id: string; name: string }>;
+  items: Array<{
+    id: string;
+    slug: string;
+    title: string;
+    status: string;
+    visibility: string;
+    publishAt: Date | null;
+    archivedAt: Date | null;
+    team: { name: string } | null;
+  }>;
+}
+
+const STATUS_COLOR = {
+  DRAFT: "default", SCHEDULED: "warning", PUBLISHED: "success", ARCHIVED: "default",
+} as const;
+
+export function ContentEditor({ leagueId, teams, items }: ContentEditorProps) {
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+  const [form, setForm] = useState({
+    slug: "", title: "", summary: "", body: "", teamId: "", publishAt: "",
+    visibility: "PUBLIC" as "PUBLIC" | "MEMBERS_ONLY",
+  });
+
+  function run(action: () => Promise<{ success: boolean; error?: string }>, message: string) {
+    setError(null);
+    setNotice(null);
+    startTransition(async () => {
+      const result = await action();
+      if (result.success) setNotice(message);
+      else setError(result.error ?? "That change could not be saved.");
+    });
+  }
+
+  return (
+    <Stack spacing={3}>
+      {error ? <Alert severity="error">{error}</Alert> : null}
+      {notice ? <Alert severity="success">{notice}</Alert> : null}
+
+      <Card variant="outlined" sx={{ p: 2 }}>
+        <Typography variant="h6" component="h2" gutterBottom>
+          New post
+        </Typography>
+        <Stack spacing={2}>
+          <TextField label="Title" value={form.title} fullWidth
+            onChange={(e) => setForm({ ...form, title: e.target.value })} />
+          <TextField label="Address" value={form.slug} fullWidth
+            helperText="Lowercase letters, numbers, and hyphens."
+            onChange={(e) => setForm({ ...form, slug: e.target.value })} />
+          <TextField label="Summary" value={form.summary} fullWidth
+            onChange={(e) => setForm({ ...form, summary: e.target.value })} />
+          <TextField label="Body" value={form.body} multiline minRows={4} fullWidth
+            onChange={(e) => setForm({ ...form, body: e.target.value })} />
+          <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
+            <TextField select label="Team (optional)" value={form.teamId} fullWidth
+              onChange={(e) => setForm({ ...form, teamId: e.target.value })}>
+              <MenuItem value="">Whole association</MenuItem>
+              {teams.map((team) => (
+                <MenuItem key={team.id} value={team.id}>{team.name}</MenuItem>
+              ))}
+            </TextField>
+            <TextField select label="Visibility" value={form.visibility} fullWidth
+              onChange={(e) =>
+                setForm({ ...form, visibility: e.target.value as "PUBLIC" | "MEMBERS_ONLY" })}>
+              <MenuItem value="PUBLIC">Public</MenuItem>
+              <MenuItem value="MEMBERS_ONLY">Members only</MenuItem>
+            </TextField>
+          </Stack>
+          <TextField
+            label="Publish at" type="datetime-local" value={form.publishAt} fullWidth
+            slotProps={{ inputLabel: { shrink: true } }}
+            helperText="Leave empty to publish now. A future time schedules it."
+            onChange={(e) => setForm({ ...form, publishAt: e.target.value })}
+          />
+          <Box>
+            <Button
+              variant="contained" disabled={pending || !form.title || !form.slug || !form.body}
+              sx={{ minHeight: 44 }}
+              onClick={() =>
+                run(() => createPublicContent({
+                  leagueId,
+                  slug: form.slug,
+                  title: form.title,
+                  summary: form.summary || undefined,
+                  body: form.body,
+                  visibility: form.visibility,
+                  ...(form.teamId ? { teamId: form.teamId } : {}),
+                  ...(form.publishAt ? { publishAt: new Date(form.publishAt) } : {}),
+                }), "Post saved.")
+              }
+            >
+              Save post
+            </Button>
+          </Box>
+        </Stack>
+      </Card>
+
+      <Card variant="outlined" sx={{ p: 2 }}>
+        <Typography variant="h6" component="h2" gutterBottom>
+          Posts
+        </Typography>
+        {items.length === 0 ? (
+          <Typography variant="body2" color="text.secondary">Nothing posted yet.</Typography>
+        ) : (
+          <Box sx={{ overflowX: "auto" }}>
+            <Table size="small">
+              <TableHead>
+                <TableRow>
+                  <TableCell>Title</TableCell>
+                  <TableCell>Scope</TableCell>
+                  <TableCell>Status</TableCell>
+                  <TableCell>Publishes</TableCell>
+                  <TableCell align="right">Actions</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {items.map((item) => (
+                  <TableRow key={item.id}>
+                    <TableCell>{item.title}</TableCell>
+                    <TableCell>{item.team?.name ?? "Association"}</TableCell>
+                    <TableCell>
+                      <Stack direction="row" spacing={0.5}>
+                        <Chip size="small" label={item.status}
+                          color={STATUS_COLOR[item.status as keyof typeof STATUS_COLOR] ?? "default"} />
+                        {item.visibility === "MEMBERS_ONLY" ? (
+                          <Chip size="small" variant="outlined" label="Members" />
+                        ) : null}
+                      </Stack>
+                    </TableCell>
+                    <TableCell>
+                      {item.publishAt ? new Date(item.publishAt).toLocaleString() : "—"}
+                    </TableCell>
+                    <TableCell align="right">
+                      {item.status !== "ARCHIVED" ? (
+                        <Button size="small" color="error" disabled={pending} sx={{ minHeight: 44 }}
+                          onClick={() => run(() => archivePublicContent(item.id), "Post archived.")}>
+                          Archive
+                        </Button>
+                      ) : null}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </Box>
+        )}
+      </Card>
+    </Stack>
+  );
+}
+
+export default ContentEditor;

--- a/components/features/association-profile/ContentEditor.tsx
+++ b/components/features/association-profile/ContentEditor.tsx
@@ -9,10 +9,12 @@ import {
 import {
   archivePublicContent,
   createPublicContent,
+  updatePublicContent,
 } from "@/lib/actions/public-content";
 
 export interface ContentEditorProps {
   leagueId: string;
+  canPublishAssociationWide: boolean;
   teams: Array<{ id: string; name: string }>;
   items: Array<{
     id: string;
@@ -30,12 +32,22 @@ const STATUS_COLOR = {
   DRAFT: "default", SCHEDULED: "warning", PUBLISHED: "success", ARCHIVED: "default",
 } as const;
 
-export function ContentEditor({ leagueId, teams, items }: ContentEditorProps) {
+export function ContentEditor({
+  leagueId,
+  canPublishAssociationWide,
+  teams,
+  items,
+}: ContentEditorProps) {
   const [pending, startTransition] = useTransition();
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
   const [form, setForm] = useState({
-    slug: "", title: "", summary: "", body: "", teamId: "", publishAt: "",
+    slug: "",
+    title: "",
+    summary: "",
+    body: "",
+    teamId: canPublishAssociationWide ? "" : (teams[0]?.id ?? ""),
+    publishAt: "",
     visibility: "PUBLIC" as "PUBLIC" | "MEMBERS_ONLY",
   });
 
@@ -71,7 +83,9 @@ export function ContentEditor({ leagueId, teams, items }: ContentEditorProps) {
           <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
             <TextField select label="Team (optional)" value={form.teamId} fullWidth
               onChange={(e) => setForm({ ...form, teamId: e.target.value })}>
-              <MenuItem value="">Whole association</MenuItem>
+              {canPublishAssociationWide ? (
+                <MenuItem value="">Whole association</MenuItem>
+              ) : null}
               {teams.map((team) => (
                 <MenuItem key={team.id} value={team.id}>{team.name}</MenuItem>
               ))}
@@ -89,9 +103,16 @@ export function ContentEditor({ leagueId, teams, items }: ContentEditorProps) {
             helperText="Leave empty to publish now. A future time schedules it."
             onChange={(e) => setForm({ ...form, publishAt: e.target.value })}
           />
-          <Box>
+          <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
             <Button
-              variant="contained" disabled={pending || !form.title || !form.slug || !form.body}
+              variant="outlined"
+              disabled={
+                pending
+                || !form.title.trim()
+                || !form.slug
+                || !form.body.trim()
+                || (!canPublishAssociationWide && !form.teamId)
+              }
               sx={{ minHeight: 44 }}
               onClick={() =>
                 run(() => createPublicContent({
@@ -101,14 +122,41 @@ export function ContentEditor({ leagueId, teams, items }: ContentEditorProps) {
                   summary: form.summary || undefined,
                   body: form.body,
                   visibility: form.visibility,
+                  status: "DRAFT",
                   ...(form.teamId ? { teamId: form.teamId } : {}),
                   ...(form.publishAt ? { publishAt: new Date(form.publishAt) } : {}),
-                }), "Post saved.")
+                }), "Draft saved.")
               }
             >
-              Save post
+              Save draft
             </Button>
-          </Box>
+            <Button
+              variant="contained"
+              disabled={
+                pending
+                || !form.title.trim()
+                || !form.slug
+                || !form.body.trim()
+                || (!canPublishAssociationWide && !form.teamId)
+              }
+              sx={{ minHeight: 44 }}
+              onClick={() =>
+                run(() => createPublicContent({
+                  leagueId,
+                  slug: form.slug,
+                  title: form.title,
+                  summary: form.summary || undefined,
+                  body: form.body,
+                  visibility: form.visibility,
+                  status: "PUBLISHED",
+                  ...(form.teamId ? { teamId: form.teamId } : {}),
+                  ...(form.publishAt ? { publishAt: new Date(form.publishAt) } : {}),
+                }), form.publishAt ? "Post scheduled." : "Post published.")
+              }
+            >
+              {form.publishAt ? "Schedule" : "Publish"}
+            </Button>
+          </Stack>
         </Stack>
       </Card>
 
@@ -148,12 +196,54 @@ export function ContentEditor({ leagueId, teams, items }: ContentEditorProps) {
                       {item.publishAt ? new Date(item.publishAt).toLocaleString() : "—"}
                     </TableCell>
                     <TableCell align="right">
-                      {item.status !== "ARCHIVED" ? (
-                        <Button size="small" color="error" disabled={pending} sx={{ minHeight: 44 }}
-                          onClick={() => run(() => archivePublicContent(item.id), "Post archived.")}>
-                          Archive
-                        </Button>
-                      ) : null}
+                      <Stack direction="row" spacing={1} justifyContent="flex-end">
+                        {item.status === "DRAFT" ? (
+                          <Button
+                            size="small"
+                            disabled={pending}
+                            sx={{ minHeight: 44 }}
+                            onClick={() =>
+                              run(
+                                () => updatePublicContent({
+                                  itemId: item.id,
+                                  status: "PUBLISHED",
+                                }),
+                                "Post published.",
+                              )}
+                          >
+                            Publish
+                          </Button>
+                        ) : null}
+                        {item.status === "SCHEDULED" ? (
+                          <Button
+                            size="small"
+                            disabled={pending}
+                            sx={{ minHeight: 44 }}
+                            onClick={() =>
+                              run(
+                                () => updatePublicContent({
+                                  itemId: item.id,
+                                  status: "DRAFT",
+                                }),
+                                "Post moved to draft.",
+                              )}
+                          >
+                            Move to draft
+                          </Button>
+                        ) : null}
+                        {item.status !== "ARCHIVED" ? (
+                          <Button
+                            size="small"
+                            color="error"
+                            disabled={pending}
+                            sx={{ minHeight: 44 }}
+                            onClick={() =>
+                              run(() => archivePublicContent(item.id), "Post archived.")}
+                          >
+                            Archive
+                          </Button>
+                        ) : null}
+                      </Stack>
                     </TableCell>
                   </TableRow>
                 ))}

--- a/components/features/association-profile/PublicAssociationProfile.tsx
+++ b/components/features/association-profile/PublicAssociationProfile.tsx
@@ -1,6 +1,7 @@
 import { Avatar, Box, Card, CardContent, Chip, Stack, Typography } from "@mui/material";
 
 import { LinkButton, LinkCardActionArea } from "@/components/ui/NextLinkComposites";
+import { contrastTextFor } from "@/lib/utils/contrast-color";
 import { formatSport } from "@/lib/utils/validation";
 
 /**
@@ -24,6 +25,8 @@ export interface PublicAssociationProfileProps {
     sport: string;
     publicDescription: string | null;
     logoUrl: string | null;
+    brandPrimaryColor: string | null;
+    brandSecondaryColor: string | null;
     publicEmail: string | null;
     publicPhone: string | null;
     divisions: Array<{ id: string; name: string; ageGroup: string | null }>;
@@ -51,7 +54,19 @@ export function PublicAssociationProfile({ association }: PublicAssociationProfi
 
   return (
     <Stack spacing={5}>
-      <Stack direction={{ xs: "column", sm: "row" }} spacing={3} alignItems="center">
+      <Stack
+        direction={{ xs: "column", sm: "row" }}
+        spacing={3}
+        alignItems="center"
+        sx={(theme) => ({
+          borderRadius: 3,
+          borderBottom: "6px solid",
+          borderBottomColor: association.brandSecondaryColor || "secondary.main",
+          bgcolor: association.brandPrimaryColor || "primary.main",
+          color: contrastTextFor(theme, association.brandPrimaryColor),
+          p: { xs: 3, md: 5 },
+        })}
+      >
         {association.logoUrl ? (
           <Avatar
             src={association.logoUrl}
@@ -64,7 +79,11 @@ export function PublicAssociationProfile({ association }: PublicAssociationProfi
           <Typography variant="h3" component="h1">
             {association.name}
           </Typography>
-          <Chip size="small" label={formatSport(association.sport)} sx={{ mt: 1 }} />
+          <Chip
+            size="small"
+            label={formatSport(association.sport)}
+            sx={{ mt: 1, bgcolor: "background.paper", color: "text.primary" }}
+          />
           {association.publicDescription ? (
             <Typography variant="body1" sx={{ mt: 2 }}>
               {association.publicDescription}
@@ -82,6 +101,9 @@ export function PublicAssociationProfile({ association }: PublicAssociationProfi
         </LinkButton>
         <LinkButton href={`${base}/events`} variant="outlined" sx={{ minHeight: 44 }}>
           Events &amp; registration
+        </LinkButton>
+        <LinkButton href={`${base}/news`} variant="outlined" sx={{ minHeight: 44 }}>
+          News
         </LinkButton>
         {/* Linked only while the wishlist is published. The token route is the
             existing hardened public surface; no inventory, donor, custodian, or

--- a/components/features/association-profile/PublicAssociationProfile.tsx
+++ b/components/features/association-profile/PublicAssociationProfile.tsx
@@ -1,0 +1,199 @@
+import { Avatar, Box, Card, CardContent, Chip, Stack, Typography } from "@mui/material";
+
+import { LinkButton, LinkCardActionArea } from "@/components/ui/NextLinkComposites";
+import { formatSport } from "@/lib/utils/validation";
+
+/**
+ * The public association landing page (feature 007 / User Story 4).
+ *
+ * SC-007 requires every published team, the public schedule, public signup
+ * events, public announcements, and an active public wishlist to be reachable
+ * from here in no more than three activations. Everything below is one
+ * activation away, which leaves two to spare for the pages themselves.
+ *
+ * A Server Component: all links go through the NextLinkComposites wrappers.
+ * `component={Link}` on a MUI element from an RSC compiles, type-checks, and
+ * passes tests, then crashes at runtime.
+ */
+
+export interface PublicAssociationProfileProps {
+  association: {
+    id: string;
+    name: string;
+    slug: string | null;
+    sport: string;
+    publicDescription: string | null;
+    logoUrl: string | null;
+    publicEmail: string | null;
+    publicPhone: string | null;
+    divisions: Array<{ id: string; name: string; ageGroup: string | null }>;
+    teams: Array<{
+      id: string;
+      name: string;
+      slug: string | null;
+      season: string;
+      division: { name: string; ageGroup: string | null } | null;
+    }>;
+    publicContentItems: Array<{
+      id: string;
+      slug: string;
+      title: string;
+      summary: string | null;
+      publishAt: Date | null;
+      team: { name: string; slug: string | null } | null;
+    }>;
+    gearWishlist: { shareToken: string; title: string } | null;
+  };
+}
+
+export function PublicAssociationProfile({ association }: PublicAssociationProfileProps) {
+  const base = `/associations/${association.slug}`;
+
+  return (
+    <Stack spacing={5}>
+      <Stack direction={{ xs: "column", sm: "row" }} spacing={3} alignItems="center">
+        {association.logoUrl ? (
+          <Avatar
+            src={association.logoUrl}
+            alt=""
+            sx={{ width: 96, height: 96 }}
+            variant="rounded"
+          />
+        ) : null}
+        <Box>
+          <Typography variant="h3" component="h1">
+            {association.name}
+          </Typography>
+          <Chip size="small" label={formatSport(association.sport)} sx={{ mt: 1 }} />
+          {association.publicDescription ? (
+            <Typography variant="body1" sx={{ mt: 2 }}>
+              {association.publicDescription}
+            </Typography>
+          ) : null}
+        </Box>
+      </Stack>
+
+      <Stack direction="row" spacing={2} flexWrap="wrap" useFlexGap>
+        <LinkButton href={`${base}/schedule`} variant="contained" sx={{ minHeight: 44 }}>
+          Schedule
+        </LinkButton>
+        <LinkButton href={`${base}/teams`} variant="outlined" sx={{ minHeight: 44 }}>
+          Teams
+        </LinkButton>
+        <LinkButton href={`${base}/events`} variant="outlined" sx={{ minHeight: 44 }}>
+          Events &amp; registration
+        </LinkButton>
+        {/* Linked only while the wishlist is published. The token route is the
+            existing hardened public surface; no inventory, donor, custodian, or
+            location data is read here to render this button. */}
+        {association.gearWishlist ? (
+          <LinkButton
+            href={`/gear-wishlist/${association.gearWishlist.shareToken}`}
+            variant="outlined"
+            sx={{ minHeight: 44 }}
+          >
+            {association.gearWishlist.title}
+          </LinkButton>
+        ) : null}
+      </Stack>
+
+      {association.teams.length > 0 ? (
+        <Box>
+          <Typography variant="h5" component="h2" gutterBottom>
+            Teams
+          </Typography>
+          <Box
+            sx={{
+              display: "grid",
+              gridTemplateColumns: { xs: "1fr", sm: "repeat(2, 1fr)", md: "repeat(3, 1fr)" },
+              gap: 2,
+            }}
+          >
+            {association.teams.map((team) => (
+              <Card key={team.id} variant="outlined">
+                <LinkCardActionArea href={`${base}/teams/${team.slug}`} sx={{ height: "100%" }}>
+                  <CardContent>
+                    <Typography variant="h6" component="h3">
+                      {team.name}
+                    </Typography>
+                    <Typography variant="body2" color="text.secondary">
+                      {team.division?.name ?? "No division"} · {team.season}
+                    </Typography>
+                  </CardContent>
+                </LinkCardActionArea>
+              </Card>
+            ))}
+          </Box>
+        </Box>
+      ) : null}
+
+      {association.publicContentItems.length > 0 ? (
+        <Box>
+          <Typography variant="h5" component="h2" gutterBottom>
+            News
+          </Typography>
+          <Stack spacing={2}>
+            {association.publicContentItems.map((item) => (
+              <Card key={item.id} variant="outlined">
+                <LinkCardActionArea href={`${base}/news/${item.slug}`}>
+                  <CardContent>
+                    <Typography variant="h6" component="h3">
+                      {item.title}
+                    </Typography>
+                    {item.summary ? (
+                      <Typography variant="body2" color="text.secondary">
+                        {item.summary}
+                      </Typography>
+                    ) : null}
+                    {item.team ? (
+                      <Chip size="small" label={item.team.name} sx={{ mt: 1 }} />
+                    ) : null}
+                  </CardContent>
+                </LinkCardActionArea>
+              </Card>
+            ))}
+          </Stack>
+        </Box>
+      ) : null}
+
+      {association.divisions.length > 0 ? (
+        <Box>
+          <Typography variant="h5" component="h2" gutterBottom>
+            Divisions
+          </Typography>
+          <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+            {association.divisions.map((division) => (
+              <Chip
+                key={division.id}
+                label={
+                  division.ageGroup ? `${division.name} · ${division.ageGroup}` : division.name
+                }
+              />
+            ))}
+          </Stack>
+        </Box>
+      ) : null}
+
+      {association.publicEmail || association.publicPhone ? (
+        <Box>
+          <Typography variant="h5" component="h2" gutterBottom>
+            Contact
+          </Typography>
+          {/* The association's *public* contact details, which an administrator
+              opts into. League.contactEmail / contactPhone are the private
+              administrative contact and are never selected for this page. */}
+          <Stack spacing={0.5}>
+            {association.publicEmail ? (
+              <Typography variant="body2">{association.publicEmail}</Typography>
+            ) : null}
+            {association.publicPhone ? (
+              <Typography variant="body2">{association.publicPhone}</Typography>
+            ) : null}
+          </Stack>
+        </Box>
+      ) : null}
+    </Stack>
+  );
+}
+
+export default PublicAssociationProfile;

--- a/components/features/dashboard/DashboardNav.tsx
+++ b/components/features/dashboard/DashboardNav.tsx
@@ -31,6 +31,7 @@ import {
   Inventory2 as GearIcon,
   EmojiEvents as LeagueIcon,
   Diversity3 as WorkforceIcon,
+  Article as NewsIcon,
   Assessment as OperationsIcon,
   EventAvailable as VenueReservationsIcon,
 } from "@mui/icons-material";
@@ -107,6 +108,7 @@ export default function DashboardNav({
         icon: <VenueReservationsIcon />,
       },
       { label: "Messages", path: `${leaguePrefix}/messages`, icon: <ForumIcon /> },
+      { label: "News", path: `${leaguePrefix}/content`, icon: <NewsIcon /> },
       { label: "Signup Events", path: "/signup-events", icon: <HowToRegIcon /> },
       // League-scoped venues; falls back to the global page without league context
       {

--- a/components/providers/LeagueProvider.tsx
+++ b/components/providers/LeagueProvider.tsx
@@ -59,11 +59,13 @@ const LEAGUE_SECTION_LABELS: Record<string, string> = {
   payments: 'Payments',
   gear: 'Gear',
   workforce: 'Workforce',
+  content: 'News',
 };
 
 // Well-known nested segments; unknown tails (ids) render as 'Details'.
 const SUBPAGE_LABELS: Record<string, string> = {
   new: 'New',
+  public: 'Public page',
   edit: 'Edit',
   'new-game': 'New Game',
   proposals: 'Proposals',

--- a/lib/actions/association-profile.ts
+++ b/lib/actions/association-profile.ts
@@ -247,15 +247,28 @@ export async function updateTeamPublicProfile(
     }
 
     if (validated.slug && validated.slug !== team.slug) {
-      const taken = await prisma.team.findFirst({
-        where: {
-          leagueId: validated.leagueId,
-          slug: validated.slug,
-          NOT: { id: validated.teamId },
-        },
-        select: { id: true },
-      });
-      if (taken) return { success: false, error: "Another team already uses that address." };
+      const [takenByTeam, takenByRedirect] = await Promise.all([
+        prisma.team.findFirst({
+          where: {
+            leagueId: validated.leagueId,
+            slug: validated.slug,
+            NOT: { id: validated.teamId },
+          },
+          select: { id: true },
+        }),
+        prisma.publicSlugRedirect.findFirst({
+          where: {
+            leagueId: validated.leagueId,
+            slug: validated.slug,
+            teamId: { not: null },
+            NOT: { teamId: validated.teamId },
+          },
+          select: { id: true },
+        }),
+      ]);
+      if (takenByTeam || takenByRedirect) {
+        return { success: false, error: "Another team already uses that address." };
+      }
     }
 
     await prisma.$transaction(async (tx) => {
@@ -292,7 +305,7 @@ export async function updateTeamPublicProfile(
           where: {
             leagueId: validated.leagueId,
             slug: validated.slug,
-            teamId: { not: null },
+            teamId: validated.teamId,
           },
         });
       }
@@ -321,11 +334,20 @@ export async function updateTeamPublicProfile(
  * page at a stale address, which keeps one URL per association for search
  * engines and for anybody copying the link out of the address bar.
  */
-export async function resolvePublicAssociation(
+type ResolvedAssociation = {
+  id: string;
+  canonicalSlug: string;
+  redirected: boolean;
+};
+
+async function resolveAssociationSlug(
   slug: string,
-): Promise<{ id: string; canonicalSlug: string; redirected: boolean } | null> {
+  requirePublishedProfile: boolean,
+): Promise<ResolvedAssociation | null> {
   const league = await prisma.league.findFirst({
-    where: { ...publicPublishedAssociationWhere, slug },
+    where: requirePublishedProfile
+      ? { ...publicPublishedAssociationWhere, slug }
+      : { isActive: true, slug },
     select: { id: true, slug: true },
   });
   if (league?.slug) {
@@ -342,12 +364,30 @@ export async function resolvePublicAssociation(
   if (
     redirect?.league?.slug &&
     redirect.league.isActive &&
-    redirect.league.profileStatus === "PUBLISHED"
+    (!requirePublishedProfile || redirect.league.profileStatus === "PUBLISHED")
   ) {
     return { id: redirect.league.id, canonicalSlug: redirect.league.slug, redirected: true };
   }
 
   return null;
+}
+
+export async function resolvePublicAssociation(
+  slug: string,
+): Promise<ResolvedAssociation | null> {
+  return resolveAssociationSlug(slug, true);
+}
+
+/**
+ * Resolve the public-events namespace, which predates association profiles.
+ * An active association may publish signup events while its profile is still a
+ * draft, so this resolver preserves retired event links without exposing the
+ * profile, team, news, or schedule surfaces.
+ */
+export async function resolveActiveAssociation(
+  slug: string,
+): Promise<ResolvedAssociation | null> {
+  return resolveAssociationSlug(slug, false);
 }
 
 export async function getPublicAssociationProfile(slug: string) {

--- a/lib/actions/association-profile.ts
+++ b/lib/actions/association-profile.ts
@@ -1,0 +1,410 @@
+"use server";
+
+import { z } from "zod";
+import { revalidatePath } from "next/cache";
+
+import { prisma } from "@/lib/db/prisma";
+import { requireUserId } from "@/lib/auth/session";
+import { Capability, hasCapability } from "@/lib/auth/capabilities";
+import { rethrowIfNextRedirectError } from "@/lib/utils/next-errors";
+import {
+  getPublicAssociationProfileSelect,
+  getPublicTeamProfileSelect,
+  publicPublishedAssociationWhere,
+  publicPublishedTeamWhere,
+  publicTeamSummarySelect,
+} from "@/lib/utils/public-associations";
+
+/**
+ * Public association and team profiles (feature 007 / User Story 4).
+ *
+ * Every mutation is gated on `hasCapability`, never on `requireLeagueRole`.
+ * That is deliberate: the gear domain shipped guarding on the legacy role and
+ * consequently ignored role grants entirely, which took a follow-up pass to
+ * unpick. New surfaces start grant-native.
+ */
+
+export type ActionResult<T> =
+  | { success: true; data: T }
+  | { success: false; error: string; details?: unknown };
+
+const cuid = z.string().cuid("Invalid ID format");
+
+/** URL-safe, lowercase, no leading/trailing or doubled separators. */
+const slugSchema = z
+  .string()
+  .min(3, "A slug needs at least 3 characters")
+  .max(60)
+  .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, "Use lowercase letters, numbers, and single hyphens");
+
+const profileSchema = z.object({
+  leagueId: cuid,
+  publicDescription: z.string().max(2000).nullable().optional(),
+  logoUrl: z.string().url().max(500).nullable().optional(),
+  brandPrimaryColor: z.string().regex(/^#[0-9a-fA-F]{6}$/).nullable().optional(),
+  brandSecondaryColor: z.string().regex(/^#[0-9a-fA-F]{6}$/).nullable().optional(),
+  publicEmail: z.string().email().max(255).nullable().optional(),
+  publicPhone: z.string().max(40).nullable().optional(),
+});
+
+async function canAdminister(userId: string, leagueId: string): Promise<boolean> {
+  return hasCapability({
+    userId,
+    leagueId,
+    capability: Capability.ADMINISTER_ASSOCIATION,
+  });
+}
+
+export async function updateAssociationProfile(
+  input: z.infer<typeof profileSchema>,
+): Promise<ActionResult<{ id: string }>> {
+  try {
+    const userId = await requireUserId();
+    const validated = profileSchema.parse(input);
+
+    if (!(await canAdminister(userId, validated.leagueId))) {
+      return { success: false, error: "You do not have permission to edit this profile." };
+    }
+
+    const { leagueId, ...fields } = validated;
+    await prisma.league.update({
+      where: { id: leagueId },
+      // Only fields the caller actually sent; omitted keys keep their values
+      // rather than being nulled by a partial form submit.
+      data: Object.fromEntries(
+        Object.entries(fields).filter(([, value]) => value !== undefined),
+      ),
+    });
+
+    revalidatePath(`/league/${leagueId}/settings/public`);
+    return { success: true, data: { id: leagueId } };
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return { success: false, error: "Invalid input.", details: error.issues };
+    }
+    rethrowIfNextRedirectError(error);
+    console.error("Error updating association profile:", error);
+    return { success: false, error: "Failed to save the profile." };
+  }
+}
+
+const slugInputSchema = z.object({ leagueId: cuid, slug: slugSchema });
+
+/**
+ * Rename an association's public slug, retiring the old one.
+ *
+ * The retirement is written in the same transaction that frees the slug, so a
+ * shared link never points at nothing — the window where neither the league
+ * nor a redirect answers for it does not exist.
+ */
+export async function updateAssociationSlug(
+  input: z.infer<typeof slugInputSchema>,
+): Promise<ActionResult<{ slug: string }>> {
+  try {
+    const userId = await requireUserId();
+    const validated = slugInputSchema.parse(input);
+
+    if (!(await canAdminister(userId, validated.leagueId))) {
+      return { success: false, error: "You do not have permission to change this address." };
+    }
+
+    const league = await prisma.league.findUnique({
+      where: { id: validated.leagueId },
+      select: { slug: true },
+    });
+    if (!league) return { success: false, error: "That association could not be found." };
+    if (league.slug === validated.slug) {
+      return { success: true, data: { slug: validated.slug } };
+    }
+
+    const [takenByLeague, takenByRedirect] = await Promise.all([
+      prisma.league.findFirst({
+        where: { slug: validated.slug, NOT: { id: validated.leagueId } },
+        select: { id: true },
+      }),
+      prisma.publicSlugRedirect.findFirst({
+        where: { slug: validated.slug, teamId: null, NOT: { leagueId: validated.leagueId } },
+        select: { id: true },
+      }),
+    ]);
+    // A retired slug is as taken as a live one: reusing it would silently
+    // hijack somebody else's old links.
+    if (takenByLeague || takenByRedirect) {
+      return { success: false, error: "That address is already in use." };
+    }
+
+    await prisma.$transaction(async (tx) => {
+      if (league.slug) {
+        await tx.publicSlugRedirect.upsert({
+          where: { id: `${validated.leagueId}:${league.slug}` },
+          create: {
+            id: `${validated.leagueId}:${league.slug}`,
+            slug: league.slug,
+            leagueId: validated.leagueId,
+          },
+          update: {},
+        });
+      }
+      await tx.league.update({
+        where: { id: validated.leagueId },
+        data: { slug: validated.slug },
+      });
+      // The association's own new slug must not stay retired, or it would
+      // redirect to itself forever.
+      await tx.publicSlugRedirect.deleteMany({
+        where: { slug: validated.slug, teamId: null },
+      });
+    });
+
+    revalidatePath(`/league/${validated.leagueId}/settings/public`);
+    return { success: true, data: { slug: validated.slug } };
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return { success: false, error: "Invalid input.", details: error.issues };
+    }
+    rethrowIfNextRedirectError(error);
+    console.error("Error updating association slug:", error);
+    return { success: false, error: "Failed to change the address." };
+  }
+}
+
+const publishSchema = z.object({ leagueId: cuid, publish: z.boolean() });
+
+export async function setAssociationProfilePublished(
+  input: z.infer<typeof publishSchema>,
+): Promise<ActionResult<{ status: string }>> {
+  try {
+    const userId = await requireUserId();
+    const validated = publishSchema.parse(input);
+
+    if (!(await canAdminister(userId, validated.leagueId))) {
+      return { success: false, error: "You do not have permission to publish this profile." };
+    }
+
+    const league = await prisma.league.findUnique({
+      where: { id: validated.leagueId },
+      select: { slug: true },
+    });
+    if (!league) return { success: false, error: "That association could not be found." };
+
+    // The database enforces this too; checking here turns a constraint error
+    // into an instruction the administrator can act on.
+    if (validated.publish && !league.slug) {
+      return {
+        success: false,
+        error: "Choose a public address before publishing.",
+      };
+    }
+
+    await prisma.league.update({
+      where: { id: validated.leagueId },
+      data: validated.publish
+        ? { profileStatus: "PUBLISHED", publishedAt: new Date() }
+        : { profileStatus: "UNPUBLISHED" },
+    });
+
+    revalidatePath(`/league/${validated.leagueId}/settings/public`);
+    return { success: true, data: { status: validated.publish ? "PUBLISHED" : "UNPUBLISHED" } };
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return { success: false, error: "Invalid input.", details: error.issues };
+    }
+    rethrowIfNextRedirectError(error);
+    console.error("Error publishing association profile:", error);
+    return { success: false, error: "Failed to change publication." };
+  }
+}
+
+const teamProfileSchema = z.object({
+  leagueId: cuid,
+  teamId: cuid,
+  slug: slugSchema.optional(),
+  publicDescription: z.string().max(2000).nullable().optional(),
+  logoUrl: z.string().url().max(500).nullable().optional(),
+  publish: z.boolean().optional(),
+});
+
+export async function updateTeamPublicProfile(
+  input: z.infer<typeof teamProfileSchema>,
+): Promise<ActionResult<{ id: string }>> {
+  try {
+    const userId = await requireUserId();
+    const validated = teamProfileSchema.parse(input);
+
+    if (!(await canAdminister(userId, validated.leagueId))) {
+      return { success: false, error: "You do not have permission to edit this team page." };
+    }
+
+    const team = await prisma.team.findFirst({
+      where: { id: validated.teamId, leagueId: validated.leagueId },
+      select: { id: true, slug: true },
+    });
+    if (!team) return { success: false, error: "That team could not be found." };
+
+    const nextSlug = validated.slug ?? team.slug;
+    if (validated.publish && !nextSlug) {
+      return { success: false, error: "Choose a public address before publishing." };
+    }
+
+    if (validated.slug && validated.slug !== team.slug) {
+      const taken = await prisma.team.findFirst({
+        where: {
+          leagueId: validated.leagueId,
+          slug: validated.slug,
+          NOT: { id: validated.teamId },
+        },
+        select: { id: true },
+      });
+      if (taken) return { success: false, error: "Another team already uses that address." };
+    }
+
+    await prisma.$transaction(async (tx) => {
+      if (validated.slug && team.slug && validated.slug !== team.slug) {
+        await tx.publicSlugRedirect.upsert({
+          where: { id: `${validated.teamId}:${team.slug}` },
+          create: {
+            id: `${validated.teamId}:${team.slug}`,
+            slug: team.slug,
+            leagueId: validated.leagueId,
+            teamId: validated.teamId,
+          },
+          update: {},
+        });
+      }
+
+      await tx.team.update({
+        where: { id: validated.teamId },
+        data: {
+          ...(validated.slug !== undefined ? { slug: validated.slug } : {}),
+          ...(validated.publicDescription !== undefined
+            ? { publicDescription: validated.publicDescription }
+            : {}),
+          ...(validated.logoUrl !== undefined ? { logoUrl: validated.logoUrl } : {}),
+          ...(validated.publish === true
+            ? { profileStatus: "PUBLISHED" as const, publishedAt: new Date() }
+            : {}),
+          ...(validated.publish === false ? { profileStatus: "UNPUBLISHED" as const } : {}),
+        },
+      });
+
+      if (validated.slug) {
+        await tx.publicSlugRedirect.deleteMany({
+          where: {
+            leagueId: validated.leagueId,
+            slug: validated.slug,
+            teamId: { not: null },
+          },
+        });
+      }
+    });
+
+    revalidatePath(`/league/${validated.leagueId}/settings/public`);
+    return { success: true, data: { id: validated.teamId } };
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return { success: false, error: "Invalid input.", details: error.issues };
+    }
+    rethrowIfNextRedirectError(error);
+    console.error("Error updating team public profile:", error);
+    return { success: false, error: "Failed to save the team page." };
+  }
+}
+
+/* ------------------------------------------------------------------------- */
+/* Public readers. No session, no capability — these serve anonymous visitors. */
+/* ------------------------------------------------------------------------- */
+
+/**
+ * Resolve a public association by slug, following one retirement hop.
+ *
+ * Returns the canonical slug so the caller can redirect rather than serve the
+ * page at a stale address, which keeps one URL per association for search
+ * engines and for anybody copying the link out of the address bar.
+ */
+export async function resolvePublicAssociation(
+  slug: string,
+): Promise<{ id: string; canonicalSlug: string; redirected: boolean } | null> {
+  const league = await prisma.league.findFirst({
+    where: { ...publicPublishedAssociationWhere, slug },
+    select: { id: true, slug: true },
+  });
+  if (league?.slug) {
+    return { id: league.id, canonicalSlug: league.slug, redirected: false };
+  }
+
+  const redirect = await prisma.publicSlugRedirect.findFirst({
+    where: { slug, teamId: null },
+    select: { league: { select: { id: true, slug: true, profileStatus: true, isActive: true } } },
+  });
+  // Redirects store the target id, so this always lands on whatever the
+  // association is called today — no chains to walk, and a second rename does
+  // not strand the first old link.
+  if (
+    redirect?.league?.slug &&
+    redirect.league.isActive &&
+    redirect.league.profileStatus === "PUBLISHED"
+  ) {
+    return { id: redirect.league.id, canonicalSlug: redirect.league.slug, redirected: true };
+  }
+
+  return null;
+}
+
+export async function getPublicAssociationProfile(slug: string) {
+  const resolved = await resolvePublicAssociation(slug);
+  if (!resolved) return null;
+
+  const now = new Date();
+  const association = await prisma.league.findFirst({
+    where: { ...publicPublishedAssociationWhere, id: resolved.id },
+    select: getPublicAssociationProfileSelect(now),
+  });
+  return association ? { ...association, canonicalSlug: resolved.canonicalSlug } : null;
+}
+
+export async function getPublicAssociationTeams(leagueId: string) {
+  return prisma.team.findMany({
+    where: { ...publicPublishedTeamWhere, leagueId },
+    select: publicTeamSummarySelect,
+    orderBy: { name: "asc" },
+  });
+}
+
+export async function resolvePublicTeam(
+  leagueId: string,
+  teamSlug: string,
+): Promise<{ id: string; canonicalSlug: string; redirected: boolean } | null> {
+  const team = await prisma.team.findFirst({
+    where: { ...publicPublishedTeamWhere, leagueId, slug: teamSlug },
+    select: { id: true, slug: true },
+  });
+  if (team?.slug) {
+    return { id: team.id, canonicalSlug: team.slug, redirected: false };
+  }
+
+  const redirect = await prisma.publicSlugRedirect.findFirst({
+    where: { leagueId, slug: teamSlug, teamId: { not: null } },
+    select: { team: { select: { id: true, slug: true, profileStatus: true, isActive: true } } },
+  });
+  if (
+    redirect?.team?.slug &&
+    redirect.team.isActive &&
+    redirect.team.profileStatus === "PUBLISHED"
+  ) {
+    return { id: redirect.team.id, canonicalSlug: redirect.team.slug, redirected: true };
+  }
+
+  return null;
+}
+
+export async function getPublicTeamProfile(leagueId: string, teamSlug: string) {
+  const resolved = await resolvePublicTeam(leagueId, teamSlug);
+  if (!resolved) return null;
+
+  const now = new Date();
+  const team = await prisma.team.findFirst({
+    where: { ...publicPublishedTeamWhere, id: resolved.id },
+    select: getPublicTeamProfileSelect(now),
+  });
+  return team ? { ...team, canonicalSlug: resolved.canonicalSlug } : null;
+}

--- a/lib/actions/public-content.ts
+++ b/lib/actions/public-content.ts
@@ -1,0 +1,294 @@
+"use server";
+
+import { z } from "zod";
+import { revalidatePath } from "next/cache";
+
+import { prisma } from "@/lib/db/prisma";
+import { requireUserId } from "@/lib/auth/session";
+import { Capability, hasCapability } from "@/lib/auth/capabilities";
+import { rethrowIfNextRedirectError } from "@/lib/utils/next-errors";
+import {
+  publicContentDetailSelect,
+  publicContentSelect,
+  publicContentWhere,
+  publicPublishedAssociationWhere,
+} from "@/lib/utils/public-associations";
+
+/**
+ * Association news and announcements (feature 007 / User Story 4).
+ *
+ * Publication is scheduled by *time*, not by a job: an item with a past
+ * `publishAt` reads as published. Nothing has to run at the appointed minute,
+ * which is what makes scheduled publication idempotent — and means a missed or
+ * doubled worker run cannot withhold or duplicate an announcement.
+ */
+
+/**
+ * Author-supplied text is stored as written, trimmed only.
+ *
+ * It is deliberately NOT HTML-escaped at rest: React escapes on render, so
+ * escaping here would store `&amp;` and display it literally. No other action
+ * in this codebase escapes display text at rest either — see the roster, gear,
+ * and volunteer actions.
+ */
+export type ActionResult<T> =
+  | { success: true; data: T }
+  | { success: false; error: string; details?: unknown };
+
+const cuid = z.string().cuid("Invalid ID format");
+
+const slugSchema = z
+  .string()
+  .min(3)
+  .max(80)
+  .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, "Use lowercase letters, numbers, and single hyphens");
+
+const createSchema = z.object({
+  leagueId: cuid,
+  teamId: cuid.optional(),
+  slug: slugSchema,
+  title: z.string().min(1, "A title is required").max(200),
+  summary: z.string().max(400).optional(),
+  body: z.string().min(1, "Some content is required").max(20000),
+  visibility: z.enum(["PUBLIC", "MEMBERS_ONLY"]).default("PUBLIC"),
+  /** Omitted publishes immediately; a future value schedules it. */
+  publishAt: z.coerce.date().optional(),
+});
+
+export type CreatePublicContentInput = z.input<typeof createSchema>;
+
+async function canPublish(userId: string, leagueId: string, teamId?: string) {
+  return hasCapability({
+    userId,
+    leagueId,
+    capability: Capability.MANAGE_PUBLIC_CONTENT,
+    teamId,
+  });
+}
+
+export async function createPublicContent(
+  input: CreatePublicContentInput,
+): Promise<ActionResult<{ id: string }>> {
+  try {
+    const userId = await requireUserId();
+    const validated = createSchema.parse(input);
+
+    if (!(await canPublish(userId, validated.leagueId, validated.teamId))) {
+      return { success: false, error: "You do not have permission to publish here." };
+    }
+
+    if (validated.teamId) {
+      const team = await prisma.team.findFirst({
+        where: { id: validated.teamId, leagueId: validated.leagueId },
+        select: { id: true },
+      });
+      if (!team) {
+        return { success: false, error: "That team does not belong to this association." };
+      }
+    }
+
+    const existing = await prisma.publicContentItem.findFirst({
+      where: { leagueId: validated.leagueId, slug: validated.slug },
+      select: { id: true },
+    });
+    if (existing) {
+      return { success: false, error: "That address is already used by another post." };
+    }
+
+    const now = new Date();
+    const publishAt = validated.publishAt ?? now;
+    // SCHEDULED and PUBLISHED are the same row with a different publishAt; the
+    // public reader gates on the timestamp, so the status is a label for
+    // administrators rather than a switch the reader consults.
+    const scheduled = publishAt > now;
+
+    const item = await prisma.publicContentItem.create({
+      data: {
+        leagueId: validated.leagueId,
+        teamId: validated.teamId ?? null,
+        slug: validated.slug,
+        title: validated.title.trim(),
+        summary: validated.summary ? validated.summary.trim() : null,
+        body: validated.body.trim(),
+        visibility: validated.visibility,
+        status: scheduled ? "SCHEDULED" : "PUBLISHED",
+        publishAt,
+        publishedAt: scheduled ? null : now,
+        authorId: userId,
+      },
+      select: { id: true },
+    });
+
+    revalidatePath(`/league/${validated.leagueId}/content`);
+    return { success: true, data: { id: item.id } };
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return { success: false, error: "Invalid input.", details: error.issues };
+    }
+    rethrowIfNextRedirectError(error);
+    console.error("Error creating public content:", error);
+    return { success: false, error: "Failed to save the post." };
+  }
+}
+
+const updateSchema = z.object({
+  itemId: cuid,
+  title: z.string().min(1).max(200).optional(),
+  summary: z.string().max(400).nullable().optional(),
+  body: z.string().min(1).max(20000).optional(),
+  visibility: z.enum(["PUBLIC", "MEMBERS_ONLY"]).optional(),
+  publishAt: z.coerce.date().optional(),
+});
+
+export async function updatePublicContent(
+  input: z.infer<typeof updateSchema>,
+): Promise<ActionResult<{ id: string }>> {
+  try {
+    const userId = await requireUserId();
+    const validated = updateSchema.parse(input);
+
+    const item = await prisma.publicContentItem.findUnique({
+      where: { id: validated.itemId },
+      select: { id: true, leagueId: true, teamId: true, status: true, publishedAt: true },
+    });
+    if (!item) return { success: false, error: "That post could not be found." };
+
+    if (!(await canPublish(userId, item.leagueId, item.teamId ?? undefined))) {
+      return { success: false, error: "You do not have permission to edit this post." };
+    }
+    if (item.status === "ARCHIVED") {
+      return { success: false, error: "Archived posts cannot be edited." };
+    }
+
+    const now = new Date();
+    const nextPublishAt = validated.publishAt;
+    const scheduled = nextPublishAt ? nextPublishAt > now : undefined;
+
+    await prisma.publicContentItem.update({
+      where: { id: item.id },
+      data: {
+        ...(validated.title !== undefined ? { title: validated.title.trim() } : {}),
+        ...(validated.summary !== undefined
+          ? { summary: validated.summary === null ? null : validated.summary.trim() }
+          : {}),
+        ...(validated.body !== undefined ? { body: validated.body.trim() } : {}),
+        ...(validated.visibility !== undefined ? { visibility: validated.visibility } : {}),
+        ...(nextPublishAt
+          ? {
+              publishAt: nextPublishAt,
+              status: scheduled ? ("SCHEDULED" as const) : ("PUBLISHED" as const),
+              // Keep the original publication moment when one exists; moving a
+              // published post's date forward should not rewrite its history.
+              publishedAt: scheduled ? null : (item.publishedAt ?? now),
+            }
+          : {}),
+      },
+    });
+
+    revalidatePath(`/league/${item.leagueId}/content`);
+    return { success: true, data: { id: item.id } };
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return { success: false, error: "Invalid input.", details: error.issues };
+    }
+    rethrowIfNextRedirectError(error);
+    console.error("Error updating public content:", error);
+    return { success: false, error: "Failed to save the post." };
+  }
+}
+
+export async function archivePublicContent(
+  itemId: string,
+): Promise<ActionResult<{ id: string }>> {
+  try {
+    const userId = await requireUserId();
+    const validated = cuid.parse(itemId);
+
+    const item = await prisma.publicContentItem.findUnique({
+      where: { id: validated },
+      select: { id: true, leagueId: true, teamId: true, status: true },
+    });
+    if (!item) return { success: false, error: "That post could not be found." };
+
+    if (!(await canPublish(userId, item.leagueId, item.teamId ?? undefined))) {
+      return { success: false, error: "You do not have permission to archive this post." };
+    }
+    if (item.status === "ARCHIVED") {
+      return { success: true, data: { id: item.id } };
+    }
+
+    await prisma.publicContentItem.update({
+      where: { id: item.id },
+      data: { status: "ARCHIVED", archivedAt: new Date() },
+    });
+
+    revalidatePath(`/league/${item.leagueId}/content`);
+    return { success: true, data: { id: item.id } };
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return { success: false, error: "Invalid post ID." };
+    }
+    rethrowIfNextRedirectError(error);
+    console.error("Error archiving public content:", error);
+    return { success: false, error: "Failed to archive the post." };
+  }
+}
+
+/** Administrator view: every item, including drafts and archived ones. */
+export async function listAssociationContent(leagueId: string) {
+  const userId = await requireUserId();
+  if (!(await canPublish(userId, leagueId))) {
+    return { success: false as const, error: "You do not have permission to view content." };
+  }
+
+  const items = await prisma.publicContentItem.findMany({
+    where: { leagueId },
+    select: {
+      id: true,
+      slug: true,
+      title: true,
+      status: true,
+      visibility: true,
+      publishAt: true,
+      archivedAt: true,
+      team: { select: { name: true } },
+    },
+    orderBy: [{ publishAt: "desc" }, { createdAt: "desc" }],
+  });
+
+  return { success: true as const, data: items };
+}
+
+/* ------------------------------------------------------------------------- */
+/* Public readers. No session — these serve anonymous visitors.               */
+/* ------------------------------------------------------------------------- */
+
+export async function listPublicAssociationContent(leagueId: string, limit = 20) {
+  return prisma.publicContentItem.findMany({
+    where: { leagueId, ...publicContentWhere(new Date()) },
+    select: publicContentSelect,
+    orderBy: { publishAt: "desc" },
+    take: limit,
+  });
+}
+
+/**
+ * One public news item, resolved by association slug so the route never has to
+ * trust a league id from the URL.
+ */
+export async function getPublicContentItem(associationSlug: string, contentSlug: string) {
+  const now = new Date();
+  const league = await prisma.league.findFirst({
+    where: { ...publicPublishedAssociationWhere, slug: associationSlug },
+    select: { id: true, name: true, slug: true },
+  });
+  if (!league) return null;
+
+  const item = await prisma.publicContentItem.findFirst({
+    where: { leagueId: league.id, slug: contentSlug, ...publicContentWhere(now) },
+    select: publicContentDetailSelect,
+  });
+  if (!item) return null;
+
+  return { item, association: league };
+}

--- a/lib/actions/public-content.ts
+++ b/lib/actions/public-content.ts
@@ -5,7 +5,13 @@ import { revalidatePath } from "next/cache";
 
 import { prisma } from "@/lib/db/prisma";
 import { requireUserId } from "@/lib/auth/session";
-import { Capability, hasCapability } from "@/lib/auth/capabilities";
+import {
+  Capability,
+  hasCapability,
+  loadActiveGrants,
+  ROLE_CAPABILITY_MATRIX,
+} from "@/lib/auth/capabilities";
+import { resolvePublicAssociation } from "@/lib/actions/association-profile";
 import { rethrowIfNextRedirectError } from "@/lib/utils/next-errors";
 import {
   publicContentDetailSelect,
@@ -47,10 +53,11 @@ const createSchema = z.object({
   leagueId: cuid,
   teamId: cuid.optional(),
   slug: slugSchema,
-  title: z.string().min(1, "A title is required").max(200),
-  summary: z.string().max(400).optional(),
-  body: z.string().min(1, "Some content is required").max(20000),
+  title: z.string().trim().min(1, "A title is required").max(200),
+  summary: z.string().trim().max(400).optional(),
+  body: z.string().trim().min(1, "Some content is required").max(20000),
   visibility: z.enum(["PUBLIC", "MEMBERS_ONLY"]).default("PUBLIC"),
+  status: z.enum(["DRAFT", "PUBLISHED"]).default("PUBLISHED"),
   /** Omitted publishes immediately; a future value schedules it. */
   publishAt: z.coerce.date().optional(),
 });
@@ -96,24 +103,25 @@ export async function createPublicContent(
     }
 
     const now = new Date();
-    const publishAt = validated.publishAt ?? now;
+    const draft = validated.status === "DRAFT";
+    const publishAt = validated.publishAt ?? (draft ? null : now);
     // SCHEDULED and PUBLISHED are the same row with a different publishAt; the
     // public reader gates on the timestamp, so the status is a label for
     // administrators rather than a switch the reader consults.
-    const scheduled = publishAt > now;
+    const scheduled = !draft && publishAt !== null && publishAt > now;
 
     const item = await prisma.publicContentItem.create({
       data: {
         leagueId: validated.leagueId,
         teamId: validated.teamId ?? null,
         slug: validated.slug,
-        title: validated.title.trim(),
-        summary: validated.summary ? validated.summary.trim() : null,
-        body: validated.body.trim(),
+        title: validated.title,
+        summary: validated.summary || null,
+        body: validated.body,
         visibility: validated.visibility,
-        status: scheduled ? "SCHEDULED" : "PUBLISHED",
+        status: draft ? "DRAFT" : scheduled ? "SCHEDULED" : "PUBLISHED",
         publishAt,
-        publishedAt: scheduled ? null : now,
+        publishedAt: draft || scheduled ? null : now,
         authorId: userId,
       },
       select: { id: true },
@@ -133,10 +141,11 @@ export async function createPublicContent(
 
 const updateSchema = z.object({
   itemId: cuid,
-  title: z.string().min(1).max(200).optional(),
-  summary: z.string().max(400).nullable().optional(),
-  body: z.string().min(1).max(20000).optional(),
+  title: z.string().trim().min(1).max(200).optional(),
+  summary: z.string().trim().max(400).nullable().optional(),
+  body: z.string().trim().min(1).max(20000).optional(),
   visibility: z.enum(["PUBLIC", "MEMBERS_ONLY"]).optional(),
+  status: z.enum(["DRAFT", "PUBLISHED"]).optional(),
   publishAt: z.coerce.date().optional(),
 });
 
@@ -149,7 +158,14 @@ export async function updatePublicContent(
 
     const item = await prisma.publicContentItem.findUnique({
       where: { id: validated.itemId },
-      select: { id: true, leagueId: true, teamId: true, status: true, publishedAt: true },
+      select: {
+        id: true,
+        leagueId: true,
+        teamId: true,
+        status: true,
+        publishAt: true,
+        publishedAt: true,
+      },
     });
     if (!item) return { success: false, error: "That post could not be found." };
 
@@ -159,21 +175,30 @@ export async function updatePublicContent(
     if (item.status === "ARCHIVED") {
       return { success: false, error: "Archived posts cannot be edited." };
     }
-
     const now = new Date();
-    const nextPublishAt = validated.publishAt;
-    const scheduled = nextPublishAt ? nextPublishAt > now : undefined;
+    const alreadyPublic =
+      item.status === "PUBLISHED"
+      || (
+        item.status === "SCHEDULED"
+        && item.publishAt !== null
+        && item.publishAt <= now
+      );
+    if (validated.status === "DRAFT" && alreadyPublic) {
+      return {
+        success: false,
+        error: "Published posts can be archived but cannot return to draft.",
+      };
+    }
 
-    await prisma.publicContentItem.update({
-      where: { id: item.id },
-      data: {
-        ...(validated.title !== undefined ? { title: validated.title.trim() } : {}),
-        ...(validated.summary !== undefined
-          ? { summary: validated.summary === null ? null : validated.summary.trim() }
-          : {}),
-        ...(validated.body !== undefined ? { body: validated.body.trim() } : {}),
-        ...(validated.visibility !== undefined ? { visibility: validated.visibility } : {}),
-        ...(nextPublishAt
+    const nextPublishAt =
+      validated.status === "PUBLISHED"
+        ? (validated.publishAt ?? item.publishAt ?? now)
+        : validated.publishAt;
+    const scheduled = nextPublishAt ? nextPublishAt > now : undefined;
+    const publication =
+      validated.status === "DRAFT"
+        ? { status: "DRAFT" as const, publishedAt: null }
+        : nextPublishAt
           ? {
               publishAt: nextPublishAt,
               status: scheduled ? ("SCHEDULED" as const) : ("PUBLISHED" as const),
@@ -181,7 +206,18 @@ export async function updatePublicContent(
               // published post's date forward should not rewrite its history.
               publishedAt: scheduled ? null : (item.publishedAt ?? now),
             }
+          : {};
+
+    await prisma.publicContentItem.update({
+      where: { id: item.id },
+      data: {
+        ...(validated.title !== undefined ? { title: validated.title } : {}),
+        ...(validated.summary !== undefined
+          ? { summary: validated.summary === null ? null : validated.summary }
           : {}),
+        ...(validated.body !== undefined ? { body: validated.body } : {}),
+        ...(validated.visibility !== undefined ? { visibility: validated.visibility } : {}),
+        ...publication,
       },
     });
 
@@ -234,15 +270,65 @@ export async function archivePublicContent(
   }
 }
 
-/** Administrator view: every item, including drafts and archived ones. */
+async function getContentManagementScope(userId: string, leagueId: string) {
+  const canPublishAssociationWide = await canPublish(userId, leagueId);
+  if (canPublishAssociationWide) {
+    const teams = await prisma.team.findMany({
+      where: { leagueId, isActive: true },
+      select: { id: true, name: true },
+      orderBy: { name: "asc" },
+    });
+    return { canPublishAssociationWide, teams };
+  }
+
+  const grants = await loadActiveGrants(userId, leagueId);
+  const teamIds = new Set<string>();
+  const divisionIds = new Set<string>();
+
+  for (const grant of grants) {
+    const role = ROLE_CAPABILITY_MATRIX[grant.role];
+    if (
+      !role.capabilities.includes(Capability.MANAGE_PUBLIC_CONTENT)
+      || !role.scopes.includes(grant.scopeType)
+    ) {
+      continue;
+    }
+    if (grant.scopeType === "TEAM" && grant.teamId) teamIds.add(grant.teamId);
+    if (grant.scopeType === "DIVISION" && grant.divisionId) {
+      divisionIds.add(grant.divisionId);
+    }
+  }
+
+  const targets = [
+    ...(teamIds.size ? [{ id: { in: [...teamIds] } }] : []),
+    ...(divisionIds.size ? [{ divisionId: { in: [...divisionIds] } }] : []),
+  ];
+  const teams = targets.length
+    ? await prisma.team.findMany({
+        where: { leagueId, isActive: true, OR: targets },
+        select: { id: true, name: true },
+        orderBy: { name: "asc" },
+      })
+    : [];
+
+  return { canPublishAssociationWide, teams };
+}
+
+/** Management view: every item covered by the caller's active grant scope. */
 export async function listAssociationContent(leagueId: string) {
   const userId = await requireUserId();
-  if (!(await canPublish(userId, leagueId))) {
+  const scope = await getContentManagementScope(userId, leagueId);
+  if (!scope.canPublishAssociationWide && scope.teams.length === 0) {
     return { success: false as const, error: "You do not have permission to view content." };
   }
 
   const items = await prisma.publicContentItem.findMany({
-    where: { leagueId },
+    where: {
+      leagueId,
+      ...(!scope.canPublishAssociationWide
+        ? { teamId: { in: scope.teams.map(({ id }) => id) } }
+        : {}),
+    },
     select: {
       id: true,
       slug: true,
@@ -256,20 +342,61 @@ export async function listAssociationContent(leagueId: string) {
     orderBy: [{ publishAt: "desc" }, { createdAt: "desc" }],
   });
 
-  return { success: true as const, data: items };
+  return {
+    success: true as const,
+    data: {
+      items,
+      teams: scope.teams,
+      canPublishAssociationWide: scope.canPublishAssociationWide,
+    },
+  };
 }
 
 /* ------------------------------------------------------------------------- */
 /* Public readers. No session — these serve anonymous visitors.               */
 /* ------------------------------------------------------------------------- */
 
-export async function listPublicAssociationContent(leagueId: string, limit = 20) {
+export async function listPublicAssociationContent(
+  leagueId: string,
+  limit = 20,
+  offset = 0,
+) {
   return prisma.publicContentItem.findMany({
     where: { leagueId, ...publicContentWhere(new Date()) },
     select: publicContentSelect,
     orderBy: { publishAt: "desc" },
-    take: limit,
+    take: Math.min(100, Math.max(1, Math.trunc(limit))),
+    skip: Math.max(0, Math.trunc(offset)),
   });
+}
+
+export async function listPublicAssociationContentPage(
+  leagueId: string,
+  page: number,
+  pageSize = 20,
+) {
+  const normalizedPage = Math.max(1, Math.trunc(page));
+  const normalizedPageSize = Math.min(100, Math.max(1, Math.trunc(pageSize)));
+  const where = { leagueId, ...publicContentWhere(new Date()) };
+  const totalItems = await prisma.publicContentItem.count({ where });
+  const totalPages = Math.max(1, Math.ceil(totalItems / normalizedPageSize));
+  const items =
+    normalizedPage > totalPages
+      ? []
+      : await prisma.publicContentItem.findMany({
+      where,
+      select: publicContentSelect,
+      orderBy: { publishAt: "desc" },
+      take: normalizedPageSize,
+      skip: (normalizedPage - 1) * normalizedPageSize,
+    });
+
+  return {
+    items,
+    page: normalizedPage,
+    totalItems,
+    totalPages,
+  };
 }
 
 /**
@@ -278,8 +405,11 @@ export async function listPublicAssociationContent(leagueId: string, limit = 20)
  */
 export async function getPublicContentItem(associationSlug: string, contentSlug: string) {
   const now = new Date();
+  const resolved = await resolvePublicAssociation(associationSlug);
+  if (!resolved) return null;
+
   const league = await prisma.league.findFirst({
-    where: { ...publicPublishedAssociationWhere, slug: associationSlug },
+    where: { ...publicPublishedAssociationWhere, id: resolved.id },
     select: { id: true, name: true, slug: true },
   });
   if (!league) return null;
@@ -290,5 +420,8 @@ export async function getPublicContentItem(associationSlug: string, contentSlug:
   });
   if (!item) return null;
 
-  return { item, association: league };
+  return {
+    item,
+    association: { ...league, slug: resolved.canonicalSlug },
+  };
 }

--- a/lib/data/schedule-items.ts
+++ b/lib/data/schedule-items.ts
@@ -245,6 +245,20 @@ export function getPublicAssociationScheduleItems(
   });
 }
 
+export async function getPublicTeamScheduleItems(
+  leagueId: string,
+  teamId: string,
+  window: ScheduleItemsWindow = {},
+) {
+  const items = await getPublicAssociationScheduleItems(leagueId, window);
+  return items.filter(
+    (item) =>
+      item.teamId === teamId
+      || item.homeTeam?.id === teamId
+      || item.awayTeam?.id === teamId,
+  );
+}
+
 /** Resolve the exact active venue resources a signed-in staff user may read. */
 export async function getUserVenueIds(userId: string): Promise<string[]> {
   const rows = await findMany<{

--- a/lib/data/schedule-items.ts
+++ b/lib/data/schedule-items.ts
@@ -926,7 +926,21 @@ async function readReservations(
     ? [
       ...(scope.leagueIds?.length
         ? [
-          { seasonGames: { some: { season: { leagueId: { in: scope.leagueIds, scheduleVisibility: "PUBLIC" } }, status: { in: ["SCHEDULED", "COMPLETED"] } } } },
+          // scheduleVisibility belongs to the season, not to the leagueId
+          // filter. Nested one level deeper it lands inside a StringFilter,
+          // which Prisma rejects at request time with "Unknown argument
+          // scheduleVisibility" — taking down the public schedule and the
+          // /api/associations/[slug]/schedule.ics feed for any association
+          // reaching this branch. Type-checking cannot catch it: the misplaced
+          // key is still a valid object literal.
+          {
+            seasonGames: {
+              some: {
+                season: { leagueId: { in: scope.leagueIds }, scheduleVisibility: "PUBLIC" },
+                status: { in: ["SCHEDULED", "COMPLETED"] },
+              },
+            },
+          },
           { signupEvents: { some: { hostLeagueId: { in: scope.leagueIds }, status: "PUBLISHED", visibility: "PUBLIC" } } },
         ]
         : []),

--- a/lib/utils/public-associations.ts
+++ b/lib/utils/public-associations.ts
@@ -1,0 +1,144 @@
+import type { Prisma } from "@prisma/client";
+
+/**
+ * Allowlist selectors for the public association and team pages
+ * (feature 007 / User Story 4).
+ *
+ * Everything here is an explicit `select`, never an `include` and never a bare
+ * model read. That is the whole privacy mechanism: a field reaches a public
+ * page only because somebody wrote it down in this file, so adding a column to
+ * `League`, `Team`, or `PublicContentItem` cannot leak it by default.
+ *
+ * Deliberately absent, and the reason each matters:
+ *  - contact rows and roster entries — participant and guardian PII;
+ *  - `contactEmail` / `contactPhone` on League — the *private* administrative
+ *    contact; the public page uses `publicEmail` / `publicPhone`, which an
+ *    administrator opts into separately;
+ *  - Stripe account and fee fields — merchant configuration;
+ *  - gear inventory, storage locations, custody, donors, and pledges — the
+ *    public surface links a published wishlist by token and nothing more;
+ *  - notification outbox state — operational data with recipient addresses in it.
+ *
+ * Mirrors lib/utils/public-venues.ts, which does the same job for rinks.
+ */
+
+/** A published, reachable association. */
+export const publicPublishedAssociationWhere = {
+  isActive: true,
+  profileStatus: "PUBLISHED",
+  slug: { not: null },
+} as const satisfies Prisma.LeagueWhereInput;
+
+/** A published, reachable team within one. */
+export const publicPublishedTeamWhere = {
+  isActive: true,
+  profileStatus: "PUBLISHED",
+  slug: { not: null },
+} as const satisfies Prisma.TeamWhereInput;
+
+export const publicAssociationSummarySelect = {
+  id: true,
+  name: true,
+  slug: true,
+  sport: true,
+  publicDescription: true,
+  logoUrl: true,
+  brandPrimaryColor: true,
+  brandSecondaryColor: true,
+} as const satisfies Prisma.LeagueSelect;
+
+export const publicTeamSummarySelect = {
+  id: true,
+  name: true,
+  slug: true,
+  sport: true,
+  season: true,
+  publicDescription: true,
+  logoUrl: true,
+  division: { select: { name: true, ageGroup: true } },
+} as const satisfies Prisma.TeamSelect;
+
+/**
+ * Content readable by an anonymous visitor at `now`.
+ *
+ * Scheduled publication is a time-gated read rather than a job: an item becomes
+ * visible because `publishAt` has passed, not because something ran at the
+ * appointed minute. That is what makes it idempotent — and it means a missed
+ * cron cannot silently withhold an announcement.
+ */
+export function publicContentWhere(now: Date) {
+  return {
+    visibility: "PUBLIC",
+    status: { in: ["PUBLISHED", "SCHEDULED"] },
+    publishAt: { lte: now },
+    archivedAt: null,
+  } as const satisfies Prisma.PublicContentItemWhereInput;
+}
+
+export const publicContentSelect = {
+  id: true,
+  slug: true,
+  title: true,
+  summary: true,
+  publishAt: true,
+  publishedAt: true,
+  // Author identity is deliberately omitted: a volunteer who posts a schedule
+  // change has not consented to having their name on a public page.
+  team: { select: { name: true, slug: true } },
+} as const satisfies Prisma.PublicContentItemSelect;
+
+/** The full item, for the single-news-item page. */
+export const publicContentDetailSelect = {
+  ...publicContentSelect,
+  body: true,
+} as const satisfies Prisma.PublicContentItemSelect;
+
+/**
+ * The association home, assembled in one query.
+ *
+ * `take` bounds are presentational, not security: the `where` clauses above are
+ * what make the result safe. Both are applied so a large association cannot
+ * turn its landing page into an unbounded read.
+ */
+export function getPublicAssociationProfileSelect(now: Date) {
+  return {
+    ...publicAssociationSummarySelect,
+    publicEmail: true,
+    publicPhone: true,
+    divisions: {
+      where: { isActive: true },
+      select: { id: true, name: true, ageGroup: true },
+      orderBy: { name: "asc" },
+    },
+    teams: {
+      where: publicPublishedTeamWhere,
+      select: publicTeamSummarySelect,
+      orderBy: { name: "asc" },
+    },
+    publicContentItems: {
+      where: publicContentWhere(now),
+      select: publicContentSelect,
+      orderBy: { publishAt: "desc" },
+      take: 10,
+    },
+    // Linked by token only, and only while published. The items, donors,
+    // pledges, and custodians are never selected here.
+    gearWishlist: {
+      where: { status: "PUBLISHED" },
+      select: { shareToken: true, title: true },
+    },
+  } as const satisfies Prisma.LeagueSelect;
+}
+
+export function getPublicTeamProfileSelect(now: Date) {
+  return {
+    ...publicTeamSummarySelect,
+    league: { select: publicAssociationSummarySelect },
+    publicContentItems: {
+      where: publicContentWhere(now),
+      select: publicContentSelect,
+      orderBy: { publishAt: "desc" },
+      take: 10,
+    },
+  } as const satisfies Prisma.TeamSelect;
+}

--- a/prisma/migrations/20260819043438_add_association_public_profiles/migration.sql
+++ b/prisma/migrations/20260819043438_add_association_public_profiles/migration.sql
@@ -1,0 +1,142 @@
+-- CreateEnum
+CREATE TYPE "PublicProfileStatus" AS ENUM ('DRAFT', 'PUBLISHED', 'UNPUBLISHED', 'ARCHIVED');
+
+-- CreateEnum
+CREATE TYPE "PublicContentStatus" AS ENUM ('DRAFT', 'SCHEDULED', 'PUBLISHED', 'ARCHIVED');
+
+-- CreateEnum
+CREATE TYPE "PublicContentVisibility" AS ENUM ('PUBLIC', 'MEMBERS_ONLY');
+
+-- AlterTable
+ALTER TABLE "Team" ADD COLUMN     "logoUrl" TEXT,
+ADD COLUMN     "profileStatus" "PublicProfileStatus" NOT NULL DEFAULT 'DRAFT',
+ADD COLUMN     "publicDescription" TEXT,
+ADD COLUMN     "publishedAt" TIMESTAMP(3),
+ADD COLUMN     "slug" TEXT;
+
+-- AlterTable
+ALTER TABLE "leagues" ADD COLUMN     "brandPrimaryColor" TEXT,
+ADD COLUMN     "brandSecondaryColor" TEXT,
+ADD COLUMN     "logoUrl" TEXT,
+ADD COLUMN     "profileStatus" "PublicProfileStatus" NOT NULL DEFAULT 'DRAFT',
+ADD COLUMN     "publicDescription" TEXT,
+ADD COLUMN     "publicEmail" TEXT,
+ADD COLUMN     "publicPhone" TEXT,
+ADD COLUMN     "publishedAt" TIMESTAMP(3);
+
+-- CreateTable
+CREATE TABLE "public_slug_redirects" (
+    "id" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "leagueId" TEXT NOT NULL,
+    "teamId" TEXT,
+
+    CONSTRAINT "public_slug_redirects_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public_content_items" (
+    "id" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "body" TEXT NOT NULL,
+    "summary" TEXT,
+    "status" "PublicContentStatus" NOT NULL DEFAULT 'DRAFT',
+    "visibility" "PublicContentVisibility" NOT NULL DEFAULT 'PUBLIC',
+    "publishAt" TIMESTAMP(3),
+    "publishedAt" TIMESTAMP(3),
+    "archivedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "leagueId" TEXT NOT NULL,
+    "teamId" TEXT,
+    "authorId" TEXT,
+
+    CONSTRAINT "public_content_items_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "public_slug_redirects_leagueId_idx" ON "public_slug_redirects"("leagueId");
+
+-- CreateIndex
+CREATE INDEX "public_content_items_leagueId_status_publishAt_idx" ON "public_content_items"("leagueId", "status", "publishAt");
+
+-- CreateIndex
+CREATE INDEX "public_content_items_leagueId_teamId_status_idx" ON "public_content_items"("leagueId", "teamId", "status");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "public_content_items_leagueId_slug_key" ON "public_content_items"("leagueId", "slug");
+
+-- AddForeignKey
+ALTER TABLE "public_slug_redirects" ADD CONSTRAINT "public_slug_redirects_leagueId_fkey" FOREIGN KEY ("leagueId") REFERENCES "leagues"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public_slug_redirects" ADD CONSTRAINT "public_slug_redirects_leagueId_teamId_fkey" FOREIGN KEY ("leagueId", "teamId") REFERENCES "Team"("leagueId", "id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public_content_items" ADD CONSTRAINT "public_content_items_leagueId_fkey" FOREIGN KEY ("leagueId") REFERENCES "leagues"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public_content_items" ADD CONSTRAINT "public_content_items_leagueId_teamId_fkey" FOREIGN KEY ("leagueId", "teamId") REFERENCES "Team"("leagueId", "id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public_content_items" ADD CONSTRAINT "public_content_items_authorId_fkey" FOREIGN KEY ("authorId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- ---------------------------------------------------------------------------
+-- Hand-authored invariants (feature 007 US4).
+-- ---------------------------------------------------------------------------
+
+-- A team slug is unique within its association, not globally: two associations
+-- may each have a "storm". Partial, because most teams have no slug and
+-- Postgres would otherwise treat every NULL as distinct anyway — being explicit
+-- keeps the intent readable.
+CREATE UNIQUE INDEX "teams_league_slug_key"
+  ON "Team" ("leagueId", "slug")
+  WHERE "slug" IS NOT NULL;
+
+-- Retired association slugs resolve globally, so they must not collide with
+-- each other. teamId IS NULL is what marks a row as an association slug.
+CREATE UNIQUE INDEX "public_slug_redirects_association_slug_key"
+  ON "public_slug_redirects" ("slug")
+  WHERE "teamId" IS NULL;
+
+-- Retired team slugs only need to be unambiguous within their association.
+CREATE UNIQUE INDEX "public_slug_redirects_team_slug_key"
+  ON "public_slug_redirects" ("leagueId", "slug")
+  WHERE "teamId" IS NOT NULL;
+
+-- A retired association slug must never shadow a live one, and vice versa.
+-- Enforced in the application when renaming (the old slug is inserted in the
+-- same transaction that frees it); this comment records why no constraint can
+-- express it — the two live in different tables.
+
+-- Publication timestamps agree with state.
+ALTER TABLE "leagues"
+  ADD CONSTRAINT "leagues_published_timestamp_check"
+  CHECK ("profileStatus" <> 'PUBLISHED' OR "publishedAt" IS NOT NULL);
+
+ALTER TABLE "Team"
+  ADD CONSTRAINT "teams_published_timestamp_check"
+  CHECK ("profileStatus" <> 'PUBLISHED' OR "publishedAt" IS NOT NULL);
+
+-- A published association profile needs a slug to be reachable at all.
+ALTER TABLE "leagues"
+  ADD CONSTRAINT "leagues_published_requires_slug_check"
+  CHECK ("profileStatus" <> 'PUBLISHED' OR "slug" IS NOT NULL);
+
+ALTER TABLE "Team"
+  ADD CONSTRAINT "teams_published_requires_slug_check"
+  CHECK ("profileStatus" <> 'PUBLISHED' OR "slug" IS NOT NULL);
+
+-- Content state agrees with its timestamps: SCHEDULED needs a future-facing
+-- publishAt, PUBLISHED needs publishedAt, ARCHIVED needs archivedAt.
+ALTER TABLE "public_content_items"
+  ADD CONSTRAINT "public_content_items_state_timestamp_check"
+  CHECK (
+    ("status" <> 'SCHEDULED' OR "publishAt" IS NOT NULL)
+    AND ("status" <> 'PUBLISHED' OR "publishedAt" IS NOT NULL)
+    AND ("status" <> 'ARCHIVED' OR "archivedAt" IS NOT NULL)
+  ),
+  ADD CONSTRAINT "public_content_items_slug_not_blank_check"
+    CHECK (length(btrim("slug")) > 0);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -98,6 +98,9 @@ model User {
   volunteerNeedsCreated        VolunteerNeed[]        @relation("VolunteerNeedCreator")
   volunteerAssignments         VolunteerAssignment[]  @relation("VolunteerAssignmentSubject")
   volunteerAssignmentsAssigned VolunteerAssignment[]  @relation("VolunteerAssignmentAssigner")
+
+  // Feature 007 US4 — public profiles and content.
+  publicContentItems  PublicContentItem[] @relation("PublicContentAuthor")
 }
 
 // Single-use, hashed account-lifecycle tokens (email verification, password
@@ -182,6 +185,13 @@ enum Sport {
 // Team model
 model Team {
   id        String   @id @default(cuid())
+  // Feature 007 US4 — publishable team profile. The slug is unique per
+  // association, not globally: two associations may both have a "storm".
+  slug              String?
+  publicDescription String?
+  logoUrl           String?
+  profileStatus     PublicProfileStatus @default(DRAFT)
+  publishedAt       DateTime?
   name      String
   sport     Sport    @default(HOCKEY)
   season    String
@@ -231,6 +241,10 @@ model Team {
   // Feature 007 US3 — scoped responsibilities and volunteers.
   associationRoleGrants AssociationRoleGrant[]
   volunteerNeeds        VolunteerNeed[]
+
+  // Feature 007 US4 — public profiles and content.
+  publicSlugRedirects PublicSlugRedirect[]
+  publicContentItems  PublicContentItem[]
   @@unique([leagueId, id])
   @@index([leagueId]) // Optimize league-team queries
   @@index([divisionId]) // Optimize division-team queries
@@ -560,8 +574,21 @@ model League {
   contactPhone String?
   isActive     Boolean @default(true)
   // Public URL slug for the association events page; generated when the league
-  // first publishes a PUBLIC signup event, editable by league admins.
+  // first publishes a PUBLIC signup event, editable by league admins. Also the
+  // slug for the public association home added in feature 007 US4 — there is
+  // deliberately only one.
   slug         String? @unique
+
+  // Feature 007 US4 — publishable association profile. Field names mirror
+  // Venue's so the two public profiles read the same way.
+  publicDescription   String?
+  logoUrl             String?
+  brandPrimaryColor   String?
+  brandSecondaryColor String?
+  publicEmail         String?
+  publicPhone         String?
+  profileStatus       PublicProfileStatus @default(DRAFT)
+  publishedAt         DateTime?
 
   // Stripe Connect (direct charges) — the league/association is the merchant of
   // record for its hosted signup events. Mirrors VenueOrganization.
@@ -616,6 +643,10 @@ model League {
   // Feature 007 US3 — scoped responsibilities and volunteers.
   associationRoleGrants     AssociationRoleGrant[]
   volunteerNeeds            VolunteerNeed[]
+
+  // Feature 007 US4 — public profiles and content.
+  publicSlugRedirects PublicSlugRedirect[]
+  publicContentItems  PublicContentItem[]
   @@map("leagues")
 }
 
@@ -3502,4 +3533,93 @@ model VolunteerAssignment {
   @@index([needId, status])
   @@index([userId, status])
   @@map("volunteer_assignments")
+}
+
+// ---------------------------------------------------------------------------
+// Feature 007 / User Story 4 — public association and team identity.
+//
+// League.slug already exists (minted when a league publishes its first PUBLIC
+// signup event) and stays the single association slug: adding a second would
+// give /associations/<slug>/events and the new pages divergent identities.
+// ---------------------------------------------------------------------------
+
+/// Publication state for association and team public profiles. Mirrors
+/// VenueProfileStatus rather than reusing it so the two can diverge.
+enum PublicProfileStatus {
+  DRAFT
+  PUBLISHED
+  UNPUBLISHED
+  ARCHIVED
+}
+
+enum PublicContentStatus {
+  DRAFT
+  SCHEDULED
+  PUBLISHED
+  ARCHIVED
+}
+
+/// Who may read a content item. MEMBERS_ONLY is never selected by the public
+/// readers; it exists so an association can post to its own people without a
+/// second system.
+enum PublicContentVisibility {
+  PUBLIC
+  MEMBERS_ONLY
+}
+
+/// A slug that used to point somewhere and must keep resolving.
+///
+/// The row stores the *id* of the current target, not its slug, so renames
+/// never build chains and a redirect always lands on whatever the target is
+/// called today. `teamId` null means the row is a retired association slug.
+model PublicSlugRedirect {
+  id        String   @id @default(cuid())
+  slug      String
+  createdAt DateTime @default(now())
+
+  leagueId String
+  league   League @relation(fields: [leagueId], references: [id], onDelete: Cascade)
+
+  teamId String?
+  team   Team?   @relation(fields: [leagueId, teamId], references: [leagueId, id], onDelete: Cascade)
+
+  // Association slugs are globally unique, team slugs unique within a league.
+  // Both are partial unique indexes in the migration, because Postgres treats
+  // NULL teamId values as distinct and a plain @@unique would not dedupe them.
+  @@index([leagueId])
+  @@map("public_slug_redirects")
+}
+
+/// An association or team news item / announcement.
+model PublicContentItem {
+  id          String                  @id @default(cuid())
+  slug        String
+  title       String
+  body        String
+  summary     String?
+  status      PublicContentStatus     @default(DRAFT)
+  visibility  PublicContentVisibility @default(PUBLIC)
+  /// When the item becomes readable. Publication is a time-gated read rather
+  /// than a scheduled job, which is what makes it idempotent: nothing has to
+  /// run at the appointed minute.
+  publishAt   DateTime?
+  publishedAt DateTime?
+  archivedAt  DateTime?
+  createdAt   DateTime                @default(now())
+  updatedAt   DateTime                @updatedAt
+
+  leagueId String
+  league   League @relation(fields: [leagueId], references: [id], onDelete: Cascade)
+
+  /// Set for a team news post; null for an association-wide one.
+  teamId String?
+  team   Team?   @relation(fields: [leagueId, teamId], references: [leagueId, id], onDelete: Cascade)
+
+  authorId String?
+  author   User?   @relation("PublicContentAuthor", fields: [authorId], references: [id], onDelete: SetNull)
+
+  @@unique([leagueId, slug])
+  @@index([leagueId, status, publishAt])
+  @@index([leagueId, teamId, status])
+  @@map("public_content_items")
 }

--- a/specs/007-association-operations/tasks.md
+++ b/specs/007-association-operations/tasks.md
@@ -158,24 +158,24 @@ description: "Dependency-ordered implementation backlog for association operatio
 
 ### Tests
 
-- [ ] T068 [P] [US4] Add association/team profile validation and slug redirect action tests to `__tests__/lib/actions/association-profile.test.ts`
-- [ ] T069 [P] [US4] Add content lifecycle and scheduled-publication tests to `__tests__/lib/actions/public-content.test.ts`
-- [ ] T070 [P] [US4] Add public association/team privacy tests including gear token, donor/custodian PII, location, inventory, and outbox exclusions to `__tests__/app/public-association-privacy.test.tsx` and `__tests__/app/public-team-privacy.test.tsx`
-- [ ] T071 [P] [US4] Add public association profile/wishlist tests and automated no-more-than-three-activation navigation coverage for every published team, schedule, signup event, announcement, and active wishlist in `__tests__/components/features/association-profile/PublicAssociationProfile.test.tsx` and `__tests__/app/public-association-navigation.test.tsx`
+- [x] T068 [P] [US4] Add association/team profile validation and slug redirect action tests to `__tests__/lib/actions/association-profile.test.ts`
+- [x] T069 [P] [US4] Add content lifecycle and scheduled-publication tests to `__tests__/lib/actions/public-content.test.ts`
+- [x] T070 [P] [US4] Add public association/team privacy tests including gear token, donor/custodian PII, location, inventory, and outbox exclusions to `__tests__/app/public-association-privacy.test.tsx` and `__tests__/app/public-team-privacy.test.tsx`
+- [x] T071 [P] [US4] Add public association profile/wishlist tests and automated no-more-than-three-activation navigation coverage for every published team, schedule, signup event, announcement, and active wishlist in `__tests__/components/features/association-profile/PublicAssociationProfile.test.tsx` and `__tests__/app/public-association-navigation.test.tsx`
 
 ### Implementation
 
-- [ ] T072 [US4] Add publishable League/Team profile fields, redirect models, `PublicContentItem`, and enums to `prisma/schema.prisma`
-- [ ] T073 [US4] Create public profile/content migration and uniqueness constraints, then regenerate Prisma before profile/content actions, in `prisma/migrations/<timestamp>_add_association_public_profiles/migration.sql` with `bun run db:generate`
-- [ ] T074 [US4] Implement profile update/publish/unpublish/slug actions with dedicated public selectors and a safe published-wishlist link derived through existing gear selectors in `lib/actions/association-profile.ts` and `lib/actions/gear-wishlist.ts`
-- [ ] T075 [US4] Implement content draft/schedule/publish/archive actions and safe selectors in `lib/actions/public-content.ts`
-- [ ] T076 [US4] Add association profile and content editors to `components/features/association-profile/AssociationProfileEditor.tsx` and `components/features/association-profile/ContentEditor.tsx`
-- [ ] T077 [US4] Add public association home with published gear-wishlist navigation and team directory routes in `app/(marketing)/associations/[slug]/page.tsx` and `app/(marketing)/associations/[slug]/teams/page.tsx`
-- [ ] T078 [US4] Add public team and news routes in `app/(marketing)/associations/[slug]/teams/[teamSlug]/page.tsx` and `app/(marketing)/associations/[slug]/news/[contentSlug]/page.tsx`
-- [ ] T079 [US4] Add canonical public association schedule in `app/(marketing)/associations/[slug]/schedule/page.tsx`
-- [ ] T080 [US4] Retain and integrate existing event rollup in `app/(marketing)/associations/[slug]/events/page.tsx`
-- [ ] T081 [US4] Add public profile/content management routes in `app/(dashboard)/league/[leagueId]/settings/public/page.tsx` and `app/(dashboard)/league/[leagueId]/content/page.tsx`
-- [ ] T082 [US4] Add published association/team/content discovery to `app/sitemap.ts`
+- [x] T072 [US4] Add publishable League/Team profile fields, redirect models, `PublicContentItem`, and enums to `prisma/schema.prisma`
+- [x] T073 [US4] Create public profile/content migration and uniqueness constraints, then regenerate Prisma before profile/content actions, in `prisma/migrations/<timestamp>_add_association_public_profiles/migration.sql` with `bun run db:generate`
+- [x] T074 [US4] Implement profile update/publish/unpublish/slug actions with dedicated public selectors and a safe published-wishlist link derived through existing gear selectors in `lib/actions/association-profile.ts` and `lib/actions/gear-wishlist.ts`
+- [x] T075 [US4] Implement content draft/schedule/publish/archive actions and safe selectors in `lib/actions/public-content.ts`
+- [x] T076 [US4] Add association profile and content editors to `components/features/association-profile/AssociationProfileEditor.tsx` and `components/features/association-profile/ContentEditor.tsx`
+- [x] T077 [US4] Add public association home with published gear-wishlist navigation and team directory routes in `app/(marketing)/associations/[slug]/page.tsx` and `app/(marketing)/associations/[slug]/teams/page.tsx`
+- [x] T078 [US4] Add public team and news routes in `app/(marketing)/associations/[slug]/teams/[teamSlug]/page.tsx` and `app/(marketing)/associations/[slug]/news/[contentSlug]/page.tsx`
+- [x] T079 [US4] Add canonical public association schedule in `app/(marketing)/associations/[slug]/schedule/page.tsx`
+- [x] T080 [US4] Retain and integrate existing event rollup in `app/(marketing)/associations/[slug]/events/page.tsx`
+- [x] T081 [US4] Add public profile/content management routes in `app/(dashboard)/league/[leagueId]/settings/public/page.tsx` and `app/(dashboard)/league/[leagueId]/content/page.tsx`
+- [x] T082 [US4] Add published association/team/content discovery to `app/sitemap.ts`
 
 **Checkpoint**: Families and partners have one public association source without private roster exposure.
 


### PR DESCRIPTION
Implements **Phase 6** of `specs/007-association-operations` — tasks **T068–T082** (15 tasks). Spec 007 is now **82/110**.

## What it adds

A public association home, team directory, team pages, news, and a canonical schedule — plus the dashboard surfaces to manage them.

| Route | |
|---|---|
| `/associations/[slug]` | Home: teams, news, divisions, public contact, wishlist link |
| `/associations/[slug]/teams` + `/[teamSlug]` | Directory and team pages |
| `/associations/[slug]/schedule` | Canonical schedule (ADR-0007 reader) |
| `/associations/[slug]/news/[contentSlug]` | Announcements |
| `/associations/[slug]/events` | Existing rollup, now sharing slug resolution |
| `/league/[id]/settings/public`, `/league/[id]/content` | Management |

## Privacy is structural, not incidental

`lib/utils/public-associations.ts` is an allowlist of explicit `select` objects — never an `include`, never a bare model read. A field reaches a public page only because somebody wrote it down there, so **adding a column cannot leak it by default**.

Absent by construction: the private administrative contact (`League.contactEmail`; the page uses `publicEmail`, which an admin opts into), Stripe configuration, rosters and invitations, gear inventory/custody/donors, the notification outbox, and **the content author** — a volunteer posting a schedule change has not consented to a byline.

## Design notes

**Scheduled publication is a time-gated read, not a job.** An item with a past `publishAt` reads as published. Nothing runs at the appointed minute, which is what makes it idempotent — and a missed worker cannot withhold an announcement.

**Renames never strand a link.** The old slug is retired in the same transaction that frees it, so there is no window where neither answers. Redirects store the *target id*, not a slug, so renames build no chains and an old link always lands on the current name. A retired slug is as taken as a live one, or reusing it would hijack someone else's links.

**New actions guard on `hasCapability` from the first line.** The gear domain shipped guarding on the legacy league role and so ignored role grants entirely, which took a follow-up pass to unpick (#345). This starts grant-native.

## A pre-existing production bug, found and fixed

In `lib/data/schedule-items.ts` the public reservations reader nested `scheduleVisibility` **inside** the `leagueId` filter instead of beside it:

```ts
// before — lands inside a StringFilter
{ season: { leagueId: { in: ids, scheduleVisibility: "PUBLIC" } } }
```

Prisma rejects that at request time, which was **500ing the existing `/api/associations/[slug]/schedule.ics` feed** for any association reaching that branch. Type-checking cannot catch it — the misplaced key is still a valid object literal — and no test exercised the path. Both the ICS feed and the new schedule page now return 200.

## Verification

Beyond the unit tests, every public route was fetched **unauthenticated** against a seeded database and checked for required public strings *and* forbidden private ones:

```
/associations/metro-hockey                    HTTP 200  no leaks
/associations/metro-hockey/teams              HTTP 200  no leaks
/associations/metro-hockey/teams/metro-blades HTTP 200  no leaks
/associations/metro-hockey/schedule           HTTP 200  no leaks
/associations/metro-hockey/events             HTTP 200  no leaks
/associations/metro-hockey/news/season-opens  HTTP 200  no leaks
old-metro -> 307 -> /associations/metro-hockey
```

Forbidden set: private contact email, player names, user emails, gear storage locations, a `MEMBERS_ONLY` post, and a scheduled-but-not-yet-live post. **Zero leaks.** That sweep is also the only gate that catches a `component={Link}` RSC crash, which is invisible to build, tsc, and the suite.

The migration's **14 constraints were exercised individually against Postgres**, accepted or rejected per case — publication timestamps, published-requires-slug, per-league team slug uniqueness, association vs team redirect uniqueness, and content state/timestamp agreement.

| Gate | Result |
|---|---|
| type-check / lint / raw-SQL | pass (866 files scanned) |
| tests | **2787 passing**, 5 skipped (2720 before) |
| build | pass; all 7 public routes registered |
| `adr check` | 6 governing, 0 errors |

## Notes

- **No new ADR.** This implements within ADR-0007 (the schedule page consumes the canonical reservation-backed reader rather than re-deriving occupancy) and ADR-0009.
- The **sitemap** now enumerates published surfaces — bounded, published-only, failing soft — and revalidates hourly rather than baking a build-time snapshot that would freeze whatever state the build database was in.
- `COMMUNICATIONS_LEAD` still is not offered in the invite UI: it now has a functioning capability (public content) but not messaging, which is Phase 7. Adding it there is a one-line change once Phase 7 lands.