### PR TITLE
fix(email): restore verification email via SES over Vercel OIDC

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,9 +18,17 @@ NEXTAUTH_SECRET=""
 # (MAILCHIMP_API_KEY -> mailchimp, AWS_REGION -> ses) and falls back to "log";
 # unconfigured production sends fail loudly at send time, never at boot.
 # EMAIL_PROVIDER="ses"
-# SES: set AWS_REGION below and provide AWS credentials via the standard env
-# vars (AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY) or Vercel's AWS integration.
-# Mailchimp: get an API key from https://mandrillapp.com/settings
+# SES: set AWS_REGION, then authenticate one of two ways.
+#   Vercel  — set AWS_ROLE_ARN and let OIDC mint short-lived STS credentials
+#             (no stored secret). Requires an IAM role trusting
+#             oidc.vercel.com/<team-slug>; see DEPLOYMENT.md.
+#   Elsewhere — leave AWS_ROLE_ARN unset and use the SDK default chain
+#             (AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY, or an `aws sso` profile).
+# AWS_REGION="us-east-1"
+# AWS_ROLE_ARN=""
+# Mailchimp (legacy): a *Transactional* key from the Mandrill dashboard, NOT a
+# Mailchimp Marketing key — the two are different key spaces and a Marketing
+# key fails with 401 Invalid_Key. Transactional also requires a paid plan.
 MAILCHIMP_API_KEY=""
 EMAIL_FROM="noreply@openl.app"
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -340,7 +340,8 @@ export default async function RosterPage({ params }: { params: { teamId: string 
 
 Email is provider-agnostic behind `sendEmail()` in `lib/email/client.ts`:
 - Providers: AWS SES (`@aws-sdk/client-sesv2`, recommended), Mailchimp Transactional (legacy), and a dev-only `log` provider
-- Selection: `EMAIL_PROVIDER` env var, or inferred from credentials (`MAILCHIMP_API_KEY` → mailchimp, `AWS_REGION` → ses), else `log`
+- Selection: `EMAIL_PROVIDER` env var, or inferred from credentials (`MAILCHIMP_API_KEY` → mailchimp, `AWS_REGION` → ses), else `log`. Inference checks Mailchimp **first**, so a leftover `MAILCHIMP_API_KEY` silently beats an SES setup — set `EMAIL_PROVIDER` explicitly when switching
+- SES credentials: `AWS_ROLE_ARN` selects Vercel OIDC via `awsCredentialsProvider` (short-lived STS, no stored secret). The AWS SDK's default chain cannot do this on its own — it reads `AWS_WEB_IDENTITY_TOKEN_FILE`, while Vercel supplies `VERCEL_OIDC_TOKEN` as an env var. Unset `AWS_ROLE_ARN` falls back to the default chain for local dev and CI
 - The app boots without email credentials; in production an unconfigured send throws at send time (never at boot)
 - SES sends one API call per recipient so recipients never see each other's addresses (matches Mailchimp's `preserve_recipients: false` default)
 - All templates in `lib/email/templates.ts` call `sendEmail()` — never import a provider SDK directly
@@ -369,8 +370,9 @@ EMAIL_FROM             # Verified sender email address
 **Optional Variables**:
 ```bash
 EMAIL_PROVIDER                # ses | mailchimp | log (inferred from credentials when unset)
-AWS_REGION                     # SES region (EMAIL_PROVIDER=ses; credentials via AWS env vars)
-MAILCHIMP_API_KEY              # Mailchimp Transactional API key (EMAIL_PROVIDER=mailchimp)
+AWS_REGION                     # SES region (required when EMAIL_PROVIDER=ses)
+AWS_ROLE_ARN                   # SES on Vercel: IAM role assumed via OIDC; omit to use the SDK default chain
+MAILCHIMP_API_KEY              # Mailchimp *Transactional* key (EMAIL_PROVIDER=mailchimp) — a Marketing key 401s
 NEXT_PUBLIC_UMAMI_WEBSITE_ID  # Umami analytics (privacy-friendly)
 ```
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -30,8 +30,10 @@ DATABASE_URL="postgresql://user:password@ep-xxx.us-east-2.aws.neon.tech/dbname?s
 NEXTAUTH_URL="https://your-domain.vercel.app"
 NEXTAUTH_SECRET="your-generated-secret-here"
 
-# Email Service
-MAILCHIMP_API_KEY="your-mailchimp-transactional-api-key"
+# Email Service (AWS SES — recommended)
+EMAIL_PROVIDER="ses"
+AWS_REGION="us-east-1"
+AWS_ROLE_ARN="arn:aws:iam::<account-id>:role/<role-name>"  # Vercel OIDC
 EMAIL_FROM="noreply@yourdomain.com"
 
 # Cron job authentication
@@ -82,12 +84,26 @@ Preview deployments skip automatic migration deployment by default. Set `OPENLEA
 
 ### Email Service Setup
 
-#### Mailchimp Transactional (Mandrill)
+#### AWS SES (recommended)
 
-1. Sign up for Mailchimp Transactional at [mandrillapp.com](https://mandrillapp.com)
-2. Generate an API key in Settings → SMTP & API Info
-3. Set the API key as `MAILCHIMP_API_KEY` in Vercel
-4. Configure `EMAIL_FROM` with your verified sender email
+1. Verify your sending domain in SES (Easy DKIM, plus a custom MAIL FROM
+   subdomain so DMARC aligns without touching an existing SPF record).
+2. Confirm the account has **production access** — a new SES region starts in
+   sandbox and will only deliver to pre-verified addresses (200/day).
+3. Create an IAM role for Vercel OIDC. Trust `oidc.vercel.com/<team-slug>` with
+   `aud` = `https://vercel.com/<team-slug>` and `sub` pinned to
+   `owner:<team-slug>:project:<project>:environment:production` (add `preview`
+   if preview deployments should send). Grant only `ses:SendEmail` on the
+   identity ARN, conditioned on `ses:FromAddress`.
+4. Set `EMAIL_PROVIDER=ses`, `AWS_REGION`, `AWS_ROLE_ARN`, and `EMAIL_FROM` in
+   Vercel, then **redeploy** — env changes never reach an existing build.
+
+#### Mailchimp Transactional (Mandrill, legacy)
+
+1. Generate a key in the **Transactional** dashboard → Settings → SMTP & API
+   Info. A Mailchimp *Marketing* API key is a different credential and fails
+   with `401 Invalid_Key`; sending also requires a paid Transactional plan.
+2. Set it as `MAILCHIMP_API_KEY` in Vercel and configure `EMAIL_FROM`.
 
 ### Security Configuration
 
@@ -381,7 +397,8 @@ bun run validate-env
 # - Ensure all required variables are set
 # - Generate new NEXTAUTH_SECRET: openssl rand -base64 32
 # - Verify DATABASE_URL includes ?sslmode=require
-# - Check MAILCHIMP_API_KEY format (starts with 'md-')
+# - SES: confirm AWS_REGION matches the verified identity's region
+# - Mailchimp: confirm the key is a Transactional key, not a Marketing key
 ```
 
 #### Database Connection Issues

--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ NEXTAUTH_SECRET=""  # Generate with: openssl rand -base64 32
 
 # Email Service — "ses" (recommended), "mailchimp", or "log" (dev default when unset)
 # EMAIL_PROVIDER="ses"
-# AWS_REGION="us-east-1"  # SES region; AWS credentials via standard env vars
+# AWS_REGION="us-east-1"  # SES region
+# AWS_ROLE_ARN=""         # SES on Vercel: OIDC role; omit to use the SDK default chain
 MAILCHIMP_API_KEY=""  # Only for EMAIL_PROVIDER="mailchimp"
 EMAIL_FROM="noreply@yourdomain.com"  # Your sender email address
 
@@ -312,8 +313,10 @@ OpenLeague sends through a provider-agnostic `sendEmail()` seam (`lib/email/clie
 4. **Set Environment Variables**:
 
    ```bash
-   MAILCHIMP_API_KEY="md-your-api-key-here"
-   EMAIL_FROM="noreply@yourdomain.com"  # Must be verified domain
+   EMAIL_PROVIDER="ses"
+   AWS_REGION="us-east-1"
+   AWS_ROLE_ARN="arn:aws:iam::<account>:role/<role>"  # Vercel OIDC; omit off-Vercel
+   EMAIL_FROM="noreply@yourdomain.com"  # Must be a verified SES identity
    ```
 
 5. **Test Email Setup**:
@@ -810,7 +813,7 @@ A professionally hosted version is live at [openl.app](https://openl.app), offer
 - Free forever for teams — no per-player or per-season subscription, ever
 - No third-party ads (especially not on pages containing minors' data)
 
-The free team plan is a commitment, not a trial. Paid tiers exist only for leagues and clubs (multi-team orgs), and revenue comes from those org-level plans and opt-in local sponsorships clubs choose — never from charging teams or serving third-party ads.
+The free team plan is a commitment, not a trial. There are no paid tiers, no subscriptions, and no third-party ads — and because the source is Apache 2.0, you can always run it yourself.
 
 📚 **Developer Documentation:** [openleague.dev](https://openleague.dev)
 

--- a/__tests__/app/marketing/pricing.test.tsx
+++ b/__tests__/app/marketing/pricing.test.tsx
@@ -9,11 +9,11 @@ const renderWithTheme = (component: React.ReactElement) => {
 };
 
 describe('PricingPage', () => {
-  it('communicates permanent free-for-teams pricing and no-credit-card onboarding', () => {
+  it('communicates permanent free pricing and no-credit-card onboarding', () => {
     renderWithTheme(<PricingPage />);
 
-    expect(screen.getByRole('heading', { level: 1, name: /simple pricing for busy teams/i })).toBeInTheDocument();
-    expect(screen.getByText('Free forever for teams')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 1, name: /free\. all of it\./i })).toBeInTheDocument();
+    expect(screen.getByText('Free forever')).toBeInTheDocument();
     expect(screen.getByText('$0')).toBeInTheDocument();
     expect(screen.getAllByText(/no credit card/i).length).toBeGreaterThan(0);
     expect(
@@ -28,17 +28,27 @@ describe('PricingPage', () => {
     expect(screen.getByRole('link', { name: /start free today/i })).toHaveAttribute('href', '/signup');
   });
 
-  it('offers a contact-driven league and club tier without a public price', () => {
+  it('offers multi-team organization capabilities on the same free terms, with no paid tier', () => {
     renderWithTheme(<PricingPage />);
 
-    expect(screen.getByRole('heading', { level: 2, name: /league & club/i })).toBeInTheDocument();
-    expect(screen.getByText(/for leagues, clubs, and associations/i)).toBeInTheDocument();
+    // Org capabilities are presented as part of the free plan...
     expect(
-      screen.getByRole('link', { name: /talk to us about your league or club/i })
-    ).toHaveAttribute('href', '/contact');
+      screen.getByRole('heading', { level: 3, name: /for leagues, clubs, and associations/i })
+    ).toBeInTheDocument();
+    expect(screen.getByText(/multiple teams and divisions in one organization/i)).toBeInTheDocument();
+    expect(screen.getByText(/cross-team and cross-division scheduling/i)).toBeInTheDocument();
+
+    // ...and never as a separate, sellable tier.
+    expect(screen.queryByRole('heading', { level: 2, name: /league & club/i })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: /talk to us about your league or club/i })
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/funds the free/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/let's talk/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/pricing set with design-partner clubs/i)).not.toBeInTheDocument();
   });
 
-  it('states commitments and the repositioned pricing FAQ without future-bill hedging', () => {
+  it('states commitments and a sustainability FAQ that claims no revenue model', () => {
     renderWithTheme(<PricingPage />);
 
     // Comparison table and the future-bill FAQ are gone.
@@ -51,14 +61,21 @@ describe('PricingPage', () => {
     expect(screen.getByText(/no per-team paywall, ever/i)).toBeInTheDocument();
     expect(screen.getByText(/no third-party ads/i)).toBeInTheDocument();
 
-    // FAQ affirms the permanent-free stance and explains the revenue model.
+    // The FAQ explains sustainability via open source, not a revenue model.
     expect(screen.getByRole('heading', { level: 2, name: /pricing faq/i })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { level: 3, name: /how does openleague make money/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { level: 3, name: /how is openleague sustained/i })
+    ).toBeInTheDocument();
+    expect(screen.getByText(/an open-source project, not a business/i)).toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', { level: 3, name: /how does openleague make money/i })
+    ).not.toBeInTheDocument();
   });
 
   it('sets indexable SEO metadata with canonical pricing URL', () => {
     expect(metadata.title).toBe('Pricing - OpenLeague');
-    expect(metadata.description).toMatch(/free forever for teams/i);
+    expect(metadata.description).toMatch(/no paid tiers/i);
+    expect(metadata.description).not.toMatch(/fund the free team plan/i);
     expect(metadata.alternates?.canonical).toBe('https://openl.app/pricing');
     expect(metadata.robots).toHaveProperty('index', true);
   });

--- a/__tests__/lib/email/client.test.ts
+++ b/__tests__/lib/email/client.test.ts
@@ -5,9 +5,12 @@ const state = vi.hoisted(() => ({
     EMAIL_PROVIDER: undefined as string | undefined,
     MAILCHIMP_API_KEY: undefined as string | undefined,
     AWS_REGION: undefined as string | undefined,
+    AWS_ROLE_ARN: undefined as string | undefined,
     EMAIL_FROM: "noreply@openl.app",
   },
   isProduction: false,
+  sesClientConfig: undefined as Record<string, unknown> | undefined,
+  awsCredentialsProvider: vi.fn(),
   sesSend: vi.fn(),
   mailchimpSend: vi.fn(),
 }));
@@ -26,10 +29,17 @@ vi.mock("@aws-sdk/client-sesv2", () => {
     constructor(public input: unknown) {}
   }
   class SESv2Client {
+    constructor(config: Record<string, unknown>) {
+      state.sesClientConfig = config;
+    }
     send = (command: InstanceType<typeof SendEmailCommand>) => state.sesSend(command.input);
   }
   return { SESv2Client, SendEmailCommand };
 });
+
+vi.mock("@vercel/oidc-aws-credentials-provider", () => ({
+  awsCredentialsProvider: (options: { roleArn: string }) => state.awsCredentialsProvider(options),
+}));
 
 vi.mock("@mailchimp/mailchimp_transactional", () => ({
   default: () => ({ messages: { send: state.mailchimpSend } }),
@@ -45,9 +55,12 @@ beforeEach(() => {
     EMAIL_PROVIDER: undefined,
     MAILCHIMP_API_KEY: undefined,
     AWS_REGION: undefined,
+    AWS_ROLE_ARN: undefined,
     EMAIL_FROM: "noreply@openl.app",
   };
   state.isProduction = false;
+  state.sesClientConfig = undefined;
+  state.awsCredentialsProvider.mockReset().mockReturnValue("oidc-credentials");
   state.sesSend.mockReset().mockResolvedValue({ MessageId: "id" });
   state.mailchimpSend.mockReset().mockResolvedValue([{ email: "a@b.c", status: "sent" }]);
 });
@@ -223,5 +236,43 @@ describe("sendEmail via log provider", () => {
     await expect(
       sendEmail({ to: [{ email: "one@example.com" }], subject: "S", html: "<p>H</p>" })
     ).rejects.toThrow("No email provider configured");
+  });
+});
+
+describe("SES credential resolution", () => {
+  const message = {
+    to: [{ email: "one@example.com" }],
+    subject: "Hi",
+    html: "<p>Hi</p>",
+  };
+
+  beforeEach(() => {
+    state.env.EMAIL_PROVIDER = "ses";
+    state.env.AWS_REGION = "us-east-1";
+  });
+
+  it("uses Vercel OIDC credentials when AWS_ROLE_ARN is set", async () => {
+    state.env.AWS_ROLE_ARN = "arn:aws:iam::123456789012:role/openleague-vercel-ses";
+    const { sendEmail } = await loadClient();
+
+    await sendEmail(message);
+
+    expect(state.awsCredentialsProvider).toHaveBeenCalledWith({
+      roleArn: "arn:aws:iam::123456789012:role/openleague-vercel-ses",
+    });
+    expect(state.sesClientConfig).toEqual({
+      region: "us-east-1",
+      credentials: "oidc-credentials",
+    });
+  });
+
+  it("falls back to the SDK default chain when AWS_ROLE_ARN is unset", async () => {
+    const { sendEmail } = await loadClient();
+
+    await sendEmail(message);
+
+    expect(state.awsCredentialsProvider).not.toHaveBeenCalled();
+    expect(state.sesClientConfig).toEqual({ region: "us-east-1" });
+    expect(state.sesClientConfig).not.toHaveProperty("credentials");
   });
 });

--- a/app/(marketing)/about/page.tsx
+++ b/app/(marketing)/about/page.tsx
@@ -84,7 +84,7 @@ export default function AboutPage() {
                 Free & Transparent
               </Typography>
               <Typography variant="body2" color="text.secondary">
-                Free forever for teams. Paid tiers exist only for leagues and clubs, and we never charge teams or serve third-party ads.
+                Free forever. No paid tiers, no subscriptions, and no third-party ads.
               </Typography>
             </Box>
             <Box>

--- a/app/(marketing)/pricing/page.tsx
+++ b/app/(marketing)/pricing/page.tsx
@@ -18,7 +18,6 @@ import {
   Shield as ShieldIcon,
   Code as CodeIcon,
   CloudDownload as CloudDownloadIcon,
-  AccountTree as AccountTreeIcon,
 } from '@mui/icons-material';
 import CTAButton from '@/components/features/marketing/CTAButton';
 import { generatePageMetadata, getBreadcrumbSchema, getFAQSchema } from '@/lib/config/seo';
@@ -27,7 +26,7 @@ import StructuredData from '@/components/ui/StructuredData';
 export const metadata = generatePageMetadata({
   title: 'Pricing',
   description:
-    'OpenLeague is free forever for teams — roster, scheduling, RSVPs, and communication with no subscriptions and no credit card. Optional paid tiers for leagues and clubs fund the free team plan.',
+    'OpenLeague is free — roster, scheduling, RSVPs, and communication for teams, leagues, and clubs, with no subscriptions, no paid tiers, and no credit card.',
   path: '/pricing',
   keywords: ['pricing', 'free team management', 'free sports team software', 'league management pricing'],
 });
@@ -82,15 +81,12 @@ const commitments = [
   },
 ];
 
-const leagueFeatures = [
+const organizationFeatures = [
   'Multiple teams and divisions in one organization',
   'Cross-team and cross-division scheduling',
   'Facility and ice allocation across teams',
   'Org-wide communications and announcements',
-  'Custom domain for your league or club',
-  'Single sign-on (SSO) for staff and admins',
   'Data export for your whole organization',
-  'Priority support from the OpenLeague team',
 ];
 
 const faqs = [
@@ -110,9 +106,14 @@ const faqs = [
       'No. Teams can sign up and start using OpenLeague right away without a credit card — now or ever.',
   },
   {
-    question: 'How does OpenLeague make money?',
+    question: 'How is OpenLeague sustained?',
     answer:
-      'Through optional paid tiers for leagues and clubs (below) and, later, opt-in local sponsorships that clubs choose — never by charging teams or showing third-party ads.',
+      'It is an open-source project, not a business. There are no paid tiers and no ads. The source is public under the Apache License 2.0, so anyone can run their own copy — that portability is the guarantee, not a pricing page.',
+  },
+  {
+    question: 'Is this free for leagues and clubs too?',
+    answer:
+      'Yes. Multi-team organizations get divisions, cross-team scheduling, facility allocation, and org-wide communication on the same free terms as a single team.',
   },
 ];
 
@@ -129,12 +130,12 @@ export default function PricingPage() {
       <Container maxWidth="lg">
         <Box sx={{ py: { xs: 8, md: 10 } }}>
           <Stack spacing={3} alignItems="center" textAlign="center" sx={{ mb: 8 }}>
-            <Chip label="Free forever for teams" color="success" variant="outlined" />
+            <Chip label="Free forever" color="success" variant="outlined" />
             <Typography variant="h1" component="h1" gutterBottom>
-              Simple Pricing for Busy Teams
+              Free. All of it.
             </Typography>
             <Typography variant="h5" color="text.secondary" sx={{ maxWidth: 820 }}>
-              OpenLeague gives coaches and managers the core team-management tools they need — free, forever, with no subscriptions, paid tiers, or credit card.
+              Every feature, for teams and for multi-team organizations alike — no subscriptions, no paid tiers, no credit card, and no ads.
             </Typography>
             <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} sx={{ pt: 2 }}>
               <CTAButton
@@ -170,7 +171,7 @@ export default function PricingPage() {
               <Stack direction={{ xs: 'column', md: 'row' }} spacing={4} justifyContent="space-between">
                 <Box>
                   <Typography variant="h3" component="h2" gutterBottom>
-                    Free Team Plan
+                    The Free Plan
                   </Typography>
                   <Typography variant="body1" color="text.secondary" sx={{ maxWidth: 620 }}>
                     Built for teams replacing spreadsheets, email chains, and group chats with one organized hub.
@@ -226,71 +227,13 @@ export default function PricingPage() {
             </Stack>
           </Box>
 
-          {/* League & Club tier — contact-driven, funds the free team plan */}
-          <Card
-            sx={{
-              mb: 8,
-              border: '2px solid',
-              borderColor: 'primary.main',
-              boxShadow: '0 12px 32px rgba(13, 71, 161, 0.12)',
-            }}
-          >
-            <CardContent sx={{ p: { xs: 3, md: 5 } }}>
-              <Stack direction={{ xs: 'column', md: 'row' }} spacing={4} justifyContent="space-between" alignItems={{ md: 'center' }}>
-                <Box>
-                  <Chip
-                    icon={<AccountTreeIcon />}
-                    label="For leagues, clubs, and associations"
-                    color="primary"
-                    variant="outlined"
-                    sx={{ mb: 2 }}
-                  />
-                  <Typography variant="h3" component="h2" gutterBottom>
-                    League &amp; Club
-                  </Typography>
-                  <Typography variant="body1" color="text.secondary" sx={{ maxWidth: 620 }}>
-                    Everything a multi-team organization needs to run a season — and the tier that funds the free team plan.
-                  </Typography>
-                </Box>
-                <Box sx={{ textAlign: { xs: 'left', md: 'right' } }}>
-                  <Typography variant="h4" component="p" color="primary.main">
-                    Let&apos;s talk
-                  </Typography>
-                  <Typography variant="body2" color="text.secondary">
-                    Pricing set with design-partner clubs
-                  </Typography>
-                </Box>
-              </Stack>
-              <Divider sx={{ my: 4 }} />
-              <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', md: 'repeat(2, 1fr)' }, gap: 2 }}>
-                {leagueFeatures.map((feature) => (
-                  <Stack key={feature} direction="row" spacing={1.5} alignItems="center">
-                    <CheckCircleIcon sx={{ color: 'primary.main', fontSize: 22 }} />
-                    <Typography variant="body1">{feature}</Typography>
-                  </Stack>
-                ))}
-              </Box>
-              <Box sx={{ mt: 4 }}>
-                <CTAButton
-                  href="/contact"
-                  variant="contained"
-                  size="large"
-                  trackingAction="pricing_league_contact_click"
-                  trackingLabel="pricing_league_tier"
-                >
-                  Talk to us about your league or club
-                </CTAButton>
-              </Box>
-            </CardContent>
-          </Card>
-
           {/* What's included, free + Our commitments */}
           <Box sx={{ mb: 8 }}>
             <Typography variant="h4" component="h2" gutterBottom textAlign="center">
               Free, and honest about it
             </Typography>
             <Typography variant="body1" color="text.secondary" textAlign="center" sx={{ mb: 4, maxWidth: 720, mx: 'auto' }}>
-              Here is exactly what teams get for free, and the commitments we make to keep it that way.
+              Here is exactly what you get for free, and the commitments we make to keep it that way.
             </Typography>
 
             <Typography variant="h6" component="h3" gutterBottom>
@@ -308,6 +251,25 @@ export default function PricingPage() {
                 <Stack key={feature.title} direction="row" spacing={1.5} alignItems="center">
                   <CheckCircleIcon color="success" sx={{ fontSize: 22 }} />
                   <Typography variant="body1">{feature.title}</Typography>
+                </Stack>
+              ))}
+            </Box>
+
+            <Typography variant="h6" component="h3" gutterBottom>
+              For leagues, clubs, and associations
+            </Typography>
+            <Box
+              sx={{
+                display: 'grid',
+                gridTemplateColumns: { xs: '1fr', sm: 'repeat(2, 1fr)' },
+                gap: 2,
+                mb: 5,
+              }}
+            >
+              {organizationFeatures.map((feature) => (
+                <Stack key={feature} direction="row" spacing={1.5} alignItems="center">
+                  <CheckCircleIcon color="success" sx={{ fontSize: 22 }} />
+                  <Typography variant="body1">{feature}</Typography>
                 </Stack>
               ))}
             </Box>

--- a/bun.lock
+++ b/bun.lock
@@ -26,6 +26,7 @@
         "@prisma/client": "^7.9.1",
         "@sentry/nextjs": "^10.69.0",
         "@vercel/blob": "^2.7.0",
+        "@vercel/oidc-aws-credentials-provider": "^3.3.5",
         "bcryptjs": "^3.0.3",
         "date-fns": "^4.4.0",
         "next": "16.3.0",
@@ -823,6 +824,8 @@
     "@vercel/cli-exec": ["@vercel/cli-exec@1.0.0", "", { "dependencies": { "execa": "5.1.1" } }, "sha512-kQF8LGie/Hbdq9/psJxLE7owRTcqMQMhgybU04gCeR7cbQAr5t8OrjefDNColJv1QSSucFt4pLwRiARVmlOnug=="],
 
     "@vercel/oidc": ["@vercel/oidc@3.7.1", "", { "dependencies": { "@vercel/cli-config": "0.2.0", "@vercel/cli-exec": "1.0.0", "jose": "^5.9.6" } }, "sha512-RrSsVWbq3KLK5lJobyTPp3tSthNfUp+zWkXno5Wkko0oEW05rA4ngOrnVypP4+L8/Av89uPo2rWFmzL8iwnsmA=="],
+
+    "@vercel/oidc-aws-credentials-provider": ["@vercel/oidc-aws-credentials-provider@3.3.5", "", { "dependencies": { "@aws-sdk/credential-provider-web-identity": "^3.609.0", "@vercel/oidc": "3.8.5" } }, "sha512-l03pONDI2r255W6SjBg5I6vvetUqYdXSheKyJgDMmCGOLIQFWOwLq5E1Ypltn9r+pgapaK6dZotMR4zYf8Tq7g=="],
 
     "@visx/curve": ["@visx/curve@4.0.1-alpha.0", "", { "dependencies": { "@visx/vendor": "4.0.0-alpha.0" } }, "sha512-jRu61Uz274pV1zyioXmboyrLutYbnKsgjj4njSGCnhdXj5GkZvZbg+ThDb6oOzoAnJOBRLz4rzPlWvNJOzuVMg=="],
 
@@ -2204,6 +2207,8 @@
 
     "@vercel/cli-config/zod": ["zod@4.1.11", "", {}, "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg=="],
 
+    "@vercel/oidc-aws-credentials-provider/@vercel/oidc": ["@vercel/oidc@3.8.5", "", { "dependencies": { "@vercel/cli-config": "0.2.4", "@vercel/cli-exec": "1.0.1", "jose": "^5.9.6" } }, "sha512-RwXYtnt6za+5UO4IaLywN/6B95AlLqynPRUWRJxeJ/qufwkcLUbZNUxYtzT0uMpuraWhlNcGqPNGkTnZr4BGBw=="],
+
     "@visx/vendor/d3-array": ["d3-array@3.2.1", "", { "dependencies": { "internmap": "1 - 2" } }, "sha512-gUY/qeHq/yNqqoCKNq4vtpFLdoCdvyNpWoC/KNjhGbhDuQpAM9sIQQKkXSNpXa9h5KySs/gzm7R88WkUutgwWQ=="],
 
     "ajv-formats/ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
@@ -2376,6 +2381,10 @@
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@5.0.4", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg=="],
 
+    "@vercel/oidc-aws-credentials-provider/@vercel/oidc/@vercel/cli-config": ["@vercel/cli-config@0.2.4", "", { "dependencies": { "xdg-app-paths": "5", "zod": "4.1.11" } }, "sha512-kZ5SojbrV06GHoU6QIWGwDXLov+s9rWZ7QqdqKfJfBGCNUieGfgaCjeeenNy8Y+QC0bwC0dZ2B4l5Hvdmrgpdw=="],
+
+    "@vercel/oidc-aws-credentials-provider/@vercel/oidc/@vercel/cli-exec": ["@vercel/cli-exec@1.0.1", "", { "dependencies": { "execa": "5.1.1" } }, "sha512-g9XerViJ/paZujufXYcu5XYI2vU2rtB4sgdpjUHde5RnOkdmpu0ngH46LCFGHoPXO/C+qDPSczIHIRN+8Q2YKQ=="],
+
     "ajv-formats/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "ajv-keywords/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
@@ -2497,6 +2506,8 @@
     "webpack/eslint-scope/estraverse": ["estraverse@4.3.0", "", {}, "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
+    "@vercel/oidc-aws-credentials-provider/@vercel/oidc/@vercel/cli-config/zod": ["zod@4.1.11", "", {}, "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg=="],
 
     "glob/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
   }

--- a/docs/adr/0010-operate-openleague-as-a-non-commercial-open-source-project.md
+++ b/docs/adr/0010-operate-openleague-as-a-non-commercial-open-source-project.md
@@ -1,0 +1,130 @@
+---
+schemaVersion: 0.1.0
+id: "0010"
+title: "Operate OpenLeague as a non-commercial open-source project"
+status: proposed
+date: 2026-09-05
+created: 2026-09-05
+deciders: ["@mbeacom"]
+tags: [product, open-source, sustainability, trust]
+scope: org
+reversibility: one-way-door
+blastRadius: org
+relatesTo: ["0008"]
+affects:
+  - type: path
+    pattern: "README.md"
+    note: Public copy may not assert paid tiers, subscriptions, or a revenue model.
+  - type: path
+    pattern: "app/(marketing)/**"
+    note: Marketing surfaces may not advertise a commercial tier or price.
+  - type: path
+    pattern: "lib/payments/**"
+    note: Payment code may facilitate an association's own collections, never a platform take.
+  - type: path
+    pattern: "lib/actions/**"
+    note: No action may gate behaviour on a purchased entitlement.
+provenance:
+  authoredBy: agent-drafted
+review:
+  tier: async
+  tierReason: >-
+    A public, durable promise about what the project will never charge for.
+    Reversing it costs trust with the associations it asks to migrate.
+reviewBy: 2027-09-05
+---
+
+# ADR-0010: Operate OpenLeague as a non-commercial open-source project
+
+## Context
+
+The public site and README described a two-tier model: free forever for teams,
+with paid League & Club plans for multi-team organizations that "fund the free
+team plan," plus future opt-in local sponsorships.
+
+None of that exists. There is no price, no billing surface, no customer, and no
+revenue. The Stripe Connect code in `lib/payments/` is inert in production —
+`DEFAULT_PLATFORM_FEE_BPS` defaults to `0` and no `STRIPE_*` variable is set in
+the production environment, so `isStripeConfigured` is false. The League & Club
+feature list also advertised SSO, custom domains, and priority support, none of
+which are implemented.
+
+Advertising a commercial tier that does not exist is a straightforward accuracy
+problem, and it is worst precisely where the project asks for the most trust:
+volunteer-run associations deciding whether to move a season's operations onto
+it. It also creates standing pressure to build entitlement gating that
+[ADR-0008](./0008-keep-core-association-operations-free-and-provider-portable.md)
+already refuses for core association operations. ADR-0008 committed to a free
+core; it left open how the rest would be funded. This record closes that.
+
+## Decision
+
+We will operate OpenLeague as a non-commercial open-source project. There are no
+paid tiers, no subscriptions, no advertising, and no platform commission on
+payments the software facilitates. Public copy will say so plainly.
+
+Where the software touches money, it does so only to help an association collect
+its own dues or fees. The platform takes nothing.
+
+## Options considered
+
+### Option A: Non-commercial open source (chosen)
+
+| Dimension | Assessment |
+|---|---|
+| Accuracy of public copy | Matches reality exactly; nothing to caveat |
+| Pressure on ADR-0008 | Removed — the free core needs no funding story |
+| Sustainability | Maintainer-funded hosting; portability is the guarantee |
+| Reversibility | Poor. A public "never" is expensive to walk back |
+
+### Option B: Free core with a paid multi-team tier
+
+The previously advertised model.
+
+**Pros:** funds hosting; a supported offering some associations prefer to buy;
+keeps a path to paying for dedicated infrastructure or support.
+
+**Cons:** none of it is built, so the copy would stay aspirational indefinitely;
+requires an entitlement system, billing, and support commitments that no one is
+staffed to deliver; introduces exactly the paid/unpaid boundary inside
+association features that ADR-0008 was written to prevent.
+
+### Option C: Do nothing
+
+Leave the copy asserting a tier that does not exist.
+
+**Cons:** the project keeps making a claim it cannot honour, to the audience
+least able to absorb being wrong about it. Rejected.
+
+## Trade-offs
+
+The hosted instance at openl.app is funded personally by the maintainer, with no
+revenue offsetting it. That caps how much hosted scale the project can absorb and
+means there is no funded support commitment — associations get best-effort help,
+not an SLA. If hosting cost becomes untenable the answer is self-hosting and data
+portability, not a paywall. That is a real limitation, accepted deliberately.
+
+## Consequences
+
+- **Easier:** no entitlement gating, no billing surface, no pricing conversations,
+  no paid/unpaid boundary to police inside features. ADR-0008's free-core
+  commitment becomes unconditional rather than contingent on a funding model.
+- **Harder:** hosted infrastructure is unfunded and maintainer-capped. The project
+  cannot buy support capacity, dedicated IPs, or paid vendor tiers.
+- **How we would know this was wrong:** hosted infrastructure cost exceeds what
+  the maintainer will personally fund, or associations decline to adopt because
+  they require a contractual, supported offering. Either is a signal to revisit —
+  by superseding this record, never by quietly reintroducing pricing copy.
+- **Revisit if:** a governance change (foundation, grant, sponsorship) provides
+  funding that does not require charging users, or by the review date above.
+
+## Action items
+
+1. [x] Remove paid-tier and revenue language from `README.md`,
+   `app/(marketing)/about`, and `app/(marketing)/pricing`.
+2. [x] Drop unimplemented capabilities (SSO, custom domain, priority support)
+   from public feature copy.
+3. [ ] Ratify this record, or reject it and restore an accurate description of
+   an intended commercial model.
+4. [ ] Decide whether `lib/payments/` should remain in the tree as
+   association-facing collection support, or be removed.

--- a/docs/adr/0010-operate-openleague-as-a-non-commercial-open-source-project.md
+++ b/docs/adr/0010-operate-openleague-as-a-non-commercial-open-source-project.md
@@ -63,8 +63,15 @@ We will operate OpenLeague as a non-commercial open-source project. There are no
 paid tiers, no subscriptions, no advertising, and no platform commission on
 payments the software facilitates. Public copy will say so plainly.
 
-Where the software touches money, it does so only to help an association collect
-its own dues or fees. The platform takes nothing.
+Where the software touches money it does so only to help an association collect
+**its own** dues, fees, or donations — as merchant of record on its own payment
+account. The platform never takes custody of association funds and takes no
+commission.
+
+Nothing here forecloses the project later operating under a nonprofit or a
+fiscal sponsor. That is a separate decision, and nonprofit status would not by
+itself require charging users: "nonprofit" governs who may own a surplus, not
+whether an organization charges for services.
 
 ## Options considered
 
@@ -117,6 +124,20 @@ portability, not a paywall. That is a real limitation, accepted deliberately.
   by superseding this record, never by quietly reintroducing pricing copy.
 - **Revisit if:** a governance change (foundation, grant, sponsorship) provides
   funding that does not require charging users, or by the review date above.
+
+## Open questions
+
+- **Nonprofit or fiscal-sponsor structure.** Deliberately not decided here.
+  Fiscal sponsorship and an independent 501(c)(3) differ substantially in cost,
+  timeline, and governance obligations. Neither is required for this record to
+  hold, and neither would require reversing it.
+- **Regulatory posture for donations.** Association-collected donations are
+  structured to keep the platform out of the funds path (direct charges on the
+  association's connected account, association as merchant of record, no
+  platform fee). Several states nonetheless regulate "charitable fundraising
+  platforms," and the line between hosting a nonprofit's own collection tool
+  and soliciting on its behalf is fact-specific. Obtain professional advice
+  before promoting donations as a platform capability.
 
 ## Action items
 

--- a/lib/email/client.ts
+++ b/lib/email/client.ts
@@ -1,5 +1,6 @@
 import Mailchimp from "@mailchimp/mailchimp_transactional";
 import { SESv2Client, SendEmailCommand } from "@aws-sdk/client-sesv2";
+import { awsCredentialsProvider } from "@vercel/oidc-aws-credentials-provider";
 import { env, isProduction } from "@/lib/env";
 
 /**
@@ -52,9 +53,19 @@ let sesClient: SESv2Client | null = null;
 
 function getSesClient(): SESv2Client {
   if (sesClient) return sesClient;
-  // Region/credentials come from AWS_REGION and the default provider chain
-  // (env credentials or Vercel OIDC); SESv2Client validates at send time.
-  sesClient = new SESv2Client(env.AWS_REGION ? { region: env.AWS_REGION } : {});
+  // AWS_ROLE_ARN selects Vercel OIDC: the platform mints a short-lived token
+  // per invocation which awsCredentialsProvider trades for STS credentials, so
+  // no long-lived AWS secret is ever stored in the project. The SDK's own
+  // default chain cannot do this — it looks for AWS_WEB_IDENTITY_TOKEN_FILE,
+  // whereas Vercel supplies VERCEL_OIDC_TOKEN as an environment variable.
+  // Without AWS_ROLE_ARN (local dev, CI) we fall through to the default chain
+  // so an `aws sso` profile or static env credentials still work.
+  sesClient = new SESv2Client({
+    ...(env.AWS_REGION ? { region: env.AWS_REGION } : {}),
+    ...(env.AWS_ROLE_ARN
+      ? { credentials: awsCredentialsProvider({ roleArn: env.AWS_ROLE_ARN }) }
+      : {}),
+  });
   return sesClient;
 }
 

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -36,8 +36,11 @@ const envSchema = z.object({
     NEXT_PUBLIC_HOTJAR_ID: z.string().optional(),
     NEXT_PUBLIC_MIXPANEL_TOKEN: z.string().optional(),
 
-    // Optional AWS variables (for future migration)
+    // AWS — SES transport. AWS_ROLE_ARN switches credential resolution to
+    // Vercel OIDC (short-lived STS credentials, no stored secret); when it is
+    // unset the SDK's default provider chain is used instead.
     AWS_REGION: z.string().optional(),
+    AWS_ROLE_ARN: z.string().optional(),
 
     // Payments — Stripe Connect (optional; payments disabled when unset)
     STRIPE_SECRET_KEY: z.string().optional(),
@@ -80,6 +83,7 @@ function validateEnv() {
             NEXT_PUBLIC_HOTJAR_ID: process.env.NEXT_PUBLIC_HOTJAR_ID,
             NEXT_PUBLIC_MIXPANEL_TOKEN: process.env.NEXT_PUBLIC_MIXPANEL_TOKEN,
             AWS_REGION: process.env.AWS_REGION,
+            AWS_ROLE_ARN: process.env.AWS_ROLE_ARN,
             STRIPE_SECRET_KEY: process.env.STRIPE_SECRET_KEY,
             STRIPE_CONNECT_WEBHOOK_SECRET: process.env.STRIPE_CONNECT_WEBHOOK_SECRET,
             NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY,
@@ -113,7 +117,7 @@ function validateEnv() {
             console.error('   NEXTAUTH_SECRET - Random secret (generate with: openssl rand -base64 32)')
             console.error('   EMAIL_FROM - Sender email address')
             console.error('\n📧 Email provider (optional — emails are logged, not sent, when unconfigured):')
-            console.error('   EMAIL_PROVIDER=ses       requires AWS_REGION (+ AWS credentials)')
+            console.error('   EMAIL_PROVIDER=ses       requires AWS_REGION (+ AWS_ROLE_ARN for Vercel OIDC, or AWS credentials)')
             console.error('   EMAIL_PROVIDER=mailchimp requires MAILCHIMP_API_KEY')
             console.error('\n💡 Copy .env.example to .env.local and fill in the values')
 
@@ -134,7 +138,7 @@ function assertEmailProviderConfig(env: z.infer<typeof envSchema>): void {
         process.exit(1)
     }
     if (env.EMAIL_PROVIDER === 'ses' && !env.AWS_REGION) {
-        console.error('🚨 EMAIL_PROVIDER=ses requires AWS_REGION to be set (credentials via AWS env vars or Vercel OIDC)')
+        console.error('🚨 EMAIL_PROVIDER=ses requires AWS_REGION to be set (credentials via AWS_ROLE_ARN + Vercel OIDC, or AWS env vars)')
         process.exit(1)
     }
 }

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@prisma/client": "^7.9.1",
     "@sentry/nextjs": "^10.69.0",
     "@vercel/blob": "^2.7.0",
+    "@vercel/oidc-aws-credentials-provider": "^3.3.5",
     "bcryptjs": "^3.0.3",
     "date-fns": "^4.4.0",
     "next": "16.3.0",


### PR DESCRIPTION
## Summary

Verification ("activation") emails are not being delivered in production. This
fixes the transport and corrects public copy that described a commercial tier
that does not exist.

## Email: SES via Vercel OIDC

Production email was failing at the transport. The configured Mailchimp
Transactional key returned `401 Invalid_Key` on every send, so no verification
mail went out — signup and the login resend both reported success to the user
regardless, because each catches the send error and logs it (deliberately, for
enumeration-safety on resend). The only signal was `console.error` in the
runtime logs.

Cutting over to SES surfaced a second problem. `getSesClient()` relied on the
AWS SDK's default credential chain, which cannot authenticate on Vercel: the
chain looks for `AWS_WEB_IDENTITY_TOKEN_FILE`, while Vercel supplies
`VERCEL_OIDC_TOKEN` as an environment variable. Every send failed with
`CredentialsProviderError: Could not load credentials from any providers`.

Credentials are now passed explicitly via `awsCredentialsProvider` when
`AWS_ROLE_ARN` is set, falling through to the default chain when it is not so
local development against an `aws sso` profile still works. No long-lived AWS
secret is stored in the project — the role is assumed per-invocation via OIDC.

The comment in `client.ts` and the error string in `env.ts` both claimed the
default chain handled Vercel OIDC; both are corrected.

Two tests cover the credential paths: OIDC used when `AWS_ROLE_ARN` is set, and
the default chain left untouched when it is not.

## Copy: no commercial tier

The README and marketing pages described paid League & Club plans funding the
free team plan, plus a revenue model. None of it exists — there is no price, no
billing surface, and no revenue. The advertised tier also listed SSO, custom
domains, and priority support, none of which are implemented.

- README and `/about`: paid-tier and revenue language replaced with a plain
  statement that there are no paid tiers, subscriptions, or ads.
- `/pricing`: League & Club card, its contact CTA, and the `pricing_league_tier`
  tracking removed. "How does OpenLeague make money?" replaced with a
  sustainability answer grounded in the Apache 2.0 license. Multi-team
  capabilities move into the free plan; unimplemented ones are dropped rather
  than advertised as free.
- Tests assert the free-only structure, including negative assertions that a
  sellable tier cannot silently return.

ADR-0010 records the decision. It is `proposed` and needs ratification — see
its action items, which include rejecting it in favour of an accurate
description of an intended commercial model. It explicitly does not foreclose
associations collecting their own dues, fees, or donations: the platform takes
no commission and never holds association funds (direct charges on the
association's connected account, association as merchant of record).

ADR-0008 is unchanged. Its ratified decision is that core association
operations stay free; the revenue strings there are in its rejected
alternatives.

## Deployment note

`EMAIL_PROVIDER=ses`, `AWS_REGION`, and `AWS_ROLE_ARN` are already set on
Production and Preview, and the IAM role and OIDC provider exist. Production is
currently running a build without this change and cannot send mail, so this
needs to deploy to restore verification email.

## Verification

- `bun run type-check`, `bun run lint`, `bun run build` clean
- `bun run test` — 2807 passed, 5 skipped
- `bun run adr:lint` — 10 records, 0 errors
- SES identity `openl.app`: DKIM verified, custom MAIL FROM `m.openl.app`,
  account has production access in `us-east-1`

Post-merge check: trigger a verification resend and confirm no `SES send
failed` entries in the production runtime logs.
