### PR TITLE
chore(deps): update adrkit to 0.12.0

### DIFF
--- a/.github/copilot-cloud-agent-mcp.md
+++ b/.github/copilot-cloud-agent-mcp.md
@@ -33,7 +33,7 @@ unauthenticated, so there is nothing to add under `COPILOT_MCP_*`.
     "adrkit": {
       "type": "local",
       "command": "npx",
-      "args": ["-y", "@adrkit/mcp@0.11.0", "--dir", "docs/adr"],
+      "args": ["-y", "@adrkit/mcp@0.12.0", "--dir", "docs/adr"],
       "tools": [
         "get_decision",
         "get_decision_context",
@@ -86,7 +86,7 @@ This gap closes only if the agent runner gains a dependable pre-install step
 (`copilot-setup-steps.yml` installing Bun and running `bun install`), at which
 point this entry can move to the local binary like the other two.
 
-**Pinned to `@0.11.0`.** Matches the `@adrkit/cli` and `@adrkit/mcp` pins in
+**Pinned to `@0.12.0`.** Matches the `@adrkit/cli` and `@adrkit/mcp` pins in
 `package.json` and the commit-pinned CI action, per
 [ADR-0001](../docs/adr/0001-record-architecture-decisions-as-versioned-markdown-in-git.md).
 An agent given a floating `@latest` would silently change behaviour on an

--- a/.github/workflows/adr.yml
+++ b/.github/workflows/adr.yml
@@ -90,10 +90,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
-      # Pinned to the immutable v0.11.0 commit rather than the moving @v0 tag,
+      # Pinned to the immutable v0.12.0 commit rather than the moving @v0 tag,
       # matching the ADR-0001 decision to pin adrkit exactly.
       - name: Resolve decisions governing this pull request
-        uses: mbeacom/adrkit/packages/ci@9a4bdf89680b1a5b358fba0f2c8c88b9f5ac7877 # v0.11.0
+        uses: mbeacom/adrkit/packages/ci@2f19524f07938f1a7841b9f58bbcd1313e60a4dc # v0.12.0
         env:
           # Inert as pinned, and safe to delete. Through v0.6.0 the action
           # recognised its own comment only when the resolved token equalled

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -503,7 +503,7 @@ describe('Feature Name', () => {
 
 Architectural decisions are recorded as machine-readable ADRs in `docs/adr/`,
 managed by [adrkit](https://github.com/mbeacom/adrkit) (`@adrkit/cli`, pinned to
-0.11.0). See [ADR-0001](./docs/adr/0001-record-architecture-decisions-as-versioned-markdown-in-git.md)
+0.12.0). See [ADR-0001](./docs/adr/0001-record-architecture-decisions-as-versioned-markdown-in-git.md)
 for why.
 
 `CLAUDE.md` describes *how to work here*; ADRs record *why the conventions are

--- a/bun.lock
+++ b/bun.lock
@@ -37,8 +37,8 @@
         "zod": "^4.4.3",
       },
       "devDependencies": {
-        "@adrkit/cli": "0.11.0",
-        "@adrkit/mcp": "0.11.0",
+        "@adrkit/cli": "0.12.0",
+        "@adrkit/mcp": "0.12.0",
         "@eslint/eslintrc": "^3.3.6",
         "@tailwindcss/postcss": "^4.3.3",
         "@testing-library/jest-dom": "^6.10.0",
@@ -70,13 +70,13 @@
   "packages": {
     "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
 
-    "@adrkit/cli": ["@adrkit/cli@0.11.0", "", { "dependencies": { "@adrkit/core": "0.11.0", "@adrkit/evaluator": "0.11.0" }, "bin": { "adr": "dist/index.js", "adrkit": "dist/index.js" } }, "sha512-u0ko+cTT9ZBXWM54fo0FSUnr+Ft8LpC6hY0M1ikNLoVEsSJr3ZnHrgtjocYpVBPuK9Qbf58HJD78eAxtiWMnhg=="],
+    "@adrkit/cli": ["@adrkit/cli@0.12.0", "", { "dependencies": { "@adrkit/core": "0.12.0", "@adrkit/evaluator": "0.12.0" }, "bin": { "adr": "dist/index.js", "adrkit": "dist/index.js" } }, "sha512-HY1hl7l+747hcgW9GaPVeorp/3XV1Q4p43IPUaA6gMPOuPotuGdz3ynYSYJKJdaSxlmfHeGs2sb54nh4o1cZPQ=="],
 
-    "@adrkit/core": ["@adrkit/core@0.11.0", "", { "dependencies": { "picomatch": "^4", "semver": "^7", "yaml": "latest", "zod": "^4" } }, "sha512-N1gUt0/RnEl+ps3l8GvHMk2HuwLJW0Z9wXttB/mLSeP4Qa85KQPuYyQN5ULJh52HGH26RZhx5unyWxPpgYU1Vg=="],
+    "@adrkit/core": ["@adrkit/core@0.12.0", "", { "dependencies": { "picomatch": "^4", "semver": "^7", "yaml": "latest", "zod": "^4" } }, "sha512-0Prees6OTNo8Q95NuW+0bAVyaegA++hUMd5S4XiWltI+F4qLFBvtkNsFd+hHX9gt/oj/8bKYuhKCUvtHuTOU7Q=="],
 
-    "@adrkit/evaluator": ["@adrkit/evaluator@0.11.0", "", { "dependencies": { "@adrkit/core": "0.11.0", "jsonpath-rfc9535": "1.3.0" } }, "sha512-g2zugZFogKh15l8vMdos37BZ5OSDq0VasrtbfKAlkYgURrESPo+G8KL44hs7LQQaWgxYI4H8XoIFERBz3h55ZQ=="],
+    "@adrkit/evaluator": ["@adrkit/evaluator@0.12.0", "", { "dependencies": { "@adrkit/core": "0.12.0", "jsonpath-rfc9535": "1.3.0" } }, "sha512-6AC/idkcA6bcaxF+PVs/HaqaOAFClgu6cDD66/Yxk6McdtENFg8UUiRNmfB8Tp2B1QfA5lQqsD1VTn0uFX1clg=="],
 
-    "@adrkit/mcp": ["@adrkit/mcp@0.11.0", "", { "dependencies": { "@adrkit/core": "0.11.0", "@modelcontextprotocol/server": "2.0.0", "zod": "^4.2.0" }, "bin": { "adrkit-mcp": "dist/bin.js" } }, "sha512-dGCqNhKpQTDG8dF1FtNXEQAGtk4uMjjvsug/PexoJExqEUqllu/tzFjSWvVSQ1smVLZzo+qMCokkvf3jdBI/NQ=="],
+    "@adrkit/mcp": ["@adrkit/mcp@0.12.0", "", { "dependencies": { "@adrkit/core": "0.12.0", "@modelcontextprotocol/server": "2.0.0", "zod": "^4.2.0" }, "bin": { "adrkit-mcp": "dist/bin.js" } }, "sha512-+7cyLPcBUMiDzSRIfNvBogkNOzRh9SJLaGYbvJFr14PB/qEiFXvSN2Uucuv4Pr/ZJXJhQPUMHnU/MzFWK0Gbag=="],
 
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 

--- a/package.json
+++ b/package.json
@@ -78,8 +78,8 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@adrkit/cli": "0.11.0",
-    "@adrkit/mcp": "0.11.0",
+    "@adrkit/cli": "0.12.0",
+    "@adrkit/mcp": "0.12.0",
     "@eslint/eslintrc": "^3.3.6",
     "@tailwindcss/postcss": "^4.3.3",
     "@testing-library/jest-dom": "^6.10.0",


### PR DESCRIPTION
adrkit 0.12.0 is now published, so OpenLeague's exact dependency and CI pins need to advance together to prevent integrity drift.

- Updates `@adrkit/cli` and `@adrkit/mcp` to 0.12.0 with refreshed lockfile integrity hashes.
- Advances the commit-pinned adrkit CI action to the v0.12.0 release commit.
- Synchronizes the tracked documentation and cloud-agent MCP example with the repository setting that was updated separately.