### PR TITLE
test(gear): await the async focus move in the inventory dialog assertion

### DIFF
--- a/__tests__/components/features/gear/GearInventoryManager.test.tsx
+++ b/__tests__/components/features/gear/GearInventoryManager.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { GearInventoryManager } from "@/components/features/gear/GearInventoryManager";
 import type { GearInventoryContext } from "@/lib/actions/gear-context";
@@ -51,7 +51,12 @@ describe("GearInventoryManager", () => {
     const error = await screen.findByRole("alert");
     expect(error).toHaveTextContent("name: Required");
     expect(screen.getByRole("dialog", { name: "Add storage location" })).toBeVisible();
-    expect(error).toHaveFocus();
+    // Awaited, not asserted outright: the dialog sets its error inside an async
+    // transition and moves focus from a passive effect, so the alert lands in
+    // the DOM (which is all findByRole waits for) one commit before it is
+    // focused. Asserting synchronously passes on a fast machine and loses the
+    // race on a contended CI runner.
+    await waitFor(() => expect(error).toHaveFocus());
   });
 
   it("shows an explicit accessible empty state and 44px admin controls", () => {


### PR DESCRIPTION
The dialog sets its error inside an async transition and moves focus from a passive effect, so `findByRole("alert")` — which resolves as soon as the node enters the DOM — can return one commit before the alert is focused. Asserting `toHaveFocus()` synchronously therefore passed on a 16-core dev machine and lost the race on a 2-core ubuntu-latest runner, turning Quality Gates red on main at 8c6c465 while the same commit stayed green locally.

The race is pre-existing; #359 only perturbed it by adding test files, which changed vitest's worker scheduling. Awaiting the assertion fixes the test rather than the timing it happened to get.

Verified red/green: with the component's focus effect removed the assertion still fails, so the guard is not vacuous.