### PR TITLE
chore(deps): update adrkit to 0.13.0

### DIFF
--- a/.github/copilot-cloud-agent-mcp.md
+++ b/.github/copilot-cloud-agent-mcp.md
@@ -33,7 +33,7 @@ unauthenticated, so there is nothing to add under `COPILOT_MCP_*`.
     "adrkit": {
       "type": "local",
       "command": "npx",
-      "args": ["-y", "@adrkit/mcp@0.12.0", "--dir", "docs/adr"],
+      "args": ["-y", "@adrkit/mcp@0.13.0", "--dir", "docs/adr"],
       "tools": [
         "get_decision",
         "get_decision_context",
@@ -86,7 +86,7 @@ This gap closes only if the agent runner gains a dependable pre-install step
 (`copilot-setup-steps.yml` installing Bun and running `bun install`), at which
 point this entry can move to the local binary like the other two.
 
-**Pinned to `@0.12.0`.** Matches the `@adrkit/cli` and `@adrkit/mcp` pins in
+**Pinned to `@0.13.0`.** Matches the `@adrkit/cli` and `@adrkit/mcp` pins in
 `package.json` and the commit-pinned CI action, per
 [ADR-0001](../docs/adr/0001-record-architecture-decisions-as-versioned-markdown-in-git.md).
 An agent given a floating `@latest` would silently change behaviour on an

--- a/.github/workflows/adr.yml
+++ b/.github/workflows/adr.yml
@@ -90,10 +90,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
-      # Pinned to the immutable v0.12.0 commit rather than the moving @v0 tag,
-      # matching the ADR-0001 decision to pin adrkit exactly.
+      # The root Marketplace surface is pinned to the immutable v0.13.0 release
+      # commit rather than the moving @v0 tag, matching ADR-0001's exact pin.
       - name: Resolve decisions governing this pull request
-        uses: mbeacom/adrkit/packages/ci@2f19524f07938f1a7841b9f58bbcd1313e60a4dc # v0.12.0
+        uses: mbeacom/adrkit@3e40675ed6f513d9712b1dccaa68034d649d1eb9 # v0.13.0
         env:
           # Inert as pinned, and safe to delete. Through v0.6.0 the action
           # recognised its own comment only when the resolved token equalled

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -503,7 +503,7 @@ describe('Feature Name', () => {
 
 Architectural decisions are recorded as machine-readable ADRs in `docs/adr/`,
 managed by [adrkit](https://github.com/mbeacom/adrkit) (`@adrkit/cli`, pinned to
-0.12.0). See [ADR-0001](./docs/adr/0001-record-architecture-decisions-as-versioned-markdown-in-git.md)
+0.13.0). See [ADR-0001](./docs/adr/0001-record-architecture-decisions-as-versioned-markdown-in-git.md)
 for why.
 
 `CLAUDE.md` describes *how to work here*; ADRs record *why the conventions are

--- a/__tests__/scripts/check-adr-integrity.test.ts
+++ b/__tests__/scripts/check-adr-integrity.test.ts
@@ -31,6 +31,7 @@ interface FixtureOptions {
   cliVersion?: string;
   /** devDependencies pin for `@adrkit/mcp`; null omits it entirely. */
   mcpVersion?: string | null;
+  ciActionPath?: string;
   ciActionVersion?: string;
   cloudDocVersion?: string;
   /** Raw contents for the two local MCP configs. */
@@ -48,6 +49,7 @@ const LOCAL_MCP_JSON = JSON.stringify({
 /** Build a throwaway repo root that the checks can run against. */
 function makeFixture(options: FixtureOptions = {}): string {
   const {
+    ciActionPath = '',
     ciActionVersion = ADRKIT_VERSION,
     cliVersion = ADRKIT_VERSION,
     cloudDocVersion = ADRKIT_VERSION,
@@ -93,7 +95,7 @@ function makeFixture(options: FixtureOptions = {}): string {
   );
   write(
     '.github/workflows/adr.yml',
-    `jobs:\n  x:\n    steps:\n      - uses: mbeacom/adrkit/packages/ci@${CI_ACTION_SHA} # v${ciActionVersion}\n`,
+    `jobs:\n  x:\n    steps:\n      - uses: mbeacom/adrkit${ciActionPath}@${CI_ACTION_SHA} # v${ciActionVersion}\n`,
   );
 
   return root;
@@ -221,7 +223,15 @@ describe('check-adr-integrity', () => {
     it('fails when the CI action pin drifts from the CLI pin', () => {
       withFixture({ ciActionVersion: '0.3.9' }, (result) => {
         expect(result.failures.join('\n')).toContain(
-          '.github/workflows/adr.yml pins the pinned CI action at 0.3.9',
+          '.github/workflows/adr.yml pins the root Marketplace CI action at 0.3.9',
+        );
+      });
+    });
+
+    it('fails when the CI action uses the legacy nested surface', () => {
+      withFixture({ ciActionPath: '/packages/ci' }, (result) => {
+        expect(result.failures.join('\n')).toContain(
+          'does not pin the root Marketplace CI action',
         );
       });
     });

--- a/bun.lock
+++ b/bun.lock
@@ -37,8 +37,8 @@
         "zod": "^4.4.3",
       },
       "devDependencies": {
-        "@adrkit/cli": "0.12.0",
-        "@adrkit/mcp": "0.12.0",
+        "@adrkit/cli": "0.13.0",
+        "@adrkit/mcp": "0.13.0",
         "@eslint/eslintrc": "^3.3.6",
         "@tailwindcss/postcss": "^4.3.3",
         "@testing-library/jest-dom": "^6.10.0",
@@ -70,13 +70,13 @@
   "packages": {
     "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
 
-    "@adrkit/cli": ["@adrkit/cli@0.12.0", "", { "dependencies": { "@adrkit/core": "0.12.0", "@adrkit/evaluator": "0.12.0" }, "bin": { "adr": "dist/index.js", "adrkit": "dist/index.js" } }, "sha512-HY1hl7l+747hcgW9GaPVeorp/3XV1Q4p43IPUaA6gMPOuPotuGdz3ynYSYJKJdaSxlmfHeGs2sb54nh4o1cZPQ=="],
+    "@adrkit/cli": ["@adrkit/cli@0.13.0", "", { "dependencies": { "@adrkit/core": "0.13.0", "@adrkit/evaluator": "0.13.0" }, "bin": { "adr": "dist/index.js", "adrkit": "dist/index.js" } }, "sha512-MELghkeb6JfB9R96lf9oZXPIhxEGzLIJfaZD95redNPxVgNocjzSK3cIE0FBkFSEWv4SP/m5FmMXOUnyICS5BQ=="],
 
-    "@adrkit/core": ["@adrkit/core@0.12.0", "", { "dependencies": { "picomatch": "^4", "semver": "^7", "yaml": "latest", "zod": "^4" } }, "sha512-0Prees6OTNo8Q95NuW+0bAVyaegA++hUMd5S4XiWltI+F4qLFBvtkNsFd+hHX9gt/oj/8bKYuhKCUvtHuTOU7Q=="],
+    "@adrkit/core": ["@adrkit/core@0.13.0", "", { "dependencies": { "picomatch": "^4", "semver": "^7", "yaml": "latest", "zod": "^4" } }, "sha512-57OM0rBTa9mvjNra9xfJxSswDRYmuUnac2vdbH2yM6OfNHkqfZprWuEfS/1ZaUf4ZLEBBz1lkTLkuroIDgymDw=="],
 
-    "@adrkit/evaluator": ["@adrkit/evaluator@0.12.0", "", { "dependencies": { "@adrkit/core": "0.12.0", "jsonpath-rfc9535": "1.3.0" } }, "sha512-6AC/idkcA6bcaxF+PVs/HaqaOAFClgu6cDD66/Yxk6McdtENFg8UUiRNmfB8Tp2B1QfA5lQqsD1VTn0uFX1clg=="],
+    "@adrkit/evaluator": ["@adrkit/evaluator@0.13.0", "", { "dependencies": { "@adrkit/core": "0.13.0", "jsonpath-rfc9535": "1.3.0" } }, "sha512-lfnZb4R1YakAYr/8XwbKhpap/oJABiZ6wbvdezWsEbwhIGiY/Ha/tXHIfWVJT+Nf9E4nz0+1+Nip2Ue+pjSxOg=="],
 
-    "@adrkit/mcp": ["@adrkit/mcp@0.12.0", "", { "dependencies": { "@adrkit/core": "0.12.0", "@modelcontextprotocol/server": "2.0.0", "zod": "^4.2.0" }, "bin": { "adrkit-mcp": "dist/bin.js" } }, "sha512-+7cyLPcBUMiDzSRIfNvBogkNOzRh9SJLaGYbvJFr14PB/qEiFXvSN2Uucuv4Pr/ZJXJhQPUMHnU/MzFWK0Gbag=="],
+    "@adrkit/mcp": ["@adrkit/mcp@0.13.0", "", { "dependencies": { "@adrkit/core": "0.13.0", "@modelcontextprotocol/server": "2.0.0", "zod": "^4.2.0" }, "bin": { "adrkit-mcp": "dist/bin.js" } }, "sha512-aL2X38xNmriULdAlf11lMakb6FKYNsQOdzDPQwPO+6W1JO1KXgBxfVtpmEuHpZqMp9dJQH1qsi0ebd05CtlFhQ=="],
 
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 

--- a/package.json
+++ b/package.json
@@ -78,8 +78,8 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@adrkit/cli": "0.12.0",
-    "@adrkit/mcp": "0.12.0",
+    "@adrkit/cli": "0.13.0",
+    "@adrkit/mcp": "0.13.0",
     "@eslint/eslintrc": "^3.3.6",
     "@tailwindcss/postcss": "^4.3.3",
     "@testing-library/jest-dom": "^6.10.0",

--- a/scripts/check-adr-integrity.ts
+++ b/scripts/check-adr-integrity.ts
@@ -147,8 +147,8 @@ export function runIntegrityChecks(repoRoot: string): IntegrityResult {
       },
       {
         file: '.github/workflows/adr.yml',
-        find: /mbeacom\/adrkit\/packages\/ci@[0-9a-f]{40}\s*#\s*v(\d+\.\d+\.\d+)/,
-        label: 'the pinned CI action',
+        find: /mbeacom\/adrkit@[0-9a-f]{40}\s*#\s*v(\d+\.\d+\.\d+)/,
+        label: 'the root Marketplace CI action',
       },
     ];
 


### PR DESCRIPTION
## Summary

- Update the exact `@adrkit/cli` and `@adrkit/mcp` consumer pins to 0.13.0 and refresh `bun.lock` with Bun 1.4.0.
- Move the ADR workflow from the nested Action path to the repository-root Marketplace surface, pinned to the immutable v0.13.0 release commit.
- Synchronize the cloud-agent MCP documentation and maintainer guidance with the coordinated pin set.
- Update the ADR integrity guard and regression coverage so the legacy nested Action surface cannot return unnoticed.

## Reference consumer evidence

OpenLeague is the real maintainer-owned adrkit reference consumer, so this upgrade supplies ADR-0014 rung 2 evidence; it is not external-consumer rung 3 evidence. This pull request exercises the v0.13.0 root Action alias in the `Comment governing decisions` job: GitHub downloaded `mbeacom/adrkit@3e40675ed6f513d9712b1dccaa68034d649d1eb9`, the Action completed successfully, and it created the governing-decisions comment.

The v0.13.0 release is now published in GitHub Marketplace under Code quality and Continuous integration. This runtime observation validates the same repository-root surface in a real consumer repository, independently of the listing UI.

## Validation

- `bun install --frozen-lockfile`
- `bun run test __tests__/scripts/check-adr-integrity.test.ts`
- `bun run adr:check-integrity`
- `bun run adr:lint`
- `bun run check:mcp-pins`
- `bun run type-check`
- `bun run lint`
- `bun run test` (2,805 passed, 5 skipped)
- `bun run build`
